### PR TITLE
Fix formatting in function parameters on readthedocs

### DIFF
--- a/build/helper.py
+++ b/build/helper.py
@@ -549,7 +549,7 @@ def get_function_rst(fname, config, indent=0):
         if p_type.startswith('enums.'):
             p_type = p_type.replace('enums.', '')
             p_type = ':py:data:`{0}.{1}`'.format(config['module_name'], p_type)
-        rst += '\n' + (' ' * indent) + ':type {0}:'.format(p['python_name']) + p_type
+        rst += '\n' + (' ' * indent) + ':type {0}: '.format(p['python_name']) + p_type
 
 
     output_params = extract_output_parameters(function['parameters'])

--- a/docs/nidmm/functions.rst
+++ b/docs/nidmm/functions.rst
@@ -50,7 +50,7 @@ NI-DMM Functions
 
         
 
-    :type ac_minimum_frequency_hz:ViReal64
+    :type ac_minimum_frequency_hz: ViReal64
     :param ac_maximum_frequency_hz:
 
 
@@ -67,7 +67,7 @@ NI-DMM Functions
 
         
 
-    :type ac_maximum_frequency_hz:ViReal64
+    :type ac_maximum_frequency_hz: ViReal64
 
 .. function:: configure_adc_calibration(adc_calibration)
 
@@ -106,7 +106,7 @@ NI-DMM Functions
         | NIDMM\_VAL\_ADC\_CALIBRATION\_ON             | 1     | The DMM measures an internal reference to calculate the correct gain for the measurement.         |
         +----------------------------------------------+-------+---------------------------------------------------------------------------------------------------+
 
-    :type adc_calibration::py:data:`nidmm.ADCCalibration`
+    :type adc_calibration: :py:data:`nidmm.ADCCalibration`
 
 .. function:: configure_auto_zero_mode(auto_zero_mode)
 
@@ -159,7 +159,7 @@ NI-DMM Functions
 
         .. note:: The NI 4060/4065 does *not* support this setting.
 
-    :type auto_zero_mode::py:data:`nidmm.AutoZero`
+    :type auto_zero_mode: :py:data:`nidmm.AutoZero`
 
 .. function:: configure_cable_comp_type(cable_comp_type)
 
@@ -178,7 +178,7 @@ NI-DMM Functions
 
         
 
-    :type cable_comp_type::py:data:`nidmm.CableCompensationType`
+    :type cable_comp_type: :py:data:`nidmm.CableCompensationType`
 
 .. function:: configure_current_source(current_source)
 
@@ -205,7 +205,7 @@ NI-DMM Functions
         | NIDMM\_VAL\_1\_MILLIAMP (default) | 1 mA   | NI 4080/4081/4082, NI 4070/4071/4072, and NI 4065 |
         +-----------------------------------+--------+---------------------------------------------------+
 
-    :type current_source::py:data:`nidmm.CurrentSource`
+    :type current_source: :py:data:`nidmm.CurrentSource`
 
 .. function:: configure_fixed_ref_junction(fixed_reference_junction)
 
@@ -225,7 +225,7 @@ NI-DMM Functions
 
         
 
-    :type fixed_reference_junction:ViReal64
+    :type fixed_reference_junction: ViReal64
 
 .. function:: configure_frequency_voltage_range(voltage_range)
 
@@ -260,7 +260,7 @@ NI-DMM Functions
         | NIDMM\_VAL\_AUTO\_RANGE\_OFF          | -2.0  | Disables Auto Ranging. The driver sets the voltage range to the last calculated voltage range.                                   |
         +---------------------------------------+-------+----------------------------------------------------------------------------------------------------------------------------------+
 
-    :type voltage_range:ViReal64
+    :type voltage_range: ViReal64
 
 .. function:: configure_meas_complete_dest(meas_complete_destination)
 
@@ -287,7 +287,7 @@ NI-DMM Functions
             Routing <http://zone.ni.com/reference/en-XX/help/370384T-01/dmm/cvitrigger_routing/>`__
             section.
 
-    :type meas_complete_destination::py:data:`nidmm.MeasurementCompleteDest`
+    :type meas_complete_destination: :py:data:`nidmm.MeasurementCompleteDest`
 
 .. function:: configure_meas_complete_slope(meas_complete_slope)
 
