### PR TITLE
Consolidate different functions into single get_params()

### DIFF
--- a/build/helper.py
+++ b/build/helper.py
@@ -103,10 +103,10 @@ def normalize_string_type(d):
 # Functions that return snippets that can be placed directly in the templates.
 class ParamListType(Enum):
     '''Type of parameter list to return'''
-    METHOD = 1
-    '''Used for methods'''
-    FUNCTION = 2
-    '''Used for functions'''
+    API_METHOD = 1
+    '''Used for methods param list for the public API'''
+    IMPL_METHOD = 2
+    '''Used for methods param list for implementation'''
 
 
 def get_params_snippet(function, param_type, options={}):

--- a/build/helper.py
+++ b/build/helper.py
@@ -107,17 +107,59 @@ def normalize_string_type(d):
 class ParamListType(Enum):
     '''Type of parameter list to return'''
     API_METHOD = 1
-    '''Used for methods param list for the public API'''
+    '''Used for methods param list for the public API
+    
+    'skip_self': False,
+    'skip_session_handle': True,
+    'skip_output_parameters': True,
+    'skip_ivi_dance_size_parameter': True,
+    'session_name': 'vi',
+    '''
     IMPL_METHOD = 2
-    '''Used for methods param list for implementation'''
+    '''Used for methods param list for implementation
+    
+    'skip_self': False,
+    'skip_session_handle': False,
+    'skip_output_parameters': False,
+    'skip_ivi_dance_size_parameter': False,
+    'session_name': 'vi',
+    '''
     DISPLAY_METHOD = 3
-    '''Used for methods param list for display (rst)'''
+    '''Used for methods param list for display (rst)
+    
+    'skip_self': True,
+    'skip_session_handle': True,
+    'skip_output_parameters': True,
+    'skip_ivi_dance_size_parameter': True,
+    'session_name': 'vi',
+    '''
     LIBRARY_METHOD = 4
-    '''Used for methods param list when calling library'''
+    '''Used for methods param list when calling library
+    
+    'skip_self': True,
+    'skip_session_handle': False,
+    'skip_output_parameters': False,
+    'skip_ivi_dance_size_parameter': False,
+    'session_name': 'vi',
+    '''
     LIBRARY_CALL = 5
-    '''Used for methods param list when calling into the DLL'''
+    '''Used for methods param list when calling into the DLL
+    
+    'skip_self': True,
+    'skip_session_handle': False,
+    'skip_output_parameters': False,
+    'skip_ivi_dance_size_parameter': False,
+    'session_name': 'vi',
+    '''
     LIBRARY_CALL_TYPES = 6
-    '''Used for methods param list types when calling into the DLL'''
+    '''Used for methods param list types when calling into the DLL
+    
+    'skip_self': True,
+    'skip_session_handle': False,
+    'skip_output_parameters': False,
+    'skip_ivi_dance_size_parameter': False,
+    'session_name': 'vi',
+    '''
 
 
 ParamListTypeDefaults = {}
