### PR TITLE
Don't log a warning when the driver cannot get error description

### DIFF
--- a/build/templates/errors.py.mako
+++ b/build/templates/errors.py.mako
@@ -74,15 +74,15 @@ def handle_error(session, code, ignore_warnings, is_error_handling):
     and raises if necessary.
     '''
 
+    description = ''
+
     if _is_success(code) or (_is_warning(code) and ignore_warnings):
         return
 
-    if is_error_handling:
-        # The caller is in the midst of error handling. Don't get the
-        # error description in this case as that could itself fail.
-        description = "Failed to retrieve error description."
-        warnings.warn(description)
-    else:
+    if not is_error_handling:
+        # The caller is not in the midst of error handling. Get the
+        # error description. We do not want to call get_error_description
+        # if the function is an error handling function as this creates recursion.
         description = session.get_error_description(code)
 
     if _is_error(code):

--- a/generated/nidmm/errors.py
+++ b/generated/nidmm/errors.py
@@ -65,15 +65,15 @@ def handle_error(session, code, ignore_warnings, is_error_handling):
     and raises if necessary.
     '''
 
+    description = ''
+
     if _is_success(code) or (_is_warning(code) and ignore_warnings):
         return
 
-    if is_error_handling:
-        # The caller is in the midst of error handling. Don't get the
-        # error description in this case as that could itself fail.
-        description = "Failed to retrieve error description."
-        warnings.warn(description)
-    else:
+    if not is_error_handling:
+        # The caller is not in the midst of error handling. Get the
+        # error description. We do not want to call get_error_description
+        # if the function is an error handling function as this creates recursion.
         description = session.get_error_description(code)
 
     if _is_error(code):

--- a/generated/nifake/errors.py
+++ b/generated/nifake/errors.py
@@ -65,15 +65,15 @@ def handle_error(session, code, ignore_warnings, is_error_handling):
     and raises if necessary.
     '''
 
+    description = ''
+
     if _is_success(code) or (_is_warning(code) and ignore_warnings):
         return
 
-    if is_error_handling:
-        # The caller is in the midst of error handling. Don't get the
-        # error description in this case as that could itself fail.
-        description = "Failed to retrieve error description."
-        warnings.warn(description)
-    else:
+    if not is_error_handling:
+        # The caller is not in the midst of error handling. Get the
+        # error description. We do not want to call get_error_description
+        # if the function is an error handling function as this creates recursion.
         description = session.get_error_description(code)
 
     if _is_error(code):

--- a/generated/nifake/tests/test_session.py
+++ b/generated/nifake/tests/test_session.py
@@ -349,6 +349,24 @@ class TestSession(object):
         calls = [call(SESSION_NUM_FOR_TEST, test_error_code, 0, None), call(SESSION_NUM_FOR_TEST, len(test_error_desc), len(test_error_desc), ANY)]
         self.patched_library.niFake_GetErrorMessage.assert_has_calls(calls)
 
+    def test_get_error_and_get_error_message_returns_error(self):
+        test_error_code = -42
+        self.patched_library.niFake_SimpleFunction.side_effect = self.side_effects_helper.niFake_SimpleFunction
+        self.side_effects_helper['SimpleFunction']['return'] = test_error_code
+        self.patched_library.niFake_GetError.side_effect = self.side_effects_helper.niFake_GetError
+        self.side_effects_helper['GetError']['errorCode'] = -1
+        self.side_effects_helper['GetError']['description'] = "Shouldn't get this"
+        self.side_effects_helper['GetError']['return'] = -2
+        self.patched_library.niFake_GetErrorMessage.side_effect = self.side_effects_helper.niFake_GetErrorMessage
+        self.side_effects_helper['GetErrorMessage']['errorMessage'] = "Also shouldn't get this"
+        self.side_effects_helper['GetErrorMessage']['return'] = -3
+        with nifake.Session('dev1') as session:
+            try:
+                session.simple_function()
+            except nifake.Error as e:
+                assert e.code == test_error_code
+                assert e.description == 'Failed to retrieve error description.'
+
     '''
     def test_set_string_attribute(self):
         pass