@@ -309,7 +309,7 @@ NI-DMM Functions
         | Falling Edge (default) | 1 | NIDMM\_VAL\_NEGATIVE | The driver triggers on the falling edge of the trigger signal. |
         +------------------------+---+----------------------+----------------------------------------------------------------+
 
-    :type meas_complete_slope::py:data:`nidmm.Slope`
+    :type meas_complete_slope: :py:data:`nidmm.Slope`
 
 .. function:: configure_measurement_absolute(measurement_function, range, resolution_absolute)
 
@@ -328,7 +328,7 @@ NI-DMM Functions
 
         
 
-    :type measurement_function::py:data:`nidmm.Function`
+    :type measurement_function: :py:data:`nidmm.Function`
     :param range:
 
 
@@ -356,7 +356,7 @@ NI-DMM Functions
         .. note:: The NI 4050, NI 4060, and NI 4065 only support Auto Range when the
             trigger and sample trigger are set to IMMEDIATE.
 
-    :type range:ViReal64
+    :type range: ViReal64
     :param resolution_absolute:
 
 
@@ -373,7 +373,7 @@ NI-DMM Functions
             measurements, use the :py:data:`nidmm.LC\_NUMBER\_MEAS\_TO\_AVERAGE`
             attribute.
 
-    :type resolution_absolute:ViReal64
+    :type resolution_absolute: ViReal64
 
 .. function:: configure_measurement_digits(measurement_function, range, resolution_digits)
 
@@ -392,7 +392,7 @@ NI-DMM Functions
 
         
 
-    :type measurement_function::py:data:`nidmm.Function`
+    :type measurement_function: :py:data:`nidmm.Function`
     :param range:
 
 
@@ -420,7 +420,7 @@ NI-DMM Functions
         .. note:: The NI 4050, NI 4060, and NI 4065 only support Auto Range when the
             trigger and sample trigger are set to IMMEDIATE.
 
-    :type range:ViReal64
+    :type range: ViReal64
     :param resolution_digits:
 
 
@@ -440,7 +440,7 @@ NI-DMM Functions
             measurements, use the :py:data:`nidmm.LC\_NUMBER\_MEAS\_TO\_AVERAGE`
             attribute.
 
-    :type resolution_digits:ViReal64
+    :type resolution_digits: ViReal64
 
 .. function:: configure_multi_point(trigger_count, sample_count, sample_trigger, sample_interval)
 
@@ -468,7 +468,7 @@ NI-DMM Functions
 
         
 
-    :type trigger_count:ViInt32
+    :type trigger_count: ViInt32
     :param sample_count:
 
 
@@ -478,7 +478,7 @@ NI-DMM Functions
 
         
 
-    :type sample_count:ViInt32
+    :type sample_count: ViInt32
     :param sample_trigger:
 
 
@@ -493,7 +493,7 @@ NI-DMM Functions
             Routing <http://zone.ni.com/reference/en-XX/help/370384T-01/dmm/cvitrigger_routing/>`__
             section.
 
-    :type sample_trigger::py:data:`nidmm.SampleTrigger`
+    :type sample_trigger: :py:data:`nidmm.SampleTrigger`
     :param sample_interval:
 
 
@@ -514,7 +514,7 @@ NI-DMM Functions
 
         .. note:: This attribute is not used on the NI 4080/4081/4082 and the NI 4050.
 
-    :type sample_interval:ViReal64
+    :type sample_interval: ViReal64
 
 .. function:: configure_offset_comp_ohms(offset_comp_ohms)
 
@@ -543,7 +543,7 @@ NI-DMM Functions
         | NIDMM\_VAL\_OFFSET\_COMP\_OHMS\_ON            | 1     | On enables **Offset\_Comp\_Ohms**.   |
         +-----------------------------------------------+-------+--------------------------------------+
 
-    :type offset_comp_ohms::py:data:`nidmm.OffsetCompensatedOhms`
+    :type offset_comp_ohms: :py:data:`nidmm.OffsetCompensatedOhms`
 
 .. function:: configure_open_cable_comp_values(conductance, susceptance)
 
@@ -561,7 +561,7 @@ NI-DMM Functions
 
         
 
-    :type conductance:ViReal64
+    :type conductance: ViReal64
     :param susceptance:
 
 
@@ -569,7 +569,7 @@ NI-DMM Functions
 
         
 
-    :type susceptance:ViReal64
+    :type susceptance: ViReal64
 
 .. function:: configure_power_line_frequency(power_line_frequency_hz)
 
