### PR TITLE
Added more nidmm system tests and fixed test related to enum return type

### DIFF
--- a/src/nidmm/system_tests/test_system_nidmm.py
+++ b/src/nidmm/system_tests/test_system_nidmm.py
@@ -198,13 +198,13 @@ def test_writeonly_attribute(device_info):
 			
 			
 def test_init_with_valid_optionstring(device_info):
-    with nidmm.Session(device_info['name'], False, True, 'Simulate=1') as session:
+    with nidmm.Session(device_info['name'], False, True, 'Simulate = 1') as session:
         assert session.simulate == True
 
 
 def test_init_with_invalid_optionstring(device_info):
     try:
-        with nidmm.Session(device_info['name'], False, True, 'Invalidstring=1') as session:
+        with nidmm.Session(device_info['name'], False, True, 'Invalidstring = 1') as session:
             assert False
     except nidmm.Error as e:
         assert e.code == -1074134965 # Error : The option string parameter contains an entry with an unknown option name.

--- a/src/nidmm/system_tests/test_system_nidmm.py
+++ b/src/nidmm/system_tests/test_system_nidmm.py
@@ -197,14 +197,14 @@ def test_writeonly_attribute(device_info):
             assert e.code == -1074135027 #Error : Attribute is read-only.
 			
 			
-def test_init_with_Valid_optionstring(device_info):
-    with nidmm.Session(device_info['name'],False,True,'Simulate=1') as session:
+def test_init_with_valid_optionstring(device_info):
+    with nidmm.Session(device_info['name'], False, True, 'Simulate=1') as session:
         assert session.simulate == True
 
 
 def test_init_with_invalid_optionstring(device_info):
     try:
-        with nidmm.Session(device_info['name'],False,True,'Invalidstring=1') as session:
+        with nidmm.Session(device_info['name'], False, True, 'Invalidstring=1') as session:
             assert False
     except nidmm.Error as e:
         assert e.code == -1074134965 # Error : The option string parameter contains an entry with an unknown option name.

--- a/src/nidmm/system_tests/test_system_nidmm.py
+++ b/src/nidmm/system_tests/test_system_nidmm.py
@@ -186,8 +186,7 @@ def test_method_with_ViBoolean_output_type_method(device_info):
 
 def test_method_with_enum_output_type_method(device_info):
     with nidmm.Session(device_info['name']) as session:
-        #will have to update after https://github.com/ni/nimi-python/issues/128 fixed
-        assert session.read_status()[1] == 4
+        assert session.read_status()[1] == nidmm.AcquisitionStatus.NO_ACQUISITION_IN_PROGRESS
 
 
 def test_writeonly_attribute(device_info):
@@ -196,6 +195,19 @@ def test_writeonly_attribute(device_info):
             session.channel_count = 5
         except nidmm.Error as e:
             assert e.code == -1074135027 #Error : Attribute is read-only.
+			
+			
+def test_init_with_Valid_optionstring(device_info):
+    with nidmm.Session(device_info['name'],False,True,'Simulate=1') as session:
+        assert session.simulate == True
+
+
+def test_init_with_invalid_optionstring(device_info):
+    try:
+        with nidmm.Session(device_info['name'],False,True,'Invalidstring=1') as session:
+            assert False
+    except nidmm.Error as e:
+        assert e.code == -1074134965 # Error : The option string parameter contains an entry with an unknown option name.
 
 
 


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/<reponame>/blob/master/CONTRIBUTING.md).

(https://github.com/ni/<reponame>/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Added system test to check option string behavior while initializing the device.

   1.  test_init_with_Valid_optionstring
   2.  test_init_with_invalid_optionstring

Modified test test_method_with_enum_output_type_method to have enum return type

### Why should this Pull Request be merged?

System test coverage for optionstring check

### What testing has been done?

Passed on local machine
