### PR TITLE
Do a better job of minimizing building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 .cache
 .com.apple.timemachine.supported
 bin/
-
+.eggs/
+.tox/
 .com.apple.timemachine.supported
 
 

--- a/build/defines.mak
+++ b/build/defines.mak
@@ -69,4 +69,10 @@ DEFAULT_RST_FILES_TO_GENERATE := \
                      attributes.rst \
                      functions.rst \
 
+# Files for tracking parts of the build
+UNIT_TESTS_PASSED := $(LOG_DIR)/tests_passed
+FLAKE8_PASSED := $(LOG_DIR)/flake8_passed
+WHEEL_BUILT := $(LOG_DIR)/wheel_built
+SDIST_BUILT := $(LOG_DIR)/sdist_built
+GENERATED_FILES_COPIED := $(LOG_DIR)/generated_files_copied
 

--- a/build/defines.mak
+++ b/build/defines.mak
@@ -70,9 +70,9 @@ DEFAULT_RST_FILES_TO_GENERATE := \
                      functions.rst \
 
 # Files for tracking parts of the build
-UNIT_TESTS_PASSED := $(LOG_DIR)/tests_passed
-FLAKE8_PASSED := $(LOG_DIR)/flake8_passed
-WHEEL_BUILT := $(LOG_DIR)/wheel_built
-SDIST_BUILT := $(LOG_DIR)/sdist_built
-GENERATED_FILES_COPIED := $(LOG_DIR)/generated_files_copied
+UNIT_TESTS_DONE := $(LOG_DIR)/tests_passed
+FLAKE8_DONE := $(LOG_DIR)/flake8_passed
+WHEEL_DONE := $(LOG_DIR)/wheel_built
+SDIST_DONE := $(LOG_DIR)/sdist_built
+GENERATED_FILES_DONE := $(LOG_DIR)/generated_files_copied
 

--- a/build/rules.mak
+++ b/build/rules.mak
@@ -60,14 +60,14 @@ module: $(MODULE_FILES)
 
 $(UNIT_TEST_FILES): $(MODULE_FILES) $(RST_FILES)
 
-unit_tests: $(UNIT_TEST_FILES)
+unit_tests: $(UNIT_TESTS_PASSED)
 
-$(LOG_DIR)/tests_passed: $(UNIT_TEST_FILES)
+$(UNIT_TESTS_PASSED): $(UNIT_TEST_FILES)
 	$(call trace_to_console, "Running pytest",$@)
-	$(_hide_cmds)$(call log_command,touch $(LOG_DIR)/tests_passed)
-	$(_hide_cmds)$(call log_command,rm $(LOG_DIR)/tests_passed)
+	$(_hide_cmds)$(call log_command,touch $@)
+	$(_hide_cmds)$(call log_command,rm $@)
 	$(_hide_cmds)$(call log_command,cd $(OUTPUT_DIR) && python3 -m pytest -s $(LOG_OUTPUT) $(LOG_DIR)/test_results.log)
-	$(_hide_cmds)$(call log_command,touch $(LOG_DIR)/tests_passed)
+	$(_hide_cmds)$(call log_command,touch $@)
 
 $(OUTPUT_DIR)/README.rst: $(ROOT_DIR)/README.rst
 	$(call trace_to_console, "\ \ \ \ \ \ \ Copying",$@)
@@ -77,13 +77,23 @@ $(OUTPUT_DIR)/setup.py: $(TEMPLATE_DIR)/setup.py.mako
 	$(call trace_to_console, "\ \ \ \ Generating",$@)
 	$(_hide_cmds)$(call log_command,$(call GENERATE_SCRIPT, $<, $(dir $@), $(METADATA_DIR)))
 
-sdist: $(OUTPUT_DIR)/setup.py $(OUTPUT_DIR)/README.rst $(MODULE_FILES) $(LOG_DIR)/tests_passed
-	$(call trace_to_console, "Creating sdist",$(OUTPUT_DIR)/dist)
-	$(_hide_cmds)$(call log_command,cd $(OUTPUT_DIR) && python3 setup.py sdist $(LOG_OUTPUT) $(LOG_DIR)/sdist.log)
+sdist: $(SDIST_BUILT)
 
-wheel: $(OUTPUT_DIR)/setup.py $(OUTPUT_DIR)/README.rst $(MODULE_FILES) $(LOG_DIR)/tests_passed
+$(SDIST_BUILT): $(OUTPUT_DIR)/setup.py $(OUTPUT_DIR)/README.rst $(MODULE_FILES) $(UNIT_TESTS_PASSED)
+	$(call trace_to_console, "Creating sdist",$(OUTPUT_DIR)/dist)
+	$(_hide_cmds)$(call log_command,touch $@)
+	$(_hide_cmds)$(call log_command,rm $@)
+	$(_hide_cmds)$(call log_command,cd $(OUTPUT_DIR) && python3 setup.py sdist $(LOG_OUTPUT) $(LOG_DIR)/sdist.log)
+	$(_hide_cmds)$(call log_command,touch $@)
+
+wheel: $(WHEEL_BUILT)
+
+$(WHEEL_BUILT): $(OUTPUT_DIR)/setup.py $(OUTPUT_DIR)/README.rst $(MODULE_FILES) $(UNIT_TESTS_PASSED)
 	$(call trace_to_console, "Creating wheel",$(OUTPUT_DIR)/dist)
