### PR TITLE
Bug/bug238 modinst device

### DIFF
--- a/generated/nimodinst/session.py
+++ b/generated/nimodinst/session.py
@@ -9,14 +9,13 @@ from nimodinst import python_types
 
 class AttributeViInt32(object):
 
-    def __init__(self, owner, attribute_id, index=None):
+    def __init__(self, owner, attribute_id, index):
         self._owner = owner
         self._index = index
         self._attribute_id = attribute_id
 
     def __getitem__(self, index):
-        i = self._index if self._index is not None else index
-        return self._owner._get_installed_device_attribute_vi_int32(self._owner.handle, i, self._attribute_id)
+        return self._owner._get_installed_device_attribute_vi_int32(self._owner.handle, self._index, self._attribute_id)
 
     def __format__(self, format_spec):
         return format(self._owner._get_installed_device_attribute_vi_int32(self._owner.handle, self._index, self._attribute_id), format_spec)
@@ -24,14 +23,13 @@ class AttributeViInt32(object):
 
 class AttributeViString(object):
 
-    def __init__(self, owner, attribute_id, index=None):
+    def __init__(self, owner, attribute_id, index):
         self._owner = owner
         self._index = index
         self._attribute_id = attribute_id
 
     def __getitem__(self, index):
-        i = self._index if self._index is not None else index
-        return self._owner._get_installed_device_attribute_vi_string(self._owner.handle, i, self._attribute_id)
+        return self._owner._get_installed_device_attribute_vi_string(self._owner.handle, self._index, self._attribute_id)
 
     def __format__(self, format_spec):
         return format(self._owner._get_installed_device_attribute_vi_string(self._owner.handle, self._index, self._attribute_id), format_spec)
@@ -40,6 +38,7 @@ class AttributeViString(object):
 class Device(object):
 
     def __init__(self, owner, index):
+        self._index = index
         self.bus_number = AttributeViInt32(owner, 12, index=index)
         '''
         The bus on which the device has been enumerated.
@@ -77,6 +76,9 @@ class Device(object):
         The socket number on which the device has been enumerated
         '''
 
+    def __getattribute__(self, name):
+        return object.__getattribute__(self, name).__getitem__(None)
+
 
 class Session(object):
     '''A NI-ModInst session to get device information'''
@@ -85,43 +87,6 @@ class Session(object):
     _is_frozen = False
 
     def __init__(self, driver):
-        self.bus_number = AttributeViInt32(self, 12)
-        '''
-        The bus on which the device has been enumerated.
-        '''
-        self.chassis_number = AttributeViInt32(self, 11)
-        '''
-        The number of the chassis in which the device is installed. This attribute can only be queried for PXI devices installed in a chassis that has been properly identified in MAX.
-        '''
-        self.device_model = AttributeViString(self, 1)
-        '''
-        The model of the device (for example, NI PXI-5122)
-        '''
-        self.device_name = AttributeViString(self, 0)
-        '''
-        The name of the device, which can be used to open an instrument driver session for that device
-        '''
-        self.max_pciexpress_link_width = AttributeViInt32(self, 18)
-        '''
-        **MAX_PCIEXPRESS_LINK_WIDTH**
-        '''
-        self.pciexpress_link_width = AttributeViInt32(self, 17)
-        '''
-        **PCIEXPRESS_LINK_WIDTH**
-        '''
-        self.serial_number = AttributeViString(self, 2)
-        '''
-        The serial number of the device
-        '''
-        self.slot_number = AttributeViInt32(self, 10)
-        '''
-        The slot (for example, in a PXI chassis) in which the device is installed. This attribute can only be queried for PXI devices installed in a chassis that has been properly identified in MAX.
-        '''
-        self.socket_number = AttributeViInt32(self, 13)
-        '''
-        The socket number on which the device has been enumerated
-        '''
-
         self.handle = 0
         self.item_count = 0
         self.current_item = 0
@@ -134,6 +99,9 @@ class Session(object):
         if self._is_frozen and key not in dir(self):
             raise TypeError("%r is a frozen class" % self)
         object.__setattr__(self, key, value)
+
+    def __getitem__(self, index):
+        return Device(self, index)
 
     def __enter__(self):
         return self

--- a/generated/nimodinst/tests/test_modinst.py
+++ b/generated/nimodinst/tests/test_modinst.py
@@ -64,6 +64,37 @@ class TestSession(object):
             except AttributeError:
                 pass
 
