### PR TITLE
Added read/write method to read_write_integer for ni-fake

### DIFF
--- a/generated/nifake/session.py
+++ b/generated/nifake/session.py
@@ -116,7 +116,10 @@ class Session(object):
     '''
     An attribute of type string with read/write access.
     '''
-
+    read_write_integer = AttributeViInt32(1000004)
+    '''
+    An attribute of type integer with read/write access.
+    '''
     def __init__(self, resource_name, id_query=0, reset_device=False, options_string=""):
         self.library = library_singleton.get()
         self.vi = 0  # This must be set before calling _init_with_options.

--- a/src/nifake/metadata/attributes.py
+++ b/src/nifake/metadata/attributes.py
@@ -64,4 +64,16 @@ attributes = {
             'description':'An attribute of type Color with read/write access.',
         },
     },
+    1000004: {
+        'access': 'read-write',
+        'channel_based': 'False',
+        'enum': None,
+        'lv_property': 'Fake attributes:Read Write Int',
+        'name': 'READ_WRITE_INTEGER',
+        'resettable': 'No',
+        'type': 'ViInt32',
+        'documentation': {
+            'description':'An attribute of type integer with read/write access.',
+        },
+    },
 }


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/<reponame>/blob/master/CONTRIBUTING.md).


### What does this Pull Request accomplish?

Support for read_write_integer-attribute for nifake

### Why should this Pull Request be merged?

Needed this method to write test to check integer attribute read write behavior.

### What testing has been done?

tested on dev machine