@@ -586,7 +586,7 @@ NI-DMM Functions
 
         
 
-    :type power_line_frequency_hz:ViReal64
+    :type power_line_frequency_hz: ViReal64
 
 .. function:: configure_rtd_custom(rtd_a, rtd_b, rtd_c)
 
@@ -604,7 +604,7 @@ NI-DMM Functions
 
         
 
-    :type rtd_a:ViReal64
+    :type rtd_a: ViReal64
     :param rtd_b:
 
 
@@ -614,7 +614,7 @@ NI-DMM Functions
 
         
 
-    :type rtd_b:ViReal64
+    :type rtd_b: ViReal64
     :param rtd_c:
 
 
@@ -624,7 +624,7 @@ NI-DMM Functions
 
         
 
-    :type rtd_c:ViReal64
+    :type rtd_c: ViReal64
 
 .. function:: configure_rtd_type(rtd_type, rtd_resistance)
 
@@ -660,7 +660,7 @@ NI-DMM Functions
         | \*No standard. Check the TCR.   |
         +---------------------------------+
 
-    :type rtd_type:ViInt32
+    :type rtd_type: ViInt32
     :param rtd_resistance:
 
 
@@ -669,7 +669,7 @@ NI-DMM Functions
 
         
 
-    :type rtd_resistance:ViReal64
+    :type rtd_resistance: ViReal64
 
 .. function:: configure_sample_trigger_slope(sample_trigger_slope)
 
@@ -693,7 +693,7 @@ NI-DMM Functions
         | Falling Edge (default) | 1 | NIDMM\_VAL\_NEGATIVE | The driver triggers on the falling edge of the trigger signal. |
         +------------------------+---+----------------------+----------------------------------------------------------------+
 
-    :type sample_trigger_slope::py:data:`nidmm.Slope`
+    :type sample_trigger_slope: :py:data:`nidmm.Slope`
 
 .. function:: configure_short_cable_comp_values(resistance, reactance)
 
@@ -711,7 +711,7 @@ NI-DMM Functions
 
         
 
-    :type resistance:ViReal64
+    :type resistance: ViReal64
     :param reactance:
 
 
@@ -719,7 +719,7 @@ NI-DMM Functions
 
         
 
-    :type reactance:ViReal64
+    :type reactance: ViReal64
 
 .. function:: configure_thermistor_custom(thermistor_a, thermistor_b, thermistor_c)
 
@@ -737,7 +737,7 @@ NI-DMM Functions
 
         
 
-    :type thermistor_a:ViReal64
+    :type thermistor_a: ViReal64
     :param thermistor_b:
 
 
@@ -747,7 +747,7 @@ NI-DMM Functions
 
         
 
-    :type thermistor_b:ViReal64
+    :type thermistor_b: ViReal64
     :param thermistor_c:
 
 
@@ -757,7 +757,7 @@ NI-DMM Functions
 
         
 
-    :type thermistor_c:ViReal64
+    :type thermistor_c: ViReal64
 
 .. function:: configure_thermistor_type(thermistor_type)
 
@@ -792,7 +792,7 @@ NI-DMM Functions
 
         
 
-    :type thermistor_type::py:data:`nidmm.TemperatureThermistorType`
+    :type thermistor_type: :py:data:`nidmm.TemperatureThermistorType`
 
 .. function:: configure_thermocouple(thermocouple_type, reference_junction_type)
 
@@ -827,7 +827,7 @@ NI-DMM Functions
         | NIDMM\_VAL\_TEMP\_TC\_T | Thermocouple type T |
         +-------------------------+---------------------+
 
-    :type thermocouple_type:ViInt32
+    :type thermocouple_type: ViInt32
     :param reference_junction_type:
 
 
@@ -838,7 +838,7 @@ NI-DMM Functions
 
         
 
-    :type reference_junction_type:ViInt32
+    :type reference_junction_type: ViInt32
 
 .. function:: configure_transducer_type(transducer_type)
 
@@ -864,7 +864,7 @@ NI-DMM Functions
         | NIDMM\_VAL\_THERMOCOUPLE | Thermocouple |
         +--------------------------+--------------+
 
-    :type transducer_type::py:data:`nidmm.TemperatureTransducerType`
+    :type transducer_type: :py:data:`nidmm.TemperatureTransducerType`
 
 .. function:: configure_trigger(trigger_source, trigger_delay)
 
