### PR TITLE
Added test for writeonly attribute

### DIFF
--- a/src/nidmm/system_tests/test_system_nidmm.py
+++ b/src/nidmm/system_tests/test_system_nidmm.py
@@ -139,5 +139,5 @@ def test_writeonly_attribute(device_info):
         try:
             session.channel_count = 5
         except nidmm.Error as e:
-            assert e.code == -1074135027
+            assert e.code == -1074135027 #Error : Attribute is read-only.
 

--- a/src/nidmm/system_tests/test_system_nidmm.py
+++ b/src/nidmm/system_tests/test_system_nidmm.py
@@ -132,3 +132,10 @@ def test_get_dev_temp(device_info):
         temperature = session.get_dev_temp('')
         print(temperature)
         assert 20 <= temperature <= 50
+
+def test_writeonly_attribute(device_info):
+    with nidmm.Session(device_info['name']) as session:
+        try:
+            session.channel_count = 5
+        except nidmm.Error as e:
+            assert e.code == -1074135027

--- a/src/nidmm/system_tests/test_system_nidmm.py
+++ b/src/nidmm/system_tests/test_system_nidmm.py
@@ -133,9 +133,11 @@ def test_get_dev_temp(device_info):
         print(temperature)
         assert 20 <= temperature <= 50
 
+		
 def test_writeonly_attribute(device_info):
     with nidmm.Session(device_info['name']) as session:
         try:
             session.channel_count = 5
         except nidmm.Error as e:
             assert e.code == -1074135027
+


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/<reponame>/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Adds a test case for the test test_readonly_attribute, which tests that appropriate exception is thrown when trying to write into a read-only attribute.


### Why should this Pull Request be merged?
To increase coverage of tests


### What testing has been done?
Tested locally on a machine with DMM and test passes