@@ -166,7 +208,13 @@ ParamListTypeDefaults[ParamListType.LIBRARY_CALL_TYPES] = {
 
 
 def get_params_snippet(function, param_type, options={}):
-    '''Get a parameter list snippet based on type and options'''
+    '''Get a parameter list snippet based on type and options
+    
+    Name used:
+        ParamListType.LIBRARY_CALL uses 'library_call_name'
+        ParamListType.LIBRARY_CALL_TYPES uses 'ctypes_type_library_call'
+        All others use 'python_name'
+    '''
     if type(param_type) is not ParamListType:
         raise TypeError('param_type must be of type ' + str(ParamListType))
     if type(options) is not dict:

--- a/build/helper.py
+++ b/build/helper.py
@@ -152,6 +152,8 @@ def get_params_snippet(function, param_type, options={}):
         raise TypeError('param_type must be of type ' + str(dict))
 
     params_to_use = function['parameters']
+    name_to_use = 'python_name'
+
     options_to_use = ParamListTypeDefaults[param_type]
     for o in options:
         options_to_use[o] = options[o]

--- a/build/helper.py
+++ b/build/helper.py
@@ -111,7 +111,7 @@ class ParamListType(Enum):
     IMPL_METHOD = 2
     '''Used for methods param list for implementation'''
     DISPLAY_METHOD = 3
-    '''Used for methods param list for disple (rst)'''
+    '''Used for methods param list for display (rst)'''
     LIBRARY_METHOD = 4
     '''Used for methods param list when calling library'''
     LIBRARY_CALL = 5

--- a/build/helper.py
+++ b/build/helper.py
@@ -253,7 +253,9 @@ def get_enum_type_check_snippet(parameter, indent):
     '''Returns python snippet to check that the type of a parameter is what is expected'''
     assert parameter['enum'] is not None, pp.pformat(parameter)
     assert parameter['direction'] == 'in', pp.pformat(parameter)
-    return 'if type(' + parameter['python_name'] + ') is not ' + parameter['python_type'] + ':\n' + (' ' * indent) + 'raise TypeError(\'Parameter mode must be of type \' + str(' + parameter['python_type'] + '))'
+    enum_check = 'if type(' + parameter['python_name'] + ') is not ' + parameter['python_type'] + ':\n'
+    enum_check += (' ' * indent) + 'raise TypeError(\'Parameter mode must be of type \' + str(' + parameter['python_type'] + '))'
+    return enum_check
 
 
 def get_ctype_variable_declaration_snippet(parameter, parameters):
@@ -356,7 +358,8 @@ def get_rst_table_snippet(d, config, indent=0, make_link=True):
 def get_rst_admonition_snippet(admonition, d, config, indent=0):
     '''Returns a rst formatted admonition if the given admonition ('note', 'caution') exists in the dictionary'''
     if admonition in d:
-        a = '\n\n' + (' ' * indent) + '.. {0}:: '.format(admonition) + get_indented_docstring_snippet(fix_references(d[admonition], config, make_link=True), indent + 4)
+        a = '\n\n' + (' ' * indent) + '.. {0}:: '.format(admonition)
+        a += get_indented_docstring_snippet(fix_references(d[admonition], config, make_link=True), indent + 4)
         return a
     else:
         return ''
@@ -640,8 +643,7 @@ def as_rest_table(data, full=False, header=True):
     data = data if data else [['No Data']]
     table = []
     # max size of each column
-    sizes = map(max, zip(*[[len(str(elt)) for elt in member]
-                           for member in data]))
+    sizes = map(max, zip(*[[len(str(elt)) for elt in member] for member in data]))
     if sys.version_info.major >= 3:
         sizes = list(sizes)
     num_elts = len(sizes)
@@ -657,11 +659,8 @@ def as_rest_table(data, full=False, header=True):
         end_of_line = ''
         line_marker = '='
 
-    meta_template = vertical_separator.join(['{{{{{0}:{{{0}}}}}}}'.format(i)
-                                             for i in range(num_elts)])
-    template = '{0}{1}{2}'.format(start_of_line,
-                                  meta_template.format(*sizes),
-                                  end_of_line)
+    meta_template = vertical_separator.join(['{{{{{0}:{{{0}}}}}}}'.format(i) for i in range(num_elts)])
+    template = '{0}{1}{2}'.format(start_of_line, meta_template.format(*sizes), end_of_line)
     # determine top/bottom borders
     if full:
         to_separator = {ord('|'): '+', ord(' '): '-'}
@@ -674,9 +673,7 @@ def as_rest_table(data, full=False, header=True):
     start_of_line = start_of_line.translate(to_separator)
     vertical_separator = vertical_separator.translate(to_separator)
     end_of_line = end_of_line.translate(to_separator)
-    separator = '{0}{1}{2}'.format(start_of_line,
-                                   vertical_separator.join([x * line_marker for x in sizes]),
-                                   end_of_line)
+    separator = '{0}{1}{2}'.format(start_of_line, vertical_separator.join([x * line_marker for x in sizes]), end_of_line)
     # determine header separator
     th_separator_tr = {ord('-'): '='}
     if sys.version_info.major < 3:
@@ -685,9 +682,7 @@ def as_rest_table(data, full=False, header=True):
     line_marker = line_marker.translate(th_separator_tr)
     vertical_separator = vertical_separator.translate(th_separator_tr)
     end_of_line = end_of_line.translate(th_separator_tr)
-    th_separator = '{0}{1}{2}'.format(start_of_line,
-                                      vertical_separator.join([x * line_marker for x in sizes]),
-                                      end_of_line)
+    th_separator = '{0}{1}{2}'.format(start_of_line, vertical_separator.join([x * line_marker for x in sizes]), end_of_line)
     # prepare result
     table.append(separator)
     # set table header

--- a/build/helper.py
+++ b/build/helper.py
@@ -34,6 +34,7 @@ def function_to_method_name(f):
     # Method name is camelCase.
     return f['name'][0].lower() + f['name'][1:]
 
+
 # Filters
 
 
@@ -71,6 +72,7 @@ def extract_ivi_dance_parameter(parameters):
     assert param[0]['is_buffer'], "ivi-dance parameter must have 'is_buffer':True. Check your metadata."
     return param[0]
 
+
 # Find utilities
 
 
@@ -85,6 +87,7 @@ def find_size_parameter(parameter, parameters):
     if not parameter:
         return None
     return find_parameter(parameter['size']['value'], parameters)
+
 
 # Python 2/3 compatibility
 

--- a/build/helper.py
+++ b/build/helper.py
@@ -176,19 +176,6 @@ def get_params_snippet(function, param_type, options={}):
     return ', '.join(snippets)
 
 
-def get_function_parameters_snippet(parameters, session_name='vi'):
-    '''Returns a string suitable for the parameter list of a method given a list of parameter objects
-
-    If session_name set, skip that parameter
-    '''
-    snippets = []
-    for x in parameters:
-        if session_name is not None and x['python_name'] == session_name:
-            continue
-        snippets.append(x['python_name'])
-    return ', '.join(snippets)
-
-
 def get_library_call_parameter_snippet(parameters_list, session_name='vi'):
     '''Returns a string suitable to use as the parameters to the library object, i.e. "self, mode, range, digits_of_resolution"'''
     snippets = []

--- a/build/helper.py
+++ b/build/helper.py
@@ -105,9 +105,12 @@ def normalize_string_type(d):
 
 # Functions that return snippets that can be placed directly in the templates.
 class ParamListType(Enum):
-    '''Type of parameter list to return'''
+    '''Type of parameter list to return
+
+    Used by different parts of the code generator to create the parameter list
+    '''
     API_METHOD = 1
-    '''Used for methods param list for the public API
+    '''Used for methods param list for the public API declaration
 
     'skip_self': False,
     'skip_session_handle': True,

--- a/build/helper.py
+++ b/build/helper.py
@@ -113,6 +113,37 @@ class ParamListType(Enum):
     '''Used for methods param list when calling library'''
 
 
+ParamListTypeDefaults = {}
+ParamListTypeDefaults[ParamListType.API_METHOD] = {
+    'skip_self': False,
+    'skip_session_handle': True,
+    'skip_output_parameters': True,
+    'skip_ivi_dance_size_parameter': True,
+    'session_name': 'vi',
+}
+ParamListTypeDefaults[ParamListType.IMPL_METHOD] = {
+    'skip_self': False,
+    'skip_session_handle': False,
+    'skip_output_parameters': False,
+    'skip_ivi_dance_size_parameter': False,
+    'session_name': 'vi',
+}
+ParamListTypeDefaults[ParamListType.DISPLAY_METHOD] = {
+    'skip_self': True,
+    'skip_session_handle': True,
+    'skip_output_parameters': True,
+    'skip_ivi_dance_size_parameter': True,
+    'session_name': 'vi',
+}
+ParamListTypeDefaults[ParamListType.LIBRARY_METHOD] = {
+    'skip_self': True,
+    'skip_session_handle': False,
+    'skip_output_parameters': False,
+    'skip_ivi_dance_size_parameter': False,
+    'session_name': 'vi',
+}
+
+
 def get_params_snippet(function, param_type, options={}):
     '''Get a parameter list snippet based on type and options'''
     if type(param_type) is not ParamListType:
@@ -121,24 +152,7 @@ def get_params_snippet(function, param_type, options={}):
         raise TypeError('param_type must be of type ' + str(dict))
 
     params_to_use = function['parameters']
-    if param_type == ParamListType.METHOD:
-        name_to_use = 'python_name'
-        default_options = {
-            'skip_session_handle': True,
-            'skip_output_parameters': True,
-            'skip_ivi_dance_size_parameter': True,
-            'session_name': 'vi',
-        }
-    elif param_type == ParamListType.FUNCTION:
-        name_to_use = 'python_name'
-        default_options = {
-            'skip_session_handle': False,
-            'skip_output_parameters': False,
-            'skip_ivi_dance_size_parameter': False,
-            'session_name': 'vi',
-        }
-
-    options_to_use = default_options
+    options_to_use = ParamListTypeDefaults[param_type]
     for o in options:
         options_to_use[o] = options[o]
 

--- a/build/helper.py
+++ b/build/helper.py
@@ -156,7 +156,10 @@ def get_params_snippet(function, param_type, options={}):
     for o in options:
         options_to_use[o] = options[o]
 
-    snippets = ['self']
+    snippets = []
+    if not options_to_use['skip_self']:
+        snippets.append('self')
+
     ivi_dance_size_parameter = find_size_parameter(extract_ivi_dance_parameter(params_to_use), params_to_use)
     for x in params_to_use:
         skip = False

--- a/build/helper.py
+++ b/build/helper.py
@@ -115,7 +115,6 @@ class ParamListType(Enum):
     'skip_ivi_dance_size_parameter': True,
     'session_name': 'vi',
     'name_to_use': 'python_name',
-    'params_to_use': 'parameters'
     '''
     IMPL_METHOD = 2
     '''Used for methods param list for implementation
@@ -126,7 +125,6 @@ class ParamListType(Enum):
     'skip_ivi_dance_size_parameter': False,
     'session_name': 'vi',
     'name_to_use': 'python_name',
-    'params_to_use': 'parameters'
     '''
     DISPLAY_METHOD = 3
     '''Used for methods param list for display (rst)
@@ -137,7 +135,6 @@ class ParamListType(Enum):
     'skip_ivi_dance_size_parameter': True,
     'session_name': 'vi',
     'name_to_use': 'python_name',
-    'params_to_use': 'parameters'
     '''
     LIBRARY_METHOD = 4
     '''Used for methods param list when calling library
@@ -148,7 +145,6 @@ class ParamListType(Enum):
     'skip_ivi_dance_size_parameter': False,
     'session_name': 'vi',
     'name_to_use': 'python_name',
-    'params_to_use': 'parameters'
     '''
     LIBRARY_CALL = 5
     '''Used for methods param list when calling into the DLL
@@ -159,7 +155,6 @@ class ParamListType(Enum):
     'skip_ivi_dance_size_parameter': False,
     'session_name': 'vi',
     'name_to_use': 'library_call_name',
-    'params_to_use': 'parameters'
     '''
     LIBRARY_CALL_TYPES = 6
     '''Used for methods param list types when calling into the DLL
@@ -170,7 +165,6 @@ class ParamListType(Enum):
     'skip_ivi_dance_size_parameter': False,
     'session_name': 'vi',
     'name_to_use': 'ctypes_type_library_call',
-    'params_to_use': 'parameters'
     '''
 
 
@@ -182,7 +176,6 @@ ParamListTypeDefaults[ParamListType.API_METHOD] = {
     'skip_ivi_dance_size_parameter': True,
     'session_name': 'vi',
     'name_to_use': 'python_name',
-    'params_to_use': 'parameters'
 }
 ParamListTypeDefaults[ParamListType.IMPL_METHOD] = {
     'skip_self': False,
@@ -191,7 +184,6 @@ ParamListTypeDefaults[ParamListType.IMPL_METHOD] = {
     'skip_ivi_dance_size_parameter': False,
     'session_name': 'vi',
     'name_to_use': 'python_name',
-    'params_to_use': 'parameters'
 }
 ParamListTypeDefaults[ParamListType.DISPLAY_METHOD] = {
     'skip_self': True,
@@ -200,7 +192,6 @@ ParamListTypeDefaults[ParamListType.DISPLAY_METHOD] = {
     'skip_ivi_dance_size_parameter': True,
     'session_name': 'vi',
     'name_to_use': 'python_name',
-    'params_to_use': 'parameters'
 }
 ParamListTypeDefaults[ParamListType.LIBRARY_METHOD] = {
     'skip_self': True,
@@ -209,7 +200,6 @@ ParamListTypeDefaults[ParamListType.LIBRARY_METHOD] = {
     'skip_ivi_dance_size_parameter': False,
     'session_name': 'vi',
     'name_to_use': 'python_name',
-    'params_to_use': 'parameters'
 }
 ParamListTypeDefaults[ParamListType.LIBRARY_CALL] = {
     'skip_self': True,
@@ -218,7 +208,6 @@ ParamListTypeDefaults[ParamListType.LIBRARY_CALL] = {
     'skip_ivi_dance_size_parameter': False,
     'session_name': 'vi',
     'name_to_use': 'library_call_name',
-    'params_to_use': 'parameters'
 }
 ParamListTypeDefaults[ParamListType.LIBRARY_CALL_TYPES] = {
     'skip_self': True,
@@ -227,7 +216,6 @@ ParamListTypeDefaults[ParamListType.LIBRARY_CALL_TYPES] = {
     'skip_ivi_dance_size_parameter': False,
     'session_name': 'vi',
     'name_to_use': 'ctypes_type_library_call',
-    'params_to_use': 'parameters'
 }
 
 
@@ -249,14 +237,14 @@ def get_params_snippet(function, param_type, options={}):
         options_to_use[o] = options[o]
 
     name_to_use = options_to_use['name_to_use']
-    params_to_use = function[options_to_use['params_to_use']]
+    params_to_use = []
 
     snippets = []
     if not options_to_use['skip_self']:
         snippets.append('self')
 
-    ivi_dance_size_parameter = find_size_parameter(extract_ivi_dance_parameter(params_to_use), params_to_use)
-    for x in params_to_use:
+    ivi_dance_size_parameter = find_size_parameter(extract_ivi_dance_parameter(function['parameters']), function['parameters'])
+    for x in function['parameters']:
         skip = False
         if x['direction'] == 'out' and options_to_use['skip_output_parameters']:
             skip = True
@@ -265,6 +253,9 @@ def get_params_snippet(function, param_type, options={}):
         if x['name'] == options_to_use['session_name'] and options_to_use['skip_session_handle']:
             skip = True
         if not skip:
+            params_to_use.append(x)
+
+    for x in params_to_use:
             snippets.append(x[name_to_use])
     return ', '.join(snippets)
 

--- a/build/helper.py
+++ b/build/helper.py
@@ -116,6 +116,8 @@ class ParamListType(Enum):
     '''Used for methods param list when calling library'''
     LIBRARY_CALL = 5
     '''Used for methods param list when calling into the DLL'''
+    LIBRARY_CALL_TYPES = 6
+    '''Used for methods param list types when calling into the DLL'''
 
 
 ParamListTypeDefaults = {}
@@ -154,6 +156,13 @@ ParamListTypeDefaults[ParamListType.LIBRARY_CALL] = {
     'skip_ivi_dance_size_parameter': False,
     'session_name': 'vi',
 }
+ParamListTypeDefaults[ParamListType.LIBRARY_CALL_TYPES] = {
+    'skip_self': True,
+    'skip_session_handle': False,
+    'skip_output_parameters': False,
+    'skip_ivi_dance_size_parameter': False,
+    'session_name': 'vi',
+}
 
 
 def get_params_snippet(function, param_type, options={}):
@@ -167,6 +176,8 @@ def get_params_snippet(function, param_type, options={}):
     name_to_use = 'python_name'
     if param_type == ParamListType.LIBRARY_CALL:
         name_to_use = 'library_call_name'
+    if param_type == ParamListType.LIBRARY_CALL_TYPES:
+        name_to_use = 'ctypes_type_library_call'
 
     options_to_use = ParamListTypeDefaults[param_type]
     for o in options:
@@ -187,22 +198,6 @@ def get_params_snippet(function, param_type, options={}):
             skip = True
         if not skip:
             snippets.append(x[name_to_use])
-    return ', '.join(snippets)
-
-
-def get_library_call_parameter_types_snippet(parameters_list):
-    '''Returns a string suitable to use as the parameters to the library definition object'''
-    snippets = []
-    for x in parameters_list:
-        if x['direction'] == 'out':
-            if x['type'] == 'ViString' or x['type'] == 'ViRsrc' or x['type'] == 'ViConstString_ctype':
-                # These are defined as c_char_p which is already a pointer!
-                snippets.append(x['ctypes_type'])
-            else:
-                snippets.append("ctypes.POINTER(" + x['ctypes_type'] + ")")
-        else:
-            assert x['direction'] == 'in', pp.pformat(x)
-            snippets.append(x['ctypes_type'])
     return ', '.join(snippets)
 
 

--- a/build/helper.py
+++ b/build/helper.py
@@ -108,57 +108,69 @@ class ParamListType(Enum):
     '''Type of parameter list to return'''
     API_METHOD = 1
     '''Used for methods param list for the public API
-    
+
     'skip_self': False,
     'skip_session_handle': True,
     'skip_output_parameters': True,
     'skip_ivi_dance_size_parameter': True,
     'session_name': 'vi',
+    'name_to_use': 'python_name',
+    'params_to_use': 'parameters'
     '''
     IMPL_METHOD = 2
     '''Used for methods param list for implementation
-    
+
     'skip_self': False,
     'skip_session_handle': False,
     'skip_output_parameters': False,
     'skip_ivi_dance_size_parameter': False,
     'session_name': 'vi',
+    'name_to_use': 'python_name',
+    'params_to_use': 'parameters'
     '''
     DISPLAY_METHOD = 3
     '''Used for methods param list for display (rst)
-    
+
     'skip_self': True,
     'skip_session_handle': True,
     'skip_output_parameters': True,
     'skip_ivi_dance_size_parameter': True,
     'session_name': 'vi',
+    'name_to_use': 'python_name',
+    'params_to_use': 'parameters'
     '''
     LIBRARY_METHOD = 4
     '''Used for methods param list when calling library
-    
+
     'skip_self': True,
     'skip_session_handle': False,
     'skip_output_parameters': False,
     'skip_ivi_dance_size_parameter': False,
     'session_name': 'vi',
+    'name_to_use': 'python_name',
+    'params_to_use': 'parameters'
     '''
     LIBRARY_CALL = 5
     '''Used for methods param list when calling into the DLL
-    
+
     'skip_self': True,
     'skip_session_handle': False,
     'skip_output_parameters': False,
     'skip_ivi_dance_size_parameter': False,
     'session_name': 'vi',
+    'name_to_use': 'library_call_name',
+    'params_to_use': 'parameters'
     '''
     LIBRARY_CALL_TYPES = 6
     '''Used for methods param list types when calling into the DLL
-    
+
     'skip_self': True,
     'skip_session_handle': False,
     'skip_output_parameters': False,
     'skip_ivi_dance_size_parameter': False,
     'session_name': 'vi',
+    'name_to_use': 'ctypes_type_library_call',
+    'params_to_use': 'parameters'
     '''
 
 
@@ -169,6 +181,8 @@ ParamListTypeDefaults[ParamListType.API_METHOD] = {
     'skip_output_parameters': True,
     'skip_ivi_dance_size_parameter': True,
     'session_name': 'vi',
+    'name_to_use': 'python_name',
+    'params_to_use': 'parameters'
 }
 ParamListTypeDefaults[ParamListType.IMPL_METHOD] = {
     'skip_self': False,
@@ -176,6 +190,8 @@ ParamListTypeDefaults[ParamListType.IMPL_METHOD] = {
     'skip_output_parameters': False,
     'skip_ivi_dance_size_parameter': False,
     'session_name': 'vi',
+    'name_to_use': 'python_name',
+    'params_to_use': 'parameters'
 }
 ParamListTypeDefaults[ParamListType.DISPLAY_METHOD] = {
     'skip_self': True,
@@ -183,6 +199,8 @@ ParamListTypeDefaults[ParamListType.DISPLAY_METHOD] = {
     'skip_output_parameters': True,
     'skip_ivi_dance_size_parameter': True,
     'session_name': 'vi',
+    'name_to_use': 'python_name',
+    'params_to_use': 'parameters'
 }
 ParamListTypeDefaults[ParamListType.LIBRARY_METHOD] = {
     'skip_self': True,
@@ -190,6 +208,8 @@ ParamListTypeDefaults[ParamListType.LIBRARY_METHOD] = {
     'skip_output_parameters': False,
     'skip_ivi_dance_size_parameter': False,
     'session_name': 'vi',
+    'name_to_use': 'python_name',
+    'params_to_use': 'parameters'
 }
 ParamListTypeDefaults[ParamListType.LIBRARY_CALL] = {
     'skip_self': True,
@@ -197,6 +217,8 @@ ParamListTypeDefaults[ParamListType.LIBRARY_CALL] = {
     'skip_output_parameters': False,
     'skip_ivi_dance_size_parameter': False,
     'session_name': 'vi',
+    'name_to_use': 'library_call_name',
+    'params_to_use': 'parameters'
 }
 ParamListTypeDefaults[ParamListType.LIBRARY_CALL_TYPES] = {
     'skip_self': True,
@@ -204,12 +226,14 @@ ParamListTypeDefaults[ParamListType.LIBRARY_CALL_TYPES] = {
     'skip_output_parameters': False,
     'skip_ivi_dance_size_parameter': False,
     'session_name': 'vi',
+    'name_to_use': 'ctypes_type_library_call',
+    'params_to_use': 'parameters'
 }
 
 
 def get_params_snippet(function, param_type, options={}):
     '''Get a parameter list snippet based on type and options
-    
+
     Name used:
         ParamListType.LIBRARY_CALL uses 'library_call_name'
         ParamListType.LIBRARY_CALL_TYPES uses 'ctypes_type_library_call'
@@ -220,16 +244,12 @@ def get_params_snippet(function, param_type, options={}):
     if type(options) is not dict:
         raise TypeError('param_type must be of type ' + str(dict))
 
-    params_to_use = function['parameters']
-    name_to_use = 'python_name'
-    if param_type == ParamListType.LIBRARY_CALL:
-        name_to_use = 'library_call_name'
-    if param_type == ParamListType.LIBRARY_CALL_TYPES:
-        name_to_use = 'ctypes_type_library_call'
-
     options_to_use = ParamListTypeDefaults[param_type]
     for o in options:
         options_to_use[o] = options[o]
+
+    name_to_use = options_to_use['name_to_use']
+    params_to_use = function[options_to_use['params_to_use']]
 
     snippets = []
     if not options_to_use['skip_self']:

--- a/build/helper.py
+++ b/build/helper.py
@@ -107,6 +107,10 @@ class ParamListType(Enum):
     '''Used for methods param list for the public API'''
     IMPL_METHOD = 2
     '''Used for methods param list for implementation'''
+    DISPLAY_METHOD = 3
+    '''Used for methods param list for disple (rst)'''
+    LIBRARY_METHOD = 4
+    '''Used for methods param list when calling library'''
 
 
 def get_params_snippet(function, param_type, options={}):
@@ -527,7 +531,7 @@ def get_function_rst(fname, config, indent=0):
     '''
     function = config['functions'][fname]
     rst = '.. function:: ' + function['python_name'] + '('
-    rst += get_function_parameters_snippet(function['parameters'], session_name='vi') + ')'
+    rst += get_params_snippet(function, ParamListType.DISPLAY_METHOD) + ')'
     indent += 4
     rst += get_documentation_for_node_rst(function, config, indent)
 

--- a/build/metadata_utilities.py
+++ b/build/metadata_utilities.py
@@ -159,7 +159,7 @@ def add_all_metadata(functions, config):
             _add_ctypes_variable_name(p)
             _add_ctypes_type(p)
             _add_buffer_info(p)
-            _add_library_call_name(p, config['session_name'])
+            _add_library_call_name(p, config['session_handle_parameter_name'])
     return functions
 
 
@@ -228,7 +228,7 @@ def test_merge_dict_with_regex():
 
 def _do_the_test_add_all_metadata(functions, expected):
     actual = copy.deepcopy(functions)
-    actual = add_all_metadata(actual, {'session_name': 'vi'})
+    actual = add_all_metadata(actual, {'session_handle_parameter_name': 'vi'})
     assert expected == actual, "\nfunctions = {0}\nexpected = {1}\nactual = {2}".format(pp.pformat(functions), pp.pformat(expected), pp.pformat(actual))
 
 

--- a/build/metadata_utilities.py
+++ b/build/metadata_utilities.py
@@ -77,6 +77,15 @@ def _add_ctypes_variable_name(parameter):
 def _add_ctypes_type(parameter):
     '''Adds a ctypes_type key/value pair to the parameter metadata for calling into the library'''
     parameter['ctypes_type'] = parameter['type'] + '_ctype'
+    if parameter['direction'] == 'out':
+        if parameter['type'] == 'ViString' or parameter['type'] == 'ViRsrc' or parameter['type'] == 'ViConstString':
+            # These are defined as c_char_p which is already a pointer!
+            parameter['ctypes_type_library_call'] = parameter['ctypes_type']
+        else:
+            parameter['ctypes_type_library_call'] = "ctypes.POINTER(" + parameter['ctypes_type'] + ")"
+    else:
+        parameter['ctypes_type_library_call'] = parameter['ctypes_type']
+
     return parameter
 
 
@@ -255,6 +264,7 @@ def test_add_all_metadata_simple():
                 {
                     'ctypes_type': 'ViSession_ctype',
                     'ctypes_variable_name': 'vi_ctype',
+                    'ctypes_type_library_call': 'ViSession_ctype',
                     'direction': 'in',
                     'documentation': {
                         'description': 'Identifies a particular instrument session.'

--- a/build/metadata_utilities.py
+++ b/build/metadata_utilities.py
@@ -116,7 +116,27 @@ def _add_buffer_info(parameter):
     return parameter
 
 
-def add_all_metadata(functions):
+def _add_library_call_name(parameter, session_name):
+    if parameter['direction'] == 'in':
+        if parameter['name'] == session_name:
+            library_call_name = 'self.' + session_name
+        else:
+            library_call_name = parameter['python_name']
+            library_call_name += '.value' if parameter['enum'] is not None else ''
+            if parameter['type'] == 'ViString' or parameter['type'] == 'ViConstString' or parameter['type'] == 'ViRsrc':
+                library_call_name += '.encode(\'ascii\')'
+    else:
+        assert parameter['direction'] == 'out', pp.pformat(parameter)
+        if parameter['size']['mechanism'] == 'ivi-dance':
+            library_call_name = parameter['ctypes_variable_name']
+        elif parameter['is_buffer']:
+            library_call_name = 'ctypes.cast(' + parameter['ctypes_variable_name'] + ', ctypes.POINTER(ctypes_types.' + parameter['ctypes_type'] + '))'
+        else:
+            library_call_name = 'ctypes.pointer(' + (parameter['ctypes_variable_name']) + ')'
+    parameter['library_call_name'] = library_call_name
+
+
+def add_all_metadata(functions, config):
     '''Adds all codegen-specific metada to the function metadata list'''
     for f in functions:
         _add_python_method_name(functions[f], f)
@@ -130,6 +150,7 @@ def add_all_metadata(functions):
             _add_ctypes_variable_name(p)
             _add_ctypes_type(p)
             _add_buffer_info(p)
+            _add_library_call_name(p, config['session_name'])
     return functions
 
 
@@ -198,7 +219,7 @@ def test_merge_dict_with_regex():
 
 def _do_the_test_add_all_metadata(functions, expected):
     actual = copy.deepcopy(functions)
-    actual = add_all_metadata(actual)
+    actual = add_all_metadata(actual, {'session_name': 'vi'})
     assert expected == actual, "\nfunctions = {0}\nexpected = {1}\nactual = {2}".format(pp.pformat(functions), pp.pformat(expected), pp.pformat(actual))
 
 
@@ -248,7 +269,8 @@ def test_add_all_metadata_simple():
                         'mechanism': 'fixed',
                         'value': 1
                     },
-                    'type': 'ViSession'
+                    'type': 'ViSession',
+                    'library_call_name': 'self.vi',
                 }
             ],
             'python_name': 'close',

--- a/build/templates/library.py.mako
+++ b/build/templates/library.py.mako
@@ -52,7 +52,7 @@ class Library(object):
         with self._func_lock:
             if self.${c_func_name}_cfunc is None:
                 self.${c_func_name}_cfunc = self._library.${c_func_name}
-                self.${c_func_name}_cfunc.argtypes = [${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_CALL_TYPES, {'session_name': config['session_name']})}]  # noqa: F405
+                self.${c_func_name}_cfunc.argtypes = [${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_CALL_TYPES, {'session_name': config['session_handle_parameter_name']})}]  # noqa: F405
                 self.${c_func_name}_cfunc.restype = ${module_name}.python_types.${f['returns_python']}
         return self.${c_func_name}_cfunc(${param_names_library})
 % endfor

--- a/build/templates/library.py.mako
+++ b/build/templates/library.py.mako
@@ -44,8 +44,8 @@ class Library(object):
     f = functions[func_name]
     c_func_name = c_function_prefix + func_name
     params = f['parameters']
-    param_names_function = helper.get_function_parameters_snippet(params, session_name=False)
     param_names_method = helper.get_params_snippet(f, helper.ParamListType.IMPL_METHOD)
+    param_names_library = helper.get_params_snippet(f, helper.ParamListType.LIBRARY_METHOD)
 %>\
 
     def ${c_func_name}(${param_names_method}):  # noqa: N802
@@ -54,5 +54,5 @@ class Library(object):
                 self.${c_func_name}_cfunc = self._library.${c_func_name}
                 self.${c_func_name}_cfunc.argtypes = [${helper.get_library_call_parameter_types_snippet(params)}]  # noqa: F405
                 self.${c_func_name}_cfunc.restype = ${module_name}.python_types.${f['returns_python']}
-        return self.${c_func_name}_cfunc(${param_names_function})
+        return self.${c_func_name}_cfunc(${param_names_library})
 % endfor

--- a/build/templates/library.py.mako
+++ b/build/templates/library.py.mako
@@ -44,7 +44,7 @@ class Library(object):
     f = functions[func_name]
     c_func_name = c_function_prefix + func_name
     params = f['parameters']
-    param_names_method = helper.get_method_parameters_snippet(params, skip_session_handle = False, skip_output_parameters = False, skip_ivi_dance_size_parameter = False)
+    param_names_method = helper.get_params_snippet(f, helper.ParamListType.FUNCTION)
     param_names_function = helper.get_function_parameters_snippet(params, session_name=False)
 %>\
 

--- a/build/templates/library.py.mako
+++ b/build/templates/library.py.mako
@@ -44,8 +44,8 @@ class Library(object):
     f = functions[func_name]
     c_func_name = c_function_prefix + func_name
     params = f['parameters']
-    param_names_method = helper.get_params_snippet(f, helper.ParamListType.FUNCTION)
     param_names_function = helper.get_function_parameters_snippet(params, session_name=False)
+    param_names_method = helper.get_params_snippet(f, helper.ParamListType.IMPL_METHOD)
 %>\
 
     def ${c_func_name}(${param_names_method}):  # noqa: N802

--- a/build/templates/library.py.mako
+++ b/build/templates/library.py.mako
@@ -52,7 +52,7 @@ class Library(object):
         with self._func_lock:
             if self.${c_func_name}_cfunc is None:
                 self.${c_func_name}_cfunc = self._library.${c_func_name}
-                self.${c_func_name}_cfunc.argtypes = [${helper.get_library_call_parameter_types_snippet(params)}]  # noqa: F405
+                self.${c_func_name}_cfunc.argtypes = [${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_CALL_TYPES, {'session_name': config['session_name']})}]  # noqa: F405
                 self.${c_func_name}_cfunc.restype = ${module_name}.python_types.${f['returns_python']}
         return self.${c_func_name}_cfunc(${param_names_library})
 % endfor

--- a/build/templates/mock_helper.py.mako
+++ b/build/templates/mock_helper.py.mako
@@ -64,7 +64,7 @@ output_params = helper.extract_output_parameters(params)
 ivi_dance_param = helper.extract_ivi_dance_parameter(params)
 ivi_dance_size_param = helper.find_size_parameter(ivi_dance_param, params)
 %>\
-    def ${c_function_prefix}${func_name}(${helper.get_method_parameters_snippet(params, skip_session_handle = False, skip_output_parameters = False, skip_ivi_dance_size_parameter = False)}):  # noqa: N802
+    def ${c_function_prefix}${func_name}(${helper.get_params_snippet(f, helper.ParamListType.FUNCTION)}):  # noqa: N802
         if self._defaults['${func_name}']['return'] != 0:
             return self._defaults['${func_name}']['return']
 %    for p in output_params:

--- a/build/templates/mock_helper.py.mako
+++ b/build/templates/mock_helper.py.mako
@@ -64,7 +64,7 @@ output_params = helper.extract_output_parameters(params)
 ivi_dance_param = helper.extract_ivi_dance_parameter(params)
 ivi_dance_size_param = helper.find_size_parameter(ivi_dance_param, params)
 %>\
-    def ${c_function_prefix}${func_name}(${helper.get_params_snippet(f, helper.ParamListType.FUNCTION)}):  # noqa: N802
+    def ${c_function_prefix}${func_name}(${helper.get_params_snippet(f, helper.ParamListType.IMPL_METHOD)}):  # noqa: N802
         if self._defaults['${func_name}']['return'] != 0:
             return self._defaults['${func_name}']['return']
 %    for p in output_params:

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -207,7 +207,7 @@ context_name = 'acquisition' if c['direction'] == 'input' else 'generation'
     ivi_dance_parameter = helper.extract_ivi_dance_parameter(parameters)
     ivi_dance_size_parameter = helper.find_size_parameter(ivi_dance_parameter, parameters)
 %>
-    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParamListType.METHOD)}):
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParamListType.API_METHOD)}):
         '''${f['python_name']}
 
         ${helper.get_function_docstring(func_name, config, indent=8)}

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -113,7 +113,7 @@ class ${session_context_manager}(object):
 
 % endif
 class Session(object):
-    '''${config['session_description']}'''
+    '''${config['session_class_description']}'''
 
     # This is needed during __init__. Without it, __setattr__ raises an exception
     _is_frozen = False

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -207,7 +207,7 @@ context_name = 'acquisition' if c['direction'] == 'input' else 'generation'
     ivi_dance_parameter = helper.extract_ivi_dance_parameter(parameters)
     ivi_dance_size_parameter = helper.find_size_parameter(ivi_dance_parameter, parameters)
 %>
-    def ${f['python_name']}(${helper.get_method_parameters_snippet(parameters, skip_session_handle = True, skip_output_parameters = True, skip_ivi_dance_size_parameter = True)}):
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParamListType.METHOD)}):
         '''${f['python_name']}
 
         ${helper.get_function_docstring(func_name, config, indent=8)}

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -219,17 +219,17 @@ context_name = 'acquisition' if c['direction'] == 'input' else 'generation'
         ${helper.get_ctype_variable_declaration_snippet(output_parameter, parameters)}
 % endfor
 % if ivi_dance_parameter is None:
-        error_code = self.library.${c_function_prefix}${func_name}(${helper.get_library_call_parameter_snippet(f['parameters'])})
+        error_code = self.library.${c_function_prefix}${func_name}(${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_CALL)})
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=${f['is_error_handling']})
         ${helper.get_method_return_snippet(f['parameters'])}
 % else:
         ${ivi_dance_size_parameter['python_name']} = 0
         ${ivi_dance_parameter['ctypes_variable_name']} = None
-        error_code = self.library.${c_function_prefix}${func_name}(${helper.get_library_call_parameter_snippet(f['parameters'])})
+        error_code = self.library.${c_function_prefix}${func_name}(${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_CALL)})
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=${f['is_error_handling']})
         ${ivi_dance_size_parameter['python_name']} = error_code
         ${ivi_dance_parameter['ctypes_variable_name']} = ctypes.cast(ctypes.create_string_buffer(${ivi_dance_size_parameter['python_name']}), ctypes_types.${ivi_dance_parameter['ctypes_type']})
-        error_code = self.library.${c_function_prefix}${func_name}(${helper.get_library_call_parameter_snippet(f['parameters'])})
+        error_code = self.library.${c_function_prefix}${func_name}(${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_CALL)})
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=${f['is_error_handling']})
         ${helper.get_method_return_snippet(f['parameters'])}
 % endif

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -133,8 +133,8 @@ class Session(object):
 
     def __init__(self, resource_name, id_query=False, reset_device=False, options_string=""):
         self.library = library_singleton.get()
-        self.vi = 0  # This must be set before calling _init_with_options.
-        self.vi = self._init_with_options(resource_name, id_query, reset_device, options_string)
+        self.${config['session_handle_parameter_name']} = 0  # This must be set before calling _init_with_options.
+        self.${config['session_handle_parameter_name']} = self._init_with_options(resource_name, id_query, reset_device, options_string)
 
         self._is_frozen = True
 
@@ -159,7 +159,7 @@ class Session(object):
         except errors.Error:
             # TODO(marcoskirsch): This will occur when session is "stolen". Change to log instead
             print("Failed to close session.")
-        self.vi = 0
+        self.${config['session_handle_parameter_name']} = 0
 
     def get_error_description(self, error_code):
         '''get_error_description

