### PR TITLE
Move generation of html for coverage tool into bin/ folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,5 @@ bin/
 .tox/
 .coverage
 commands.log
-htmlcov/
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ skip_missing_interpreters=True
 skipsdist = true
 
 [testenv]
-description = 
+description =
     test: Run tests
     clean: Clean code generated files
     codegen: Run code generation step
@@ -18,7 +18,7 @@ description =
     pkg: Verify the package
     system_tests: Run system tests (requires driver runtime to be installed)
 
-changedir = 
+changedir =
     test: .
     codegen: .
     clean: .
@@ -32,7 +32,7 @@ commands =
     test: coverage run --source nifake -m py.test bin/nifake/nifake {posargs}
     test: coverage run --append --source nimodinst -m py.test bin/nimodinst/nimodinst {posargs}
     test: coverage report
-    test: coverage html
+    test: coverage html --directory=bin/htmlcov
     clean: make clean {posargs}
     codegen: make {posargs}
     flake8: flake8 {posargs}


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md]

### What does this Pull Request accomplish?

Moves the HTML that the coverage tool generates into bin/htmlcov, rather than the default htmlcov/

### Why should this Pull Request be merged?

* make clean now get rids of this potentially stale directory
* removes need for developer to remember that htmlcov/ is special (we already learned bin/ is special)
* Simplifies .gitignore

### What testing has been done?

Locally ran tox and HTML was created in desired location.
make clean still works.