### PR TITLE
Page headers and section name more pythonic

### DIFF
--- a/build/templates/attributes.rst.mako
+++ b/build/templates/attributes.rst.mako
@@ -7,7 +7,7 @@
     c_function_prefix = config['c_function_prefix']
     attributes = config['attributes']
 %>\
-${helper.get_rst_header_snippet(driver_name + ' Attributes', '=')}
+${helper.get_rst_header_snippet(module_name + '.Session properties', '=')}
 
 .. py:currentmodule:: ${module_name}
 

--- a/build/templates/enums.rst.mako
+++ b/build/templates/enums.rst.mako
@@ -6,7 +6,7 @@
     driver_name = config['driver_name']
     enums = config['enums']
 %>\
-${helper.get_rst_header_snippet(driver_name + ' Enums', '=')}
+${helper.get_rst_header_snippet(module_name + ' enums', '=')}
 
 Enums used in ${driver_name}
 

--- a/build/templates/functions.rst.mako
+++ b/build/templates/functions.rst.mako
@@ -10,7 +10,7 @@
     functions = helper.extract_codegen_functions(functions)
     functions = helper.add_all_metadata(functions)
 %>\
-${helper.get_rst_header_snippet(driver_name + ' Functions', '=')}
+${helper.get_rst_header_snippet(module_name + '.Session methods', '=')}
 
 .. py:currentmodule:: ${module_name}
 

--- a/build/templates/session.rst.mako
+++ b/build/templates/session.rst.mako
@@ -7,7 +7,7 @@
     driver_name = config['driver_name']
     c_function_prefix = config['c_function_prefix']
 %>\
-${helper.get_rst_header_snippet(driver_name + ' Session', '=')}
+${helper.get_rst_header_snippet(module_name + '.Session', '=')}
 
 .. py:module:: ${module_name}
 

--- a/docs/nidmm.rst
+++ b/docs/nidmm.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-NI-DMM Python API's documentation
+nidmm module
 =============================================================
 
 .. toctree::

--- a/docs/nidmm/attributes.rst
+++ b/docs/nidmm/attributes.rst
@@ -1,5 +1,5 @@
-NI-DMM Attributes
-=================
+nidmm.Session properties
+========================
 
 .. py:currentmodule:: nidmm
 

--- a/docs/nidmm/enums.rst
+++ b/docs/nidmm/enums.rst
@@ -1,5 +1,5 @@
-NI-DMM Enums
-============
+nidmm enums
+===========
 
 Enums used in NI-DMM
 

--- a/docs/nidmm/functions.rst
+++ b/docs/nidmm/functions.rst
@@ -1,5 +1,5 @@
-NI-DMM Functions
-================
+nidmm.Session methods
+=====================
 
 .. py:currentmodule:: nidmm
 

--- a/docs/nidmm/session.rst
+++ b/docs/nidmm/session.rst
@@ -1,5 +1,5 @@
-NI-DMM Session
-==============
+nidmm.Session
+=============
 
 .. py:module:: nidmm
 

--- a/docs/nifake/attributes.rst
+++ b/docs/nifake/attributes.rst
@@ -1,5 +1,5 @@
-NI-FAKE Attributes
-==================
+nifake.Session properties
+=========================
 
 .. py:currentmodule:: nifake
 

--- a/docs/nifake/enums.rst
+++ b/docs/nifake/enums.rst
@@ -1,5 +1,5 @@
-NI-FAKE Enums
-=============
+nifake enums
+============
 
 Enums used in NI-FAKE
 

--- a/docs/nifake/functions.rst
+++ b/docs/nifake/functions.rst
@@ -1,5 +1,5 @@
-NI-FAKE Functions
-=================
+nifake.Session methods
+======================
 
 .. py:currentmodule:: nifake
 

--- a/docs/nifake/session.rst
+++ b/docs/nifake/session.rst
@@ -1,5 +1,5 @@
-NI-FAKE Session
-===============
+nifake.Session
+==============
 
 .. py:module:: nifake
 

--- a/docs/nimodinst.rst
+++ b/docs/nimodinst.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-NI-ModInst Python API's documentation
+nimodinst module
 =============================================================
 
 .. toctree::

--- a/docs/nimodinst/attributes.rst
+++ b/docs/nimodinst/attributes.rst
@@ -1,5 +1,5 @@
-NI-ModInst Attributes
-=====================
+nimodinst.Session properties
+============================
 
 .. py:currentmodule:: nimodinst
 

--- a/docs/nimodinst/functions.rst
+++ b/docs/nimodinst/functions.rst
@@ -1,5 +1,5 @@
-NI-ModInst Functions
-====================
+nimodinst.Session methods
+=========================
 
 .. py:currentmodule:: nimodinst
 

--- a/docs/nimodinst/session.rst
+++ b/docs/nimodinst/session.rst
@@ -1,5 +1,5 @@
-NI-ModInst Session
-==================
+nimodinst.Session
+=================
 
 .. py:module:: nimodinst
 


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md]
### What does this Pull Request accomplish?
* Fixes #158 
* Change Page headers (which become section names on the index) to be more Pythonic. I.e.:
  * NI-DMM Functions --> nidmm.Session methods
  * NI-DMM Attributes --> nidmm.Session properties
  * NI-DMM Enums --> nidmm enums
  * NI-DMM Session --> nidmm.Session

### Why should this Pull Request be merged?
* Documentation improvement

### What testing has been done?
* Travis