--- a/build/templates/session.rst.mako
+++ b/build/templates/session.rst.mako
@@ -13,7 +13,7 @@ ${helper.get_rst_header_snippet(module_name + '.Session', '=')}
 
 .. py:class:: Session
 
-   ${helper.get_indented_docstring_snippet(config['session_description'], indent=3)}
+   ${helper.get_indented_docstring_snippet(config['session_class_description'], indent=3)}
 
 <%
 table_contents = []

--- a/docs/nidmm/functions.rst
+++ b/docs/nidmm/functions.rst
@@ -1019,7 +1019,7 @@ nidmm.Session methods
     
 
 
-.. function:: fetch(maximum_time, reading)
+.. function:: fetch(maximum_time)
 
     Returns the value from a previously initiated measurement. You must call
     :py:func:`nidmm._initiate` before calling this function.
@@ -1054,7 +1054,7 @@ nidmm.Session methods
             
 
 
-.. function:: fetch_multi_point(maximum_time, array_size, reading_array, actual_number_of_points)
+.. function:: fetch_multi_point(maximum_time, array_size)
 
     Returns an array of values from a previously initiated multipoint
     measurement. The number of measurements the DMM makes is determined by
@@ -1119,7 +1119,7 @@ nidmm.Session methods
             
 
 
