### PR TITLE
Support enums that aren't ViInt32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Python Versioning](http://legacy.python.org/dev/pep
 * #### NI-DMM
   * #### Added
   * #### Changed
+    * Added support for enums with types other than ViInt32 (Fixes [#330](https://github.com/ni/nimi-python/issues/330))
   * #### Removed
 * #### NI-ModInst
   * #### Added

--- a/build/templates/attributes.py.mako
+++ b/build/templates/attributes.py.mako
@@ -61,8 +61,8 @@ class AttributeViBoolean(Attribute):
 
 class AttributeEnum(object):
 
-    def __init__(self, underlying_meta_class, enum_meta_class, attribute_id, default_channel=''):
-        self._underlying_attribute = underlying_meta_class(attribute_id, default_channel)
+    def __init__(self, underlying_attribute_meta_class, enum_meta_class, attribute_id, default_channel=''):
+        self._underlying_attribute = underlying_attribute_meta_class(attribute_id, default_channel)
         self._attribute_type = enum_meta_class
         self._attribute_id = attribute_id
         self._default_channel = default_channel

--- a/build/templates/attributes.py.mako
+++ b/build/templates/attributes.py.mako
@@ -59,7 +59,7 @@ class AttributeViBoolean(Attribute):
         session._set_attribute_vi_boolean(channel, self._attribute_id, value)
 
 
-class AttributeEnum(Attribute):
+class AttributeEnum(object):
 
     def __init__(self, underlying_attr_type, enum_meta_class):
         self._underlying_attr_type = underlying_attr_type

--- a/build/templates/attributes.py.mako
+++ b/build/templates/attributes.py.mako
@@ -59,16 +59,20 @@ class AttributeViBoolean(Attribute):
         session._set_attribute_vi_boolean(channel, self._attribute_id, value)
 
 
-class AttributeEnum(AttributeViInt32):
+class AttributeEnum(Attribute):
 
-    def __init__(self, attribute_id, enum_meta_class, channel=''):
+    def __init__(self, underlying_attr_type, enum_meta_class):
+        self._underlying_attr_type = underlying_attr_type
         self._attribute_type = enum_meta_class
-        super(AttributeEnum, self).__init__(attribute_id, channel)
+        # To avoid redundancy, we get the attribute_id and channel from the underlying type
+        super(AttributeEnum, self).__init__(self._underlying_attr_type._attribute_id, self._underlying_attr_type._default_channel)
 
     def get(self, session, channel):
-        return self._attribute_type(super(AttributeEnum, self).get(session, channel))
+        return self._attribute_type(self._underlying_attr_type.get(session, channel))
 
     def set(self, session, channel, value):
         if type(value) is not self._attribute_type:
             raise TypeError('must be ${module_name}.' + str(self._attribute_type.__name__) + ' not ' + str(type(value).__name__))
-        return super(AttributeEnum, self).set(session, channel, value.value)
+        return self._underlying_attr_type.set(session, channel, value.value)
+
+

--- a/build/templates/attributes.py.mako
+++ b/build/templates/attributes.py.mako
@@ -61,8 +61,8 @@ class AttributeViBoolean(Attribute):
 
 class AttributeEnum(object):
 
-    def __init__(self, underlying_attr_type, enum_meta_class, attribute_id, default_channel=''):
-        self._underlying_attribute = underlying_attr_type(attribute_id, default_channel)
+    def __init__(self, underlying_meta_class, enum_meta_class, attribute_id, default_channel=''):
+        self._underlying_attribute = underlying_meta_class(attribute_id, default_channel)
         self._attribute_type = enum_meta_class
         self._attribute_id = attribute_id
         self._default_channel = default_channel

--- a/build/templates/attributes.py.mako
+++ b/build/templates/attributes.py.mako
@@ -61,18 +61,18 @@ class AttributeViBoolean(Attribute):
 
 class AttributeEnum(object):
 
-    def __init__(self, underlying_attr_type, enum_meta_class):
-        self._underlying_attr_type = underlying_attr_type
+    def __init__(self, underlying_attr_type, enum_meta_class, attribute_id, default_channel=''):
+        self._underlying_attribute = underlying_attr_type(attribute_id, default_channel)
         self._attribute_type = enum_meta_class
-        # To avoid redundancy, we get the attribute_id and channel from the underlying type
-        super(AttributeEnum, self).__init__(self._underlying_attr_type._attribute_id, self._underlying_attr_type._default_channel)
+        self._attribute_id = attribute_id
+        self._default_channel = default_channel
 
-    def get(self, session, channel):
-        return self._attribute_type(self._underlying_attr_type.get(session, channel))
+    def __get__(self, obj, objtype):
+        return self._attribute_type(self._underlying_attribute.get(obj, self._default_channel))
 
-    def set(self, session, channel, value):
+    def __set__(self, obj, value):
         if type(value) is not self._attribute_type:
             raise TypeError('must be ${module_name}.' + str(self._attribute_type.__name__) + ' not ' + str(type(value).__name__))
-        return self._underlying_attr_type.set(session, channel, value.value)
+        return self._underlying_attribute.set(obj, self._default_channel, value.value)
 
 

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -51,7 +51,7 @@ class Session(object):
 
 % for attribute in helper.sorted_attrs(attributes):
     %if attributes[attribute]['enum']:
-    ${attributes[attribute]['name'].lower()} = attributes.AttributeEnum(${attribute}, enums.${attributes[attribute]['enum']})
+    ${attributes[attribute]['name'].lower()} = attributes.AttributeEnum(attributes.Attribute${attributes[attribute]['type']}(${attribute}), enums.${attributes[attribute]['enum']})
     %else:
     ${attributes[attribute]['name'].lower()} = attributes.Attribute${attributes[attribute]['type']}(${attribute})
     %endif

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -51,7 +51,7 @@ class Session(object):
 
 % for attribute in helper.sorted_attrs(attributes):
     %if attributes[attribute]['enum']:
-    ${attributes[attribute]['name'].lower()} = attributes.AttributeEnum(attributes.Attribute${attributes[attribute]['type']}(${attribute}), enums.${attributes[attribute]['enum']})
+    ${attributes[attribute]['name'].lower()} = attributes.AttributeEnum(attributes.Attribute${attributes[attribute]['type']}, enums.${attributes[attribute]['enum']}, ${attribute})
     %else:
     ${attributes[attribute]['name'].lower()} = attributes.Attribute${attributes[attribute]['type']}(${attribute})
     %endif

--- a/generated/nidmm/attributes.py
+++ b/generated/nidmm/attributes.py
@@ -52,20 +52,20 @@ class AttributeViBoolean(Attribute):
         session._set_attribute_vi_boolean(channel, self._attribute_id, value)
 
 
-class AttributeEnum(Attribute):
+class AttributeEnum(object):
 
-    def __init__(self, underlying_attr_type, enum_meta_class):
-        self._underlying_attr_type = underlying_attr_type
+    def __init__(self, underlying_attr_type, enum_meta_class, attribute_id, default_channel=''):
+        self._underlying_attribute = underlying_attr_type(attribute_id, default_channel)
         self._attribute_type = enum_meta_class
-        # To avoid redundancy, we get the attribute_id and channel from the underlying type
-        super(AttributeEnum, self).__init__(self._underlying_attr_type._attribute_id, self._underlying_attr_type._default_channel)
+        self._attribute_id = attribute_id
+        self._default_channel = default_channel
 
-    def get(self, session, channel):
-        return self._attribute_type(self._underlying_attr_type.get(session, channel))
+    def __get__(self, obj, objtype):
+        return self._attribute_type(self._underlying_attribute.get(obj, self._default_channel))
 
-    def set(self, session, channel, value):
+    def __set__(self, obj, value):
         if type(value) is not self._attribute_type:
             raise TypeError('must be nidmm.' + str(self._attribute_type.__name__) + ' not ' + str(type(value).__name__))
-        return self._underlying_attr_type.set(session, channel, value.value)
+        return self._underlying_attribute.set(obj, self._default_channel, value.value)
 
 

--- a/generated/nidmm/attributes.py
+++ b/generated/nidmm/attributes.py
@@ -54,8 +54,8 @@ class AttributeViBoolean(Attribute):
 
 class AttributeEnum(object):
 
-    def __init__(self, underlying_meta_class, enum_meta_class, attribute_id, default_channel=''):
-        self._underlying_attribute = underlying_meta_class(attribute_id, default_channel)
+    def __init__(self, underlying_attribute_meta_class, enum_meta_class, attribute_id, default_channel=''):
+        self._underlying_attribute = underlying_attribute_meta_class(attribute_id, default_channel)
         self._attribute_type = enum_meta_class
         self._attribute_id = attribute_id
         self._default_channel = default_channel

--- a/generated/nidmm/attributes.py
+++ b/generated/nidmm/attributes.py
@@ -52,16 +52,20 @@ class AttributeViBoolean(Attribute):
         session._set_attribute_vi_boolean(channel, self._attribute_id, value)
 
 
-class AttributeEnum(AttributeViInt32):
+class AttributeEnum(Attribute):
 
-    def __init__(self, attribute_id, enum_meta_class, channel=''):
+    def __init__(self, underlying_attr_type, enum_meta_class):
+        self._underlying_attr_type = underlying_attr_type
         self._attribute_type = enum_meta_class
-        super(AttributeEnum, self).__init__(attribute_id, channel)
+        # To avoid redundancy, we get the attribute_id and channel from the underlying type
+        super(AttributeEnum, self).__init__(self._underlying_attr_type._attribute_id, self._underlying_attr_type._default_channel)
 
     def get(self, session, channel):
-        return self._attribute_type(super(AttributeEnum, self).get(session, channel))
+        return self._attribute_type(self._underlying_attr_type.get(session, channel))
 
     def set(self, session, channel, value):
         if type(value) is not self._attribute_type:
             raise TypeError('must be nidmm.' + str(self._attribute_type.__name__) + ' not ' + str(type(value).__name__))
-        return super(AttributeEnum, self).set(session, channel, value.value)
+        return self._underlying_attr_type.set(session, channel, value.value)
+
+

--- a/generated/nidmm/attributes.py
+++ b/generated/nidmm/attributes.py
@@ -54,8 +54,8 @@ class AttributeViBoolean(Attribute):
 
 class AttributeEnum(object):
 
-    def __init__(self, underlying_attr_type, enum_meta_class, attribute_id, default_channel=''):
-        self._underlying_attribute = underlying_attr_type(attribute_id, default_channel)
+    def __init__(self, underlying_meta_class, enum_meta_class, attribute_id, default_channel=''):
+        self._underlying_attribute = underlying_meta_class(attribute_id, default_channel)
         self._attribute_type = enum_meta_class
         self._attribute_id = attribute_id
         self._default_channel = default_channel

--- a/generated/nidmm/session.py
+++ b/generated/nidmm/session.py
@@ -54,7 +54,7 @@ class Session(object):
     for the NI 4080/4081/4082 and NI 4070/4071/4072, 10 Hz-100 Hz for the NI
     4065, and 20 Hz-25 kHz for the NI 4050 and NI 4060.
     '''
-    adc_calibration = attributes.AttributeEnum(1150022, enums.ADCCalibration)
+    adc_calibration = attributes.AttributeEnum(attributes.AttributeViInt32(1150022), enums.ADCCalibration)
     '''
     For the NI 4080/4081/4082 and NI 4070/4071/4072, specifies the ADC
     calibration mode.
@@ -84,7 +84,7 @@ class Session(object):
     are 1 PLC, 6 PLC, 12 PLC, and 120 PLC. When the powerline frequency is
     50 Hz, the PLCs allowed are 1 PLC, 5 PLC, 10 PLC, and 100 PLC.
     '''
-    aperture_time_units = attributes.AttributeEnum(1250322, enums.ApertureTimeUnits)
+    aperture_time_units = attributes.AttributeEnum(attributes.AttributeViInt32(1250322), enums.ApertureTimeUnits)
     '''
     Specifies the units of aperture time for the current configuration.
 
@@ -96,7 +96,7 @@ class Session(object):
     actual value of the active range. The value of this property is set
     during a read operation.
     '''
-    auto_zero = attributes.AttributeEnum(1250332, enums.AutoZero)
+    auto_zero = attributes.AttributeEnum(attributes.AttributeViInt32(1250332), enums.AutoZero)
     '''
     Specifies the AutoZero mode. This property is not supported for the NI
     4050.
@@ -107,7 +107,7 @@ class Session(object):
     is 134,217,727 (0X7FFFFFF) samples. When set to Auto (-1), NI-DMM
     chooses the buffer size.
     '''
-    cable_comp_type = attributes.AttributeEnum(1150045, enums.CableCompensationType)
+    cable_comp_type = attributes.AttributeEnum(attributes.AttributeViInt32(1150045), enums.CableCompensationType)
     '''
     For the NI 4081 and NI 4072 only, specifies the type of cable
     compensation that is applied to the current capacitance or inductance
@@ -142,18 +142,18 @@ class Session(object):
     '''
     The PCI product ID.
     '''
-    current_source = attributes.AttributeEnum(1150025, enums.CurrentSource)
+    current_source = attributes.AttributeEnum(attributes.AttributeViReal64(1150025), enums.CurrentSource)
     '''
     Specifies the current source provided during diode measurements.
 
     The NI 4050 and NI 4060 are not supported.
     '''
-    dc_bias = attributes.AttributeEnum(1150053, enums.DCBias)
+    dc_bias = attributes.AttributeEnum(attributes.AttributeViInt32(1150053), enums.DCBias)
     '''
     For the NI 4082 and NI 4072 only, controls the available DC bias for
     capacitance measurements.
     '''
-    dc_noise_rejection = attributes.AttributeEnum(1150026, enums.DCNoiseRejection)
+    dc_noise_rejection = attributes.AttributeEnum(attributes.AttributeViInt32(1150026), enums.DCNoiseRejection)
     '''
     Specifies the DC noise rejection mode.
 
@@ -208,7 +208,7 @@ class Session(object):
     | Auto Range Off | -2.0 | Disables Auto Ranging. NI-DMM sets the voltage range to the last calculated voltage range.                                       |
     +----------------+------+----------------------------------------------------------------------------------------------------------------------------------+
     '''
-    function = attributes.AttributeEnum(1250001, enums.Function)
+    function = attributes.AttributeEnum(attributes.AttributeViInt32(1250001), enums.Function)
     '''
     Specifies the measurement function. If you are setting this property
     directly, you must also set the `Operation
@@ -229,7 +229,7 @@ class Session(object):
     '''
     A string containing the type of instrument used in the current session.
     '''
-    input_resistance = attributes.AttributeEnum(1150029, enums.InputResistance)
+    input_resistance = attributes.AttributeEnum(attributes.AttributeViReal64(1150029), enums.InputResistance)
     '''
     Specifies the input resistance of the instrument.
 
@@ -280,7 +280,7 @@ class Session(object):
     instrument to an internal buffer. When set to Auto (-1), NI-DMM chooses
     the transfer size.
     '''
-    lc_calculation_model = attributes.AttributeEnum(1150052, enums.LCCalculationModel)
+    lc_calculation_model = attributes.AttributeEnum(attributes.AttributeViInt32(1150052), enums.LCCalculationModel)
     '''
     For the NI 4082 and NI 4072 only, specifies the type of algorithm that
     the measurement processing uses for capacitance and inductance
@@ -295,7 +295,7 @@ class Session(object):
     '''
     A string containing the logical name of the instrument.
     '''
-    meas_complete_dest = attributes.AttributeEnum(1250305, enums.MeasurementCompleteDest)
+    meas_complete_dest = attributes.AttributeEnum(attributes.AttributeViInt32(1250305), enums.MeasurementCompleteDest)
     '''
     Specifies the destination of the measurement complete (MC) signal.
 
@@ -305,7 +305,7 @@ class Session(object):
 
     Note: The NI 4050 is not supported.
     '''
-    meas_dest_slope = attributes.AttributeEnum(1150002, enums.MeasurementDestinationSlope)
+    meas_dest_slope = attributes.AttributeEnum(attributes.AttributeViInt32(1150002), enums.MeasurementDestinationSlope)
     '''
     Specifies the polarity of the generated measurement complete signal.
     '''
@@ -319,7 +319,7 @@ class Session(object):
 
     The NI 4050 and NI 4060 are not supported.
     '''
-    offset_comp_ohms = attributes.AttributeEnum(1150023, enums.OffsetCompensatedOhms)
+    offset_comp_ohms = attributes.AttributeEnum(attributes.AttributeViInt32(1150023), enums.OffsetCompensatedOhms)
     '''
     For the NI 4080/4081/4082 and NI 4070/4071/4072, enables or disables
     offset compensated ohms.
@@ -350,7 +350,7 @@ class Session(object):
     Measurement <dmmviref.chm::/niDMM_Config_Measurement.html>`__ resets
     this property to the default value.
     '''
-    operation_mode = attributes.AttributeEnum(1150014, enums.OperationMode)
+    operation_mode = attributes.AttributeEnum(attributes.AttributeViInt32(1150014), enums.OperationMode)
     '''
     Specifies how the DMM acquires data.
 
@@ -365,7 +365,7 @@ class Session(object):
 
     Note: The NI 4050 and NI 4060 are not supported.
     '''
-    powerline_freq = attributes.AttributeEnum(1250333, enums.PowerlineFrequency)
+    powerline_freq = attributes.AttributeEnum(attributes.AttributeViReal64(1250333), enums.PowerlineFrequency)
     '''
     Specifies the powerline frequency. The NI 4060 and NI 4050 use this
     value to select an aperture time to reject powerline noise by selecting
@@ -456,7 +456,7 @@ class Session(object):
     on the NI 4082 and NI 4072. To achieve better resolution for such
     measurements, use the Number of LC Measurements to Average property.
     '''
-    resolution_digits = attributes.AttributeEnum(1250003, enums.DigitsResolution)
+    resolution_digits = attributes.AttributeEnum(attributes.AttributeViReal64(1250003), enums.DigitsResolution)
     '''
     Specifies the measurement resolution in digits. Setting this property to
     higher values increases the measurement accuracy. Setting this property
@@ -509,7 +509,7 @@ class Session(object):
 
     Note: The NI 4080/4081/4082 and NI 4050 are not supported.
     '''
-    sample_trigger = attributes.AttributeEnum(1250302, enums.SampleTrigger)
+    sample_trigger = attributes.AttributeEnum(attributes.AttributeViInt32(1250302), enums.SampleTrigger)
     '''
     Specifies the sample trigger source.
 
@@ -517,7 +517,7 @@ class Session(object):
     `LabVIEW Trigger Routing <dmm.chm::/LVtrigger_routing.html>`__ section
     in the *NI Digital Multimeters Help*.
     '''
-    sample_trigger_slope = attributes.AttributeEnum(1150010, enums.SampleTrigSlope)
+    sample_trigger_slope = attributes.AttributeEnum(attributes.AttributeViInt32(1150010), enums.SampleTrigSlope)
     '''
     Specifies the edge of the signal from the specified sample trigger
     source on which the DMM is triggered.
@@ -653,7 +653,7 @@ class Session(object):
     '''
     Specifies the RTD resistance at 0 degrees Celsius.
     '''
-    temp_rtd_type = attributes.AttributeEnum(1150120, enums.RTDType)
+    temp_rtd_type = attributes.AttributeEnum(attributes.AttributeViInt32(1150120), enums.RTDType)
     '''
     Specifies the RTD type.
     '''
@@ -662,11 +662,11 @@ class Session(object):
     Specifies the value of the fixed reference junction temperature for a
     thermocouple in degrees Celsius.
     '''
-    temp_tc_ref_junc_type = attributes.AttributeEnum(1250232, enums.ThermocoupleReferenceJunctionType)
+    temp_tc_ref_junc_type = attributes.AttributeEnum(attributes.AttributeViInt32(1250232), enums.ThermocoupleReferenceJunctionType)
     '''
     Specifies the thermocouple reference junction type.
     '''
-    temp_tc_type = attributes.AttributeEnum(1250231, enums.ThermocoupleType)
+    temp_tc_type = attributes.AttributeEnum(attributes.AttributeViInt32(1250231), enums.ThermocoupleType)
     '''
     Specifies the thermocouple type.
     '''
@@ -685,11 +685,11 @@ class Session(object):
     Specifies the Steinhart-Hart C coefficient for thermistor scaling when
     the **Thermistor Type property** is set to Custom.
     '''
-    temp_thermistor_type = attributes.AttributeEnum(1150124, enums.ThermistorType)
+    temp_thermistor_type = attributes.AttributeEnum(attributes.AttributeViInt32(1150124), enums.ThermistorType)
     '''
     Specifies the thermistor type.
     '''
-    temp_transducer_type = attributes.AttributeEnum(1250201, enums.TransducerType)
+    temp_transducer_type = attributes.AttributeEnum(attributes.AttributeViInt32(1250201), enums.TransducerType)
     '''
     Specifies the transducer type.
     '''
@@ -735,12 +735,12 @@ class Session(object):
 
     Default Value: Auto Delay
     '''
-    trigger_slope = attributes.AttributeEnum(1250334, enums.TriggerSlope)
+    trigger_slope = attributes.AttributeEnum(attributes.AttributeViInt32(1250334), enums.TriggerSlope)
     '''
     Specifies the edge of the signal from the specified trigger source on
     which the DMM is triggered.
     '''
-    trigger_source = attributes.AttributeEnum(1250004, enums.TriggerSource)
+    trigger_source = attributes.AttributeEnum(attributes.AttributeViInt32(1250004), enums.TriggerSource)
     '''
     Specifies the trigger source. When `niDMM
     Initiate <dmmviref.chm::/niDMM_Initiate.html>`__ is called, the DMM
@@ -753,7 +753,7 @@ class Session(object):
     `LabVIEW Trigger Routing <dmm.chm::/LVtrigger_routing.html>`__ section
     in the *NI Digital Multimeters Help*.
     '''
-    waveform_coupling = attributes.AttributeEnum(1150027, enums.WaveformCoupling)
+    waveform_coupling = attributes.AttributeEnum(attributes.AttributeViInt32(1150027), enums.WaveformCoupling)
     '''
     For the NI 4080/4081/4082 and NI 4070/4071/4072 only, specifies the
     coupling during a waveform acquisition.

--- a/generated/nidmm/session.py
+++ b/generated/nidmm/session.py
@@ -54,7 +54,7 @@ class Session(object):
     for the NI 4080/4081/4082 and NI 4070/4071/4072, 10 Hz-100 Hz for the NI
     4065, and 20 Hz-25 kHz for the NI 4050 and NI 4060.
     '''
-    adc_calibration = attributes.AttributeEnum(attributes.AttributeViInt32(1150022), enums.ADCCalibration)
+    adc_calibration = attributes.AttributeEnum(attributes.AttributeViInt32, enums.ADCCalibration, 1150022)
     '''
     For the NI 4080/4081/4082 and NI 4070/4071/4072, specifies the ADC
     calibration mode.
@@ -84,7 +84,7 @@ class Session(object):
     are 1 PLC, 6 PLC, 12 PLC, and 120 PLC. When the powerline frequency is
     50 Hz, the PLCs allowed are 1 PLC, 5 PLC, 10 PLC, and 100 PLC.
     '''
-    aperture_time_units = attributes.AttributeEnum(attributes.AttributeViInt32(1250322), enums.ApertureTimeUnits)
+    aperture_time_units = attributes.AttributeEnum(attributes.AttributeViInt32, enums.ApertureTimeUnits, 1250322)
     '''
     Specifies the units of aperture time for the current configuration.
 
@@ -96,7 +96,7 @@ class Session(object):
     actual value of the active range. The value of this property is set
     during a read operation.
     '''
-    auto_zero = attributes.AttributeEnum(attributes.AttributeViInt32(1250332), enums.AutoZero)
+    auto_zero = attributes.AttributeEnum(attributes.AttributeViInt32, enums.AutoZero, 1250332)
     '''
     Specifies the AutoZero mode. This property is not supported for the NI
     4050.
@@ -107,7 +107,7 @@ class Session(object):
     is 134,217,727 (0X7FFFFFF) samples. When set to Auto (-1), NI-DMM
     chooses the buffer size.
     '''
-    cable_comp_type = attributes.AttributeEnum(attributes.AttributeViInt32(1150045), enums.CableCompensationType)
+    cable_comp_type = attributes.AttributeEnum(attributes.AttributeViInt32, enums.CableCompensationType, 1150045)
     '''
     For the NI 4081 and NI 4072 only, specifies the type of cable
     compensation that is applied to the current capacitance or inductance
@@ -142,18 +142,18 @@ class Session(object):
     '''
     The PCI product ID.
     '''
-    current_source = attributes.AttributeEnum(attributes.AttributeViReal64(1150025), enums.CurrentSource)
+    current_source = attributes.AttributeEnum(attributes.AttributeViReal64, enums.CurrentSource, 1150025)
     '''
     Specifies the current source provided during diode measurements.
 
     The NI 4050 and NI 4060 are not supported.
     '''
-    dc_bias = attributes.AttributeEnum(attributes.AttributeViInt32(1150053), enums.DCBias)
+    dc_bias = attributes.AttributeEnum(attributes.AttributeViInt32, enums.DCBias, 1150053)
     '''
     For the NI 4082 and NI 4072 only, controls the available DC bias for
     capacitance measurements.
     '''
-    dc_noise_rejection = attributes.AttributeEnum(attributes.AttributeViInt32(1150026), enums.DCNoiseRejection)
+    dc_noise_rejection = attributes.AttributeEnum(attributes.AttributeViInt32, enums.DCNoiseRejection, 1150026)
     '''
     Specifies the DC noise rejection mode.
 
@@ -208,7 +208,7 @@ class Session(object):
     | Auto Range Off | -2.0 | Disables Auto Ranging. NI-DMM sets the voltage range to the last calculated voltage range.                                       |
     +----------------+------+----------------------------------------------------------------------------------------------------------------------------------+
     '''
-    function = attributes.AttributeEnum(attributes.AttributeViInt32(1250001), enums.Function)
+    function = attributes.AttributeEnum(attributes.AttributeViInt32, enums.Function, 1250001)
     '''
     Specifies the measurement function. If you are setting this property
     directly, you must also set the `Operation
@@ -229,7 +229,7 @@ class Session(object):
     '''
     A string containing the type of instrument used in the current session.
     '''
-    input_resistance = attributes.AttributeEnum(attributes.AttributeViReal64(1150029), enums.InputResistance)
+    input_resistance = attributes.AttributeEnum(attributes.AttributeViReal64, enums.InputResistance, 1150029)
     '''
     Specifies the input resistance of the instrument.
 
@@ -280,7 +280,7 @@ class Session(object):
     instrument to an internal buffer. When set to Auto (-1), NI-DMM chooses
     the transfer size.
     '''
-    lc_calculation_model = attributes.AttributeEnum(attributes.AttributeViInt32(1150052), enums.LCCalculationModel)
+    lc_calculation_model = attributes.AttributeEnum(attributes.AttributeViInt32, enums.LCCalculationModel, 1150052)
     '''
     For the NI 4082 and NI 4072 only, specifies the type of algorithm that
     the measurement processing uses for capacitance and inductance
@@ -295,7 +295,7 @@ class Session(object):
     '''
     A string containing the logical name of the instrument.
     '''
-    meas_complete_dest = attributes.AttributeEnum(attributes.AttributeViInt32(1250305), enums.MeasurementCompleteDest)
+    meas_complete_dest = attributes.AttributeEnum(attributes.AttributeViInt32, enums.MeasurementCompleteDest, 1250305)
     '''
     Specifies the destination of the measurement complete (MC) signal.
 
@@ -305,7 +305,7 @@ class Session(object):
 
     Note: The NI 4050 is not supported.
     '''
-    meas_dest_slope = attributes.AttributeEnum(attributes.AttributeViInt32(1150002), enums.MeasurementDestinationSlope)
+    meas_dest_slope = attributes.AttributeEnum(attributes.AttributeViInt32, enums.MeasurementDestinationSlope, 1150002)
     '''
     Specifies the polarity of the generated measurement complete signal.
     '''
@@ -319,7 +319,7 @@ class Session(object):
 
     The NI 4050 and NI 4060 are not supported.
     '''
-    offset_comp_ohms = attributes.AttributeEnum(attributes.AttributeViInt32(1150023), enums.OffsetCompensatedOhms)
+    offset_comp_ohms = attributes.AttributeEnum(attributes.AttributeViInt32, enums.OffsetCompensatedOhms, 1150023)
     '''
     For the NI 4080/4081/4082 and NI 4070/4071/4072, enables or disables
     offset compensated ohms.
@@ -350,7 +350,7 @@ class Session(object):
     Measurement <dmmviref.chm::/niDMM_Config_Measurement.html>`__ resets
     this property to the default value.
     '''
-    operation_mode = attributes.AttributeEnum(attributes.AttributeViInt32(1150014), enums.OperationMode)
+    operation_mode = attributes.AttributeEnum(attributes.AttributeViInt32, enums.OperationMode, 1150014)
     '''
     Specifies how the DMM acquires data.
 
@@ -365,7 +365,7 @@ class Session(object):
 
     Note: The NI 4050 and NI 4060 are not supported.
     '''
-    powerline_freq = attributes.AttributeEnum(attributes.AttributeViReal64(1250333), enums.PowerlineFrequency)
+    powerline_freq = attributes.AttributeEnum(attributes.AttributeViReal64, enums.PowerlineFrequency, 1250333)
     '''
     Specifies the powerline frequency. The NI 4060 and NI 4050 use this
     value to select an aperture time to reject powerline noise by selecting
@@ -456,7 +456,7 @@ class Session(object):
     on the NI 4082 and NI 4072. To achieve better resolution for such
     measurements, use the Number of LC Measurements to Average property.
     '''
-    resolution_digits = attributes.AttributeEnum(attributes.AttributeViReal64(1250003), enums.DigitsResolution)
+    resolution_digits = attributes.AttributeEnum(attributes.AttributeViReal64, enums.DigitsResolution, 1250003)
     '''
     Specifies the measurement resolution in digits. Setting this property to
     higher values increases the measurement accuracy. Setting this property
@@ -509,7 +509,7 @@ class Session(object):
 
     Note: The NI 4080/4081/4082 and NI 4050 are not supported.
     '''
-    sample_trigger = attributes.AttributeEnum(attributes.AttributeViInt32(1250302), enums.SampleTrigger)
+    sample_trigger = attributes.AttributeEnum(attributes.AttributeViInt32, enums.SampleTrigger, 1250302)
     '''
     Specifies the sample trigger source.
 
@@ -517,7 +517,7 @@ class Session(object):
     `LabVIEW Trigger Routing <dmm.chm::/LVtrigger_routing.html>`__ section
     in the *NI Digital Multimeters Help*.
     '''
-    sample_trigger_slope = attributes.AttributeEnum(attributes.AttributeViInt32(1150010), enums.SampleTrigSlope)
+    sample_trigger_slope = attributes.AttributeEnum(attributes.AttributeViInt32, enums.SampleTrigSlope, 1150010)
     '''
     Specifies the edge of the signal from the specified sample trigger
     source on which the DMM is triggered.
@@ -653,7 +653,7 @@ class Session(object):
     '''
     Specifies the RTD resistance at 0 degrees Celsius.
     '''
-    temp_rtd_type = attributes.AttributeEnum(attributes.AttributeViInt32(1150120), enums.RTDType)
+    temp_rtd_type = attributes.AttributeEnum(attributes.AttributeViInt32, enums.RTDType, 1150120)
     '''
     Specifies the RTD type.
     '''
@@ -662,11 +662,11 @@ class Session(object):
     Specifies the value of the fixed reference junction temperature for a
     thermocouple in degrees Celsius.
     '''
-    temp_tc_ref_junc_type = attributes.AttributeEnum(attributes.AttributeViInt32(1250232), enums.ThermocoupleReferenceJunctionType)
+    temp_tc_ref_junc_type = attributes.AttributeEnum(attributes.AttributeViInt32, enums.ThermocoupleReferenceJunctionType, 1250232)
     '''
     Specifies the thermocouple reference junction type.
     '''
-    temp_tc_type = attributes.AttributeEnum(attributes.AttributeViInt32(1250231), enums.ThermocoupleType)
+    temp_tc_type = attributes.AttributeEnum(attributes.AttributeViInt32, enums.ThermocoupleType, 1250231)
     '''
     Specifies the thermocouple type.
     '''
@@ -685,11 +685,11 @@ class Session(object):
     Specifies the Steinhart-Hart C coefficient for thermistor scaling when
     the **Thermistor Type property** is set to Custom.
     '''
-    temp_thermistor_type = attributes.AttributeEnum(attributes.AttributeViInt32(1150124), enums.ThermistorType)
+    temp_thermistor_type = attributes.AttributeEnum(attributes.AttributeViInt32, enums.ThermistorType, 1150124)
     '''
     Specifies the thermistor type.
     '''
-    temp_transducer_type = attributes.AttributeEnum(attributes.AttributeViInt32(1250201), enums.TransducerType)
+    temp_transducer_type = attributes.AttributeEnum(attributes.AttributeViInt32, enums.TransducerType, 1250201)
     '''
     Specifies the transducer type.
     '''
@@ -735,12 +735,12 @@ class Session(object):
 
     Default Value: Auto Delay
     '''
-    trigger_slope = attributes.AttributeEnum(attributes.AttributeViInt32(1250334), enums.TriggerSlope)
+    trigger_slope = attributes.AttributeEnum(attributes.AttributeViInt32, enums.TriggerSlope, 1250334)
     '''
     Specifies the edge of the signal from the specified trigger source on
     which the DMM is triggered.
     '''
-    trigger_source = attributes.AttributeEnum(attributes.AttributeViInt32(1250004), enums.TriggerSource)
+    trigger_source = attributes.AttributeEnum(attributes.AttributeViInt32, enums.TriggerSource, 1250004)
     '''
     Specifies the trigger source. When `niDMM
     Initiate <dmmviref.chm::/niDMM_Initiate.html>`__ is called, the DMM
@@ -753,7 +753,7 @@ class Session(object):
     `LabVIEW Trigger Routing <dmm.chm::/LVtrigger_routing.html>`__ section
     in the *NI Digital Multimeters Help*.
     '''
-    waveform_coupling = attributes.AttributeEnum(attributes.AttributeViInt32(1150027), enums.WaveformCoupling)
+    waveform_coupling = attributes.AttributeEnum(attributes.AttributeViInt32, enums.WaveformCoupling, 1150027)
     '''
     For the NI 4080/4081/4082 and NI 4070/4071/4072 only, specifies the
     coupling during a waveform acquisition.

--- a/generated/nifake/attributes.py
+++ b/generated/nifake/attributes.py
@@ -52,16 +52,20 @@ class AttributeViBoolean(Attribute):
         session._set_attribute_vi_boolean(channel, self._attribute_id, value)
 
 
-class AttributeEnum(AttributeViInt32):
+class AttributeEnum(Attribute):
 
-    def __init__(self, attribute_id, enum_meta_class, channel=''):
+    def __init__(self, underlying_attr_type, enum_meta_class):
+        self._underlying_attr_type = underlying_attr_type
         self._attribute_type = enum_meta_class
-        super(AttributeEnum, self).__init__(attribute_id, channel)
+        # To avoid redundancy, we get the attribute_id and channel from the underlying type
+        super(AttributeEnum, self).__init__(self._underlying_attr_type._attribute_id, self._underlying_attr_type._default_channel)
 
     def get(self, session, channel):
-        return self._attribute_type(super(AttributeEnum, self).get(session, channel))
+        return self._attribute_type(self._underlying_attr_type.get(session, channel))
 
     def set(self, session, channel, value):
         if type(value) is not self._attribute_type:
             raise TypeError('must be nifake.' + str(self._attribute_type.__name__) + ' not ' + str(type(value).__name__))
-        return super(AttributeEnum, self).set(session, channel, value.value)
+        return self._underlying_attr_type.set(session, channel, value.value)
+
+

--- a/generated/nifake/attributes.py
+++ b/generated/nifake/attributes.py
@@ -54,8 +54,8 @@ class AttributeViBoolean(Attribute):
 
 class AttributeEnum(object):
 
-    def __init__(self, underlying_meta_class, enum_meta_class, attribute_id, default_channel=''):
-        self._underlying_attribute = underlying_meta_class(attribute_id, default_channel)
+    def __init__(self, underlying_attribute_meta_class, enum_meta_class, attribute_id, default_channel=''):
+        self._underlying_attribute = underlying_attribute_meta_class(attribute_id, default_channel)
         self._attribute_type = enum_meta_class
         self._attribute_id = attribute_id
         self._default_channel = default_channel

--- a/generated/nifake/attributes.py
+++ b/generated/nifake/attributes.py
@@ -52,20 +52,20 @@ class AttributeViBoolean(Attribute):
         session._set_attribute_vi_boolean(channel, self._attribute_id, value)
 
 
-class AttributeEnum(Attribute):
+class AttributeEnum(object):
 
-    def __init__(self, underlying_attr_type, enum_meta_class):
-        self._underlying_attr_type = underlying_attr_type
+    def __init__(self, underlying_attr_type, enum_meta_class, attribute_id, default_channel=''):
+        self._underlying_attribute = underlying_attr_type(attribute_id, default_channel)
         self._attribute_type = enum_meta_class
-        # To avoid redundancy, we get the attribute_id and channel from the underlying type
-        super(AttributeEnum, self).__init__(self._underlying_attr_type._attribute_id, self._underlying_attr_type._default_channel)
+        self._attribute_id = attribute_id
+        self._default_channel = default_channel
 
-    def get(self, session, channel):
-        return self._attribute_type(self._underlying_attr_type.get(session, channel))
+    def __get__(self, obj, objtype):
+        return self._attribute_type(self._underlying_attribute.get(obj, self._default_channel))
 
-    def set(self, session, channel, value):
+    def __set__(self, obj, value):
         if type(value) is not self._attribute_type:
             raise TypeError('must be nifake.' + str(self._attribute_type.__name__) + ' not ' + str(type(value).__name__))
-        return self._underlying_attr_type.set(session, channel, value.value)
+        return self._underlying_attribute.set(obj, self._default_channel, value.value)
 
 

--- a/generated/nifake/attributes.py
+++ b/generated/nifake/attributes.py
@@ -54,8 +54,8 @@ class AttributeViBoolean(Attribute):
 
 class AttributeEnum(object):
 
-    def __init__(self, underlying_attr_type, enum_meta_class, attribute_id, default_channel=''):
-        self._underlying_attribute = underlying_attr_type(attribute_id, default_channel)
+    def __init__(self, underlying_meta_class, enum_meta_class, attribute_id, default_channel=''):
+        self._underlying_attribute = underlying_meta_class(attribute_id, default_channel)
         self._attribute_type = enum_meta_class
         self._attribute_id = attribute_id
         self._default_channel = default_channel

--- a/generated/nifake/enums.py
+++ b/generated/nifake/enums.py
@@ -22,6 +22,29 @@ class Color(Enum):
     '''
 
 
+class FloatEnum(Enum):
+    _3_5 = 3.5
+    '''
+    Specifies 3.5 digits resolution.
+    '''
+    _4_5 = 4.5
+    '''
+    Specifies 4.5 digits resolution.
+    '''
+    _5_5 = 5.5
+    '''
+    Specifies 5.5 digits resolution.
+    '''
+    _6_5 = 6.5
+    '''
+    Specifies 6.5 digits resolution.
+    '''
+    _7_5 = 7.5
+    '''
+    Specifies 7.5 digits resolution.
+    '''
+
+
 class Turtle(Enum):
     LEONARDO = 0
     '''

--- a/generated/nifake/session.py
+++ b/generated/nifake/session.py
@@ -28,11 +28,15 @@ class Session(object):
     # This is needed during __init__. Without it, __setattr__ raises an exception
     _is_frozen = False
 
+    float_enum = attributes.AttributeEnum(attributes.AttributeViReal64(1000005), enums.FloatEnum)
+    '''
+    An attribute with an enum that is also a float
+    '''
     read_write_bool = attributes.AttributeViBoolean(1000000)
     '''
     An attribute of type bool with read/write access.
     '''
-    read_write_color = attributes.AttributeEnum(1000003, enums.Color)
+    read_write_color = attributes.AttributeEnum(attributes.AttributeViInt32(1000003), enums.Color)
     '''
     An attribute of type Color with read/write access.
     '''
@@ -40,13 +44,13 @@ class Session(object):
     '''
     An attribute of type float with read/write access.
     '''
+    read_write_integer = attributes.AttributeViInt32(1000004)
+    '''
+    An attribute of type integer with read/write access.
+    '''
     read_write_string = attributes.AttributeViString(1000002)
     '''
     An attribute of type string with read/write access.
-    '''
-    read_write_integer = AttributeViInt32(1000004)
-    '''
-    An attribute of type integer with read/write access.
     '''
 
     def __init__(self, resource_name, id_query=False, reset_device=False, options_string=""):

--- a/generated/nifake/session.py
+++ b/generated/nifake/session.py
@@ -28,7 +28,7 @@ class Session(object):
     # This is needed during __init__. Without it, __setattr__ raises an exception
     _is_frozen = False
 
-    float_enum = attributes.AttributeEnum(attributes.AttributeViReal64(1000005), enums.FloatEnum)
+    float_enum = attributes.AttributeEnum(attributes.AttributeViReal64, enums.FloatEnum, 1000005)
     '''
     An attribute with an enum that is also a float
     '''
@@ -36,7 +36,7 @@ class Session(object):
     '''
     An attribute of type bool with read/write access.
     '''
-    read_write_color = attributes.AttributeEnum(attributes.AttributeViInt32(1000003), enums.Color)
+    read_write_color = attributes.AttributeEnum(attributes.AttributeViInt32, enums.Color, 1000003)
     '''
     An attribute of type Color with read/write access.
     '''

--- a/generated/nifake/tests/test_session.py
+++ b/generated/nifake/tests/test_session.py
@@ -256,6 +256,14 @@ class TestSession(object):
             attribute_id = 1000003
             self.patched_library.niFake_SetAttributeViInt32.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', attribute_id, enum_value.value)
 
+    def test_set_float_enum_attribute(self):
+        self.patched_library.niFake_SetAttributeViReal64.side_effect = self.side_effects_helper.niFake_SetAttributeViReal64
+        enum_value = nifake.FloatEnum._5_5
+        with nifake.Session('dev1') as session:
+            session.float_enum = enum_value
+            attribute_id = 1000005
+            self.patched_library.niFake_SetAttributeViReal64.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', attribute_id, enum_value.value)
+
     def test_set_enum_attribute_bad_type(self):
         with nifake.Session('dev1') as session:
             try:
@@ -270,6 +278,15 @@ class TestSession(object):
             assert session.read_write_color == nifake.Color.BLUE
             attribute_id = 1000003
             self.patched_library.niFake_GetAttributeViInt32.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', attribute_id, ANY)
+
+    def test_get_float_enum_attribute(self):
+        self.patched_library.niFake_GetAttributeViReal64.side_effect = self.side_effects_helper.niFake_GetAttributeViReal64
+        enum_value = nifake.FloatEnum._6_5
+        self.side_effects_helper['GetAttributeViReal64']['attributeValue'] = enum_value.value
+        with nifake.Session('dev1') as session:
+            assert session.float_enum == enum_value
+            attribute_id = 1000005
+            self.patched_library.niFake_GetAttributeViReal64.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', attribute_id, ANY)
 
     def test_acquisition_context_manager(self):
         self.patched_library.niFake_Initiate.side_effect = self.side_effects_helper.niFake_Initiate
@@ -415,7 +432,7 @@ class TestSession(object):
         test_number = 1
         with nifake.Session('dev1') as session:
             session.read_write_integer = test_number
-            self.patched_library.niFake_SetAttributeViInt32.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', attribute_id, test_number)
+            self.patched_library.niFake_SetAttributeViInt32.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', attribute_id, 1)
 
     def test_read(self):
         test_maximum_time = 10
@@ -436,3 +453,6 @@ class TestSession(object):
         self.side_effects_helper['Read']['reading'] = test_reading
         with nifake.Session('dev1') as session:
             assert math.isnan(session.read(test_maximum_time))
+
+
+

--- a/generated/nimodinst/attributes.py
+++ b/generated/nimodinst/attributes.py
@@ -52,16 +52,20 @@ class AttributeViBoolean(Attribute):
         session._set_attribute_vi_boolean(channel, self._attribute_id, value)
 
 
-class AttributeEnum(AttributeViInt32):
+class AttributeEnum(Attribute):
 
-    def __init__(self, attribute_id, enum_meta_class, channel=''):
+    def __init__(self, underlying_attr_type, enum_meta_class):
+        self._underlying_attr_type = underlying_attr_type
         self._attribute_type = enum_meta_class
-        super(AttributeEnum, self).__init__(attribute_id, channel)
+        # To avoid redundancy, we get the attribute_id and channel from the underlying type
+        super(AttributeEnum, self).__init__(self._underlying_attr_type._attribute_id, self._underlying_attr_type._default_channel)
 
     def get(self, session, channel):
-        return self._attribute_type(super(AttributeEnum, self).get(session, channel))
+        return self._attribute_type(self._underlying_attr_type.get(session, channel))
 
     def set(self, session, channel, value):
         if type(value) is not self._attribute_type:
             raise TypeError('must be nimodinst.' + str(self._attribute_type.__name__) + ' not ' + str(type(value).__name__))
-        return super(AttributeEnum, self).set(session, channel, value.value)
+        return self._underlying_attr_type.set(session, channel, value.value)
+
+

--- a/generated/nimodinst/attributes.py
+++ b/generated/nimodinst/attributes.py
@@ -52,20 +52,20 @@ class AttributeViBoolean(Attribute):
         session._set_attribute_vi_boolean(channel, self._attribute_id, value)
 
 
-class AttributeEnum(Attribute):
+class AttributeEnum(object):
 
-    def __init__(self, underlying_attr_type, enum_meta_class):
-        self._underlying_attr_type = underlying_attr_type
+    def __init__(self, underlying_attr_type, enum_meta_class, attribute_id, default_channel=''):
+        self._underlying_attribute = underlying_attr_type(attribute_id, default_channel)
         self._attribute_type = enum_meta_class
-        # To avoid redundancy, we get the attribute_id and channel from the underlying type
-        super(AttributeEnum, self).__init__(self._underlying_attr_type._attribute_id, self._underlying_attr_type._default_channel)
+        self._attribute_id = attribute_id
+        self._default_channel = default_channel
 
-    def get(self, session, channel):
-        return self._attribute_type(self._underlying_attr_type.get(session, channel))
+    def __get__(self, obj, objtype):
+        return self._attribute_type(self._underlying_attribute.get(obj, self._default_channel))
 
-    def set(self, session, channel, value):
+    def __set__(self, obj, value):
         if type(value) is not self._attribute_type:
             raise TypeError('must be nimodinst.' + str(self._attribute_type.__name__) + ' not ' + str(type(value).__name__))
-        return self._underlying_attr_type.set(session, channel, value.value)
+        return self._underlying_attribute.set(obj, self._default_channel, value.value)
 
 

--- a/generated/nimodinst/attributes.py
+++ b/generated/nimodinst/attributes.py
@@ -54,8 +54,8 @@ class AttributeViBoolean(Attribute):
 
 class AttributeEnum(object):
 
-    def __init__(self, underlying_meta_class, enum_meta_class, attribute_id, default_channel=''):
-        self._underlying_attribute = underlying_meta_class(attribute_id, default_channel)
+    def __init__(self, underlying_attribute_meta_class, enum_meta_class, attribute_id, default_channel=''):
+        self._underlying_attribute = underlying_attribute_meta_class(attribute_id, default_channel)
         self._attribute_type = enum_meta_class
         self._attribute_id = attribute_id
         self._default_channel = default_channel

--- a/generated/nimodinst/attributes.py
+++ b/generated/nimodinst/attributes.py
@@ -54,8 +54,8 @@ class AttributeViBoolean(Attribute):
 
 class AttributeEnum(object):
 
-    def __init__(self, underlying_attr_type, enum_meta_class, attribute_id, default_channel=''):
-        self._underlying_attribute = underlying_attr_type(attribute_id, default_channel)
+    def __init__(self, underlying_meta_class, enum_meta_class, attribute_id, default_channel=''):
+        self._underlying_attribute = underlying_meta_class(attribute_id, default_channel)
         self._attribute_type = enum_meta_class
         self._attribute_id = attribute_id
         self._default_channel = default_channel

--- a/generated/niswitch/attributes.py
+++ b/generated/niswitch/attributes.py
@@ -52,16 +52,20 @@ class AttributeViBoolean(Attribute):
         session._set_attribute_vi_boolean(channel, self._attribute_id, value)
 
 
-class AttributeEnum(AttributeViInt32):
+class AttributeEnum(Attribute):
 
-    def __init__(self, attribute_id, enum_meta_class, channel=''):
+    def __init__(self, underlying_attr_type, enum_meta_class):
+        self._underlying_attr_type = underlying_attr_type
         self._attribute_type = enum_meta_class
-        super(AttributeEnum, self).__init__(attribute_id, channel)
+        # To avoid redundancy, we get the attribute_id and channel from the underlying type
+        super(AttributeEnum, self).__init__(self._underlying_attr_type._attribute_id, self._underlying_attr_type._default_channel)
 
     def get(self, session, channel):
-        return self._attribute_type(super(AttributeEnum, self).get(session, channel))
+        return self._attribute_type(self._underlying_attr_type.get(session, channel))
 
     def set(self, session, channel, value):
         if type(value) is not self._attribute_type:
             raise TypeError('must be niswitch.' + str(self._attribute_type.__name__) + ' not ' + str(type(value).__name__))
-        return super(AttributeEnum, self).set(session, channel, value.value)
+        return self._underlying_attr_type.set(session, channel, value.value)
+
+

--- a/generated/niswitch/attributes.py
+++ b/generated/niswitch/attributes.py
@@ -52,20 +52,20 @@ class AttributeViBoolean(Attribute):
         session._set_attribute_vi_boolean(channel, self._attribute_id, value)
 
 
-class AttributeEnum(Attribute):
+class AttributeEnum(object):
 
-    def __init__(self, underlying_attr_type, enum_meta_class):
-        self._underlying_attr_type = underlying_attr_type
+    def __init__(self, underlying_attr_type, enum_meta_class, attribute_id, default_channel=''):
+        self._underlying_attribute = underlying_attr_type(attribute_id, default_channel)
         self._attribute_type = enum_meta_class
-        # To avoid redundancy, we get the attribute_id and channel from the underlying type
-        super(AttributeEnum, self).__init__(self._underlying_attr_type._attribute_id, self._underlying_attr_type._default_channel)
+        self._attribute_id = attribute_id
+        self._default_channel = default_channel
 
-    def get(self, session, channel):
-        return self._attribute_type(self._underlying_attr_type.get(session, channel))
+    def __get__(self, obj, objtype):
+        return self._attribute_type(self._underlying_attribute.get(obj, self._default_channel))
 
-    def set(self, session, channel, value):
+    def __set__(self, obj, value):
         if type(value) is not self._attribute_type:
             raise TypeError('must be niswitch.' + str(self._attribute_type.__name__) + ' not ' + str(type(value).__name__))
-        return self._underlying_attr_type.set(session, channel, value.value)
+        return self._underlying_attribute.set(obj, self._default_channel, value.value)
 
 

--- a/generated/niswitch/attributes.py
+++ b/generated/niswitch/attributes.py
@@ -54,8 +54,8 @@ class AttributeViBoolean(Attribute):
 
 class AttributeEnum(object):
 
-    def __init__(self, underlying_meta_class, enum_meta_class, attribute_id, default_channel=''):
-        self._underlying_attribute = underlying_meta_class(attribute_id, default_channel)
+    def __init__(self, underlying_attribute_meta_class, enum_meta_class, attribute_id, default_channel=''):
+        self._underlying_attribute = underlying_attribute_meta_class(attribute_id, default_channel)
         self._attribute_type = enum_meta_class
         self._attribute_id = attribute_id
         self._default_channel = default_channel

--- a/generated/niswitch/attributes.py
+++ b/generated/niswitch/attributes.py
@@ -54,8 +54,8 @@ class AttributeViBoolean(Attribute):
 
 class AttributeEnum(object):
 
-    def __init__(self, underlying_attr_type, enum_meta_class, attribute_id, default_channel=''):
-        self._underlying_attribute = underlying_attr_type(attribute_id, default_channel)
+    def __init__(self, underlying_meta_class, enum_meta_class, attribute_id, default_channel=''):
+        self._underlying_attribute = underlying_meta_class(attribute_id, default_channel)
         self._attribute_type = enum_meta_class
         self._attribute_id = attribute_id
         self._default_channel = default_channel

--- a/generated/niswitch/session.py
+++ b/generated/niswitch/session.py
@@ -170,7 +170,7 @@ class Session(object):
 
     `niSwitch Properties <switchpropref.chm::/cniSwitch.html>`__
     '''
-    handshaking_initiation = attributes.AttributeEnum(1150013, enums.HandshakingInitiation)
+    handshaking_initiation = attributes.AttributeEnum(attributes.AttributeViInt32(1150013), enums.HandshakingInitiation)
     '''
     Specifies how to start handshaking with a measurement device.
 
@@ -569,7 +569,7 @@ class Session(object):
     Record <switchviref.chm::/niSwitch_Get_Next_Coercion_Record.html>`__
     `niSwitch Properties <switchpropref.chm::/cniSwitch.html>`__
     '''
-    scan_advanced_output = attributes.AttributeEnum(1250023, enums.ScanAdvancedOutput)
+    scan_advanced_output = attributes.AttributeEnum(attributes.AttributeViInt32(1250023), enums.ScanAdvancedOutput)
     '''
     Specifies the method to use to notify another instrument that all
     signals through the switch module have settled following the processing
@@ -580,7 +580,7 @@ class Session(object):
     `niSwitch Properties <switchpropref.chm::/cniSwitch.html>`__
     `Scanning <SWITCH.chm::/scanning_fundamentals.html>`__
     '''
-    scan_advanced_polarity = attributes.AttributeEnum(1150011, enums.ScanAdvancedPolarity)
+    scan_advanced_polarity = attributes.AttributeEnum(attributes.AttributeViInt32(1150011), enums.ScanAdvancedPolarity)
     '''
     Specifies the driving level for the Scan Advanced Output signal sent
     from the switch module through either the external (PXI/PXIe) or front
@@ -651,7 +651,7 @@ class Session(object):
     Lists <SWITCH.chm::/scan_list.html>`__
     `Scanning <SWITCH.chm::/scanning_fundamentals.html>`__
     '''
-    scan_mode = attributes.AttributeEnum(1250021, enums.ScanMode)
+    scan_mode = attributes.AttributeEnum(attributes.AttributeViInt32(1250021), enums.ScanMode)
     '''
     Specifies how to handle existing connections that conflict with the
     connections you make in a scan list. For example, if CH1 is already
@@ -782,7 +782,7 @@ class Session(object):
 
     `niSwitch Properties <switchpropref.chm::/cniSwitch.html>`__
     '''
-    trigger_input = attributes.AttributeEnum(1250022, enums.TriggerInput)
+    trigger_input = attributes.AttributeEnum(attributes.AttributeViInt32(1250022), enums.TriggerInput)
     '''
     Specifies the source of the trigger for which the switch module can wait
     upon encountering a semi-colon (;) when processing a scan list. When the
@@ -796,7 +796,7 @@ class Session(object):
     Properties <switchpropref.chm::/cniSwitch.html>`__
     `Scanning <SWITCH.chm::/scanning_fundamentals.html>`__
     '''
-    trigger_input_polarity = attributes.AttributeEnum(1150010, enums.TriggerInputPolarity)
+    trigger_input_polarity = attributes.AttributeEnum(attributes.AttributeViInt32(1150010), enums.TriggerInputPolarity)
     '''
     Determines the behavior of the trigger input.
 

--- a/generated/niswitch/session.py
+++ b/generated/niswitch/session.py
@@ -170,7 +170,7 @@ class Session(object):
 
     `niSwitch Properties <switchpropref.chm::/cniSwitch.html>`__
     '''
-    handshaking_initiation = attributes.AttributeEnum(attributes.AttributeViInt32(1150013), enums.HandshakingInitiation)
+    handshaking_initiation = attributes.AttributeEnum(attributes.AttributeViInt32, enums.HandshakingInitiation, 1150013)
     '''
     Specifies how to start handshaking with a measurement device.
 
@@ -569,7 +569,7 @@ class Session(object):
     Record <switchviref.chm::/niSwitch_Get_Next_Coercion_Record.html>`__
     `niSwitch Properties <switchpropref.chm::/cniSwitch.html>`__
     '''
-    scan_advanced_output = attributes.AttributeEnum(attributes.AttributeViInt32(1250023), enums.ScanAdvancedOutput)
+    scan_advanced_output = attributes.AttributeEnum(attributes.AttributeViInt32, enums.ScanAdvancedOutput, 1250023)
     '''
     Specifies the method to use to notify another instrument that all
     signals through the switch module have settled following the processing
@@ -580,7 +580,7 @@ class Session(object):
     `niSwitch Properties <switchpropref.chm::/cniSwitch.html>`__
     `Scanning <SWITCH.chm::/scanning_fundamentals.html>`__
     '''
-    scan_advanced_polarity = attributes.AttributeEnum(attributes.AttributeViInt32(1150011), enums.ScanAdvancedPolarity)
+    scan_advanced_polarity = attributes.AttributeEnum(attributes.AttributeViInt32, enums.ScanAdvancedPolarity, 1150011)
     '''
     Specifies the driving level for the Scan Advanced Output signal sent
     from the switch module through either the external (PXI/PXIe) or front
@@ -651,7 +651,7 @@ class Session(object):
     Lists <SWITCH.chm::/scan_list.html>`__
     `Scanning <SWITCH.chm::/scanning_fundamentals.html>`__
     '''
-    scan_mode = attributes.AttributeEnum(attributes.AttributeViInt32(1250021), enums.ScanMode)
+    scan_mode = attributes.AttributeEnum(attributes.AttributeViInt32, enums.ScanMode, 1250021)
     '''
     Specifies how to handle existing connections that conflict with the
     connections you make in a scan list. For example, if CH1 is already
@@ -782,7 +782,7 @@ class Session(object):
 
     `niSwitch Properties <switchpropref.chm::/cniSwitch.html>`__
     '''
-    trigger_input = attributes.AttributeEnum(attributes.AttributeViInt32(1250022), enums.TriggerInput)
+    trigger_input = attributes.AttributeEnum(attributes.AttributeViInt32, enums.TriggerInput, 1250022)
     '''
     Specifies the source of the trigger for which the switch module can wait
     upon encountering a semi-colon (;) when processing a scan list. When the
@@ -796,7 +796,7 @@ class Session(object):
     Properties <switchpropref.chm::/cniSwitch.html>`__
     `Scanning <SWITCH.chm::/scanning_fundamentals.html>`__
     '''
-    trigger_input_polarity = attributes.AttributeEnum(attributes.AttributeViInt32(1150010), enums.TriggerInputPolarity)
+    trigger_input_polarity = attributes.AttributeEnum(attributes.AttributeViInt32, enums.TriggerInputPolarity, 1150010)
     '''
     Determines the behavior of the trigger input.
 

--- a/src/nifake/metadata/attributes.py
+++ b/src/nifake/metadata/attributes.py
@@ -76,4 +76,16 @@ attributes = {
             'description':'An attribute of type integer with read/write access.',
         },
     },
+    1000005: {
+        'access': 'read-write',
+        'channel_based': 'False',
+        'enum': 'FloatEnum',
+        'lv_property': 'Fake attributes:Float enum',
+        'name': 'FLOAT_ENUM',
+        'resettable': 'No',
+        'type': 'ViReal64',
+        'documentation': {
+            'description': 'An attribute with an enum that is also a float',
+        },
+    },
 }

--- a/src/nifake/metadata/enums.py
+++ b/src/nifake/metadata/enums.py
@@ -66,5 +66,44 @@ enums = {
                 }
             },
         ],
-    }
+    },
+    'FloatEnum': {
+        'values': [
+            {
+                'name': '_3_5',
+                'value': 3.5,
+                'documentation': {
+                    'description': 'Specifies 3.5 digits resolution.',
+                },
+            },
+            {
+                'name': '_4_5',
+                'value': 4.5,
+                'documentation': {
+                    'description': 'Specifies 4.5 digits resolution.',
+                },
+            },
+            {
+                'name': '_5_5',
+                'value': 5.5,
+                'documentation': {
+                    'description': 'Specifies 5.5 digits resolution.',
+                },
+            },
+            {
+                'name': '_6_5',
+                'value': 6.5,
+                'documentation': {
+                    'description': 'Specifies 6.5 digits resolution.',
+                },
+            },
+            {
+                'name': '_7_5',
+                'value': 7.5,
+                'documentation': {
+                    'description': 'Specifies 7.5 digits resolution.',
+                },
+            },
+        ],
+    },
 }

--- a/src/nifake/tests/test_session.py
+++ b/src/nifake/tests/test_session.py
@@ -256,6 +256,14 @@ class TestSession(object):
             attribute_id = 1000003
             self.patched_library.niFake_SetAttributeViInt32.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', attribute_id, enum_value.value)
 
+    def test_set_float_enum_attribute(self):
+        self.patched_library.niFake_SetAttributeViReal64.side_effect = self.side_effects_helper.niFake_SetAttributeViReal64
+        enum_value = nifake.FloatEnum._5_5
+        with nifake.Session('dev1') as session:
+            session.float_enum = enum_value
+            attribute_id = 1000005
+            self.patched_library.niFake_SetAttributeViReal64.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', attribute_id, enum_value.value)
+
     def test_set_enum_attribute_bad_type(self):
         with nifake.Session('dev1') as session:
             try:
@@ -270,6 +278,15 @@ class TestSession(object):
             assert session.read_write_color == nifake.Color.BLUE
             attribute_id = 1000003
             self.patched_library.niFake_GetAttributeViInt32.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', attribute_id, ANY)
+
+    def test_get_float_enum_attribute(self):
+        self.patched_library.niFake_GetAttributeViReal64.side_effect = self.side_effects_helper.niFake_GetAttributeViReal64
+        enum_value = nifake.FloatEnum._6_5
+        self.side_effects_helper['GetAttributeViReal64']['attributeValue'] = enum_value.value
+        with nifake.Session('dev1') as session:
+            assert session.float_enum == enum_value
+            attribute_id = 1000005
+            self.patched_library.niFake_GetAttributeViReal64.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', attribute_id, ANY)
 
     def test_acquisition_context_manager(self):
         self.patched_library.niFake_Initiate.side_effect = self.side_effects_helper.niFake_Initiate
@@ -436,3 +453,6 @@ class TestSession(object):
         self.side_effects_helper['Read']['reading'] = test_reading
         with nifake.Session('dev1') as session:
             assert math.isnan(session.read(test_maximum_time))
+
+
+


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md]
### What does this Pull Request accomplish?
* Fixes #330 
* Changes to `AttributeEnum()`
  * Now inherits from `object` instead of `AttributeViInt32`
  * Class of appropriate underlying type is passed in to the constructor
    ``` python
    resolution_digits = attributes.AttributeEnum(attributes.AttributeViReal64, enums.DigitsResolution, 1250003)
    ```
  * Instantiates the underlying type and uses that for actual get/set
  * Enum type is still used to return the correct type and to do type checking on the incoming type
* Tests added to get/set float based enum

### Why should this Pull Request be merged?
* Fixes issue

### What testing has been done?
* Travis
* System tests