### PR TITLE
Change using byref() to using pointer()

### DIFF
--- a/build/helper.py
+++ b/build/helper.py
@@ -121,7 +121,7 @@ def get_library_call_parameter_snippet(parameters_list):
                     snippet += '.encode(\'ascii\')'
             else:
                 assert x['direction'] is 'out'
-                snippet += ', ctypes.byref(' + (x['ctypes_variable_name']) + ')'
+                snippet += ', ctypes.pointer(' + (x['ctypes_variable_name']) + ')'
     return snippet
 
 def get_library_call_parameter_types_snippet(parameters_list):

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -115,7 +115,7 @@ class Session(object):
         self.vi = 0
         self.library = library.get_library()
         session_handle = ctypes_types.ViSession_ctype(0)
-        error_code = self.library.${c_function_prefix}InitWithOptions(resourceName.encode('ascii'), idQuery, reset, optionString.encode('ascii'), ctypes.byref(session_handle))
+        error_code = self.library.${c_function_prefix}InitWithOptions(resourceName.encode('ascii'), idQuery, reset, optionString.encode('ascii'), ctypes.pointer(session_handle))
         self.vi = session_handle.value
         errors._handle_error(self.library, self.vi, error_code.value)
 


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md]
### What does this Pull Request accomplish?
* Use ctypes.pointer() instead of ctypes.byref()
  * Based on the answer here: [pointer vs. byref](https://stackoverflow.com/questions/12281306/what-is-the-difference-between-ctypes-pointer-ctypes-pointer-and-ctypes-byref)
  * Because we need access in Python, we should use pointer() instead of
byref()
  * To use byref() we would need to use internal implementation details
when mocking: [How to mock when using byref()](https://stackoverflow.com/questions/44598746/how-to-mock-ctypes-function-in-python-that-uses-ctypes-byref-for-one-of-the-para/44598804#44598804)
* Missed couple of .value's for error handling

### Why should this Pull Request be merged?
* Common change required for different mock options

### What testing has been done?
Installed and ran example