-.. function:: fetch_waveform(maximum_time, array_size, waveform_array, actual_number_of_points)
+.. function:: fetch_waveform(maximum_time, array_size)
 
     For the NI 4080/4081/4082 and the NI 4070/4071/4072, returns an array of
     values from a previously initiated waveform acquisition. You must call
@@ -1177,7 +1177,7 @@ nidmm.Session methods
             
 
 
-.. function:: format_meas_absolute(measurement_function, range, resolution, measurement, mode_string, range_string, data_string)
+.. function:: format_meas_absolute(measurement_function, range, resolution, measurement)
 
     Formats the **Measurement** to the proper number of displayed digits
     according to the **Measurement\_Function**, **Range**, and
@@ -1249,7 +1249,7 @@ nidmm.Session methods
             
 
 
-.. function:: get_aperture_time_info(aperture_time, aperture_time_units)
+.. function:: get_aperture_time_info()
 
     Returns the DMM **Aperture\_Time** and **Aperture\_Time\_Units**.
 
@@ -1300,7 +1300,7 @@ nidmm.Session methods
             +---------------------------------+---+------------------+
 
 
-.. function:: get_auto_range_value(actual_range)
+.. function:: get_auto_range_value()
 
     Returns the **Actual\_Range** that the DMM is using, even when Auto
     Range is off.