@@ -892,7 +892,7 @@ NI-DMM Functions
             Routing <http://zone.ni.com/reference/en-XX/help/370384T-01/dmm/cvitrigger_routing/>`__
             section.
 
-    :type trigger_source::py:data:`nidmm.TriggerSource`
+    :type trigger_source: :py:data:`nidmm.TriggerSource`
     :param trigger_delay:
 
 
@@ -910,7 +910,7 @@ NI-DMM Functions
         .. note:: When using the NI 4050, **Trigger\_Delay** must be set to
             NIDMM\_VAL\_AUTO\_DELAY (-1).
 
-    :type trigger_delay:ViReal64
+    :type trigger_delay: ViReal64
 
 .. function:: configure_trigger_slope(trigger_slope)
 
@@ -934,7 +934,7 @@ NI-DMM Functions
         | NIDMM\_VAL\_NEGATIVE (default) | 1 | The driver triggers on the falling edge of the trigger signal. |
         +--------------------------------+---+----------------------------------------------------------------+
 
-    :type trigger_slope::py:data:`nidmm.Slope`
+    :type trigger_slope: :py:data:`nidmm.Slope`
 
 .. function:: configure_waveform_acquisition(measurement_function, range, rate, waveform_points)
 
@@ -956,7 +956,7 @@ NI-DMM Functions
         | NIDMM\_VAL\_WAVEFORM\_CURRENT           | 1004 | Current Waveform |
         +-----------------------------------------+------+------------------+
 
-    :type measurement_function::py:data:`nidmm.Function`
+    :type measurement_function: :py:data:`nidmm.Function`
     :param range:
 
 
@@ -972,7 +972,7 @@ NI-DMM Functions
 
         
 
-    :type range:ViReal64
+    :type range: ViReal64
     :param rate:
 
 
@@ -985,7 +985,7 @@ NI-DMM Functions
 
         
 
-    :type rate:ViReal64
+    :type rate: ViReal64
     :param waveform_points:
 
 
@@ -1002,7 +1002,7 @@ NI-DMM Functions
 
         
 
-    :type waveform_points:ViInt32
+    :type waveform_points: ViInt32
 
 .. function:: configure_waveform_coupling(waveform_coupling)
 
@@ -1026,7 +1026,7 @@ NI-DMM Functions
         | NIDMM\_VAL\_WAVEFORM\_COUPLING\_DC (default) | 1     | DC coupling |
         +----------------------------------------------+-------+-------------+
 
-    :type waveform_coupling::py:data:`nidmm.WaveformCouplingMode`
+    :type waveform_coupling: :py:data:`nidmm.WaveformCouplingMode`
 
 .. function:: disable()
 
@@ -1061,7 +1061,7 @@ NI-DMM Functions
 
         
 
-    :type maximum_time:ViInt32
+    :type maximum_time: ViInt32
 
     :rtype: ViReal64
 
@@ -1098,7 +1098,7 @@ NI-DMM Functions
 
         
 
-    :type maximum_time:ViInt32
+    :type maximum_time: ViInt32
     :param array_size:
 
 
@@ -1112,7 +1112,7 @@ NI-DMM Functions
 
         
 
-    :type array_size:ViInt32
+    :type array_size: ViInt32
 
     :rtype: tuple (reading_array, actual_number_of_points)
 
@@ -1161,7 +1161,7 @@ NI-DMM Functions
 
         
 
-    :type maximum_time:ViInt32
+    :type maximum_time: ViInt32
     :param array_size:
 
 
@@ -1172,7 +1172,7 @@ NI-DMM Functions
 
         
 
-    :type array_size:ViInt32
+    :type array_size: ViInt32
 
     :rtype: tuple (waveform_array, actual_number_of_points)
 
@@ -1211,7 +1211,7 @@ NI-DMM Functions
 
         
 
-    :type measurement_function:ViInt32
+    :type measurement_function: ViInt32
     :param range:
 
 
@@ -1219,7 +1219,7 @@ NI-DMM Functions
 
         
 
-    :type range:ViReal64
+    :type range: ViReal64
     :param resolution:
 
 
@@ -1227,7 +1227,7 @@ NI-DMM Functions
 
         
 
-    :type resolution:ViReal64
+    :type resolution: ViReal64
     :param measurement:
 
 