+    def test_cannot_add_properties_to_device(self):
+        with nimodinst.Session('') as session:
+            try:
+                session[0].nonexistent_property = 5
+                assert False
+            except TypeError:
+                pass
+            try:
+                session[0].nonexistent_property
+                assert False
+            except AttributeError:
+                pass
+
+    def test_vi_int32_attribute_read_only(self):
+        self.side_effects_helper['OpenInstalledDevicesSession']['deviceCount'] = 1
+        with nimodinst.Session('') as session:
+            try:
+                session[0].chassis_number = 5
+                assert False
+            except TypeError:
+                pass
+
+    def test_vi_string_attribute_read_only(self):
+        self.side_effects_helper['OpenInstalledDevicesSession']['deviceCount'] = 1
+        with nimodinst.Session('') as session:
+            try:
+                session[0].device_name = "Not Possible"
+                assert False
+            except TypeError:
+                pass
+
     def test_iterating(self):
         self.side_effects_helper['OpenInstalledDevicesSession']['deviceCount'] = 2
         with nimodinst.Session('') as session:

--- a/generated/nimodinst/tests/test_modinst.py
+++ b/generated/nimodinst/tests/test_modinst.py
@@ -56,14 +56,12 @@ class TestSession(object):
             try:
                 session.nonexistent_property = 5
                 assert False
-            except TypeError as e:
-                print(e)
+            except TypeError:
                 pass
             try:
-                value = session.nonexistent_property  # noqa: F841
+                session.nonexistent_property
                 assert False
-            except AttributeError as e:
-                print(e)
+            except AttributeError:
                 pass
 
     def test_iterating(self):
@@ -72,3 +70,47 @@ class TestSession(object):
             assert len(session) == 2
             for d in session:
                 pass
+
+    def test_get_attribute_session(self):
+        val = 123
+        self.side_effects_helper['OpenInstalledDevicesSession']['deviceCount'] = 1
+        self.patched_library.niModInst_GetInstalledDeviceAttributeViInt32.side_effect = self.side_effects_helper.niModInst_GetInstalledDeviceAttributeViInt32
+        self.side_effects_helper['GetInstalledDeviceAttributeViInt32']['attributeValue'] = val
+        with nimodinst.Session('') as session:
+            attr_int = session[0].chassis_number
+            assert(attr_int == val)
+
+    def test_get_attribute_session_no_index(self):
+        val = 123
+        self.side_effects_helper['OpenInstalledDevicesSession']['deviceCount'] = 1
+        self.patched_library.niModInst_GetInstalledDeviceAttributeViInt32.side_effect = self.side_effects_helper.niModInst_GetInstalledDeviceAttributeViInt32
+        self.side_effects_helper['GetInstalledDeviceAttributeViInt32']['attributeValue'] = val
+        with nimodinst.Session('') as session:
+            try:
+                session.chassis_number
+                assert False
+            except AttributeError:
+                pass
+
+    def test_get_attribute_session_index_wrong_location(self):
+        val = 123
+        self.side_effects_helper['OpenInstalledDevicesSession']['deviceCount'] = 1
+        self.patched_library.niModInst_GetInstalledDeviceAttributeViInt32.side_effect = self.side_effects_helper.niModInst_GetInstalledDeviceAttributeViInt32
+        self.side_effects_helper['GetInstalledDeviceAttributeViInt32']['attributeValue'] = val
+        with nimodinst.Session('') as session:
+            try:
+                session.chassis_number[0]
+                assert False
+            except AttributeError:
+                pass
+
+    def test_get_attribute_for_loop(self):
+        val = 123
+        self.patched_library.niModInst_GetInstalledDeviceAttributeViInt32.side_effect = self.side_effects_helper.niModInst_GetInstalledDeviceAttributeViInt32
+        self.side_effects_helper['GetInstalledDeviceAttributeViInt32']['attributeValue'] = val
+        self.side_effects_helper['OpenInstalledDevicesSession']['deviceCount'] = 1
+        with nimodinst.Session('') as session:
+            for d in session:
+                attr_int = d.chassis_number
+                assert(attr_int == val)
+

--- a/src/nimodinst/system_tests/test_system_nimodinst.py
+++ b/src/nimodinst/system_tests/test_system_nimodinst.py
@@ -46,16 +46,6 @@ def test_string_attribute_error_on_non_existant_device():
             assert e.description.lower().find('the device index is out of the range of valid device indices for this session.') != -1
 
 