--- a/generated/nimodinst/errors.py
+++ b/generated/nimodinst/errors.py
@@ -65,15 +65,15 @@ def handle_error(session, code, ignore_warnings, is_error_handling):
     and raises if necessary.
     '''
 
+    description = ''
+
     if _is_success(code) or (_is_warning(code) and ignore_warnings):
         return
 
-    if is_error_handling:
-        # The caller is in the midst of error handling. Don't get the
-        # error description in this case as that could itself fail.
-        description = "Failed to retrieve error description."
-        warnings.warn(description)
-    else:
+    if not is_error_handling:
+        # The caller is not in the midst of error handling. Get the
+        # error description. We do not want to call get_error_description
+        # if the function is an error handling function as this creates recursion.
         description = session.get_error_description(code)
 
     if _is_error(code):

--- a/generated/niswitch/errors.py
+++ b/generated/niswitch/errors.py
@@ -65,15 +65,15 @@ def handle_error(session, code, ignore_warnings, is_error_handling):
     and raises if necessary.
     '''
 
+    description = ''
+
     if _is_success(code) or (_is_warning(code) and ignore_warnings):
         return
 
-    if is_error_handling:
-        # The caller is in the midst of error handling. Don't get the
-        # error description in this case as that could itself fail.
-        description = "Failed to retrieve error description."
-        warnings.warn(description)
-    else:
+    if not is_error_handling:
+        # The caller is not in the midst of error handling. Get the
+        # error description. We do not want to call get_error_description
+        # if the function is an error handling function as this creates recursion.
         description = session.get_error_description(code)
 
     if _is_error(code):

--- a/src/nifake/tests/test_session.py
+++ b/src/nifake/tests/test_session.py
@@ -349,6 +349,25 @@ class TestSession(object):
         calls = [call(SESSION_NUM_FOR_TEST, test_error_code, 0, None), call(SESSION_NUM_FOR_TEST, len(test_error_desc), len(test_error_desc), ANY)]
         self.patched_library.niFake_GetErrorMessage.assert_has_calls(calls)
 
+    def test_get_error_and_get_error_message_returns_error(self):
+        test_error_code = -42
+        self.patched_library.niFake_SimpleFunction.side_effect = self.side_effects_helper.niFake_SimpleFunction
+        self.side_effects_helper['SimpleFunction']['return'] = test_error_code
+        self.patched_library.niFake_GetError.side_effect = self.side_effects_helper.niFake_GetError
+        self.side_effects_helper['GetError']['errorCode'] = -1
+        self.side_effects_helper['GetError']['description'] = "Shouldn't get this"
+        self.side_effects_helper['GetError']['return'] = -2
+        self.patched_library.niFake_GetErrorMessage.side_effect = self.side_effects_helper.niFake_GetErrorMessage
+        self.side_effects_helper['GetErrorMessage']['errorMessage'] = "Also shouldn't get this"
+        self.side_effects_helper['GetErrorMessage']['return'] = -3
+        with nifake.Session('dev1') as session:
+            try:
+                session.simple_function()
+            except nifake.Error as e:
+                assert e.code == test_error_code
+                assert e.description == 'Failed to retrieve error description.'
+
+
     '''
     def test_set_string_attribute(self):
         pass

--- a/src/nifake/tests/test_session.py
+++ b/src/nifake/tests/test_session.py
@@ -367,7 +367,6 @@ class TestSession(object):
                 assert e.code == test_error_code
                 assert e.description == 'Failed to retrieve error description.'
 
-
     '''
     def test_set_string_attribute(self):
         pass


### PR DESCRIPTION
[ x] This contribution adheres to [CONTRIBUTING.md]

### What does this Pull Request accomplish?

Fixes #312 

### Why should this Pull Request be merged?

Removes redundant warnings for error handling functions.
Adds additional tests to cover if we get errors in both _get_error and _get_error_message

### What testing has been done?

Built and tested system tests
