### PR TITLE
Change how tox is used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - pip install --upgrade coveralls
 
 script:
-  - make clean all flake8 test html PRINT=1 PYTHON_CMD=python
+  - make clean all test PRINT=1 PYTHON_CMD=python
 
 #after_success:
 #  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,9 @@ python:
 install:
   - pip install --upgrade setuptools 
   - pip install --upgrade mako 
-  - pip install --upgrade mock 
   - pip install --upgrade tox 
   - pip install --upgrade tox-travis 
-  - pip install --upgrade flake8
   - pip install --upgrade wheel 
-  - pip install --upgrade sphinx 
-  - pip install --upgrade sphinx_rtd_theme 
   - pip install --upgrade coveralls
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ install:
 script:
   - make clean all PRINT=1 PYTHON_CMD=python
   - tox
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then tox -e flake8; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then tox -e docs; fi
 
 #after_success:
 #  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
 
 script:
   - make clean all PRINT=1 PYTHON_CMD=python
+  - tox
 
 #after_success:
 #  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - pip install --upgrade coveralls
 
 script:
-  - make clean all test PRINT=1 PYTHON_CMD=python
+  - make clean all PRINT=1 PYTHON_CMD=python
 
 #after_success:
 #  - coveralls

--- a/build/Makefile
+++ b/build/Makefile
@@ -13,11 +13,6 @@ export COMMAND_LOG_BATCH
 COMMAND_LOG_SH := $(GENERATED_DIR)/command_history.sh
 export COMMAND_LOG_SH
 
-define log_command
-	@echo '$1' >> $(COMMAND_LOG_BATCH)
-	@echo '$1' >> $(COMMAND_LOG_SH)
-	$1
-endef
 
 ifeq (,$(PRINT))
 _hide_cmds := @

--- a/build/Makefile
+++ b/build/Makefile
@@ -3,9 +3,6 @@ include $(BUILD_HELPER_DIR)/tools.mak
 DEFAULT_TARGETS := module unit_tests update_generated_files update_system_tests update_examples wheel sdist
 export DEFAULT_TARGETS
 
-ADDITIONAL_TARGETS := 
-export ADDITIONAL_TARGETS
-
 GENERATED_DIR := $(ROOT_DIR)/generated
 export GENERATED_DIR
 