+	$(_hide_cmds)$(call log_command,touch $@)
+	$(_hide_cmds)$(call log_command,rm $@)
 	$(_hide_cmds)$(call log_command,cd $(OUTPUT_DIR) && python3 setup.py bdist_wheel --universal $(LOG_OUTPUT) $(LOG_DIR)/wheel.log)
+	$(_hide_cmds)$(call log_command,touch $@)
 
 # From https://stackoverflow.com/questions/16467718/how-to-print-out-a-variable-in-makefile
 print-%: ; $(info $(DRIVER): $* is $(flavor $*) variable set to [$($*)]) @true
@@ -96,16 +106,17 @@ test: $(TOX_INI)
 	$(call trace_to_console, "\ \ \ \ \ \ \ Running tox",$(OUTPUT_DIR))
 	$(_hide_cmds)$(call log_command,cd $(OUTPUT_DIR) && set DRIVER=$(DRIVER) && tox)
 
-flake8: $(TOX_INI)
-	$(call trace_to_console, "\ \ \ \ \ Running flake",$(OUTPUT_DIR))
-	$(_hide_cmds)$(call log_command,cd $(OUTPUT_DIR) && tox -e flake8)
+update_generated_files: $(GENERATED_FILES_COPIED)
 
-update_generated_files: $(MODULE_FILES) $(OUTPUT_DIR)/setup.py
+$(GENERATED_FILES_COPIED): $(MODULE_FILES) $(OUTPUT_DIR)/setup.py
 	$(call trace_to_console, "\ \ \ \ \ \ Updating",$(GENERATED_DIR)/$(DRIVER)/)