-def test_writeonly_attribute():
-    with nimodinst.Session('') as session:
-        assert len(session) > 0, 'Must have hardware for ModInst tests to be valid.'
-        try:
-            session[0].device_name = 'New Name'
-            assert False
-        except TypeError as e:
-            assert str(e).find('does not support item assignment') != -1
-
-
 def test_device_name_attribute():
     with nimodinst.Session('') as session:
         assert len(session) > 0, 'Must have hardware for ModInst tests to be valid.'

--- a/src/nimodinst/system_tests/test_system_nimodinst.py
+++ b/src/nimodinst/system_tests/test_system_nimodinst.py
@@ -28,7 +28,7 @@ def test_int_attribute_error_on_non_existant_device():
     with nimodinst.Session('') as session:
         device = len(session) + 1
         try:
-            session.slot_number[device]
+            session[device].slot_number
             assert False
         except nimodinst.Error as e:
             assert e.code == -250202  # NIMODINST_ERROR_INVALID_DEVICE_INDEX
@@ -39,7 +39,7 @@ def test_string_attribute_error_on_non_existant_device():
     with nimodinst.Session('') as session:
         device = len(session) + 1
         try:
-            session.slot_number[device]
+            session[device].slot_number
             assert False
         except nimodinst.Error as e:
             assert e.code == -250202  # NIMODINST_ERROR_INVALID_DEVICE_INDEX
@@ -50,7 +50,7 @@ def test_writeonly_attribute():
     with nimodinst.Session('') as session:
         assert len(session) > 0, 'Must have hardware for ModInst tests to be valid.'
         try:
-            session.device_name[0] = 'New Name'
+            session[0].device_name = 'New Name'
             assert False
         except TypeError as e:
             assert str(e).find('does not support item assignment') != -1
@@ -59,58 +59,58 @@ def test_writeonly_attribute():
 def test_device_name_attribute():
     with nimodinst.Session('') as session:
         assert len(session) > 0, 'Must have hardware for ModInst tests to be valid.'
-        assert isinstance(session.device_name[0], str)
-        assert len(session.device_name[0]) > 0  # device name must be at least 1 character
+        assert isinstance(session[0].device_name, str)
+        assert len(session[0].device_name) > 0  # device name must be at least 1 character
 
 
 def test_device_model_attribute():
     with nimodinst.Session('') as session:
         assert len(session) > 0, 'Must have hardware for ModInst tests to be valid.'
-        assert len(session.device_model[0]) > 0
-        assert isinstance(session.device_model[0], str)
+        assert len(session[0].device_model) > 0
+        assert isinstance(session[0].device_model, str)
         pattern = r'(NI )?[A-Z]+e?-\d\d\d\d'
-        assert re.search(pattern, session.device_model[0]) is not None  # NI Model numbers are generally "NI PXIe-2532", but might also be "USB-2532"
+        assert re.search(pattern, session[0].device_model) is not None  # NI Model numbers are generally "NI PXIe-2532", but might also be "USB-2532"
 
 
 def test_serial_number_attribute():
     with nimodinst.Session('') as session:
         assert len(session) > 0, 'Must have hardware for ModInst tests to be valid.'
         pattern = r'^[0-9A-F]+$'
-        assert isinstance(session.serial_number[0], str)
-        assert (len(session.serial_number[0]) == 0) | (re.search(pattern, session.serial_number[0]) is not None)  # NI Serial numbers hex unless it is simulated than it is 0
+        assert isinstance(session[0].serial_number, str)
+        assert (len(session[0].serial_number) == 0) | (re.search(pattern, session.serial_number[0]) is not None)  # NI Serial numbers hex unless it is simulated than it is 0
 
 
 def test_bus_number_attribute():
     with nimodinst.Session('') as session:
         assert len(session) > 0, 'Must have hardware for ModInst tests to be valid.'
-        assert isinstance(session.bus_number[0], int)
+        assert isinstance(session[0].bus_number, int)
 
 
 def test_chassis_number_attribute():
     with nimodinst.Session('') as session:
         assert len(session) > 0, 'Must have hardware for ModInst tests to be valid.'
-        assert isinstance(session.chassis_number[0], int)
+        assert isinstance(session[0].chassis_number, int)
 
 
 def test_max_pciexpress_link_width_attribute():
     with nimodinst.Session('') as session:
         assert len(session) > 0, 'Must have hardware for ModInst tests to be valid.'