@@ -1235,7 +1235,7 @@ NI-DMM Functions
 
         
 
-    :type measurement:ViReal64
+    :type measurement: ViReal64
 
     :rtype: tuple (mode_string, range_string, data_string)
 
@@ -1345,7 +1345,7 @@ NI-DMM Functions
 
         
 
-    :type channel_name:ViConstString
+    :type channel_name: ViConstString
     :param attribute_id:
 
 
@@ -1353,7 +1353,7 @@ NI-DMM Functions
 
         
 
-    :type attribute_id:ViAttr
+    :type attribute_id: ViAttr
 
     :rtype: ViBoolean
 
@@ -1392,7 +1392,7 @@ NI-DMM Functions
 
         
 
-    :type channel_name:ViConstString
+    :type channel_name: ViConstString
     :param attribute_id:
 
 
@@ -1400,7 +1400,7 @@ NI-DMM Functions
 
         
 
-    :type attribute_id:ViAttr
+    :type attribute_id: ViAttr
 
     :rtype: ViInt32
 
@@ -1439,7 +1439,7 @@ NI-DMM Functions
 
         
 
-    :type channel_name:ViConstString
+    :type channel_name: ViConstString
     :param attribute_id:
 
 
@@ -1447,7 +1447,7 @@ NI-DMM Functions
 
         
 
-    :type attribute_id:ViAttr
+    :type attribute_id: ViAttr
 
     :rtype: ViReal64
 
@@ -1486,7 +1486,7 @@ NI-DMM Functions
 
         
 
-    :type channel_name:ViConstString
+    :type channel_name: ViConstString
     :param attribute_id:
 
 
@@ -1494,7 +1494,7 @@ NI-DMM Functions
 
         
 
-    :type attribute_id:ViAttr
+    :type attribute_id: ViAttr
 
     :rtype: ViSession
 
@@ -1536,7 +1536,7 @@ NI-DMM Functions
 
         
 
-    :type channel_name:ViConstString
+    :type channel_name: ViConstString
     :param attribute_id:
 
 
@@ -1544,7 +1544,7 @@ NI-DMM Functions
 
         
 
-    :type attribute_id:ViAttr
+    :type attribute_id: ViAttr
     :param buffer_size:
 
 
@@ -1565,7 +1565,7 @@ NI-DMM Functions
 
         
 
-    :type buffer_size:ViInt32
+    :type buffer_size: ViInt32
 
 .. function:: get_auto_range_value(actual_range)
 
@@ -1608,7 +1608,7 @@ NI-DMM Functions
 
         .. note:: The NI 4065 does not support self-calibration.
 
-    :type cal_type:ViInt32
+    :type cal_type: ViInt32
 
     :rtype: ViInt32
 
@@ -1641,7 +1641,7 @@ NI-DMM Functions
 
         .. note:: The NI 4065 does not support self-calibration.
 
-    :type cal_type:ViInt32
+    :type cal_type: ViInt32
 
     :rtype: tuple (month, day, year, hour, minute)
 
@@ -1699,7 +1699,7 @@ NI-DMM Functions
 
         
 
-    :type index:ViInt32
+    :type index: ViInt32
     :param buffer_size:
 
 
@@ -1720,7 +1720,7 @@ NI-DMM Functions
 
         
 
-    :type buffer_size:ViInt32
+    :type buffer_size: ViInt32
 
     :rtype: ViChar
 
@@ -1748,7 +1748,7 @@ NI-DMM Functions
 
         
 
-    :type options:ViString
+    :type options: ViString
 
     :rtype: ViReal64
 
@@ -1788,7 +1788,7 @@ NI-DMM Functions
 
         
 
-    :type buffer_size:ViInt32
+    :type buffer_size: ViInt32
 
     :rtype: ViStatus
 
@@ -1817,7 +1817,7 @@ NI-DMM Functions
 
         
 
-    :type error_code:ViStatus
+    :type error_code: ViStatus
     :param buffer_size:
 
 
@@ -1830,7 +1830,7 @@ NI-DMM Functions
 
         
 
-    :type buffer_size:ViInt32
+    :type buffer_size: ViInt32
 
 .. function:: get_last_cal_temp(cal_type, temperature)
 
@@ -1855,7 +1855,7 @@ NI-DMM Functions
 
         .. note:: The NI 4065 does not support self-calibration.
 