@@ -1319,7 +1319,7 @@ nidmm.Session methods
             
 
 
-.. function:: get_cal_count(cal_type, count)
+.. function:: get_cal_count(cal_type)
 
     Returns the calibration **Count** for the specified type of calibration.
 
@@ -1353,7 +1353,7 @@ nidmm.Session methods
             
 
 
-.. function:: get_cal_date_and_time(cal_type, month, day, year, hour, minute)
+.. function:: get_cal_date_and_time(cal_type)
 
     Returns the date and time of the last calibration performed.
 
@@ -1418,7 +1418,7 @@ nidmm.Session methods
             
 
 
-.. function:: get_channel_name(index, buffer_size, channel_string)
+.. function:: get_channel_name(index, buffer_size)
 
     Returns the **Channel\_String** that is in the channel table at an
     **Index** you specify. Not applicable to National Instruments DMMs.
@@ -1468,7 +1468,7 @@ nidmm.Session methods
             
 
 
-.. function:: get_dev_temp(options, temperature)
+.. function:: get_dev_temp(options)
 
     Returns the current **Temperature** of the device.
 
@@ -1495,7 +1495,7 @@ nidmm.Session methods
             
 
 
-.. function:: get_last_cal_temp(cal_type, temperature)
+.. function:: get_last_cal_temp(cal_type)
 
     Returns the **Temperature** during the last calibration procedure.
 
