### PR TITLE
Init with options

### DIFF
--- a/src/nidmm/examples/nidmm_measurement.py
+++ b/src/nidmm/examples/nidmm_measurement.py
@@ -9,17 +9,14 @@ import argparse
 import nidmm
 
 parser = argparse.ArgumentParser(description='Performs a single measurement using the NI-DMM API.', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-parser.add_argument('-n',  '--name', default='PXI1Slot2', help='Resource name of a National Instruments Digital Multimeter.')
-parser.add_argument('-i',  '--idquery', default=0, help='Verifies that the device you initialize is one that the driver supports.')
-parser.add_argument('-re', '--reset', default=False, help='Specifies whether to reset the instrument during the initialization procedure.')
-parser.add_argument('-o',  '--optionstring', default='', help='Sets the initial value of certain properties for the session.')
-parser.add_argument('-f',  '--function', default='DC_VOLTS', choices=nidmm.Function.__members__.keys(), type=str.upper, help='Measurement function.')
-parser.add_argument('-ra', '--range', default=10, type=float, help='Measurement range.')
-parser.add_argument('-d',  '--digits', default=6.5, type=float, help='Digits of resolution for the measurement.')
+parser.add_argument('-n', '--name', default='PXI1Slot2', help='Resource name of a National Instruments Digital Multimeter.')
+parser.add_argument('-f', '--function', default='DC_VOLTS', choices=nidmm.Function.__members__.keys(), type=str.upper, help='Measurement function.')
+parser.add_argument('-r', '--range', default=10, type=float, help='Measurement range.')
+parser.add_argument('-d', '--digits', default=6.5, type=float, help='Digits of resolution for the measurement.')
 args = parser.parse_args()
 
 try:
-    with nidmm.Session(args.name, args.idquery, args.reset, args.optionstring) as session:
+    with nidmm.Session(args.name) as session:
         session.configure_measurement_digits(nidmm.Function[args.function], args.range, args.digits)
         print(session.read())
 except nidmm.Error as e:


### PR DESCRIPTION
[x ] This contribution adheres to [CONTRIBUTING.md]

### What does this Pull Request accomplish?

This updates to use init with options. This is similar to LabVIEW NXG, which exposes only Initialize with options. This will enable customers to simulate devices (such as on a VM)

### Why should this Pull Request be merged?

We need to be able to test on Linux during development without having a dedicated Linux machine with hardware.

### What testing has been done?

Built, ran and validated via IO Trace that we are calling init with options
