### PR TITLE
Python27 does not handle this type of printing

### DIFF
--- a/src/nidmm/examples/nidmm_measurement.py
+++ b/src/nidmm/examples/nidmm_measurement.py
@@ -20,5 +20,5 @@ try:
         session.configure_measurement_digits(nidmm.Function[args.function], args.range, args.digits)
         print(session.read())
 except nidmm.Error as e:
-    print(e, file=sys.stderr)
+    sys.stderr.write(e)
     sys.exit(e.code)


### PR DESCRIPTION
[x ] This contribution adheres to [CONTRIBUTING.md]

### What does this Pull Request accomplish?

Enables the example to build in Python 2.7

### Why should this Pull Request be merged?

It fixes the issue and otherwise examples dont build

### What testing has been done?

I built and ran in python 27 and python 36. I also diffed the error output when an exception occurs and they were the same.