@@ -1529,7 +1529,7 @@ nidmm.Session methods
             
 
 
-.. function:: get_measurement_period(period)
+.. function:: get_measurement_period()
 
     Returns the measurement **Period**, which is the amount of time it takes
     to complete one measurement with the current configuration. Use this
@@ -1555,7 +1555,7 @@ nidmm.Session methods
             
 
 
-.. function:: get_next_coercion_record(buffer_size, coercion_record)
+.. function:: get_next_coercion_record(buffer_size)
 
     This function returns the coercion information associated with the IVI
     session, and it retrieves and clears the oldest instance in which NI-DMM
@@ -1607,7 +1607,7 @@ nidmm.Session methods
             
 
 
-.. function:: get_next_interchange_warning(buffer_size, interchange_warning)
+.. function:: get_next_interchange_warning()
 
     This function returns the interchangeability warnings associated with
     the IVI session. It retrieves and clears the oldest instance in which
@@ -1648,7 +1648,7 @@ nidmm.Session methods
 
     :type buffer_size: int
 
-.. function:: get_self_cal_supported(self_cal_supported)
+.. function:: get_self_cal_supported()
 
     Returns a Boolean value that expresses whether or not the DMM that you
     are using can perform self-calibration.
@@ -1670,7 +1670,7 @@ nidmm.Session methods
             +-----------+---+-------------------------------------------------------------+
 
 
-.. function:: is_over_range(measurement_value, is_over_range)
+.. function:: is_over_range(measurement_value)
 
     Takes a **Measurement\_Value** and determines if the value is a valid
     measurement or a value indicating that an overrange condition occurred.
@@ -1704,7 +1704,7 @@ nidmm.Session methods
             +-----------+---+-----------------------------------------------------------+
 
 
-.. function:: is_under_range(measurement_value, is_under_range)
+.. function:: is_under_range(measurement_value)
 
     Takes a **Measurement\_Value** and determines if the value is a valid
     measurement or a value indicating that an underrange condition occurred.
@@ -1738,7 +1738,7 @@ nidmm.Session methods
             +-----------+---+------------------------------------------------------------+
 
 
-.. function:: perform_open_cable_comp(conductance, susceptance)
+.. function:: perform_open_cable_comp()
 
     For the NI 4082 and NI 4072 only, performs the open cable compensation
     measurements for the current capacitance/inductance range, and returns
@@ -1774,7 +1774,7 @@ nidmm.Session methods
             
 
 
-.. function:: perform_short_cable_comp(resistance, reactance)
+.. function:: perform_short_cable_comp()
 
     Performs the short cable compensation measurements for the current
     capacitance/inductance range, and returns short cable compensation
@@ -1809,7 +1809,7 @@ nidmm.Session methods
             
 
 
-.. function:: read(maximum_time, reading)
+.. function:: read(maximum_time)
 
     Acquires a single measurement and returns the measured value.
 
@@ -1843,7 +1843,7 @@ nidmm.Session methods
             
 
 
-.. function:: read_multi_point(maximum_time, array_size, reading_array, actual_number_of_points)
+.. function:: read_multi_point(maximum_time, array_size)
 
     Acquires multiple measurements and returns an array of measured values.
     The number of measurements the DMM makes is determined by the values you
@@ -1907,7 +1907,7 @@ nidmm.Session methods
             
 
 
-.. function:: read_status(acquisition_backlog, acquisition_status)
+.. function:: read_status()
 
     Returns measurement backlog and acquisition status. Use this function to
     determine how many measurements are available before calling
@@ -1956,7 +1956,7 @@ nidmm.Session methods
             +---+----------------------------+
 
 
-.. function:: read_waveform(maximum_time, array_size, waveform_array, actual_number_of_points)
+.. function:: read_waveform(maximum_time, array_size)
 
     For the NI 4080/4081/4082 and the NI 4070/4071/4072, acquires a waveform
     and returns data as an array of values or as a waveform data type. The
@@ -2086,7 +2086,7 @@ nidmm.Session methods
     
 
 
-.. function:: error_query(error_code, error_message)
+.. function:: error_query()
 
     Reads an **Error\_Code** and message from the DMM error queue. National
     Instruments DMMs do not contain an error queue. Errors are reported as