-    :type cal_type:ViInt32
+    :type cal_type: ViInt32
 
     :rtype: ViReal64
 
@@ -1927,7 +1927,7 @@ NI-DMM Functions
 
         
 
-    :type buffer_size:ViInt32
+    :type buffer_size: ViInt32
 
     :rtype: ViChar
 
@@ -1980,7 +1980,7 @@ NI-DMM Functions
 
         
 
-    :type buffer_size:ViInt32
+    :type buffer_size: ViInt32
 
 .. function:: get_self_cal_supported(self_cal_supported)
 
@@ -2051,7 +2051,7 @@ NI-DMM Functions
 
         
 
-    :type resource_name:ViString
+    :type resource_name: ViString
     :param id_query:
 
 
@@ -2066,7 +2066,7 @@ NI-DMM Functions
         | VI\_FALSE          | 0 | Skip ID Query    |
         +--------------------+---+------------------+
 
-    :type id_query:ViBoolean
+    :type id_query: ViBoolean
     :param reset_device:
 
 
@@ -2080,7 +2080,7 @@ NI-DMM Functions
         | VI\_FALSE          | 0 | Don't Reset  |
         +--------------------+---+--------------+
 
-    :type reset_device:ViBoolean
+    :type reset_device: ViBoolean
     :param option_string:
 
 
@@ -2115,7 +2115,7 @@ NI-DMM Functions
         | DriverSetup      | :py:data:`nidmm.DRIVER\_SETUP`        | "" (empty string) | "" |
         +------------------+---------------------------------------+-------------------+----+
 
-    :type option_string:ViString
+    :type option_string: ViString
 
     :rtype: ViSession
 
@@ -2155,7 +2155,7 @@ NI-DMM Functions
         .. note:: If an overrange condition occurs, the **Measurement\_Value** contains
             an IEEE-defined NaN (Not a Number) value.
 
-    :type measurement_value:ViReal64
+    :type measurement_value: ViReal64
 
     :rtype: ViBoolean
 
@@ -2188,7 +2188,7 @@ NI-DMM Functions
         .. note:: If an overrange condition occurs, the **Measurement\_Value** contains
             an IEEE-defined NaN (Not a Number) value.
 
-    :type measurement_value:ViReal64
+    :type measurement_value: ViReal64
 
     :rtype: ViBoolean
 
@@ -2406,7 +2406,7 @@ NI-DMM Functions
 
         
 
-    :type maximum_time:ViInt32
+    :type maximum_time: ViInt32
 
     :rtype: ViReal64
 
@@ -2442,7 +2442,7 @@ NI-DMM Functions
 
         
 
-    :type maximum_time:ViInt32
+    :type maximum_time: ViInt32
     :param array_size:
 
 
@@ -2456,7 +2456,7 @@ NI-DMM Functions
 
         
 
-    :type array_size:ViInt32
+    :type array_size: ViInt32
 
     :rtype: tuple (reading_array, actual_number_of_points)
 
@@ -2556,7 +2556,7 @@ NI-DMM Functions
 
         
 
-    :type maximum_time:ViInt32
+    :type maximum_time: ViInt32
     :param array_size:
 
 
@@ -2567,7 +2567,7 @@ NI-DMM Functions
 
         
 
-    :type array_size:ViInt32
+    :type array_size: ViInt32
 
     :rtype: tuple (waveform_array, actual_number_of_points)
 
@@ -2702,7 +2702,7 @@ NI-DMM Functions
 
         
 
-    :type channel_name:ViConstString
+    :type channel_name: ViConstString
     :param attribute_id:
 
 
@@ -2710,7 +2710,7 @@ NI-DMM Functions
 
         
 
-    :type attribute_id:ViAttr
+    :type attribute_id: ViAttr
     :param attribute_value:
 
 
@@ -2718,7 +2718,7 @@ NI-DMM Functions
 
         
 
-    :type attribute_value:ViBoolean
+    :type attribute_value: ViBoolean
 
 .. function:: _set_attribute_vi_int32(channel_name, attribute_id, attribute_value)
 
@@ -2763,7 +2763,7 @@ NI-DMM Functions
 
         
 
-    :type channel_name:ViConstString
+    :type channel_name: ViConstString
     :param attribute_id:
 
 
@@ -2771,7 +2771,7 @@ NI-DMM Functions
 
         
 
