### PR TITLE
Only look for .py files when getting system tests and examples

### DIFF
--- a/build/rules.mak
+++ b/build/rules.mak
@@ -116,7 +116,7 @@ update_generated_files: $(MODULE_FILES) $(OUTPUT_DIR)/setup.py
 	$(_hide_cmds)$(call log_command,cp -Rf $(OUTPUT_DIR)/setup.py $(GENERATED_DIR)/$(DRIVER))
 
 ifneq (,$(wildcard $(DRIVER_DIR)/system_tests))
-SYSTEM_TESTS_FILES_TO_COPY := $(wildcard $(DRIVER_DIR)/system_tests/*)
+SYSTEM_TESTS_FILES_TO_COPY := $(wildcard $(DRIVER_DIR)/system_tests/*.py)
 SYSTEM_TESTS_FILES := $(addprefix $(SYSTEM_TEST_DIR)/,$(notdir $(SYSTEM_TESTS_FILES_TO_COPY)))
 endif
 update_system_tests: $(SYSTEM_TESTS_FILES)
@@ -126,7 +126,7 @@ $(SYSTEM_TEST_DIR)/%.py: $(DRIVER_DIR)/system_tests/%.py
 	$(_hide_cmds)$(call log_command,cp $< $@)
 
 ifneq (,$(wildcard $(DRIVER_DIR)/examples))
-EXAMPLE_FILES_TO_COPY := $(wildcard $(DRIVER_DIR)/examples/*)
+EXAMPLE_FILES_TO_COPY := $(wildcard $(DRIVER_DIR)/examples/*.py)
 EXAMPLE_FILES := $(addprefix $(EXAMPLES_DIR)/,$(notdir $(EXAMPLE_FILES_TO_COPY)))
 endif
 update_examples: $(EXAMPLE_FILES)


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md]
### What does this Pull Request accomplish?
* Fixes #176 
* Only add .py files to be copied when gathering files for system tests and examples

### Why should this Pull Request be merged?
* Improve build

### What testing has been done?
* Travis