@@ -2128,7 +2128,7 @@ nidmm.Session methods
     
 
 
-.. function:: revision_query(instrument_driver_revision, firmware_revision)
+.. function:: revision_query()
 
     Returns the revision numbers of the instrument driver and instrument
     firmware.
@@ -2161,7 +2161,7 @@ nidmm.Session methods
             .. note:: The array must contain at least 256 elements ViChar[256].
 
 
-.. function:: self_test(self_test_result, self_test_message)
+.. function:: self_test()
 
     Performs a self-test on the DMM to ensure that the DMM is functioning
     properly. Self-test does not calibrate the DMM.

--- a/docs/niswitch/functions.rst
+++ b/docs/niswitch/functions.rst
@@ -3,7 +3,7 @@ niswitch.Session methods
 
 .. py:currentmodule:: niswitch
 
-.. function:: can_connect(channel1, channel2, path_capability)
+.. function:: can_connect(channel1, channel2)
 
     Verifies that a path between channel 1 and channel 2 can be created. If
     a path is possible in the switch module, the availability of that path
@@ -337,7 +337,7 @@ niswitch.Session methods
 
     :type disconnection_list: str
 
-.. function:: get_channel_name(index, buffer_size, channel_name_buffer)
+.. function:: get_channel_name(index)
 
     Returns the channel string that is in the channel table at the specified
     index. Use :py:func:`niswitch.get_channel_name` in a For Loop to get a complete list
@@ -375,7 +375,7 @@ niswitch.Session methods
 
     :type buffer_size: int
 
-.. function:: get_next_coercion_record(buffer_size, coercion_record)
+.. function:: get_next_coercion_record()
 
     This function returns the coercion information associated with the IVI
     session. This function retrieves and clears the oldest instance in which
@@ -418,7 +418,7 @@ niswitch.Session methods
 
     :type buffer_size: int
 
-.. function:: get_next_interchange_warning(buffer_size, interchange_warning)
+.. function:: get_next_interchange_warning()
 
     This function returns the interchangeability warnings associated with
     the IVI session. It retrieves and clears the oldest instance in which
@@ -455,7 +455,7 @@ niswitch.Session methods
 
     :type buffer_size: int
 
-.. function:: get_path(channel1, channel2, buffer_size, path)
+.. function:: get_path(channel1, channel2)
 
     Returns a string that identifies the explicit path created with
     :py:func:`niswitch.connect`. Pass this string to :py:func:`niswitch.set_path` to establish
@@ -513,7 +513,7 @@ niswitch.Session methods
 
     :type buffer_size: int
 
-.. function:: get_relay_count(relay_name, relay_count)
+.. function:: get_relay_count(relay_name)
 
     Returns the number of times the relay has changed from Closed to Open.
     Relay count is useful for tracking relay lifetime and usage. Call
@@ -544,7 +544,7 @@ niswitch.Session methods
             
 
 
-.. function:: get_relay_name(index, relay_name_buffer_size, relay_name_buffer)
+.. function:: get_relay_name(index)
 
     Returns the relay name string that is in the relay list at the specified
     index. Use :py:func:`niswitch.get_relay_name` in a For Loop to get a complete list
@@ -582,7 +582,7 @@ niswitch.Session methods
 
     :type relay_name_buffer_size: int
 
-.. function:: get_relay_position(relay_name, relay_position)
+.. function:: get_relay_position(relay_name)
 
     Returns the relay position for the relay specified in the Relay Name
     parameter.
@@ -878,7 +878,7 @@ niswitch.Session methods
             
 
 
-.. function:: is_debounced(is_debounced)
+.. function:: is_debounced()
 
     Indicates if all created paths have settled by returning the value of
     the :py:data:`niswitch.IS\_DEBOUNCED` attribute.
@@ -896,7 +896,7 @@ niswitch.Session methods
             
 
 
-.. function:: is_scanning(is_scanning)
+.. function:: is_scanning()
 
     Indicates the status of the scan.
 
@@ -1257,7 +1257,7 @@ niswitch.Session methods
 
     :type maximum_time_ms: int
 
-.. function:: error_query(error_code, error_message)
+.. function:: error_query()
 
     This function reads an error code and a message from the instrument's
     error queue. NI-SWITCH does not have an error queue, so this function
@@ -1298,7 +1298,7 @@ niswitch.Session methods
     
 
 
-.. function:: revision_query(instrument_driver_revision, firmware_revision)
+.. function:: revision_query()
 
     Returns the revision of the NI-SWITCH driver.
 
@@ -1325,7 +1325,7 @@ niswitch.Session methods
             
 
 
-.. function:: self_test(self_test_result, self_test_message)
+.. function:: self_test()
 
     Verifies that the driver can communicate with the switch module.
 

--- a/src/nidmm/metadata/__init__.py
+++ b/src/nidmm/metadata/__init__.py
@@ -18,7 +18,7 @@ build.metadata_utilities.merge_dicts(functions, functions_params_types)
 build.metadata_utilities.merge_dicts(functions, functions_buffer_info)
 build.metadata_utilities.merge_dicts(functions, functions_is_error_handling)
 
-build.metadata_utilities.add_all_metadata(functions)
+build.metadata_utilities.add_all_metadata(functions, config)
 
 __version__ = config['module_version']
 