-    :type attribute_id:ViAttr
+    :type attribute_id: ViAttr
     :param attribute_value:
 
 
@@ -2779,7 +2779,7 @@ NI-DMM Functions
 
         
 
-    :type attribute_value:ViInt32
+    :type attribute_value: ViInt32
 
 .. function:: _set_attribute_vi_real64(channel_name, attribute_id, attribute_value)
 
@@ -2824,7 +2824,7 @@ NI-DMM Functions
 
         
 
-    :type channel_name:ViConstString
+    :type channel_name: ViConstString
     :param attribute_id:
 
 
@@ -2832,7 +2832,7 @@ NI-DMM Functions
 
         
 
-    :type attribute_id:ViAttr
+    :type attribute_id: ViAttr
     :param attribute_value:
 
 
@@ -2840,7 +2840,7 @@ NI-DMM Functions
 
         
 
-    :type attribute_value:ViReal64
+    :type attribute_value: ViReal64
 
 .. function:: _set_attribute_vi_session(channel_name, attribute_id, attribute_value)
 
@@ -2872,7 +2872,7 @@ NI-DMM Functions
 
         
 
-    :type channel_name:ViConstString
+    :type channel_name: ViConstString
     :param attribute_id:
 
 
@@ -2880,7 +2880,7 @@ NI-DMM Functions
 
         
 
-    :type attribute_id:ViAttr
+    :type attribute_id: ViAttr
     :param attribute_value:
 
 
@@ -2888,7 +2888,7 @@ NI-DMM Functions
 
         
 
-    :type attribute_value:ViSession
+    :type attribute_value: ViSession
 
 .. function:: _set_attribute_vi_string(channel_name, attribute_id, attribute_value)
 
@@ -2933,7 +2933,7 @@ NI-DMM Functions
 
         
 
-    :type channel_name:ViConstString
+    :type channel_name: ViConstString
     :param attribute_id:
 
 
@@ -2941,7 +2941,7 @@ NI-DMM Functions
 
         
 
-    :type attribute_id:ViAttr
+    :type attribute_id: ViAttr
     :param attribute_value:
 
 
@@ -2949,7 +2949,7 @@ NI-DMM Functions
 
         
 
-    :type attribute_value:ViString
+    :type attribute_value: ViString
 
 .. function:: _unlock_session(caller_has_lock)
 
@@ -3067,7 +3067,7 @@ NI-DMM Functions
 
         
 
-    :type error_code:ViStatus
+    :type error_code: ViStatus
 
     :rtype: ViChar
 

--- a/docs/nimodinst/functions.rst
+++ b/docs/nimodinst/functions.rst
@@ -7,25 +7,25 @@ NI-ModInst Functions
 
     :param handle:
 
-    :type handle:ViSession
+    :type handle: ViSession
 
 .. function:: get_extended_error_info(error_info_buffer_size, error_info)
 
     :param error_info_buffer_size:
 
-    :type error_info_buffer_size:ViInt32
+    :type error_info_buffer_size: ViInt32
 
 .. function:: _get_installed_device_attribute_vi_int32(handle, index, attribute_id, attribute_value)
 
     :param handle:
 
-    :type handle:ViSession
+    :type handle: ViSession
     :param index:
 
-    :type index:ViInt32
+    :type index: ViInt32
     :param attribute_id:
 
-    :type attribute_id:ViInt32
+    :type attribute_id: ViInt32
 
     :rtype: ViInt32
 
@@ -34,22 +34,22 @@ NI-ModInst Functions
 
     :param handle:
 
-    :type handle:ViSession
+    :type handle: ViSession
     :param index:
 
-    :type index:ViInt32
+    :type index: ViInt32
     :param attribute_id:
 
-    :type attribute_id:ViInt32
+    :type attribute_id: ViInt32
     :param attribute_value_buffer_size:
 
-    :type attribute_value_buffer_size:ViInt32
+    :type attribute_value_buffer_size: ViInt32
 
 .. function:: _open_installed_devices_session(driver, handle, item_count)
 
     :param driver:
 
-    :type driver:ViConstString
+    :type driver: ViConstString
 
     :rtype: tuple (handle, item_count)
 


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md]
### What does this Pull Request accomplish?
* Fix parameter type formatting on read the docs
* Need a space after rst instruction

### Why should this Pull Request be merged?
* Fix documentation

### What testing has been done?
Travis