-        assert isinstance(session.max_pciexpress_link_width[0], int)
+        assert isinstance(session[0].max_pciexpress_link_width, int)
 
 
 def test_pciexpress_link_width_attribute():
     with nimodinst.Session('') as session:
         assert len(session) > 0, 'Must have hardware for ModInst tests to be valid.'
-        assert isinstance(session.pciexpress_link_width[0], int)
+        assert isinstance(session[0].pciexpress_link_width, int)
 
 
 def test_slot_number_attribute():
     with nimodinst.Session('') as session:
         assert len(session) > 0, 'Must have hardware for ModInst tests to be valid.'
-        assert isinstance(session.slot_number[0], int)
+        assert isinstance(session[0].slot_number, int)
 
 
 def test_socket_number_attribute():
     with nimodinst.Session('') as session:
         assert len(session) > 0, 'Must have hardware for ModInst tests to be valid.'
-        assert isinstance(session.socket_number[0], int)
+        assert isinstance(session[0].socket_number, int)

--- a/src/nimodinst/system_tests/test_system_nimodinst.py
+++ b/src/nimodinst/system_tests/test_system_nimodinst.py
@@ -77,7 +77,7 @@ def test_serial_number_attribute():
         assert len(session) > 0, 'Must have hardware for ModInst tests to be valid.'
         pattern = r'^[0-9A-F]+$'
         assert isinstance(session[0].serial_number, str)
-        assert (len(session[0].serial_number) == 0) | (re.search(pattern, session.serial_number[0]) is not None)  # NI Serial numbers hex unless it is simulated than it is 0
+        assert (len(session[0].serial_number) == 0) | (re.search(pattern, session[0].serial_number) is not None)  # NI Serial numbers hex unless it is simulated than it is 0
 
 
 def test_bus_number_attribute():

--- a/src/nimodinst/templates/session.py.mako
+++ b/src/nimodinst/templates/session.py.mako
@@ -22,7 +22,7 @@ from ${module_name} import python_types
 
 class AttributeViInt32(object):
 
-    def __init__(self, owner, attribute_id, index=None):
+    def __init__(self, owner, attribute_id, index):
         self._owner = owner
         self._index = index
         self._attribute_id = attribute_id
@@ -37,7 +37,7 @@ class AttributeViInt32(object):
 
 class AttributeViString(object):
 
-    def __init__(self, owner, attribute_id, index=None):
+    def __init__(self, owner, attribute_id, index):
         self._owner = owner
         self._index = index
         self._attribute_id = attribute_id

--- a/src/nimodinst/templates/session.py.mako
+++ b/src/nimodinst/templates/session.py.mako
@@ -51,6 +51,7 @@ class AttributeViString(object):
 class Device(object):
 
     def __init__(self, owner, index):
+        self._index = index
 % for attribute in helper.sorted_attrs(attributes):
         self.${attributes[attribute]['name'].lower()} = Attribute${attributes[attribute]['type']}(owner, ${attribute}, index=index)
 %   if 'documentation' in attributes[attribute]:
@@ -59,6 +60,9 @@ class Device(object):
         '''
 %   endif
 % endfor
+
+    def __getattribute__(self, name):
+        return object.__getattribute__(self, name).__getitem__(None)
 
 
 class Session(object):
@@ -80,6 +84,9 @@ class Session(object):
         if self._is_frozen and key not in dir(self):
             raise TypeError("%r is a frozen class" % self)
         object.__setattr__(self, key, value)
+
+    def __getitem__(self, index):
+        return Device(self, index)
 
     def __enter__(self):
         return self

--- a/src/nimodinst/templates/session.py.mako
+++ b/src/nimodinst/templates/session.py.mako
@@ -30,6 +30,9 @@ class AttributeViInt32(object):
     def __getitem__(self, index):
         return self._owner._get_installed_device_attribute_vi_int32(self._owner.handle, self._index, self._attribute_id)
 
+    def __setitem__(self, index):
+        raise TypeError('%r is read only' % self)
+
     def __format__(self, format_spec):
         return format(self._owner._get_installed_device_attribute_vi_int32(self._owner.handle, self._index, self._attribute_id), format_spec)
 
@@ -44,11 +47,17 @@ class AttributeViString(object):
     def __getitem__(self, index):
         return self._owner._get_installed_device_attribute_vi_string(self._owner.handle, self._index, self._attribute_id)
 
+    def __setitem__(self, index):
+        raise TypeError('%r is read only' % self)
+
     def __format__(self, format_spec):
         return format(self._owner._get_installed_device_attribute_vi_string(self._owner.handle, self._index, self._attribute_id), format_spec)
 
 
 class Device(object):
+
+    # This is needed during __init__. Without it, __setattr__ raises an exception
+    _is_frozen = False
 
     def __init__(self, owner, index):
         self._index = index
@@ -60,9 +69,18 @@ class Device(object):
         '''
 %   endif
 % endfor