--- a/src/nidmm/metadata/config.py
+++ b/src/nidmm/metadata/config.py
@@ -4,8 +4,8 @@ config = {
     'module_version': '0.2.0.dev1',
     'c_function_prefix': 'niDMM_',
     'driver_name': 'NI-DMM',
-    'session_description': 'An NI-DMM session to a National Instruments Digital Multimeter',
-    'session_name': 'vi',
+    'session_class_description': 'An NI-DMM session to a National Instruments Digital Multimeter',
+    'session_handle_parameter_name': 'vi',
     'library_info':
     {
         'Windows': {

--- a/src/nidmm/metadata/config.py
+++ b/src/nidmm/metadata/config.py
@@ -5,6 +5,7 @@ config = {
     'c_function_prefix': 'niDMM_',
     'driver_name': 'NI-DMM',
     'session_description': 'An NI-DMM session to a National Instruments Digital Multimeter',
+    'session_name': 'vi',
     'library_info':
     {
         'Windows': {

--- a/src/nifake/metadata/__init__.py
+++ b/src/nifake/metadata/__init__.py
@@ -18,7 +18,7 @@ build.metadata_utilities.merge_dicts(functions, functions_params_types)
 build.metadata_utilities.merge_dicts(functions, functions_buffer_info)
 build.metadata_utilities.merge_dicts(functions, functions_is_error_handling)
 
-build.metadata_utilities.add_all_metadata(functions)
+build.metadata_utilities.add_all_metadata(functions, config)
 
 __version__ = config['module_version']
 

--- a/src/nifake/metadata/config.py
+++ b/src/nifake/metadata/config.py
@@ -4,8 +4,8 @@ config = {
     'module_version': '0.2.0.dev0',
     'c_function_prefix': 'niFake_',
     'driver_name': 'NI-FAKE',
-    'session_description': 'An NI-FAKE session to a fake MI driver whose sole purpose is to test nimi-python code generation',
-    'session_name': 'vi',
+    'session_class_description': 'An NI-FAKE session to a fake MI driver whose sole purpose is to test nimi-python code generation',
+    'session_handle_parameter_name': 'vi',
     'library_info':
     {
         'Windows': {

--- a/src/nifake/metadata/config.py
+++ b/src/nifake/metadata/config.py
@@ -5,6 +5,7 @@ config = {
     'c_function_prefix': 'niFake_',
     'driver_name': 'NI-FAKE',
     'session_description': 'An NI-FAKE session to a fake MI driver whose sole purpose is to test nimi-python code generation',
+    'session_name': 'vi',
     'library_info':
     {
         'Windows': {

--- a/src/nimodinst/metadata/__init__.py
+++ b/src/nimodinst/metadata/__init__.py
@@ -16,7 +16,7 @@ build.metadata_utilities.merge_dicts(functions, functions_params_types)
 build.metadata_utilities.merge_dicts(functions, functions_buffer_info)
 build.metadata_utilities.merge_dicts(functions, functions_is_error_handling)
 
-build.metadata_utilities.add_all_metadata(functions)
+build.metadata_utilities.add_all_metadata(functions, config)
 
 __version__ = config['module_version']
 

--- a/src/nimodinst/metadata/config.py
+++ b/src/nimodinst/metadata/config.py
@@ -4,8 +4,8 @@ config = {
     'module_version': '0.2.0.dev1',
     'c_function_prefix': 'niModInst_',
     'driver_name': 'NI-ModInst',
-    'session_description': 'A NI-ModInst session to get device information',
-    'session_name': 'handle',
+    'session_class_description': 'A NI-ModInst session to get device information',
+    'session_handle_parameter_name': 'handle',
     'library_info':
     {
         'Windows': {

--- a/src/nimodinst/metadata/config.py
+++ b/src/nimodinst/metadata/config.py
@@ -5,6 +5,7 @@ config = {
     'c_function_prefix': 'niModInst_',
     'driver_name': 'NI-ModInst',
     'session_description': 'A NI-ModInst session to get device information',
+    'session_name': 'handle',
     'library_info':
     {
         'Windows': {

--- a/src/nimodinst/templates/session.py.mako
+++ b/src/nimodinst/templates/session.py.mako
@@ -77,11 +77,11 @@ class Session(object):
     _is_frozen = False
 
     def __init__(self, driver):
-        self.handle = 0
+        self.${config['session_handle_parameter_name']} = 0
         self.item_count = 0
         self.current_item = 0
         self.library = library_singleton.get()
-        self.handle, self.item_count = self._open_installed_devices_session(driver)
+        self.${config['session_handle_parameter_name']}, self.item_count = self._open_installed_devices_session(driver)
 
         self._is_frozen = True
 
@@ -145,7 +145,7 @@ class Session(object):
         # TODO(marcoskirsch): Should we raise an exception on double close? Look at what File does.
         if(self.handle != 0):
             self._close_installed_devices_session(self.handle)
-            self.handle = 0
+            self.${config['session_handle_parameter_name']} = 0
 
     ''' These are code-generated '''
 % for func_name in sorted(functions):

--- a/src/nimodinst/templates/session.py.mako
+++ b/src/nimodinst/templates/session.py.mako
@@ -158,7 +158,7 @@ class Session(object):
     ivi_dance_parameter = helper.extract_ivi_dance_parameter(parameters)
     ivi_dance_size_parameter = helper.find_size_parameter(ivi_dance_parameter, parameters)
 %>
-    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParamListType.METHOD)}):
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParamListType.API_METHOD)}):
 % for parameter in enum_input_parameters:
         ${helper.get_enum_type_check_snippet(parameter)}
 % endfor

--- a/src/nimodinst/templates/session.py.mako
+++ b/src/nimodinst/templates/session.py.mako
@@ -166,17 +166,17 @@ class Session(object):
         ${helper.get_ctype_variable_declaration_snippet(output_parameter, parameters)}
 % endfor
 % if ivi_dance_parameter is None:
-        error_code = self.library.${c_function_prefix}${func_name}(${helper.get_library_call_parameter_snippet(f['parameters'], session_name='handle')})
+        error_code = self.library.${c_function_prefix}${func_name}(${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_CALL, {'session_name': 'handle'})})
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=${f['is_error_handling']})
         ${helper.get_method_return_snippet(f['parameters'])}
 % else:
         ${ivi_dance_size_parameter['python_name']} = 0
         ${ivi_dance_parameter['ctypes_variable_name']} = None
-        error_code = self.library.${c_function_prefix}${func_name}(${helper.get_library_call_parameter_snippet(f['parameters'], session_name='handle')})
+        error_code = self.library.${c_function_prefix}${func_name}(${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_CALL, {'session_name': 'handle'})})
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=${f['is_error_handling']})
         ${ivi_dance_size_parameter['python_name']} = error_code
         ${ivi_dance_parameter['ctypes_variable_name']} = ctypes.cast(ctypes.create_string_buffer(${ivi_dance_size_parameter['python_name']}), ctypes_types.${ivi_dance_parameter['ctypes_type']})
-        error_code = self.library.${c_function_prefix}${func_name}(${helper.get_library_call_parameter_snippet(f['parameters'], session_name='handle')})
+        error_code = self.library.${c_function_prefix}${func_name}(${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_CALL, {'session_name': 'handle'})})
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=${f['is_error_handling']})
         ${helper.get_method_return_snippet(f['parameters'])}
 % endif

--- a/src/nimodinst/templates/session.py.mako
+++ b/src/nimodinst/templates/session.py.mako
@@ -71,7 +71,7 @@ class Device(object):
 
 
 class Session(object):
-    '''${config['session_description']}'''
+    '''${config['session_class_description']}'''
 
     # This is needed during __init__. Without it, __setattr__ raises an exception
     _is_frozen = False

--- a/src/nimodinst/templates/session.py.mako
+++ b/src/nimodinst/templates/session.py.mako
@@ -158,7 +158,7 @@ class Session(object):
     ivi_dance_parameter = helper.extract_ivi_dance_parameter(parameters)
     ivi_dance_size_parameter = helper.find_size_parameter(ivi_dance_parameter, parameters)
 %>
-    def ${f['python_name']}(${helper.get_method_parameters_snippet(parameters, skip_session_handle = True, skip_output_parameters = True, skip_ivi_dance_size_parameter = True)}):
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParamListType.METHOD)}):
 % for parameter in enum_input_parameters:
         ${helper.get_enum_type_check_snippet(parameter)}
 % endfor

--- a/src/niswitch/metadata/__init__.py
+++ b/src/niswitch/metadata/__init__.py
@@ -16,7 +16,7 @@ build.metadata_utilities.merge_dicts(functions, functions_enums)
 build.metadata_utilities.merge_dicts(functions, functions_params_types)
 build.metadata_utilities.merge_dicts(functions, functions_buffer_info)
 
-build.metadata_utilities.add_all_metadata(functions)
+build.metadata_utilities.add_all_metadata(functions, config)
 
 __version__ = config['module_version']
 

--- a/src/niswitch/metadata/config.py
+++ b/src/niswitch/metadata/config.py
@@ -5,6 +5,7 @@ config = {
     'c_function_prefix': 'niSwitch_',
     'driver_name': 'NI-SWITCH',
     'session_description': 'An NI-SWITCH session to a National Instruments Switch Module',
+    'session_name': 'vi',
     'library_info':
     {
         'Windows': {

--- a/src/niswitch/metadata/config.py
+++ b/src/niswitch/metadata/config.py
@@ -4,8 +4,8 @@ config = {
     'module_version': '0.2.0.dev1',
     'c_function_prefix': 'niSwitch_',
     'driver_name': 'NI-SWITCH',
-    'session_description': 'An NI-SWITCH session to a National Instruments Switch Module',
-    'session_name': 'vi',
+    'session_class_description': 'An NI-SWITCH session to a National Instruments Switch Module',
+    'session_handle_parameter_name': 'vi',
     'library_info':
     {
         'Windows': {

--- a/tox.ini
+++ b/tox.ini
@@ -69,6 +69,7 @@ deps =
     codegen: mako
     codegen: wheel
     codegen: setuptools
+    codegen: enum34;python_version<"3.4"
     flake8: flake8
     flake8: hacking
     flake8: pep8-naming


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md]
### What does this Pull Request accomplish?
* Take the different flavors of get parameter list snippet and consolidate into single function
* Pick which flavor using enum
  ``` python
  class ParamListType(Enum):
      '''Type of parameter list to return'''
      API_METHOD = 1
      '''Used for methods param list for the public API'''
      IMPL_METHOD = 2
      '''Used for methods param list for implementation'''
      DISPLAY_METHOD = 3
      '''Used for methods param list for display (rst)'''
      LIBRARY_METHOD = 4
      '''Used for methods param list when calling library'''
      LIBRARY_CALL = 5
      '''Used for methods param list when calling into the DLL'''
      LIBRARY_CALL_TYPES = 6
      '''Used for methods param list types when calling into the DLL'''
  ```
* Add extra types to metadata
* Add session name to config metadata
* Each flavor has defaults for options:
  * skip_self (bool)
  * skip_session_handle (bool)
  * skip_output_parameters (bool)
  * skip_ivi_dance_size_parameter (bool)
  * session_name (str)
* Default options can be overridden by passing an additional dictionary
  ``` python
  get_params_snippet(f, helper.ParamListType.LIBRARY_CALL_TYPES, {'session_name': config['session_name']})
  ```
### Why should this Pull Request be merged?
* This will simplify parameter list generation when adding default parameters

### What testing has been done?
* Travis
* System tests