### PR TITLE
New/ivi dance cleanup

### DIFF
--- a/build/helper.py
+++ b/build/helper.py
@@ -118,7 +118,7 @@ def _add_python_return_type(f):
     f['returns_python'] = f['returns']
     return f
 
-def _add_is_buffer(parameter):
+def _add_buffer_info(parameter):
     '''Adds buffer information to the parameter metadata iff 'size' is defined else assume not a buffer'''
     try:
         parameter['size']
@@ -140,7 +140,7 @@ def add_all_metadata(functions):
             _add_python_type(p)
             _add_ctypes_variable_name(p)
             _add_ctypes_type(p)
-            _add_is_buffer(p)
+            _add_buffer_info(p)
     return functions
 
 # Python 2/3 compatibility

--- a/build/helper.py
+++ b/build/helper.py
@@ -157,7 +157,7 @@ def normalize_string_type(d):
 
 # Functions that return snippets that can be placed directly in the templates.
 
-def get_method_parameters_snippet(parameters, skip_session_handle, skip_ivi_dance_size_parameter, skip_output_parameters):
+def get_method_parameters_snippet(parameters, skip_session_handle, skip_output_parameters, skip_ivi_dance_size_parameter, session_name = 'vi'):
     '''
     Returns a string suitable for the parameter list of a method given a list of parameter objects.
     You can optionally skip session handle parameter, the parameter used for an output
@@ -171,7 +171,7 @@ def get_method_parameters_snippet(parameters, skip_session_handle, skip_ivi_danc
             skip = True
         if x == ivi_dance_size_parameter and skip_ivi_dance_size_parameter:
             skip = True
-        if x['name'] == 'vi' and skip_session_handle:
+        if x['name'] == session_name and skip_session_handle:
             skip = True
         if not skip:
             snippets.append(x['python_name'])

--- a/build/templates/ctypes_library.py.mako
+++ b/build/templates/ctypes_library.py.mako
@@ -43,7 +43,7 @@ class ${module_name.title()}CtypesLibrary(object):
     f = functions[func_name]
     c_func_name = c_function_prefix + func_name
     params = f['parameters']
-    param_names_method = helper.get_method_parameters_snippet(params, skip_session_handle = False, skip_ivi_dance_size_parameter = False, skip_output_parameters = False)
+    param_names_method = helper.get_method_parameters_snippet(params, skip_session_handle = False, skip_output_parameters = False, skip_ivi_dance_size_parameter = False)
     param_names_function = helper.get_function_parameters_snippet(params)
 %>\
 

--- a/build/templates/ctypes_library.py.mako
+++ b/build/templates/ctypes_library.py.mako
@@ -43,7 +43,7 @@ class ${module_name.title()}CtypesLibrary(object):
     f = functions[func_name]
     c_func_name = c_function_prefix + func_name
     params = f['parameters']
-    param_names_method = helper.get_method_parameters_snippet(params)
+    param_names_method = helper.get_method_parameters_snippet(params, skip_session_handle = False, skip_ivi_dance_size_parameter = False, skip_output_parameters = False)
     param_names_function = helper.get_function_parameters_snippet(params)
 %>\
 

--- a/build/templates/mock_helper.py.mako
+++ b/build/templates/mock_helper.py.mako
@@ -63,7 +63,7 @@ f = functions[func_name]
 params = f['parameters']
 output_params = helper.extract_output_parameters(params)
 ivi_dance_param = helper.extract_ivi_dance_parameter(params)
-ivi_dance_size_param = helper.extract_ivi_dance_size_parameter(params)
+ivi_dance_size_param = helper.find_size_parameter(ivi_dance_param, params)
 %>\
     def ${c_function_prefix}${func_name}(${helper.get_method_parameters_snippet(params, skip_session_handle = False, skip_ivi_dance_size_parameter = False, skip_output_parameters = False)}):  # noqa: N802
 %    for p in output_params:

--- a/build/templates/mock_helper.py.mako
+++ b/build/templates/mock_helper.py.mako
@@ -35,7 +35,7 @@ class SideEffectsHelper(object):
     def __init__(self):
         self._defaults = {}
 % for func_name in sorted(helper.extract_codegen_functions(functions)):
-<% 
+<%
 f = functions[func_name]
 %>\
         self._defaults['${func_name}'] = {}
@@ -58,13 +58,14 @@ ivi_dance_param = helper.extract_ivi_dance_parameter(f['parameters'])
         self._defaults[func] = val
 
 % for func_name in sorted(helper.extract_codegen_functions(functions)):
-<% 
+<%
 f = functions[func_name]
 params = f['parameters']
 output_params = helper.extract_output_parameters(params)
-ivi_dance_param = helper.extract_ivi_dance_parameter(f['parameters'])
+ivi_dance_param = helper.extract_ivi_dance_parameter(params)
+ivi_dance_size_param = helper.extract_ivi_dance_size_parameter(params)
 %>\
-    def ${c_function_prefix}${func_name}(${helper.get_method_parameters_snippet(params)}):  # noqa: N802
+    def ${c_function_prefix}${func_name}(${helper.get_method_parameters_snippet(params, skip_session_handle = False, skip_ivi_dance_size_parameter = False, skip_output_parameters = False)}):  # noqa: N802
 %    for p in output_params:
         if self._defaults['${func_name}']['${p['name']}'] is None:
             raise MockFunctionCallError("${c_function_prefix}${func_name}", param='${p['name']}')
@@ -73,7 +74,7 @@ ivi_dance_param = helper.extract_ivi_dance_parameter(f['parameters'])
 %    if ivi_dance_param is not None:
         if self._defaults['${func_name}']['${ivi_dance_param['name']}'] is None:
             raise MockFunctionCallError("${c_function_prefix}${func_name}", param='${ivi_dance_param['name']}')
-        if ${ivi_dance_param['size']} == 0:
+        if ${ivi_dance_size_param['python_name']} == 0:
             return len(self._defaults['${func_name}']['${ivi_dance_param['name']}'])
         t = ${module_name}.ctypes_types.${ivi_dance_param['ctypes_type']}(self._defaults['${func_name}']['${ivi_dance_param['name']}'].encode('ascii'))
         ${ivi_dance_param['python_name']}.value = ctypes.cast(t, ${module_name}.ctypes_types.${ivi_dance_param['ctypes_type']}).value
@@ -84,7 +85,7 @@ ivi_dance_param = helper.extract_ivi_dance_parameter(f['parameters'])
     # Helper function to setup Mock object with default side effects and return values
     def set_side_effects_and_return_values(self, mock_library):
 % for func_name in sorted(helper.extract_codegen_functions(functions)):
-<% 
+<%
 f = functions[func_name]
 %>\
         mock_library.${c_function_prefix}${func_name}.side_effect = MockFunctionCallError("${c_function_prefix}${func_name}")

--- a/build/templates/mock_helper.py.mako
+++ b/build/templates/mock_helper.py.mako
@@ -65,7 +65,7 @@ output_params = helper.extract_output_parameters(params)
 ivi_dance_param = helper.extract_ivi_dance_parameter(params)
 ivi_dance_size_param = helper.find_size_parameter(ivi_dance_param, params)
 %>\
-    def ${c_function_prefix}${func_name}(${helper.get_method_parameters_snippet(params, skip_session_handle = False, skip_ivi_dance_size_parameter = False, skip_output_parameters = False)}):  # noqa: N802
+    def ${c_function_prefix}${func_name}(${helper.get_method_parameters_snippet(params, skip_session_handle = False, skip_output_parameters = False, skip_ivi_dance_size_parameter = False)}):  # noqa: N802
 %    for p in output_params:
         if self._defaults['${func_name}']['${p['name']}'] is None:
             raise MockFunctionCallError("${c_function_prefix}${func_name}", param='${p['name']}')

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -219,7 +219,7 @@ context_name = 'acquisition' if c['direction'] == 'input' else 'generation'
     ivi_dance_parameter = helper.extract_ivi_dance_parameter(parameters)
     ivi_dance_size_parameter = helper.find_size_parameter(ivi_dance_parameter, parameters)
 %>
-    def ${f['python_name']}(${helper.get_method_parameters_snippet(parameters, skip_session_handle = True, skip_ivi_dance_size_parameter = True, skip_output_parameters = True)}):
+    def ${f['python_name']}(${helper.get_method_parameters_snippet(parameters, skip_session_handle = True, skip_output_parameters = True, skip_ivi_dance_size_parameter = True)}):
 % for parameter in enum_input_parameters:
         ${helper.get_enum_type_check_snippet(parameter, indent=12)}
 % endfor

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -217,14 +217,14 @@ context_name = 'acquisition' if c['direction'] == 'input' else 'generation'
     output_parameters = helper.extract_output_parameters(parameters)
     enum_input_parameters = helper.extract_enum_parameters(input_parameters)
     ivi_dance_parameter = helper.extract_ivi_dance_parameter(parameters)
-    ivi_dance_size_parameter = helper.extract_ivi_dance_size_parameter(parameters)
+    ivi_dance_size_parameter = helper.find_size_parameter(ivi_dance_parameter, parameters)
 %>
     def ${f['python_name']}(${helper.get_method_parameters_snippet(parameters, skip_session_handle = True, skip_ivi_dance_size_parameter = True, skip_output_parameters = True)}):
 % for parameter in enum_input_parameters:
         ${helper.get_enum_type_check_snippet(parameter, indent=12)}
 % endfor
 % for output_parameter in output_parameters:
-        ${helper.get_ctype_variable_declaration_snippet(output_parameter)}
+        ${helper.get_ctype_variable_declaration_snippet(output_parameter, parameters)}
 % endfor
 % if ivi_dance_parameter is None:
         error_code = self.library.${c_function_prefix}${func_name}(${helper.get_library_call_parameter_snippet(f['parameters'])})

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -212,16 +212,14 @@ context_name = 'acquisition' if c['direction'] == 'input' else 'generation'
 % for func_name in sorted(functions):
 <%
     f = functions[func_name]
-    input_parameters = helper.extract_input_parameters(f['parameters'])
-    output_parameters = helper.extract_output_parameters(f['parameters'])
+    parameters = f['parameters']
+    input_parameters = helper.extract_input_parameters(parameters)
+    output_parameters = helper.extract_output_parameters(parameters)
     enum_input_parameters = helper.extract_enum_parameters(input_parameters)
-    ivi_dance_parameter = helper.extract_ivi_dance_parameter(f['parameters'])
-
-    # If there is an ivi_dance parameter, we need to remove the associated size parameter from the input_params
-    if ivi_dance_parameter is not None:
-        input_parameters[:] = [p for p in input_parameters if p['python_name'] != ivi_dance_parameter['size']]
+    ivi_dance_parameter = helper.extract_ivi_dance_parameter(parameters)
+    ivi_dance_size_parameter = helper.extract_ivi_dance_size_parameter(parameters)
 %>
-    def ${f['python_name']}(${helper.get_method_parameters_snippet(input_parameters)}):
+    def ${f['python_name']}(${helper.get_method_parameters_snippet(parameters, skip_session_handle = True, skip_ivi_dance_size_parameter = True, skip_output_parameters = True)}):
 % for parameter in enum_input_parameters:
         ${helper.get_enum_type_check_snippet(parameter, indent=12)}
 % endfor
@@ -233,14 +231,14 @@ context_name = 'acquisition' if c['direction'] == 'input' else 'generation'
         errors._handle_error(self, error_code)
         ${helper.get_method_return_snippet(f['parameters'])}
 % else:
-        ${ivi_dance_parameter['size']} = 0
-        ${ivi_dance_parameter['ctypes_variable_name']} = ctypes.cast(ctypes.create_string_buffer(${ivi_dance_parameter['size']}), ctypes_types.${ivi_dance_parameter['ctypes_type']})
+        ${ivi_dance_size_parameter['python_name']} = 0
+        ${ivi_dance_parameter['ctypes_variable_name']} = ctypes.cast(ctypes.create_string_buffer(${ivi_dance_size_parameter['python_name']}), ctypes_types.${ivi_dance_parameter['ctypes_type']})
         error_code = self.library.${c_function_prefix}${func_name}(${helper.get_library_call_parameter_snippet(f['parameters'])})
         # Don't use _handle_error, because positive value in error_code means size, not warning.
         if (errors._is_error(error_code)):
             raise errors.Error(self.library, self.vi, error_code)
-        ${ivi_dance_parameter['size']} = error_code
-        ${ivi_dance_parameter['ctypes_variable_name']} = ctypes.cast(ctypes.create_string_buffer(${ivi_dance_parameter['size']}), ctypes_types.${ivi_dance_parameter['ctypes_type']})
+        ${ivi_dance_size_parameter['python_name']} = error_code
+        ${ivi_dance_parameter['ctypes_variable_name']} = ctypes.cast(ctypes.create_string_buffer(${ivi_dance_size_parameter['python_name']}), ctypes_types.${ivi_dance_parameter['ctypes_type']})
         error_code = self.library.${c_function_prefix}${func_name}(${helper.get_library_call_parameter_snippet(f['parameters'])})
         errors._handle_error(self, error_code)
         ${helper.get_method_return_snippet(f['parameters'])}

--- a/src/nidmm/metadata/functions_addon.py
+++ b/src/nidmm/metadata/functions_addon.py
@@ -57,28 +57,28 @@ functions_params_types = {
 # This is the additional information needed by the code generator to properly generate the buffer retrieval mechanism
 # {'is_buffer': True} is required for all parameters that are arrays. Some were able to be detected as an array when
 #   generating functions.py. This sets 'is_buffer' for those parameters where the dectection didn't work
-# {'size': <size information>} is required for all output buffers
-#    possibilities for <size information> is:
-#        * int - this is for output parameters where the buffer size is known ahead of time, possibly due to IVI
-#        * '<parameter name>' - this is used when the size of the buffer is passed in as one of the other parameters.
-#                               This size will be used to create the appropriate buffer and then the function will be called
-#        * 'ivi-dance,<parameter name>' - 'ivi-dance' is when the function is called with a zero size and the function then
-#                                         returns the size of the string as the return value.
-#                                         When this is used, the generated code will call the function with a 0 size, get
-#                                         the size from the return values, allocate a buffer of that size and call again
-#                                         <parameter name> is the name of the parameter that is used to pass in the size
-#                                         This parameter is not part of the Python function parameter list
+# {'size': <size information>} is required for all output buffers.
+# <size information> is a dictionary with two keys: 'mechanism' and 'value'.
+#   'mechanism' can be:
+#       'fixed':        The size is known ahead of time, usually defined by the API.
+#                       'value' should be an int.
+#       'passed-in':    When the size comes from another parameter.
+#                       'value' should be the name of the parameter through which this is specified.
+#       'ivi-dance':    When the size is determined by calling into the function using a size of zero and
+#                       interpreting the return value as a size rather than an error.
+#                       'value' should be the name of the parameter through which the size (0, then the real
+#                       one) is passed in. This parameter won't exist in the corresponding Python Session method.
 functions_buffer_info = {
-    'GetError':                     { 'parameters': { 3: { 'size': 'ivi-dance,bufferSize', }, }, },
-    'GetErrorMessage':              { 'parameters': { 3: { 'size': 'ivi-dance,bufferSize', }, }, },
-    'self_test':                    { 'parameters': { 2: { 'size': 256, }, }, }, # From documentation
-    'ReadMultiPoint':               { 'parameters': { 3: { 'size': 'arraySize', }, }, },
-    'FetchMultiPoint':              { 'parameters': { 3: { 'size': 'arraySize', }, }, },
-    'FetchWaveform':                { 'parameters': { 3: { 'size': 'arraySize', }, }, },
-    'ReadWaveform':                 { 'parameters': { 3: { 'size': 'arraySize', }, }, },
-    'GetAttributeViString':         { 'parameters': { 4: { 'size': 'ivi-dance,bufferSize', }, }, },
-    'GetNextInterchangeWarning':    { 'parameters': { 2: { 'size': 'ivi-dance,bufferSize', }, }, },
-    'GetCalUserDefinedInfo':        { 'parameters': { 2: { 'size': 256, }, }, }, # From LabVIEW VI, even though niDMM_GetCalUserDefinedInfoMaxSize() exists.
+    'GetError':                     { 'parameters': { 3: { 'size': {'mechanism':'ivi-dance', 'value':'bufferSize'}, }, }, },
+    'GetErrorMessage':              { 'parameters': { 3: { 'size': {'mechanism':'ivi-dance', 'value':'buffer_size'}, }, }, },
+    'self_test':                    { 'parameters': { 2: { 'size': {'mechanism':'fixed', 'value':256}, }, }, }, # From documentation
+    'ReadMultiPoint':               { 'parameters': { 3: { 'size': {'mechanism':'passed-in', 'value':'arraySize'}, }, }, },
+    'FetchMultiPoint':              { 'parameters': { 3: { 'size': {'mechanism':'passed-in', 'value':'arraySize'}, }, }, },
+    'FetchWaveform':                { 'parameters': { 3: { 'size': {'mechanism':'passed-in', 'value':'arraySize'}, }, }, },
+    'ReadWaveform':                 { 'parameters': { 3: { 'size': {'mechanism':'passed-in', 'value':'arraySize'}, }, }, },
+    'GetAttributeViString':         { 'parameters': { 4: { 'size': {'mechanism':'ivi-dance', 'value':'bufferSize'}, }, }, },
+    'GetNextInterchangeWarning':    { 'parameters': { 2: { 'size': {'mechanism':'ivi-dance', 'value':'bufferSize'}, }, }, },
+    'GetCalUserDefinedInfo':        { 'parameters': { 2: { 'size': {'mechanism':'fixed', 'value':256}, }, }, }, # From LabVIEW VI, even though niDMM_GetCalUserDefinedInfoMaxSize() exists.
     'init':                         { 'parameters': { 0: { 'is_buffer': True, }, }, },
     'InitWithOptions':              { 'parameters': { 0: { 'is_buffer': True, },
                                                       3: { 'is_buffer': True, }, }, },

--- a/src/nimodinst/metadata/functions.py
+++ b/src/nimodinst/metadata/functions.py
@@ -33,7 +33,7 @@ functions = {
              'name': 'attributeValue',
              'type': 'ViString',
              'is_buffer': True,
-             'size': 'ivi-dance,attributeValueBufferSize',
+             'size': {'mechanism':'ivi-dance', 'value':'attributeValueBufferSize'}
              },
         ],
         'returns': 'ViStatus',
@@ -73,7 +73,7 @@ functions = {
              'name': 'errorInfo',
              'type': 'ViString',
              'is_buffer': True,
-             'size': 'ivi-dance,errorInfoBufferSize'
+             'size': {'mechanism':'ivi-dance', 'value':'errorInfoBufferSize'}
              },
         ],
         'returns': 'ViStatus',

--- a/src/nimodinst/templates/session.py.mako
+++ b/src/nimodinst/templates/session.py.mako
@@ -154,16 +154,14 @@ class Session(object):
 % for func_name in functions:
 <%
     f = functions[func_name]
-    input_parameters = helper.extract_input_parameters(f['parameters'])
-    output_parameters = helper.extract_output_parameters(f['parameters'])
+    parameters = f['parameters']
+    input_parameters = helper.extract_input_parameters(parameters)
+    output_parameters = helper.extract_output_parameters(parameters)
     enum_input_parameters = helper.extract_enum_parameters(input_parameters)
-    ivi_dance_parameter = helper.extract_ivi_dance_parameter(f['parameters'])
-
-    # If there is an ivi_dance parameter, we need to remove the associated size parameter from the input_params
-    if ivi_dance_parameter is not None:
-        input_parameters[:] = [p for p in input_parameters if p['python_name'] != ivi_dance_parameter['size']]
+    ivi_dance_parameter = helper.extract_ivi_dance_parameter(parameters)
+    ivi_dance_size_parameter = helper.extract_ivi_dance_size_parameter(parameters)
 %>
-    def ${f['python_name']}(${helper.get_method_parameters_snippet(input_parameters)}):
+    def ${f['python_name']}(${helper.get_method_parameters_snippet(parameters, skip_session_handle = True, skip_ivi_dance_size_parameter = True, skip_output_parameters = True)}):
 % for parameter in enum_input_parameters:
         ${helper.get_enum_type_check_snippet(parameter)}
 % endfor
@@ -171,19 +169,19 @@ class Session(object):
         ${helper.get_ctype_variable_declaration_snippet(output_parameter)}
 % endfor
 % if ivi_dance_parameter is None:
-        error_code = self.library.${c_function_prefix}${func_name}(${helper.get_library_call_parameter_snippet(f['parameters'], sessionName='handle')})
+        error_code = self.library.${c_function_prefix}${func_name}(${helper.get_library_call_parameter_snippet(f['parameters'], session_name='handle')})
         errors._handle_error(self, error_code)
         ${helper.get_method_return_snippet(f['parameters'])}
 % else:
-        ${ivi_dance_parameter['size']} = 0
-        ${ivi_dance_parameter['ctypes_variable_name']} = ctypes.cast(ctypes.create_string_buffer(${ivi_dance_parameter['size']}), ctypes_types.${ivi_dance_parameter['ctypes_type']})
-        error_code = self.library.${c_function_prefix}${func_name}(${helper.get_library_call_parameter_snippet(f['parameters'], sessionName='handle')})
+        ${ivi_dance_size_parameter['python_name']} = 0
+        ${ivi_dance_parameter['ctypes_variable_name']} = ctypes.cast(ctypes.create_string_buffer(${ivi_dance_size_parameter['python_name']}), ctypes_types.${ivi_dance_parameter['ctypes_type']})
+        error_code = self.library.${c_function_prefix}${func_name}(${helper.get_library_call_parameter_snippet(f['parameters'], session_name='handle')})
         # Don't use _handle_error, because positive value in error_code means size, not warning.
         if (errors._is_error(error_code)):
             raise errors.Error(self.library, self.vi, error_code)
-        ${ivi_dance_parameter['size']} = error_code
-        ${ivi_dance_parameter['ctypes_variable_name']} = ctypes.cast(ctypes.create_string_buffer(${ivi_dance_parameter['size']}), ctypes_types.${ivi_dance_parameter['ctypes_type']})
-        error_code = self.library.${c_function_prefix}${func_name}(${helper.get_library_call_parameter_snippet(f['parameters'], sessionName='handle')})
+        ${ivi_dance_size_parameter['python_name']} = error_code
+        ${ivi_dance_parameter['ctypes_variable_name']} = ctypes.cast(ctypes.create_string_buffer(${ivi_dance_size_parameter['python_name']}), ctypes_types.${ivi_dance_parameter['ctypes_type']})
+        error_code = self.library.${c_function_prefix}${func_name}(${helper.get_library_call_parameter_snippet(f['parameters'], session_name='handle')})
         errors._handle_error(self, error_code)
         ${helper.get_method_return_snippet(f['parameters'])}
 % endif

--- a/src/nimodinst/templates/session.py.mako
+++ b/src/nimodinst/templates/session.py.mako
@@ -161,7 +161,7 @@ class Session(object):
     ivi_dance_parameter = helper.extract_ivi_dance_parameter(parameters)
     ivi_dance_size_parameter = helper.find_size_parameter(ivi_dance_parameter, parameters)
 %>
-    def ${f['python_name']}(${helper.get_method_parameters_snippet(parameters, skip_session_handle = True, skip_ivi_dance_size_parameter = True, skip_output_parameters = True)}):
+    def ${f['python_name']}(${helper.get_method_parameters_snippet(parameters, skip_session_handle = True, skip_output_parameters = True, skip_ivi_dance_size_parameter = True)}):
 % for parameter in enum_input_parameters:
         ${helper.get_enum_type_check_snippet(parameter)}
 % endfor

--- a/src/nimodinst/templates/session.py.mako
+++ b/src/nimodinst/templates/session.py.mako
@@ -159,14 +159,14 @@ class Session(object):
     output_parameters = helper.extract_output_parameters(parameters)
     enum_input_parameters = helper.extract_enum_parameters(input_parameters)
     ivi_dance_parameter = helper.extract_ivi_dance_parameter(parameters)
-    ivi_dance_size_parameter = helper.extract_ivi_dance_size_parameter(parameters)
+    ivi_dance_size_parameter = helper.find_size_parameter(ivi_dance_parameter, parameters)
 %>
     def ${f['python_name']}(${helper.get_method_parameters_snippet(parameters, skip_session_handle = True, skip_ivi_dance_size_parameter = True, skip_output_parameters = True)}):
 % for parameter in enum_input_parameters:
         ${helper.get_enum_type_check_snippet(parameter)}
 % endfor
 % for output_parameter in output_parameters:
-        ${helper.get_ctype_variable_declaration_snippet(output_parameter)}
+        ${helper.get_ctype_variable_declaration_snippet(output_parameter, parameters)}
 % endfor
 % if ivi_dance_parameter is None:
         error_code = self.library.${c_function_prefix}${func_name}(${helper.get_library_call_parameter_snippet(f['parameters'], session_name='handle')})


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md]

### What does this Pull Request accomplish?

Cleanup of code generator:

* Improved metadata format for specifying size of buffers.
    * Size now point to a dictionary with 'mechanism' and 'value' keys
    * No more need to parse the size string.
    * No more need to make assumptions about strings.
* Moved code from templates into helper functions.
* Removed hidden contract about how python_name is determined used in several places with actual lookups in the metadata. This is cleaner and will help us should we ever change rules or override how python names are determined.
* Other minor cleanup, renames, annotations.

### Why should this Pull Request be merged?

Overall improvements to code, takes care of several TODOs.

### What testing has been done?

Unit tests only, as well as diffing generated code.