### PR TITLE
Fix #343: _RepeatedCapability should not be a context manager

### DIFF
--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -151,12 +151,6 @@ class _RepeatedCapability(_SessionBase):
         self.${config['session_handle_parameter_name']} = vi
         self._is_frozen = True
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        pass
-
 
 class Session(_SessionBase):
     '''${config['session_class_description']}'''

--- a/generated/nidmm/session.py
+++ b/generated/nidmm/session.py
@@ -3066,12 +3066,6 @@ class _RepeatedCapability(_SessionBase):
         self.vi = vi
         self._is_frozen = True
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        pass
-
 
 class Session(_SessionBase):
     '''An NI-DMM session to a National Instruments Digital Multimeter'''

--- a/generated/nifake/session.py
+++ b/generated/nifake/session.py
@@ -531,12 +531,6 @@ class _RepeatedCapability(_SessionBase):
         self.vi = vi
         self._is_frozen = True
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        pass
-
 
 class Session(_SessionBase):
     '''An NI-FAKE session to a fake MI driver whose sole purpose is to test nimi-python code generation'''

--- a/generated/nifake/tests/test_session.py
+++ b/generated/nifake/tests/test_session.py
@@ -399,32 +399,6 @@ class TestSession(object):
             session['0-24'].read_write_double = test_number
             self.patched_library.niFake_SetAttributeViReal64.assert_called_once_with(SESSION_NUM_FOR_TEST, b'0-24', attribute_id, test_number)
 
-    def test_get_attribute_channel_context_manager_string_and_boolean(self):
-        self.patched_library.niFake_GetAttributeViString.side_effect = self.side_effects_helper.niFake_GetAttributeViString
-        test_string = 'Hello World!'
-        self.side_effects_helper['GetAttributeViString']['attributeValue'] = test_string
-        self.patched_library.niFake_GetAttributeViBoolean.side_effect = self.side_effects_helper.niFake_GetAttributeViBoolean
-        self.side_effects_helper['GetAttributeViBoolean']['attributeValue'] = 0
-        with nifake.Session('dev1') as session:
-            with session['5'] as channel5:
-                assert test_string == channel5.read_write_string
-                assert not channel5.read_write_bool
-            from mock import call
-            calls = [call(SESSION_NUM_FOR_TEST, b'5', 1000002, 0, None), call(SESSION_NUM_FOR_TEST, b'5', 1000002, len('Hello World!'), ANY)]
-            self.patched_library.niFake_GetAttributeViString.assert_has_calls(calls)
-            assert self.patched_library.niFake_GetAttributeViString.call_count == 2
-            self.patched_library.niFake_GetAttributeViBoolean.assert_called_once_with(SESSION_NUM_FOR_TEST, b'5', 1000000, ANY)
-
-    def test_set_attribute_channel_context_manager_boolean_and_enum(self):
-        self.patched_library.niFake_SetAttributeViBoolean.side_effect = self.side_effects_helper.niFake_SetAttributeViBoolean
-        self.patched_library.niFake_SetAttributeViInt32.side_effect = self.side_effects_helper.niFake_SetAttributeViInt32
-        with nifake.Session('dev1') as session:
-            with session['3'] as channel3:
-                channel3.read_write_bool = True
-                channel3.read_write_color = nifake.Color.YELLOW
-            self.patched_library.niFake_SetAttributeViInt32.assert_called_once_with(SESSION_NUM_FOR_TEST, b'3', 1000003, 2)
-            self.patched_library.niFake_SetAttributeViBoolean.assert_called_once_with(SESSION_NUM_FOR_TEST, b'3', 1000000, 1)
-
     def test_set_attribute_error(self):
         test_error_code = -1
         test_error_desc = 'Test'