+        self._is_frozen = True
 
     def __getattribute__(self, name):
-        return object.__getattribute__(self, name).__getitem__(None)
+        if name in ['_is_frozen', 'index']:
+            return object.__getattribute__(self, name)
+        else:
+            return object.__getattribute__(self, name).__getitem__(None)
+
+    def __setattr__(self, name, value):
+        if self._is_frozen and name not in ['_is_frozen', 'index']:
+            raise TypeError("%s is not writable" % name)
+        object.__setattr__(self, name, value)
 
 
 class Session(object):

--- a/src/nimodinst/templates/session.py.mako
+++ b/src/nimodinst/templates/session.py.mako
@@ -70,15 +70,6 @@ class Session(object):
     _is_frozen = False
 
     def __init__(self, driver):
-% for attribute in helper.sorted_attrs(attributes):
-        self.${attributes[attribute]['name'].lower()} = Attribute${attributes[attribute]['type']}(self, ${attribute})
-%   if 'documentation' in attributes[attribute]:
-        '''
-        ${helper.get_documentation_for_node_docstring(attributes[attribute], config, indent=4)}
-        '''
-%   endif
-% endfor
-
         self.handle = 0
         self.item_count = 0
         self.current_item = 0

--- a/src/nimodinst/templates/session.py.mako
+++ b/src/nimodinst/templates/session.py.mako
@@ -28,8 +28,7 @@ class AttributeViInt32(object):
         self._attribute_id = attribute_id
 
     def __getitem__(self, index):
-        i = self._index if self._index is not None else index
-        return self._owner._get_installed_device_attribute_vi_int32(self._owner.handle, i, self._attribute_id)
+        return self._owner._get_installed_device_attribute_vi_int32(self._owner.handle, self._index, self._attribute_id)
 
     def __format__(self, format_spec):
         return format(self._owner._get_installed_device_attribute_vi_int32(self._owner.handle, self._index, self._attribute_id), format_spec)
@@ -43,8 +42,7 @@ class AttributeViString(object):
         self._attribute_id = attribute_id
 
     def __getitem__(self, index):
-        i = self._index if self._index is not None else index
-        return self._owner._get_installed_device_attribute_vi_string(self._owner.handle, i, self._attribute_id)
+        return self._owner._get_installed_device_attribute_vi_string(self._owner.handle, self._index, self._attribute_id)
 
     def __format__(self, format_spec):
         return format(self._owner._get_installed_device_attribute_vi_string(self._owner.handle, self._index, self._attribute_id), format_spec)

--- a/src/nimodinst/tests/test_modinst.py
+++ b/src/nimodinst/tests/test_modinst.py
@@ -56,14 +56,12 @@ class TestSession(object):
             try:
                 session.nonexistent_property = 5
                 assert False
-            except TypeError as e:
-                print(e)
+            except TypeError:
                 pass
             try:
-                value = session.nonexistent_property  # noqa: F841
+                session.nonexistent_property
                 assert False
-            except AttributeError as e:
-                print(e)
+            except AttributeError:
                 pass
 
     def test_iterating(self):
@@ -73,11 +71,46 @@ class TestSession(object):
             for d in session:
                 pass
 