@@ -38,7 +35,7 @@ endef
 
 $(foreach d,$(ALL_DRIVERS),$(eval $(call per_driver_all,$(d))))
 $(foreach d,$(ALL_DRIVERS),\
-   $(foreach t,$(DEFAULT_TARGETS) $(ADDITIONAL_TARGETS),\
+   $(foreach t,$(DEFAULT_TARGETS),\
       $(eval $(call per_driver_per_target,$(d),$(t)))))
 
 define per_target
@@ -48,7 +45,7 @@ endef
 
 # We add test when we create the $(DEFAULT_TARGETS). This is because it shouldn't be
 # run when all is used, but we want it to work
-$(foreach t,$(DEFAULT_TARGETS) $(ADDITIONAL_TARGETS),$(eval $(call per_target,$(t))))
+$(foreach t,$(DEFAULT_TARGETS),$(eval $(call per_target,$(t))))
 
 SUPPRESS_ERROR_OUTPUT ?= 2> /dev/null
 clean: start
@@ -66,10 +63,10 @@ start:
 
 # From https://stackoverflow.com/questions/14760124/how-to-split-in-gnu-makefile-list-of-files-into-separate-lines
 DRIVER_ALL_TARGETS_HELP := echo Drivers: $(addprefix  && echo - ,$(ALL_DRIVERS))
-TARGETS_HELP := echo Targets: $(addprefix  && echo - ,$(DEFAULT_TARGETS) $(ADDITIONAL_TARGETS))
+TARGETS_HELP := echo Targets: $(addprefix  && echo - ,$(DEFAULT_TARGETS))
 PER_DRIVER_PER_TARGET := \
    $(foreach d,$(ALL_DRIVERS),\
-      $(foreach t,$(DEFAULT_TARGETS) $(ADDITIONAL_TARGETS),\
+      $(foreach t,$(DEFAULT_TARGETS),\
          $(d)_$(t)))
 DRIVER_TARGETS_HELP := echo Per driver, per target: $(addprefix  && echo - ,$(PER_DRIVER_PER_TARGET))
 help:

--- a/build/Makefile
+++ b/build/Makefile
@@ -2,7 +2,7 @@
 DEFAULT_TARGETS := module unit_tests update_generated_files update_system_tests update_examples run_unit_tests wheel sdist
 export DEFAULT_TARGETS
 
-ADDITIONAL_TARGETS := test flake8
+ADDITIONAL_TARGETS := 
 export ADDITIONAL_TARGETS
 
 GENERATED_DIR := $(ROOT_DIR)/generated

--- a/build/Makefile
+++ b/build/Makefile
@@ -1,5 +1,5 @@
 
-DEFAULT_TARGETS := module unit_tests update_generated_files update_system_tests update_examples run_unit_tests wheel sdist
+DEFAULT_TARGETS := module unit_tests update_generated_files update_system_tests update_examples wheel sdist
 export DEFAULT_TARGETS
 
 ADDITIONAL_TARGETS := 
@@ -13,12 +13,13 @@ export COMMAND_LOG_BATCH
 COMMAND_LOG_SH := $(GENERATED_DIR)/command_history.sh
 export COMMAND_LOG_SH
 
+include $(BUILD_HELPER_DIR)/tools.mak
 
 ifeq (,$(PRINT))
 _hide_cmds := @
 endif
 
-all: $(DRIVERS)
+all: $(DRIVERS) test
 
 define per_driver_per_target
 $1_$2: start
@@ -50,7 +51,7 @@ endef
 # run when all is used, but we want it to work
 $(foreach t,$(DEFAULT_TARGETS) $(ADDITIONAL_TARGETS),$(eval $(call per_target,$(t))))
 
-SUPPRESS_ERROR_OUTPUT := 2> /dev/null
+SUPPRESS_ERROR_OUTPUT ?= 2> /dev/null
 clean: start
 	@echo 'Cleaning...'
 	-@rm -Rf $(BIN_DIR) $(SUPPRESS_ERROR_OUTPUT)
@@ -97,20 +98,19 @@ printvar:
 	$(_hide_cmds)$(foreach d,$(DRIVERS),$(call per_driver_variable_print,$(d),$(VAR)) && ) echo
 
 
-# Minimal makefile for Sphinx documentation
-#
 PYTHON_CMD ?= python3
-
-# You can set these variables from the command line.
-SPHINXOPTS    =
-SPHINXBUILD   = $(PYTHON_CMD) -msphinx
-SPHINXPROJ    = NIModularInstrumentsPythonAPI
-SOURCEDIR     = $(ROOT_DIR)/docs
-BUILDDIR      = $(BIN_DIR)/docs
-
-html:
-	$(_hide_cmds)$(call log_command,$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS))
 
 .PHONY: help Makefile
 
 
+# Any step that any driver build does that would invalidate unit testing, flake8 or generated html
+# needs to delete this file. This will trigger a tox run.
+TOX_RUN_DONE := bin/tox_run_done
+export TOX_RUN_DONE
+
+test: $(TOX_RUN_DONE)
+
+$(TOX_RUN_DONE): 
+	@echo
+	$(call trace_to_console, "Running tox",$@)
+	$(_hide_cmds)$(call make_with_tracking_file,$@,tox)

--- a/build/Makefile
+++ b/build/Makefile
@@ -1,3 +1,4 @@
+include $(BUILD_HELPER_DIR)/tools.mak
 
 DEFAULT_TARGETS := module unit_tests update_generated_files update_system_tests update_examples wheel sdist
 export DEFAULT_TARGETS
@@ -12,8 +13,6 @@ COMMAND_LOG_BATCH := $(GENERATED_DIR)/command_history.bat
 export COMMAND_LOG_BATCH
 COMMAND_LOG_SH := $(GENERATED_DIR)/command_history.sh
 export COMMAND_LOG_SH
-
-include $(BUILD_HELPER_DIR)/tools.mak
 
 ifeq (,$(PRINT))
 _hide_cmds := @
@@ -110,7 +109,7 @@ export TOX_RUN_DONE
 
 test: $(TOX_RUN_DONE)
 
-$(TOX_RUN_DONE): 
+$(TOX_RUN_DONE):
 	@echo
 	$(call trace_to_console, "Running tox",$@)
 	$(_hide_cmds)$(call make_with_tracking_file,$@,tox)

--- a/build/defines.mak
+++ b/build/defines.mak
@@ -15,6 +15,8 @@ METADATA_FILES := $(wildcard $(METADATA_DIR)/*.py)
 
 BUILD_HELPER_SCRIPT := $(BUILD_HELPER_DIR)/helper.py
 
+DRIVER_GENERATED_DIR := $(GENERATED_DIR)/$(DRIVER)
+
 DOCS_DIR := $(ROOT_DIR)/docs
 DRIVER_DOCS_DIR := $(DOCS_DIR)/$(DRIVER)
 
@@ -30,6 +32,7 @@ MKDIRECTORIES += \
                  $(LOG_DIR) \
                  $(SYSTEM_TEST_DIR) \
                  $(EXAMPLES_DIR) \
+                 $(DRIVER_GENERATED_DIR) \
 
 VPATH = $(TEMPLATE_DIR)
 

--- a/build/defines.mak
+++ b/build/defines.mak
@@ -70,9 +70,7 @@ DEFAULT_RST_FILES_TO_GENERATE := \
                      functions.rst \
 
 # Files for tracking parts of the build
-UNIT_TESTS_DONE := $(LOG_DIR)/tests_passed
-FLAKE8_DONE := $(LOG_DIR)/flake8_passed
-WHEEL_DONE := $(LOG_DIR)/wheel_built
-SDIST_DONE := $(LOG_DIR)/sdist_built
-GENERATED_FILES_DONE := $(LOG_DIR)/generated_files_copied
+WHEEL_BUILD_DONE := $(LOG_DIR)/wheel_build_done
+SDIST_BUILD_DONE := $(LOG_DIR)/sdist_build_done
+GENERATED_FILES_COPY_DONE := $(LOG_DIR)/generated_files_copy_done
 

--- a/build/rules.mak
+++ b/build/rules.mak
@@ -115,7 +115,7 @@ update_examples: $(EXAMPLE_FILES)
 $(EXAMPLES_DIR)/%.py: $(DRIVER_DIR)/examples/%.py
 	$(call trace_to_console, "Copying",$@)
 	$(_hide_cmds)$(call log_command,cp $< $@)
-	# Need to signal the top level makefile to run tests again
+# Need to signal the top level makefile to run tests again
 	$(_hide_cmds)$(call trigger_tests)
 
 

--- a/build/rules.mak
+++ b/build/rules.mak
@@ -76,6 +76,10 @@ $(WHEEL_BUILD_DONE): $(OUTPUT_DIR)/setup.py $(OUTPUT_DIR)/README.rst $(MODULE_FI
 	$(call trace_to_console, "Creating wheel",$(OUTPUT_DIR)/dist)
 	$(_hide_cmds)$(call make_with_tracking_file,$@,cd $(OUTPUT_DIR) && python3 setup.py bdist_wheel --universal $(LOG_OUTPUT) $(LOG_DIR)/wheel.log)
 
+$(OUTPUT_DIR)/README.rst: $(ROOT_DIR)/README.rst
+	$(call trace_to_console, "Copying",$@)
+	$(_hide_cmds)$(call log_command,cp $< $@)
+
 # From https://stackoverflow.com/questions/16467718/how-to-print-out-a-variable-in-makefile
 print-%: ; $(info $(DRIVER): $* is $(flavor $*) variable set to [$($*)]) @true
 

--- a/build/rules.mak
+++ b/build/rules.mak
@@ -10,32 +10,6 @@ MKDIR: $(MKDIRECTORIES)
 
 CURRENT_DIR := $(shell pwd)
 
-# Executes a command, then logs it to $(COMMAND_LOG_BATCH) and $(COMMAND_LOG_SH).
-# $1 is the command.
-# TODO(marcoskirsch): This is duplicated in Makefile.
-define log_command
-	$1
-	@echo '$1' >> $(COMMAND_LOG_BATCH)
-	@echo '$1' >> $(COMMAND_LOG_SH)
-endef
-
-
-# Traces to console, nicely formatted.
-# $1 is the Action, for example: "Generating"
-# $2 is a Path.
-# Action will be padded on the left so colons align, for readability.
-# Path will be turned from absolute to relative, for readability.
-define trace_to_console
-	@echo "$(shell printf '%15s' $1): $(subst $(CURRENT_DIR)/,,$2)"
-endef
-
-define make_with_tracking_file
-	$(_hide_cmds)$(call log_command,touch $1)
-	$(_hide_cmds)$(call log_command,rm $1)
-	$(_hide_cmds)$(call log_command,$2)
-	$(_hide_cmds)$(call log_command,touch $1)
-endef
-
 define mkdir_rule
 $1:
 	$(call trace_to_console, "Making dir",$1)

--- a/build/rules.mak
+++ b/build/rules.mak
@@ -89,15 +89,15 @@ $(OUTPUT_DIR)/setup.py: $(TEMPLATE_DIR)/setup.py.mako
 	$(call trace_to_console, "Generating",$@)
 	$(_hide_cmds)$(call log_command,$(call GENERATE_SCRIPT, $<, $(dir $@), $(METADATA_DIR)))
 
-sdist: $(SDIST_DONE)
+sdist: $(SDIST_BUILD_DONE) $(UNIT_TEST_FILES)
 
-$(SDIST_DONE): $(OUTPUT_DIR)/setup.py $(OUTPUT_DIR)/README.rst $(MODULE_FILES) $(UNIT_TESTS_PASSED)
+$(SDIST_BUILD_DONE): $(OUTPUT_DIR)/setup.py $(OUTPUT_DIR)/README.rst $(MODULE_FILES) $(UNIT_TESTS_PASSED)
 	$(call trace_to_console, "Creating sdist",$(OUTPUT_DIR)/dist)
 	$(_hide_cmds)$(call make_with_tracking_file,$@,cd $(OUTPUT_DIR) && python3 setup.py sdist $(LOG_OUTPUT) $(LOG_DIR)/sdist.log)
 
-wheel: $(WHEEL_DONE)
+wheel: $(WHEEL_BUILD_DONE) $(UNIT_TEST_FILES)
 
-$(WHEEL_DONE): $(OUTPUT_DIR)/setup.py $(OUTPUT_DIR)/README.rst $(MODULE_FILES) $(UNIT_TESTS_PASSED)
+$(WHEEL_BUILD_DONE): $(OUTPUT_DIR)/setup.py $(OUTPUT_DIR)/README.rst $(MODULE_FILES) $(UNIT_TESTS_PASSED)
 	$(call trace_to_console, "Creating wheel",$(OUTPUT_DIR)/dist)
 	$(_hide_cmds)$(call make_with_tracking_file,$@,cd $(OUTPUT_DIR) && python3 setup.py bdist_wheel --universal $(LOG_OUTPUT) $(LOG_DIR)/wheel.log)
 
@@ -112,10 +112,10 @@ test: $(TOX_INI)
 	$(call trace_to_console, "Running tox",$(OUTPUT_DIR))
 	$(_hide_cmds)$(call log_command,cd $(OUTPUT_DIR) && set DRIVER=$(DRIVER) && tox)
 
-update_generated_files: $(GENERATED_FILES_DONE)
+update_generated_files: $(GENERATED_FILES_COPY_DONE)
 
 # Can't use make_with_tracking_file since there are multiple commands
-$(GENERATED_FILES_DONE): $(MODULE_FILES) $(OUTPUT_DIR)/setup.py
+$(GENERATED_FILES_COPY_DONE): $(MODULE_FILES) $(OUTPUT_DIR)/setup.py $(UNIT_TEST_FILES)
 	$(call trace_to_console, "Updating",$(GENERATED_DIR)/$(DRIVER)/)
 	$(_hide_cmds)$(call log_command,touch $@)
 	$(_hide_cmds)$(call log_command,rm $@)

--- a/build/rules.mak
+++ b/build/rules.mak
@@ -119,10 +119,4 @@ $(EXAMPLES_DIR)/%.py: $(DRIVER_DIR)/examples/%.py
 	$(call trace_to_console, "Copying",$@)
 	$(_hide_cmds)$(call log_command,cp $< $@)
 
-flake8: $(FLAKE8_DONE) 
-
-$(FLAKE8_DONE): $(TOX_INI) $(UNIT_TEST_FILES) $(MODULE_FILES) $(SYSTEM_TESTS_FILES) $(EXAMPLE_FILES) $(UNIT_TESTS_PASSED)
-	$(call trace_to_console, "Running flake",$(OUTPUT_DIR))
-	$(_hide_cmds)$(call make_with_tracking_file,$@,cd $(OUTPUT_DIR) && tox -e flake8)
-
 

--- a/build/rules.mak
+++ b/build/rules.mak
@@ -86,12 +86,11 @@ print-%: ; $(info $(DRIVER): $* is $(flavor $*) variable set to [$($*)]) @true
 update_generated_files: $(GENERATED_FILES_COPY_DONE)
 
 $(GENERATED_FILES_COPY_DONE): $(MODULE_FILES) $(OUTPUT_DIR)/setup.py $(UNIT_TEST_FILES)
-	$(call trace_to_console, "Updating",$(GENERATED_DIR)/$(DRIVER)/)
+	$(call trace_to_console, "Updating",$(DRIVER_GENERATED_DIR)/)
 	$(_hide_cmds)$(call make_with_tracking_file, $@, \
-      rm -Rf $(GENERATED_DIR)/$(DRIVER) && \
-      mkdir -p $(GENERATED_DIR)/$(DRIVER) && \
-      cp -Rf $(MODULE_DIR)/* $(GENERATED_DIR)/$(DRIVER) && \
-      cp -Rf $(OUTPUT_DIR)/setup.py $(GENERATED_DIR)/$(DRIVER) \
+      rm -Rf $(DRIVER_GENERATED_DIR)/* && \
+      cp -Rf $(MODULE_DIR)/* $(DRIVER_GENERATED_DIR) && \
+      cp -Rf $(OUTPUT_DIR)/setup.py $(DRIVER_GENERATED_DIR) \
    )
 
 ifneq (,$(wildcard $(DRIVER_DIR)/system_tests))

--- a/build/tools.mak
+++ b/build/tools.mak
@@ -5,7 +5,7 @@
 # $2 is a Path.
 # Action will be padded on the left so colons align, for readability.
 # Path will be turned from absolute to relative, for readability.
-define trace_to_console =
+define trace_to_console
 	@echo "$(shell printf '%15s' $1): $(subst $(CURRENT_DIR)/,,$2)"
 endef
 
@@ -21,7 +21,7 @@ endef
 # created/updated upon completion
 # $1 is tracking file path
 # $2 is command to run
-define make_with_tracking_file =
+define make_with_tracking_file
 	$(_hide_cmds)$(call log_command,touch $1)
 	$(_hide_cmds)$(call log_command,rm $1)
 	$(_hide_cmds)$(call log_command,$2)
@@ -29,6 +29,6 @@ define make_with_tracking_file =
 endef
 
 # Delete the file whose absence will trigger tox to run
-define trigger_tests =
+define trigger_tests
 	$(_hide_cmds)$(if $(wildcard $(TOX_RUN_DONE)),rm $(TOX_RUN_DONE))
 endef

--- a/build/tools.mak
+++ b/build/tools.mak
@@ -1,0 +1,34 @@
+# Useful functions
+
+# Traces to console, nicely formatted.
+# $1 is the Action, for example: "Generating"
+# $2 is a Path.
+# Action will be padded on the left so colons align, for readability.
+# Path will be turned from absolute to relative, for readability.
+define trace_to_console =
+	@echo "$(shell printf '%15s' $1): $(subst $(CURRENT_DIR)/,,$2)"
+endef
+
+# Executes a command, then logs it to $(COMMAND_LOG_BATCH) and $(COMMAND_LOG_SH).
+# $1 is the command.
+define log_command
+	$1
+	@echo '$1' >> $(COMMAND_LOG_BATCH)
+	@echo '$1' >> $(COMMAND_LOG_SH)
+endef
+
+# Helper function for running a command with a tracking file 
+# created/updated upon completion
+# $1 is tracking file path
+# $2 is command to run
+define make_with_tracking_file =
+	$(_hide_cmds)$(call log_command,touch $1)
+	$(_hide_cmds)$(call log_command,rm $1)
+	$(_hide_cmds)$(call log_command,$2)
+	$(_hide_cmds)$(call log_command,touch $1)
+endef
+
+# Delete the file that will trigger tox to run
+define trigger_tests =
+	$(_hide_cmds)$(if $(wildcard $(TOX_RUN_DONE)),rm $(TOX_RUN_DONE))
+endef

--- a/build/tools.mak
+++ b/build/tools.mak
@@ -28,7 +28,7 @@ define make_with_tracking_file =
 	$(_hide_cmds)$(call log_command,touch $1)
 endef
 
-# Delete the file that will trigger tox to run
+# Delete the file whose absence will trigger tox to run
 define trigger_tests =
 	$(_hide_cmds)$(if $(wildcard $(TOX_RUN_DONE)),rm $(TOX_RUN_DONE))
 endef

--- a/generated/nidmm/setup.py
+++ b/generated/nidmm/setup.py
@@ -27,7 +27,7 @@ def read_contents(file_to_read):
 
 setup(
     name=pypi_name,
-    zip_safe=False,
+    zip_safe=True,
     version='0.1.0.dev4',
     description='NI-DMM Python API',
     long_description=read_contents('README.rst'),

--- a/generated/nifake/setup.py
+++ b/generated/nifake/setup.py
@@ -27,7 +27,7 @@ def read_contents(file_to_read):
 
 setup(
     name=pypi_name,
-    zip_safe=False,
+    zip_safe=True,
     version='0.1.0.dev1',
     description='NI-FAKE Python API',
     long_description=read_contents('README.rst'),

--- a/generated/nimodinst/setup.py
+++ b/generated/nimodinst/setup.py
@@ -27,7 +27,7 @@ def read_contents(file_to_read):
 
 setup(
     name=pypi_name,
-    zip_safe=False,
+    zip_safe=True,
     version='0.1.0.dev4',
     description='NI-ModInst Python API',
     long_description=read_contents('README.rst'),

--- a/src/nimodinst/nimodinst.mak
+++ b/src/nimodinst/nimodinst.mak
@@ -1,4 +1,5 @@
 include $(BUILD_HELPER_DIR)/defines.mak
+include $(BUILD_HELPER_DIR)/tools.mak
 
 # We want everything but enums.py
 MODULE_FILES_TO_GENERATE := $(filter-out enums.py,$(DEFAULT_PY_FILES_TO_GENERATE))
@@ -14,4 +15,6 @@ include $(BUILD_HELPER_DIR)/rules.mak
 $(MODULE_DIR)/session.py: $(DRIVER_DIR)/templates/session.py.mako
 	$(call trace_to_console, "Generating",$@)
 	$(_hide_cmds)$(call GENERATE_SCRIPT, $<, $(MODULE_DIR), $(METADATA_DIR))
+# Need to signal the top level makefile to run tests again
+	$(_hide_cmds)$(call trigger_tests)
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,23 +3,27 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 [tox]
-envlist = py{27,34,35,36,py,py3}-test,flake8
+envlist = py{27,34,35,36,py,py3}-test, flake8, docs
 #envlist = py{,2,27,3,34,35,36,py,py3}-test, flake8, docs, pkg
 skip_missing_interpreters=True
+skipsdist = true
 
 [testenv]
 description = Run tests
+changedir = bin/nifake
 commands =
-    coverage run --source {env:DRIVER} -m py.test -s {posargs}
+    coverage run --source nifake -m py.test -s {posargs}
     coverage report
 
 deps =
     pytest
     mock
     coverage
+    enum34;python_version<"3.4"
 
 [testenv:flake8]
 description = Run static analysis
+changedir = bin
 commands = flake8 {posargs}
 deps =
     flake8
@@ -29,7 +33,7 @@ deps =
 [testenv:docs]
 description = Generate documentation
 changedir = docs
-commands = sphinx-build -W -b html -d {envtmpdir}/doctrees .  {envtmpdir}/html {posargs}
+commands = sphinx-build -b html -d {envtmpdir}/doctrees . ../bin/docs/html {posargs}
 deps =
     sphinx
     sphinx-rtd-theme


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md]
### What does this Pull Request accomplish?
* Uses tox for pytest, flake8 & sphinx
  * Now these dependencies are no longer required to be installed on the build machine
  * All three are ran as part of the test target
  * Runs after all drivers are complete
* Only unit test nifake
* Run flake8 on all drivers at the same time
* Fix rerunning tests when not required
  * Use tracking file similar to other things
  * Item builds that can change testing results trigger the tests to be ran by deleting the tracking file if it exists
* Moves common functions into tools.mak
  * Allows use in multiple places without multiple defines
  * There was already a discrepancy between two versions of one of them

### Why should this Pull Request be merged?
* Improve overall build times

### What testing has been done?
* Travis