--- a/generated/niswitch/session.py
+++ b/generated/niswitch/session.py
@@ -2435,12 +2435,6 @@ class _RepeatedCapability(_SessionBase):
         self.vi = vi
         self._is_frozen = True
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        pass
-
 
 class Session(_SessionBase):
     '''An NI-SWITCH session to a National Instruments Switch Module'''

--- a/src/nifake/tests/test_session.py
+++ b/src/nifake/tests/test_session.py
@@ -399,32 +399,6 @@ class TestSession(object):
             session['0-24'].read_write_double = test_number
             self.patched_library.niFake_SetAttributeViReal64.assert_called_once_with(SESSION_NUM_FOR_TEST, b'0-24', attribute_id, test_number)
 
-    def test_get_attribute_channel_context_manager_string_and_boolean(self):
-        self.patched_library.niFake_GetAttributeViString.side_effect = self.side_effects_helper.niFake_GetAttributeViString
-        test_string = 'Hello World!'
-        self.side_effects_helper['GetAttributeViString']['attributeValue'] = test_string
-        self.patched_library.niFake_GetAttributeViBoolean.side_effect = self.side_effects_helper.niFake_GetAttributeViBoolean
-        self.side_effects_helper['GetAttributeViBoolean']['attributeValue'] = 0
-        with nifake.Session('dev1') as session:
-            with session['5'] as channel5:
-                assert test_string == channel5.read_write_string
-                assert not channel5.read_write_bool
-            from mock import call
-            calls = [call(SESSION_NUM_FOR_TEST, b'5', 1000002, 0, None), call(SESSION_NUM_FOR_TEST, b'5', 1000002, len('Hello World!'), ANY)]
-            self.patched_library.niFake_GetAttributeViString.assert_has_calls(calls)
-            assert self.patched_library.niFake_GetAttributeViString.call_count == 2
-            self.patched_library.niFake_GetAttributeViBoolean.assert_called_once_with(SESSION_NUM_FOR_TEST, b'5', 1000000, ANY)
-
-    def test_set_attribute_channel_context_manager_boolean_and_enum(self):
-        self.patched_library.niFake_SetAttributeViBoolean.side_effect = self.side_effects_helper.niFake_SetAttributeViBoolean
-        self.patched_library.niFake_SetAttributeViInt32.side_effect = self.side_effects_helper.niFake_SetAttributeViInt32
-        with nifake.Session('dev1') as session:
-            with session['3'] as channel3:
-                channel3.read_write_bool = True
-                channel3.read_write_color = nifake.Color.YELLOW
-            self.patched_library.niFake_SetAttributeViInt32.assert_called_once_with(SESSION_NUM_FOR_TEST, b'3', 1000003, 2)
-            self.patched_library.niFake_SetAttributeViBoolean.assert_called_once_with(SESSION_NUM_FOR_TEST, b'3', 1000000, 1)
-
     def test_set_attribute_error(self):
         test_error_code = -1
         test_error_desc = 'Test'

--- a/src/niswitch/examples/niswitch_get_device_info.py
+++ b/src/niswitch/examples/niswitch_get_device_info.py
@@ -31,8 +31,8 @@ try:
             print(row_format.format('Number', 'Name', 'Is Configuration', 'Is Source'))
             for i in range(1, session.channel_count + 1):
                 channel_name = session.get_channel_name(i)
-                with session[channel_name] as channel:
-                    print(row_format.format(i, channel_name, str(channel.is_configuration_channel), str(channel.is_source_channel)))
+                channel = session[channel_name]
+                print(row_format.format(i, channel_name, str(channel.is_configuration_channel), str(channel.is_source_channel)))
         if args.relay:
             print('Realy Info:')
             row_format = '{:6}' + ' ' * 12 + '{:<15}{:<22}{:6}'


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md]

### What does this Pull Request accomplish?

Removes context manager from _RepeatedCapability class. This was judged to be an abuse of Python context managers.

### Why should this Pull Request be merged?

Puts our API closer to where we want it to be.

### What testing has been done?

tox