+    def test_get_attribute_session(self):
+        val = 123
+        self.side_effects_helper['OpenInstalledDevicesSession']['deviceCount'] = 1
+        self.patched_library.niModInst_GetInstalledDeviceAttributeViInt32.side_effect = self.side_effects_helper.niModInst_GetInstalledDeviceAttributeViInt32
+        self.side_effects_helper['GetInstalledDeviceAttributeViInt32']['attributeValue'] = val
+        with nimodinst.Session('') as session:
+            attr_int = session[0].chassis_number
+            assert(attr_int == val)
+
+    def test_get_attribute_session_no_index(self):
+        val = 123
+        self.side_effects_helper['OpenInstalledDevicesSession']['deviceCount'] = 1
+        self.patched_library.niModInst_GetInstalledDeviceAttributeViInt32.side_effect = self.side_effects_helper.niModInst_GetInstalledDeviceAttributeViInt32
+        self.side_effects_helper['GetInstalledDeviceAttributeViInt32']['attributeValue'] = val
+        with nimodinst.Session('') as session:
+            try:
+                session.chassis_number
+                assert False
+            except AttributeError:
+                pass
+
+    def test_get_attribute_session_index_wrong_location(self):
+        val = 123
+        self.side_effects_helper['OpenInstalledDevicesSession']['deviceCount'] = 1
+        self.patched_library.niModInst_GetInstalledDeviceAttributeViInt32.side_effect = self.side_effects_helper.niModInst_GetInstalledDeviceAttributeViInt32
+        self.side_effects_helper['GetInstalledDeviceAttributeViInt32']['attributeValue'] = val
+        with nimodinst.Session('') as session:
+            try:
+                session.chassis_number[0]
+                assert False
+            except AttributeError:
+                pass
+
     def test_get_attribute_for_loop(self):
-        self.patched_library.niModInst_GetInstalledDeviceAttributeViInt32.side_effect = self.side_effects_helper.niModInst_GetInstalledDeviceAttributeViInt32int = 123
-        self.side_effects_helper['GetInstalledDeviceAttributeViInt32']['attributeValue'] = 5
+        val = 123
+        self.patched_library.niModInst_GetInstalledDeviceAttributeViInt32.side_effect = self.side_effects_helper.niModInst_GetInstalledDeviceAttributeViInt32
+        self.side_effects_helper['GetInstalledDeviceAttributeViInt32']['attributeValue'] = val
         self.side_effects_helper['OpenInstalledDevicesSession']['deviceCount'] = 1
         with nimodinst.Session('') as session:
             for d in session:
                 attr_int = d.chassis_number
-                assert(attr_int == 5)
+                assert(attr_int == val)
+

--- a/src/nimodinst/tests/test_modinst.py
+++ b/src/nimodinst/tests/test_modinst.py
@@ -64,6 +64,37 @@ class TestSession(object):
             except AttributeError:
                 pass
 
+    def test_cannot_add_properties_to_device(self):
+        with nimodinst.Session('') as session:
+            try:
+                session[0].nonexistent_property = 5
+                assert False
+            except TypeError:
+                pass
+            try:
+                session[0].nonexistent_property
+                assert False
+            except AttributeError:
+                pass
+
+    def test_vi_int32_attribute_read_only(self):
+        self.side_effects_helper['OpenInstalledDevicesSession']['deviceCount'] = 1
+        with nimodinst.Session('') as session:
+            try:
+                session[0].chassis_number = 5
+                assert False
+            except TypeError:
+                pass
+
+    def test_vi_string_attribute_read_only(self):
+        self.side_effects_helper['OpenInstalledDevicesSession']['deviceCount'] = 1
+        with nimodinst.Session('') as session:
+            try:
+                session[0].device_name = "Not Possible"
+                assert False
+            except TypeError:
+                pass
+
     def test_iterating(self):
         self.side_effects_helper['OpenInstalledDevicesSession']['deviceCount'] = 2
         with nimodinst.Session('') as session:

--- a/src/nimodinst/tests/test_modinst.py
+++ b/src/nimodinst/tests/test_modinst.py
@@ -72,3 +72,12 @@ class TestSession(object):
             assert len(session) == 2
             for d in session:
                 pass
+
+    def test_get_attribute_for_loop(self):
+        self.patched_library.niModInst_GetInstalledDeviceAttributeViInt32.side_effect = self.side_effects_helper.niModInst_GetInstalledDeviceAttributeViInt32int = 123
+        self.side_effects_helper['GetInstalledDeviceAttributeViInt32']['attributeValue'] = 5
+        self.side_effects_helper['OpenInstalledDevicesSession']['deviceCount'] = 1
+        with nimodinst.Session('') as session:
+            for d in session:
+                attr_int = d.chassis_number
+                assert(attr_int == 5)


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md]
### What does this Pull Request accomplish?
* Fixes #238 
* Moves index to session rather than attribute
```
with nimodinst.Session('') as session:
    name = session[0].device_name
```

### Why should this Pull Request be merged?
* Fixes issue
* mechanism maps better to driver

### What testing has been done?
* Travis & system tests