### PR TITLE
Return Python type from DLL call

### DIFF
--- a/build/templates/errors.py.mako
+++ b/build/templates/errors.py.mako
@@ -36,7 +36,7 @@ class _ErrorBase(Exception):
         buffer_size = library.${c_function_prefix}GetError(session_handle, ctypes.byref(new_error_code), 0, None)
         assert (new_error_code.value == error_code)
 
-        if (buffer_size.value > 0):
+        if (buffer_size > 0):
             '''
             Return code > 0 from first call to GetError represents the size of
             the description.  Call it again.
@@ -45,8 +45,8 @@ class _ErrorBase(Exception):
             by the driver)
             '''
             error_code = nidmm.ctypes_types.ViStatus_ctype(error_code)
-            error_message = ctypes.create_string_buffer(buffer_size.value)
-            library.${c_function_prefix}GetError(session_handle, ctypes.byref(error_code), buffer_size.value, error_message)
+            error_message = ctypes.create_string_buffer(buffer_size)
+            library.${c_function_prefix}GetError(session_handle, ctypes.byref(error_code), buffer_size, error_message)
         else:
             '''
             Return code <= 0 from GetError indicates a problem.  This is expected
@@ -56,15 +56,15 @@ class _ErrorBase(Exception):
             Call ${c_function_prefix}GetErrorMessage, pass VI_NULL for the buffer in order to retrieve
             the length of the error message.
             '''
-            error_code = buffer_size.value
+            error_code = buffer_size
             buffer_size = library.${c_function_prefix}GetErrorMessage(session_handle, error_code, 0, None)
             print("buffer_size", buffer_size)
-            error_message = ctypes.create_string_buffer(buffer_size.value)
-            library.${c_function_prefix}GetErrorMessage(session_handle, error_code, buffer_size.value, error_message)
+            error_message = ctypes.create_string_buffer(buffer_size)
+            library.${c_function_prefix}GetErrorMessage(session_handle, error_code, buffer_size, error_message)
 
         #@TODO: By hardcoding encoding "ascii", internationalized strings will throw.
         #       Which encoding should we be using? https://docs.python.org/3/library/codecs.html#standard-encodings
-        self.code = new_error_code.value
+        self.code = new_error_code
         self.elaboration = error_message.value.decode("ascii")
         super(_ErrorBase, self).__init__(str(self.code) + ": " + self.elaboration)
 

--- a/build/templates/library.py.mako
+++ b/build/templates/library.py.mako
@@ -20,6 +20,7 @@ import platform
 
 from ${module_name} import errors
 from ${module_name}.ctypes_types import * # So we can use the types without module
+import ${module_name}.python_types
 
 def get_library_name():
     try:
@@ -44,7 +45,7 @@ def get_library():
     """
 
 % for f in functions:
-    library.${c_function_prefix}${f['name']}.restype = ${f['returns_ctype']}
+    library.${c_function_prefix}${f['name']}.restype = ${module_name}.python_types.${f['returns_python']}
     library.${c_function_prefix}${f['name']}.argtypes = [${helper.get_library_call_parameter_types_snippet(f['parameters'])}]
 
 % endfor

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -117,7 +117,7 @@ class Session(object):
         session_handle = ctypes_types.ViSession_ctype(0)
         error_code = self.library.${c_function_prefix}InitWithOptions(resourceName.encode('ascii'), idQuery, reset, optionString.encode('ascii'), ctypes.pointer(session_handle))
         self.vi = session_handle.value
-        errors._handle_error(self.library, self.vi, error_code.value)
+        errors._handle_error(self.library, self.vi, error_code)
 
     def __del__(self):
         pass
@@ -132,7 +132,7 @@ class Session(object):
         # TODO(marcoskirsch): Should we raise an exception on double close? Look at what File does.
         if(self.vi != 0):
             error_code = self.library.${c_function_prefix}close(self.vi)
-            if(error_code.value < 0):
+            if(error_code < 0):
                 # TODO(marcoskirsch): This will occur when session is "stolen". Maybe don't even bother with printing?
                 print("Failed to close session.")
             self.vi = 0
@@ -160,7 +160,7 @@ class Session(object):
         ${output_parameter['ctypes_variable_name']} = ctypes_types.${output_parameter['ctypes_type']}(0)
 % endfor
         error_code = self.library.${c_function_prefix}${f['name']}(${helper.get_library_call_parameter_snippet(f['parameters'])})
-        errors._handle_error(self.library, self.vi, error_code.value)
+        errors._handle_error(self.library, self.vi, error_code)
         ${helper.get_method_return_snippet(output_parameters)}
 % endfor
 
@@ -171,9 +171,9 @@ class Session(object):
         error_code = self.library.${c_function_prefix}GetAttributeViString(self.vi, None, attribute_id, 0, None)
         # Do the IVI dance
         # Don't use _handle_error, because positive value in error_code means size, not warning.
-        if(errors._is_error(error_code.value)): raise errors.Error(self.library, self.vi, error_code.value)
+        if(errors._is_error(error_code)): raise errors.Error(self.library, self.vi, error_code)
         buffer_size = error_code
-        value = ctypes.create_string_buffer(buffer_size.value)
-        error_code = self.library.${c_function_prefix}GetAttributeViString(self.vi, None, attribute_id, buffer_size.value, value)
-        errors._handle_error(self.library, self.vi, error_code.value)
+        value = ctypes.create_string_buffer(buffer_size)
+        error_code = self.library.${c_function_prefix}GetAttributeViString(self.vi, None, attribute_id, buffer_size, value)
+        errors._handle_error(self.library, self.vi, error_code)
         return value.value.decode("ascii")


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md]
### What does this Pull Request accomplish?
* ctypes wrapper returns Python type instead of ctypes
  * Cleans up using return value - no longer need .value everywhere

### Why should this Pull Request be merged?
* Cleaner

### What testing has been done?
* Ran example with both valid and invalid device
