### PR TITLE
Only add examples if they end in .py

### DIFF
--- a/build/templates/examples.rst.mako
+++ b/build/templates/examples.rst.mako
@@ -7,7 +7,7 @@
     import os
 
     examples_dir = os.path.join('src', module_name, 'examples')
-    examples = [f for f in os.listdir(examples_dir) if os.path.isfile(os.path.join(examples_dir, f))]
+    examples = [f for f in os.listdir(examples_dir) if os.path.isfile(os.path.join(examples_dir, f)) and f.endswith('.py')]
 %>\
 ${helper.get_rst_header_snippet('Examples', '=')}
 


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md]
### What does this Pull Request accomplish?
* We shouldn't add as an example in documentation a file that doesn't end in '.py'. Some OSes may add files in there for different reasons (macOS for instance created .DSStore files)

### Why should this Pull Request be merged?
* Better documentation

### What testing has been done?
* Manually added non .py file and example.rst didn't change