+	$(_hide_cmds)$(call log_command,touch $@)
+	$(_hide_cmds)$(call log_command,rm $@)
 	$(_hide_cmds)$(call log_command,rm -Rf $(GENERATED_DIR)/$(DRIVER))
 	$(_hide_cmds)$(call log_command,mkdir -p $(GENERATED_DIR)/$(DRIVER))
 	$(_hide_cmds)$(call log_command,cp -Rf $(MODULE_DIR)/* $(GENERATED_DIR)/$(DRIVER))
 	$(_hide_cmds)$(call log_command,cp -Rf $(OUTPUT_DIR)/setup.py $(GENERATED_DIR)/$(DRIVER))
+	$(_hide_cmds)$(call log_command,touch $@)
 
 ifneq (,$(wildcard $(DRIVER_DIR)/system_tests))
 SYSTEM_TESTS_FILES_TO_COPY := $(wildcard $(DRIVER_DIR)/system_tests/*)
@@ -126,5 +137,14 @@ update_examples: $(EXAMPLE_FILES)
 $(EXAMPLES_DIR)/%.py: $(DRIVER_DIR)/examples/%.py
 	$(call trace_to_console, "\ \ \ \ \ \ \ Copying",$@)
 	$(_hide_cmds)$(call log_command,cp $< $@)
+
+flake8: $(FLAKE8_PASSED) 
+
+$(FLAKE8_PASSED): $(TOX_INI) $(UNIT_TEST_FILES) $(MODULE_FILES) $(SYSTEM_TESTS_FILES) $(EXAMPLE_FILES) $(UNIT_TESTS_PASSED)
+	$(call trace_to_console, "\ \ \ \ \ Running flake",$(OUTPUT_DIR))
+	$(_hide_cmds)$(call log_command,touch $@)
+	$(_hide_cmds)$(call log_command,rm $@)
+	$(_hide_cmds)$(call log_command,cd $(OUTPUT_DIR) && tox -e flake8)
+	$(_hide_cmds)$(call log_command,touch $@)
 
 

--- a/build/rules.mak
+++ b/build/rules.mak
@@ -66,9 +66,9 @@ module: $(MODULE_FILES)
 
 $(UNIT_TEST_FILES): $(MODULE_FILES) $(RST_FILES)
 
-unit_tests: $(UNIT_TESTS_PASSED)
+unit_tests: $(UNIT_TESTS_DONE)
 
-$(UNIT_TESTS_PASSED): $(UNIT_TEST_FILES)
+$(UNIT_TESTS_DONE): $(UNIT_TEST_FILES)
 	$(call trace_to_console, "Running pytest",$@)
 	$(_hide_cmds)$(call make_with_tracking_file,$@,cd $(OUTPUT_DIR) && python3 -m pytest -s $(LOG_OUTPUT) $(LOG_DIR)/test_results.log)
 
@@ -80,15 +80,15 @@ $(OUTPUT_DIR)/setup.py: $(TEMPLATE_DIR)/setup.py.mako
 	$(call trace_to_console, "\ \ \ \ Generating",$@)
 	$(_hide_cmds)$(call log_command,$(call GENERATE_SCRIPT, $<, $(dir $@), $(METADATA_DIR)))
 
-sdist: $(SDIST_BUILT)
+sdist: $(SDIST_DONE)
 
-$(SDIST_BUILT): $(OUTPUT_DIR)/setup.py $(OUTPUT_DIR)/README.rst $(MODULE_FILES) $(UNIT_TESTS_PASSED)
+$(SDIST_DONE): $(OUTPUT_DIR)/setup.py $(OUTPUT_DIR)/README.rst $(MODULE_FILES) $(UNIT_TESTS_PASSED)
 	$(call trace_to_console, "Creating sdist",$(OUTPUT_DIR)/dist)
 	$(_hide_cmds)$(call make_with_tracking_file,$@,cd $(OUTPUT_DIR) && python3 setup.py sdist $(LOG_OUTPUT) $(LOG_DIR)/sdist.log)
 
-wheel: $(WHEEL_BUILT)
+wheel: $(WHEEL_DONE)
 
-$(WHEEL_BUILT): $(OUTPUT_DIR)/setup.py $(OUTPUT_DIR)/README.rst $(MODULE_FILES) $(UNIT_TESTS_PASSED)
+$(WHEEL_DONE): $(OUTPUT_DIR)/setup.py $(OUTPUT_DIR)/README.rst $(MODULE_FILES) $(UNIT_TESTS_PASSED)
 	$(call trace_to_console, "Creating wheel",$(OUTPUT_DIR)/dist)
 	$(_hide_cmds)$(call make_with_tracking_file,$@,cd $(OUTPUT_DIR) && python3 setup.py bdist_wheel --universal $(LOG_OUTPUT) $(LOG_DIR)/wheel.log)
 
@@ -103,9 +103,10 @@ test: $(TOX_INI)
 	$(call trace_to_console, "\ \ \ \ \ \ \ Running tox",$(OUTPUT_DIR))
 	$(_hide_cmds)$(call log_command,cd $(OUTPUT_DIR) && set DRIVER=$(DRIVER) && tox)
 
-update_generated_files: $(GENERATED_FILES_COPIED)
+update_generated_files: $(GENERATED_FILES_DONE)
 
-$(GENERATED_FILES_COPIED): $(MODULE_FILES) $(OUTPUT_DIR)/setup.py
+# Can't use make_with_tracking_file since there are multiple commands
+$(GENERATED_FILES_DONE): $(MODULE_FILES) $(OUTPUT_DIR)/setup.py
 	$(call trace_to_console, "\ \ \ \ \ \ Updating",$(GENERATED_DIR)/$(DRIVER)/)
 	$(_hide_cmds)$(call log_command,touch $@)
 	$(_hide_cmds)$(call log_command,rm $@)
@@ -135,9 +136,9 @@ $(EXAMPLES_DIR)/%.py: $(DRIVER_DIR)/examples/%.py
 	$(call trace_to_console, "\ \ \ \ \ \ \ Copying",$@)
 	$(_hide_cmds)$(call log_command,cp $< $@)
 
-flake8: $(FLAKE8_PASSED) 
+flake8: $(FLAKE8_DONE) 
 
-$(FLAKE8_PASSED): $(TOX_INI) $(UNIT_TEST_FILES) $(MODULE_FILES) $(SYSTEM_TESTS_FILES) $(EXAMPLE_FILES) $(UNIT_TESTS_PASSED)
+$(FLAKE8_DONE): $(TOX_INI) $(UNIT_TEST_FILES) $(MODULE_FILES) $(SYSTEM_TESTS_FILES) $(EXAMPLE_FILES) $(UNIT_TESTS_PASSED)
 	$(call trace_to_console, "\ \ \ \ \ Running flake",$(OUTPUT_DIR))
 	$(_hide_cmds)$(call make_with_tracking_file,$@,cd $(OUTPUT_DIR) && tox -e flake8)
 

--- a/generated/nidmm/setup.py
+++ b/generated/nidmm/setup.py
@@ -28,7 +28,7 @@ def read_contents(file_to_read):
 setup(
     name=pypi_name,
     zip_safe=False,
-    version='0.1.0.dev3',
+    version='0.1.0.dev4',
     description='NI-DMM Python API',
     long_description=read_contents('README.rst'),
     author='National Instruments',

--- a/generated/nimodinst/setup.py
+++ b/generated/nimodinst/setup.py
@@ -28,7 +28,7 @@ def read_contents(file_to_read):
 setup(
     name=pypi_name,
     zip_safe=False,
-    version='0.1.0.dev3',
+    version='0.1.0.dev4',
     description='NI-ModInst Python API',
     long_description=read_contents('README.rst'),
     author='National Instruments',


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md]
### What does this Pull Request accomplish?
* Fixes #167 
* Create file in LOG_DIR to track when a build step has completed successfully
  * Create variables in defines.mak for all the tracking files
* All targets except test & html now use this mechanism
  * sphinx already does a good job of not rebuilding when not required
  * `make test` should always run tests

### Why should this Pull Request be merged?
* Developer effenciency

### What testing has been done?
* Travis