### PR TITLE
Add underscore prefix to all private members

### DIFF
--- a/build/helper/codegen_helper.py
+++ b/build/helper/codegen_helper.py
@@ -11,6 +11,7 @@ pp = pprint.PrettyPrinter(indent=4)
 
 # Functions that return snippets that can be placed directly in the templates.
 class ParamListType(Enum):
+    # TODO(marcoskirsch): DRY - seems like a shame to type this for doc and later for declaration.
     '''Type of parameter list to return
 
     Used by different parts of the code generator to create the parameter list
@@ -23,7 +24,7 @@ class ParamListType(Enum):
     'skip_output_parameters': True,
     'skip_ivi_dance_size_parameter': True,
     'reordered_for_default_values': True,
-    'session_name': 'vi',
+    'session_handle_parameter_name': 'vi',
     'name_to_use': 'python_name_with_default',
     '''
     API_METHOD_CALL = 2
@@ -34,7 +35,7 @@ class ParamListType(Enum):
     'skip_output_parameters': True,
     'skip_ivi_dance_size_parameter': True,
     'reordered_for_default_values': True,
-    'session_name': 'vi',
+    'session_handle_parameter_name': 'vi',
     'name_to_use': 'python_name',
     '''
     DISPLAY_METHOD = 3
@@ -45,7 +46,7 @@ class ParamListType(Enum):
     'skip_output_parameters': True,
     'skip_ivi_dance_size_parameter': True,
     'reordered_for_default_values': True,
-    'session_name': 'vi',
+    'session_handle_parameter_name': 'vi',
     'name_to_use': 'python_name',
     '''
     LIBRARY_METHOD = 4
@@ -56,7 +57,7 @@ class ParamListType(Enum):
     'skip_output_parameters': False,
     'skip_ivi_dance_size_parameter': False,
     'reordered_for_default_values': True,
-    'session_name': 'vi',
+    'session_handle_parameter_name': 'vi',
     'name_to_use': 'python_name',
     '''
     LIBRARY_CALL = 5
@@ -67,8 +68,8 @@ class ParamListType(Enum):
     'skip_output_parameters': False,
     'skip_ivi_dance_size_parameter': False,
     'reordered_for_default_values': False,
-    'session_name': 'vi',
-    'name_to_use': 'library_call_name',
+    'session_handle_parameter_name': 'vi',
+    'name_to_use': 'library_call_snippet',
     '''
     LIBRARY_CALL_TYPES = 6
     '''Used for methods param list types when calling into the DLL
@@ -78,7 +79,7 @@ class ParamListType(Enum):
     'skip_output_parameters': False,
     'skip_ivi_dance_size_parameter': False,
     'reordered_for_default_values': False,
-    'session_name': 'vi',
+    'session_handle_parameter_name': 'vi',
     'name_to_use': 'ctypes_type_library_call',
     '''
     LIBRARY_IMPL_METHOD = 7
@@ -89,7 +90,7 @@ class ParamListType(Enum):
     'skip_output_parameters': False,
     'skip_ivi_dance_size_parameter': False,
     'reordered_for_default_values': False,
-    'session_name': 'vi',
+    'session_handle_parameter_name': 'vi',
     'name_to_use': 'python_name',
     '''
 
@@ -101,7 +102,7 @@ ParamListTypeDefaults[ParamListType.API_METHOD_DECLARATION] = {
     'skip_output_parameters': True,
     'skip_ivi_dance_size_parameter': True,
     'reordered_for_default_values': True,
-    'session_name': 'vi',
+    'session_handle_parameter_name': 'vi',
     'name_to_use': 'python_name_with_default',
 }
 ParamListTypeDefaults[ParamListType.API_METHOD_CALL] = {
@@ -110,7 +111,7 @@ ParamListTypeDefaults[ParamListType.API_METHOD_CALL] = {
     'skip_output_parameters': True,
     'skip_ivi_dance_size_parameter': True,
     'reordered_for_default_values': True,
-    'session_name': 'vi',
+    'session_handle_parameter_name': 'vi',
     'name_to_use': 'python_name',
 }
 ParamListTypeDefaults[ParamListType.DISPLAY_METHOD] = {
@@ -119,7 +120,7 @@ ParamListTypeDefaults[ParamListType.DISPLAY_METHOD] = {
     'skip_output_parameters': True,
     'skip_ivi_dance_size_parameter': True,
     'reordered_for_default_values': True,
-    'session_name': 'vi',
+    'session_handle_parameter_name': 'vi',
     'name_to_use': 'python_name',
 }
 ParamListTypeDefaults[ParamListType.LIBRARY_METHOD] = {
@@ -128,7 +129,7 @@ ParamListTypeDefaults[ParamListType.LIBRARY_METHOD] = {
     'skip_output_parameters': False,
     'skip_ivi_dance_size_parameter': False,
     'reordered_for_default_values': False,
-    'session_name': 'vi',
+    'session_handle_parameter_name': 'vi',
     'name_to_use': 'python_name',
 }
 ParamListTypeDefaults[ParamListType.LIBRARY_CALL] = {
@@ -137,8 +138,8 @@ ParamListTypeDefaults[ParamListType.LIBRARY_CALL] = {
     'skip_output_parameters': False,
     'skip_ivi_dance_size_parameter': False,
     'reordered_for_default_values': False,
-    'session_name': 'vi',
-    'name_to_use': 'library_call_name',
+    'session_handle_parameter_name': 'vi',
+    'name_to_use': 'library_call_snippet',
 }
 ParamListTypeDefaults[ParamListType.LIBRARY_CALL_TYPES] = {
     'skip_self': True,
@@ -146,7 +147,7 @@ ParamListTypeDefaults[ParamListType.LIBRARY_CALL_TYPES] = {
     'skip_output_parameters': False,
     'skip_ivi_dance_size_parameter': False,
     'reordered_for_default_values': False,
-    'session_name': 'vi',
+    'session_handle_parameter_name': 'vi',
     'name_to_use': 'ctypes_type_library_call',
 }
 ParamListTypeDefaults[ParamListType.LIBRARY_IMPL_METHOD] = {
@@ -155,7 +156,7 @@ ParamListTypeDefaults[ParamListType.LIBRARY_IMPL_METHOD] = {
     'skip_output_parameters': False,
     'skip_ivi_dance_size_parameter': False,
     'reordered_for_default_values': False,
-    'session_name': 'vi',
+    'session_handle_parameter_name': 'vi',
     'name_to_use': 'python_name',
 }
 
@@ -164,7 +165,7 @@ def get_params_snippet(function, param_type, options={}):
     '''Get a parameter list snippet based on type and options
 
     Name used:
-        ParamListType.LIBRARY_CALL uses 'library_call_name'
+        ParamListType.LIBRARY_CALL uses 'library_call_snippet'
         ParamListType.LIBRARY_CALL_TYPES uses 'ctypes_type_library_call'
         All others use 'python_name'
     '''
@@ -177,7 +178,6 @@ def get_params_snippet(function, param_type, options={}):
     for o in options:
         options_to_use[o] = options[o]
 
-    name_to_use = options_to_use['name_to_use']
     params_to_use = []
 
     snippets = []
@@ -192,7 +192,7 @@ def get_params_snippet(function, param_type, options={}):
             skip = True
         if x == ivi_dance_size_parameter and options_to_use['skip_ivi_dance_size_parameter']:
             skip = True
-        if x['name'] == options_to_use['session_name'] and options_to_use['skip_session_handle']:
+        if x['name'] == options_to_use['session_handle_parameter_name'] and options_to_use['skip_session_handle']:
             skip = True
         if not skip:
             params_to_use.append(x)
@@ -211,7 +211,7 @@ def get_params_snippet(function, param_type, options={}):
 
     # Render based on options
     for x in params_to_use:
-            snippets.append(x[name_to_use])
+            snippets.append(x[options_to_use['name_to_use']])
     return ', '.join(snippets)
 
 

--- a/build/helper/metadata_add_all.py
+++ b/build/helper/metadata_add_all.py
@@ -101,24 +101,24 @@ def _add_buffer_info(parameter):
     return parameter
 
 
-def _add_library_call_name(parameter, session_name):
+def _add_library_call_snippet(parameter, session_handle_parameter_name):
     if parameter['direction'] == 'in':
-        if parameter['name'] == session_name:
-            library_call_name = 'self.' + session_name
+        if parameter['name'] == session_handle_parameter_name:
+            library_call_snippet = 'self._' + session_handle_parameter_name
         else:
-            library_call_name = parameter['python_name']
-            library_call_name += '.value' if parameter['enum'] is not None else ''
+            library_call_snippet = parameter['python_name']
+            library_call_snippet += '.value' if parameter['enum'] is not None else ''
             if parameter['type'] == 'ViString' or parameter['type'] == 'ViConstString' or parameter['type'] == 'ViRsrc':
-                library_call_name += '.encode(\'ascii\')'
+                library_call_snippet += '.encode(\'ascii\')'
     else:
         assert parameter['direction'] == 'out', pp.pformat(parameter)
         if parameter['size']['mechanism'] == 'ivi-dance':
-            library_call_name = parameter['ctypes_variable_name']
+            library_call_snippet = parameter['ctypes_variable_name']
         elif parameter['is_buffer']:
-            library_call_name = 'ctypes.cast(' + parameter['ctypes_variable_name'] + ', ctypes.POINTER(ctypes_types.' + parameter['ctypes_type'] + '))'
+            library_call_snippet = 'ctypes.cast(' + parameter['ctypes_variable_name'] + ', ctypes.POINTER(ctypes_types.' + parameter['ctypes_type'] + '))'
         else:
-            library_call_name = 'ctypes.pointer(' + (parameter['ctypes_variable_name']) + ')'
-    parameter['library_call_name'] = library_call_name
+            library_call_snippet = 'ctypes.pointer(' + (parameter['ctypes_variable_name']) + ')'
+    parameter['library_call_snippet'] = library_call_snippet
 
 
 def _add_default_value_name(parameter):
@@ -148,7 +148,7 @@ def add_all_function_metadata(functions, config):
             _add_ctypes_variable_name(p)
             _add_ctypes_type(p)
             _add_buffer_info(p)
-            _add_library_call_name(p, config['session_handle_parameter_name'])
+            _add_library_call_snippet(p, config['session_handle_parameter_name'])
             _add_default_value_name(p)
     return functions
 
@@ -209,7 +209,7 @@ def test_add_all_metadata_simple():
                         'value': 1
                     },
                     'type': 'ViSession',
-                    'library_call_name': 'self.vi',
+                    'library_call_snippet': 'self._vi',
                 }
             ],
             'python_name': 'close',

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -156,7 +156,6 @@ class Session(_SessionBase):
 
     def __init__(${init_method_params}):
         super(Session, self).__init__(repeated_capability='')
-        # TODO(marcoskirsch): private members should start with _
         self._${config['session_handle_parameter_name']} = 0  # This must be set before calling ${init_function['python_name']}().
         self._${config['session_handle_parameter_name']} = self.${init_function['python_name']}(${init_call_params})
         self._is_frozen = True

--- a/generated/nidmm/session.py
+++ b/generated/nidmm/session.py
@@ -12,14 +12,14 @@ from nidmm import python_types
 
 class _Acquisition(object):
     def __init__(self, session):
-        self.session = session
+        self._session = session
 
     def __enter__(self):
-        self.session._initiate()
+        self._session._initiate()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.session._abort()
+        self._session._abort()
 
 
 class _SessionBase(object):
@@ -773,8 +773,7 @@ class _SessionBase(object):
     '''
 
     def __init__(self, repeated_capability):
-        # TODO(marcoskirsch): rename to _library.
-        self.library = library_singleton.get()
+        self._library = library_singleton.get()
         self._repeated_capability = repeated_capability
 
     def __setattr__(self, key, value):
@@ -812,7 +811,7 @@ class _SessionBase(object):
         Aborts a previously initiated measurement and returns the DMM to the
         Idle state.
         '''
-        error_code = self.library.niDMM_Abort(self.vi)
+        error_code = self._library.niDMM_Abort(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -821,7 +820,7 @@ class _SessionBase(object):
 
         Clears the list of current interchange warnings.
         '''
-        error_code = self.library.niDMM_ClearInterchangeWarnings(self.vi)
+        error_code = self._library.niDMM_ClearInterchangeWarnings(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -851,7 +850,7 @@ class _SessionBase(object):
                 Hz–300 kHz for the NI 4080/4081/4082 and the NI 4070/4071/4072, 10
                 Hz–100 Hz for the NI 4065, and 20 Hz–25 kHz for the NI 4050 and NI 4060.
         '''
-        error_code = self.library.niDMM_ConfigureACBandwidth(self.vi, ac_minimum_frequency_hz, ac_maximum_frequency_hz)
+        error_code = self._library.niDMM_ConfigureACBandwidth(self._vi, ac_minimum_frequency_hz, ac_maximum_frequency_hz)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -890,7 +889,7 @@ class _SessionBase(object):
         '''
         if type(adc_calibration) is not enums.ADCCalibration:
             raise TypeError('Parameter mode must be of type ' + str(enums.ADCCalibration))
-        error_code = self.library.niDMM_ConfigureADCCalibration(self.vi, adc_calibration.value)
+        error_code = self._library.niDMM_ConfigureADCCalibration(self._vi, adc_calibration.value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -943,7 +942,7 @@ class _SessionBase(object):
         '''
         if type(auto_zero_mode) is not enums.AutoZero:
             raise TypeError('Parameter mode must be of type ' + str(enums.AutoZero))
-        error_code = self.library.niDMM_ConfigureAutoZeroMode(self.vi, auto_zero_mode.value)
+        error_code = self._library.niDMM_ConfigureAutoZeroMode(self._vi, auto_zero_mode.value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -960,7 +959,7 @@ class _SessionBase(object):
         '''
         if type(cable_comp_type) is not enums.CableCompensationType:
             raise TypeError('Parameter mode must be of type ' + str(enums.CableCompensationType))
-        error_code = self.library.niDMM_ConfigureCableCompType(self.vi, cable_comp_type.value)
+        error_code = self._library.niDMM_ConfigureCableCompType(self._vi, cable_comp_type.value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -987,7 +986,7 @@ class _SessionBase(object):
         '''
         if type(current_source) is not enums.CurrentSource:
             raise TypeError('Parameter mode must be of type ' + str(enums.CurrentSource))
-        error_code = self.library.niDMM_ConfigureCurrentSource(self.vi, current_source.value)
+        error_code = self._library.niDMM_ConfigureCurrentSource(self._vi, current_source.value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1003,7 +1002,7 @@ class _SessionBase(object):
                 degrees Celsius. NI-DMM uses this value to set the Fixed Reference
                 Junction property. The default is 25.00 (°C).
         '''
-        error_code = self.library.niDMM_ConfigureFixedRefJunction(self.vi, fixed_reference_junction)
+        error_code = self._library.niDMM_ConfigureFixedRefJunction(self._vi, fixed_reference_junction)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1036,7 +1035,7 @@ class _SessionBase(object):
                 | NIDMM_VAL_AUTO_RANGE_OFF          | -2.0  | Disables Auto Ranging. The driver sets the voltage range to the last calculated voltage range.                                   |
                 +-----------------------------------+-------+----------------------------------------------------------------------------------------------------------------------------------+
         '''
-        error_code = self.library.niDMM_ConfigureFrequencyVoltageRange(self.vi, voltage_range)
+        error_code = self._library.niDMM_ConfigureFrequencyVoltageRange(self._vi, voltage_range)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1062,7 +1061,7 @@ class _SessionBase(object):
         '''
         if type(meas_complete_destination) is not enums.MeasurementCompleteDest:
             raise TypeError('Parameter mode must be of type ' + str(enums.MeasurementCompleteDest))
-        error_code = self.library.niDMM_ConfigureMeasCompleteDest(self.vi, meas_complete_destination.value)
+        error_code = self._library.niDMM_ConfigureMeasCompleteDest(self._vi, meas_complete_destination.value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1084,7 +1083,7 @@ class _SessionBase(object):
         '''
         if type(meas_complete_slope) is not enums.Slope:
             raise TypeError('Parameter mode must be of type ' + str(enums.Slope))
-        error_code = self.library.niDMM_ConfigureMeasCompleteSlope(self.vi, meas_complete_slope.value)
+        error_code = self._library.niDMM_ConfigureMeasCompleteSlope(self._vi, meas_complete_slope.value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1136,7 +1135,7 @@ class _SessionBase(object):
         '''
         if type(measurement_function) is not enums.Function:
             raise TypeError('Parameter mode must be of type ' + str(enums.Function))
-        error_code = self.library.niDMM_ConfigureMeasurementAbsolute(self.vi, measurement_function.value, range, resolution_absolute)
+        error_code = self._library.niDMM_ConfigureMeasurementAbsolute(self._vi, measurement_function.value, range, resolution_absolute)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1191,7 +1190,7 @@ class _SessionBase(object):
         '''
         if type(measurement_function) is not enums.Function:
             raise TypeError('Parameter mode must be of type ' + str(enums.Function))
-        error_code = self.library.niDMM_ConfigureMeasurementDigits(self.vi, measurement_function.value, range, resolution_digits)
+        error_code = self._library.niDMM_ConfigureMeasurementDigits(self._vi, measurement_function.value, range, resolution_digits)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1243,7 +1242,7 @@ class _SessionBase(object):
         '''
         if type(sample_trigger) is not enums.SampleTrigger:
             raise TypeError('Parameter mode must be of type ' + str(enums.SampleTrigger))
-        error_code = self.library.niDMM_ConfigureMultiPoint(self.vi, trigger_count, sample_count, sample_trigger.value, sample_interval)
+        error_code = self._library.niDMM_ConfigureMultiPoint(self._vi, trigger_count, sample_count, sample_trigger.value, sample_interval)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1272,7 +1271,7 @@ class _SessionBase(object):
         '''
         if type(offset_comp_ohms) is not enums.OffsetCompensatedOhms:
             raise TypeError('Parameter mode must be of type ' + str(enums.OffsetCompensatedOhms))
-        error_code = self.library.niDMM_ConfigureOffsetCompOhms(self.vi, offset_comp_ohms.value)
+        error_code = self._library.niDMM_ConfigureOffsetCompOhms(self._vi, offset_comp_ohms.value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1287,7 +1286,7 @@ class _SessionBase(object):
             conductance (float):Specifies the open cable compensation **conductance**.
             susceptance (float):Specifies the open cable compensation **susceptance**.
         '''
-        error_code = self.library.niDMM_ConfigureOpenCableCompValues(self.vi, conductance, susceptance)
+        error_code = self._library.niDMM_ConfigureOpenCableCompValues(self._vi, conductance, susceptance)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1300,7 +1299,7 @@ class _SessionBase(object):
             power_line_frequency_hz (float):**Powerline Frequency** specifies the powerline frequency in hertz.
                 NI-DMM sets the Powerline Frequency property to this value.
         '''
-        error_code = self.library.niDMM_ConfigurePowerLineFrequency(self.vi, power_line_frequency_hz)
+        error_code = self._library.niDMM_ConfigurePowerLineFrequency(self._vi, power_line_frequency_hz)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1320,7 +1319,7 @@ class _SessionBase(object):
                 Type parameter is set to Custom in the configure_rtd_type function.
                 The default is -4.183e-12 (Pt3851).
         '''
-        error_code = self.library.niDMM_ConfigureRTDCustom(self.vi, rtd_a, rtd_b, rtd_c)
+        error_code = self._library.niDMM_ConfigureRTDCustom(self._vi, rtd_a, rtd_b, rtd_c)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1356,7 +1355,7 @@ class _SessionBase(object):
             rtd_resistance (float):Specifies the RTD resistance in ohms at 0 °C. NI-DMM uses this value to
                 set the RTD Resistance property. The default is 100 (Ω).
         '''
-        error_code = self.library.niDMM_ConfigureRTDType(self.vi, rtd_type, rtd_resistance)
+        error_code = self._library.niDMM_ConfigureRTDType(self._vi, rtd_type, rtd_resistance)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1380,7 +1379,7 @@ class _SessionBase(object):
         '''
         if type(sample_trigger_slope) is not enums.Slope:
             raise TypeError('Parameter mode must be of type ' + str(enums.Slope))
-        error_code = self.library.niDMM_ConfigureSampleTriggerSlope(self.vi, sample_trigger_slope.value)
+        error_code = self._library.niDMM_ConfigureSampleTriggerSlope(self._vi, sample_trigger_slope.value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1395,7 +1394,7 @@ class _SessionBase(object):
             resistance (float):Specifies the short cable compensation **resistance**.
             reactance (float):Specifies the short cable compensation **reactance**.
         '''
-        error_code = self.library.niDMM_ConfigureShortCableCompValues(self.vi, resistance, reactance)
+        error_code = self._library.niDMM_ConfigureShortCableCompValues(self._vi, resistance, reactance)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1415,7 +1414,7 @@ class _SessionBase(object):
                 Thermistor Type is set to Custom in the configure_thermistor_type
                 function. The default is 1.568e-7 (44006).
         '''
-        error_code = self.library.niDMM_ConfigureThermistorCustom(self.vi, thermistor_a, thermistor_b, thermistor_c)
+        error_code = self._library.niDMM_ConfigureThermistorCustom(self._vi, thermistor_a, thermistor_b, thermistor_c)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1448,7 +1447,7 @@ class _SessionBase(object):
         '''
         if type(thermistor_type) is not enums.TemperatureThermistorType:
             raise TypeError('Parameter mode must be of type ' + str(enums.TemperatureThermistorType))
-        error_code = self.library.niDMM_ConfigureThermistorType(self.vi, thermistor_type.value)
+        error_code = self._library.niDMM_ConfigureThermistorType(self._vi, thermistor_type.value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1487,7 +1486,7 @@ class _SessionBase(object):
         '''
         if type(thermocouple_type) is not enums.ThermocoupleType:
             raise TypeError('Parameter mode must be of type ' + str(enums.ThermocoupleType))
-        error_code = self.library.niDMM_ConfigureThermocouple(self.vi, thermocouple_type.value, reference_junction_type)
+        error_code = self._library.niDMM_ConfigureThermocouple(self._vi, thermocouple_type.value, reference_junction_type)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1513,7 +1512,7 @@ class _SessionBase(object):
         '''
         if type(transducer_type) is not enums.TemperatureTransducerType:
             raise TypeError('Parameter mode must be of type ' + str(enums.TemperatureTransducerType))
-        error_code = self.library.niDMM_ConfigureTransducerType(self.vi, transducer_type.value)
+        error_code = self._library.niDMM_ConfigureTransducerType(self._vi, transducer_type.value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1552,7 +1551,7 @@ class _SessionBase(object):
         '''
         if type(trigger_source) is not enums.TriggerSource:
             raise TypeError('Parameter mode must be of type ' + str(enums.TriggerSource))
-        error_code = self.library.niDMM_ConfigureTrigger(self.vi, trigger_source.value, trigger_delay)
+        error_code = self._library.niDMM_ConfigureTrigger(self._vi, trigger_source.value, trigger_delay)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1576,7 +1575,7 @@ class _SessionBase(object):
         '''
         if type(trigger_slope) is not enums.Slope:
             raise TypeError('Parameter mode must be of type ' + str(enums.Slope))
-        error_code = self.library.niDMM_ConfigureTriggerSlope(self.vi, trigger_slope.value)
+        error_code = self._library.niDMM_ConfigureTriggerSlope(self._vi, trigger_slope.value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1623,7 +1622,7 @@ class _SessionBase(object):
         '''
         if type(measurement_function) is not enums.Function:
             raise TypeError('Parameter mode must be of type ' + str(enums.Function))
-        error_code = self.library.niDMM_ConfigureWaveformAcquisition(self.vi, measurement_function.value, range, rate, waveform_points)
+        error_code = self._library.niDMM_ConfigureWaveformAcquisition(self._vi, measurement_function.value, range, rate, waveform_points)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1647,7 +1646,7 @@ class _SessionBase(object):
         '''
         if type(waveform_coupling) is not enums.WaveformCouplingMode:
             raise TypeError('Parameter mode must be of type ' + str(enums.WaveformCouplingMode))
-        error_code = self.library.niDMM_ConfigureWaveformCoupling(self.vi, waveform_coupling.value)
+        error_code = self._library.niDMM_ConfigureWaveformCoupling(self._vi, waveform_coupling.value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1658,7 +1657,7 @@ class _SessionBase(object):
         impact on the system to which it is connected. If a measurement is in
         progress when this function is called, the measurement is aborted.
         '''
-        error_code = self.library.niDMM_Disable(self.vi)
+        error_code = self._library.niDMM_Disable(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1684,7 +1683,7 @@ class _SessionBase(object):
             reading (float):The measured value returned from the DMM.
         '''
         reading_ctype = ctypes_types.ViReal64_ctype(0)
-        error_code = self.library.niDMM_Fetch(self.vi, maximum_time, ctypes.pointer(reading_ctype))
+        error_code = self._library.niDMM_Fetch(self._vi, maximum_time, ctypes.pointer(reading_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViReal64(reading_ctype.value)
 
@@ -1726,7 +1725,7 @@ class _SessionBase(object):
         '''
         reading_array_ctype = (ctypes_types.ViReal64_ctype * array_size)()
         actual_number_of_points_ctype = ctypes_types.ViInt32_ctype(0)
-        error_code = self.library.niDMM_FetchMultiPoint(self.vi, maximum_time, array_size, ctypes.cast(reading_array_ctype, ctypes.POINTER(ctypes_types.ViReal64_ctype)), ctypes.pointer(actual_number_of_points_ctype))
+        error_code = self._library.niDMM_FetchMultiPoint(self._vi, maximum_time, array_size, ctypes.cast(reading_array_ctype, ctypes.POINTER(ctypes_types.ViReal64_ctype)), ctypes.pointer(actual_number_of_points_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return [python_types.ViReal64(reading_array_ctype[i].value) for i in range(array_size)], python_types.ViInt32(actual_number_of_points_ctype.value)
 
@@ -1760,7 +1759,7 @@ class _SessionBase(object):
         '''
         waveform_array_ctype = (ctypes_types.ViReal64_ctype * array_size)()
         actual_number_of_points_ctype = ctypes_types.ViInt32_ctype(0)
-        error_code = self.library.niDMM_FetchWaveform(self.vi, maximum_time, array_size, ctypes.cast(waveform_array_ctype, ctypes.POINTER(ctypes_types.ViReal64_ctype)), ctypes.pointer(actual_number_of_points_ctype))
+        error_code = self._library.niDMM_FetchWaveform(self._vi, maximum_time, array_size, ctypes.cast(waveform_array_ctype, ctypes.POINTER(ctypes_types.ViReal64_ctype)), ctypes.pointer(actual_number_of_points_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return [python_types.ViReal64(waveform_array_ctype[i].value) for i in range(array_size)], python_types.ViInt32(actual_number_of_points_ctype.value)
 
@@ -1789,7 +1788,7 @@ class _SessionBase(object):
         mode_string_ctype = ctypes_types.ViChar_ctype(0)
         range_string_ctype = ctypes_types.ViChar_ctype(0)
         data_string_ctype = ctypes_types.ViChar_ctype(0)
-        error_code = self.library.niDMM_FormatMeasAbsolute(measurement_function, range, resolution, measurement, ctypes.pointer(mode_string_ctype), ctypes.pointer(range_string_ctype), ctypes.pointer(data_string_ctype))
+        error_code = self._library.niDMM_FormatMeasAbsolute(measurement_function, range, resolution, measurement, ctypes.pointer(mode_string_ctype), ctypes.pointer(range_string_ctype), ctypes.pointer(data_string_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViChar(mode_string_ctype.value), python_types.ViChar(range_string_ctype.value), python_types.ViChar(data_string_ctype.value)
 
@@ -1831,7 +1830,7 @@ class _SessionBase(object):
         '''
         aperture_time_ctype = ctypes_types.ViReal64_ctype(0)
         aperture_time_units_ctype = ctypes_types.ViInt32_ctype(0)
-        error_code = self.library.niDMM_GetApertureTimeInfo(self.vi, ctypes.pointer(aperture_time_ctype), ctypes.pointer(aperture_time_units_ctype))
+        error_code = self._library.niDMM_GetApertureTimeInfo(self._vi, ctypes.pointer(aperture_time_ctype), ctypes.pointer(aperture_time_units_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViReal64(aperture_time_ctype.value), enums.ApertureTimeUnits(aperture_time_units_ctype.value)
 
@@ -1863,7 +1862,7 @@ class _SessionBase(object):
                 ViBoolean variable.
         '''
         attribute_value_ctype = ctypes_types.ViBoolean_ctype(0)
-        error_code = self.library.niDMM_GetAttributeViBoolean(self.vi, channel_name.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
+        error_code = self._library.niDMM_GetAttributeViBoolean(self._vi, channel_name.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViBoolean(attribute_value_ctype.value)
 
@@ -1895,7 +1894,7 @@ class _SessionBase(object):
                 ViInt32 variable.
         '''
         attribute_value_ctype = ctypes_types.ViInt32_ctype(0)
-        error_code = self.library.niDMM_GetAttributeViInt32(self.vi, channel_name.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
+        error_code = self._library.niDMM_GetAttributeViInt32(self._vi, channel_name.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViInt32(attribute_value_ctype.value)
 
@@ -1927,7 +1926,7 @@ class _SessionBase(object):
                 ViReal64 variable.
         '''
         attribute_value_ctype = ctypes_types.ViReal64_ctype(0)
-        error_code = self.library.niDMM_GetAttributeViReal64(self.vi, channel_name.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
+        error_code = self._library.niDMM_GetAttributeViReal64(self._vi, channel_name.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViReal64(attribute_value_ctype.value)
 
@@ -1973,11 +1972,11 @@ class _SessionBase(object):
         '''
         buffer_size = 0
         attribute_value_ctype = None
-        error_code = self.library.niDMM_GetAttributeViString(self.vi, channel_name.encode('ascii'), attribute_id, buffer_size, attribute_value_ctype)
+        error_code = self._library.niDMM_GetAttributeViString(self._vi, channel_name.encode('ascii'), attribute_id, buffer_size, attribute_value_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         buffer_size = error_code
         attribute_value_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), ctypes_types.ViString_ctype)
-        error_code = self.library.niDMM_GetAttributeViString(self.vi, channel_name.encode('ascii'), attribute_id, buffer_size, attribute_value_ctype)
+        error_code = self._library.niDMM_GetAttributeViString(self._vi, channel_name.encode('ascii'), attribute_id, buffer_size, attribute_value_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return attribute_value_ctype.value.decode("ascii")
 
@@ -1993,7 +1992,7 @@ class _SessionBase(object):
                 value depend on the function.
         '''
         actual_range_ctype = ctypes_types.ViReal64_ctype(0)
-        error_code = self.library.niDMM_GetAutoRangeValue(self.vi, ctypes.pointer(actual_range_ctype))
+        error_code = self._library.niDMM_GetAutoRangeValue(self._vi, ctypes.pointer(actual_range_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViReal64(actual_range_ctype.value)
 
@@ -2020,7 +2019,7 @@ class _SessionBase(object):
             count (int):The number of times calibration has been performed.
         '''
         count_ctype = ctypes_types.ViInt32_ctype(0)
-        error_code = self.library.niDMM_GetCalCount(self.vi, cal_type, ctypes.pointer(count_ctype))
+        error_code = self._library.niDMM_GetCalCount(self._vi, cal_type, ctypes.pointer(count_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViInt32(count_ctype.value)
 
@@ -2055,7 +2054,7 @@ class _SessionBase(object):
         year_ctype = ctypes_types.ViInt32_ctype(0)
         hour_ctype = ctypes_types.ViInt32_ctype(0)
         minute_ctype = ctypes_types.ViInt32_ctype(0)
-        error_code = self.library.niDMM_GetCalDateAndTime(self.vi, cal_type, ctypes.pointer(month_ctype), ctypes.pointer(day_ctype), ctypes.pointer(year_ctype), ctypes.pointer(hour_ctype), ctypes.pointer(minute_ctype))
+        error_code = self._library.niDMM_GetCalDateAndTime(self._vi, cal_type, ctypes.pointer(month_ctype), ctypes.pointer(day_ctype), ctypes.pointer(year_ctype), ctypes.pointer(hour_ctype), ctypes.pointer(minute_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViInt32(month_ctype.value), python_types.ViInt32(day_ctype.value), python_types.ViInt32(year_ctype.value), python_types.ViInt32(hour_ctype.value), python_types.ViInt32(minute_ctype.value)
 
@@ -2089,7 +2088,7 @@ class _SessionBase(object):
                 **channel_string**.
         '''
         channel_string_ctype = ctypes_types.ViChar_ctype(0)
-        error_code = self.library.niDMM_GetChannelName(self.vi, index, buffer_size, ctypes.pointer(channel_string_ctype))
+        error_code = self._library.niDMM_GetChannelName(self._vi, index, buffer_size, ctypes.pointer(channel_string_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViChar(channel_string_ctype.value)
 
@@ -2107,7 +2106,7 @@ class _SessionBase(object):
             temperature (float):Returns the current **temperature** of the device.
         '''
         temperature_ctype = ctypes_types.ViReal64_ctype(0)
-        error_code = self.library.niDMM_GetDevTemp(self.vi, options.encode('ascii'), ctypes.pointer(temperature_ctype))
+        error_code = self._library.niDMM_GetDevTemp(self._vi, options.encode('ascii'), ctypes.pointer(temperature_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViReal64(temperature_ctype.value)
 
@@ -2143,11 +2142,11 @@ class _SessionBase(object):
         error_code_ctype = ctypes_types.ViStatus_ctype(0)
         buffer_size = 0
         description_ctype = None
-        error_code = self.library.niDMM_GetError(self.vi, ctypes.pointer(error_code_ctype), buffer_size, description_ctype)
+        error_code = self._library.niDMM_GetError(self._vi, ctypes.pointer(error_code_ctype), buffer_size, description_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=True)
         buffer_size = error_code
         description_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), ctypes_types.ViString_ctype)
-        error_code = self.library.niDMM_GetError(self.vi, ctypes.pointer(error_code_ctype), buffer_size, description_ctype)
+        error_code = self._library.niDMM_GetError(self._vi, ctypes.pointer(error_code_ctype), buffer_size, description_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return python_types.ViStatus(error_code_ctype.value), description_ctype.value.decode("ascii")
 
@@ -2170,11 +2169,11 @@ class _SessionBase(object):
         '''
         buffer_size = 0
         error_message_ctype = None
-        error_code = self.library.niDMM_GetErrorMessage(self.vi, error_code, buffer_size, error_message_ctype)
+        error_code = self._library.niDMM_GetErrorMessage(self._vi, error_code, buffer_size, error_message_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=True)
         buffer_size = error_code
         error_message_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), ctypes_types.ViString_ctype)
-        error_code = self.library.niDMM_GetErrorMessage(self.vi, error_code, buffer_size, error_message_ctype)
+        error_code = self._library.niDMM_GetErrorMessage(self._vi, error_code, buffer_size, error_message_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return error_message_ctype.value.decode("ascii")
 
@@ -2201,7 +2200,7 @@ class _SessionBase(object):
             temperature (float):Returns the **temperature** during the last calibration.
         '''
         temperature_ctype = ctypes_types.ViReal64_ctype(0)
-        error_code = self.library.niDMM_GetLastCalTemp(self.vi, cal_type, ctypes.pointer(temperature_ctype))
+        error_code = self._library.niDMM_GetLastCalTemp(self._vi, cal_type, ctypes.pointer(temperature_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViReal64(temperature_ctype.value)
 
@@ -2224,7 +2223,7 @@ class _SessionBase(object):
                 AUTO_ZERO, is included.
         '''
         period_ctype = ctypes_types.ViReal64_ctype(0)
-        error_code = self.library.niDMM_GetMeasurementPeriod(self.vi, ctypes.pointer(period_ctype))
+        error_code = self._library.niDMM_GetMeasurementPeriod(self._vi, ctypes.pointer(period_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViReal64(period_ctype.value)
 
@@ -2267,7 +2266,7 @@ class _SessionBase(object):
                 specify with the **Buffer_Size** parameter.
         '''
         coercion_record_ctype = ctypes_types.ViChar_ctype(0)
-        error_code = self.library.niDMM_GetNextCoercionRecord(self.vi, buffer_size, ctypes.pointer(coercion_record_ctype))
+        error_code = self._library.niDMM_GetNextCoercionRecord(self._vi, buffer_size, ctypes.pointer(coercion_record_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViChar(coercion_record_ctype.value)
 
@@ -2306,11 +2305,11 @@ class _SessionBase(object):
         '''
         buffer_size = 0
         interchange_warning_ctype = None
-        error_code = self.library.niDMM_GetNextInterchangeWarning(self.vi, buffer_size, interchange_warning_ctype)
+        error_code = self._library.niDMM_GetNextInterchangeWarning(self._vi, buffer_size, interchange_warning_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         buffer_size = error_code
         interchange_warning_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), ctypes_types.ViChar_ctype)
-        error_code = self.library.niDMM_GetNextInterchangeWarning(self.vi, buffer_size, interchange_warning_ctype)
+        error_code = self._library.niDMM_GetNextInterchangeWarning(self._vi, buffer_size, interchange_warning_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return interchange_warning_ctype.value.decode("ascii")
 
@@ -2331,7 +2330,7 @@ class _SessionBase(object):
                 +----------+---+-------------------------------------------------------------+
         '''
         self_cal_supported_ctype = ctypes_types.ViBoolean_ctype(0)
-        error_code = self.library.niDMM_GetSelfCalSupported(self.vi, ctypes.pointer(self_cal_supported_ctype))
+        error_code = self._library.niDMM_GetSelfCalSupported(self._vi, ctypes.pointer(self_cal_supported_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViBoolean(self_cal_supported_ctype.value)
 
@@ -2432,7 +2431,7 @@ class _SessionBase(object):
                 all subsequent instrument driver function calls.
         '''
         vi_ctype = ctypes_types.ViSession_ctype(0)
-        error_code = self.library.niDMM_InitWithOptions(resource_name.encode('ascii'), id_query, reset_device, option_string.encode('ascii'), ctypes.pointer(vi_ctype))
+        error_code = self._library.niDMM_InitWithOptions(resource_name.encode('ascii'), id_query, reset_device, option_string.encode('ascii'), ctypes.pointer(vi_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViSession(vi_ctype.value)
 
@@ -2445,7 +2444,7 @@ class _SessionBase(object):
         fetch, fetch_multi_point, or fetch_waveform to
         retrieve the measurement data.
         '''
-        error_code = self.library.niDMM_Initiate(self.vi)
+        error_code = self._library.niDMM_Initiate(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -2473,7 +2472,7 @@ class _SessionBase(object):
                 +----------+---+-----------------------------------------------------------+
         '''
         is_over_range_ctype = ctypes_types.ViBoolean_ctype(0)
-        error_code = self.library.niDMM_IsOverRange(self.vi, measurement_value, ctypes.pointer(is_over_range_ctype))
+        error_code = self._library.niDMM_IsOverRange(self._vi, measurement_value, ctypes.pointer(is_over_range_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViBoolean(is_over_range_ctype.value)
 
@@ -2501,7 +2500,7 @@ class _SessionBase(object):
                 +----------+---+------------------------------------------------------------+
         '''
         is_under_range_ctype = ctypes_types.ViBoolean_ctype(0)
-        error_code = self.library.niDMM_IsUnderRange(self.vi, measurement_value, ctypes.pointer(is_under_range_ctype))
+        error_code = self._library.niDMM_IsUnderRange(self._vi, measurement_value, ctypes.pointer(is_under_range_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViBoolean(is_under_range_ctype.value)
 
@@ -2526,7 +2525,7 @@ class _SessionBase(object):
         '''
         conductance_ctype = ctypes_types.ViReal64_ctype(0)
         susceptance_ctype = ctypes_types.ViReal64_ctype(0)
-        error_code = self.library.niDMM_PerformOpenCableComp(self.vi, ctypes.pointer(conductance_ctype), ctypes.pointer(susceptance_ctype))
+        error_code = self._library.niDMM_PerformOpenCableComp(self._vi, ctypes.pointer(conductance_ctype), ctypes.pointer(susceptance_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViReal64(conductance_ctype.value), python_types.ViReal64(susceptance_ctype.value)
 
@@ -2550,7 +2549,7 @@ class _SessionBase(object):
         '''
         resistance_ctype = ctypes_types.ViReal64_ctype(0)
         reactance_ctype = ctypes_types.ViReal64_ctype(0)
-        error_code = self.library.niDMM_PerformShortCableComp(self.vi, ctypes.pointer(resistance_ctype), ctypes.pointer(reactance_ctype))
+        error_code = self._library.niDMM_PerformShortCableComp(self._vi, ctypes.pointer(resistance_ctype), ctypes.pointer(reactance_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViReal64(resistance_ctype.value), python_types.ViReal64(reactance_ctype.value)
 
@@ -2575,7 +2574,7 @@ class _SessionBase(object):
             reading (float):The measured value returned from the DMM.
         '''
         reading_ctype = ctypes_types.ViReal64_ctype(0)
-        error_code = self.library.niDMM_Read(self.vi, maximum_time, ctypes.pointer(reading_ctype))
+        error_code = self._library.niDMM_Read(self._vi, maximum_time, ctypes.pointer(reading_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViReal64(reading_ctype.value)
 
@@ -2616,7 +2615,7 @@ class _SessionBase(object):
         '''
         reading_array_ctype = (ctypes_types.ViReal64_ctype * array_size)()
         actual_number_of_points_ctype = ctypes_types.ViInt32_ctype(0)
-        error_code = self.library.niDMM_ReadMultiPoint(self.vi, maximum_time, array_size, ctypes.cast(reading_array_ctype, ctypes.POINTER(ctypes_types.ViReal64_ctype)), ctypes.pointer(actual_number_of_points_ctype))
+        error_code = self._library.niDMM_ReadMultiPoint(self._vi, maximum_time, array_size, ctypes.cast(reading_array_ctype, ctypes.POINTER(ctypes_types.ViReal64_ctype)), ctypes.pointer(actual_number_of_points_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return [python_types.ViReal64(reading_array_ctype[i].value) for i in range(array_size)], python_types.ViInt32(actual_number_of_points_ctype.value)
 
@@ -2657,7 +2656,7 @@ class _SessionBase(object):
         '''
         acquisition_backlog_ctype = ctypes_types.ViInt32_ctype(0)
         acquisition_status_ctype = ctypes_types.ViInt16_ctype(0)
-        error_code = self.library.niDMM_ReadStatus(self.vi, ctypes.pointer(acquisition_backlog_ctype), ctypes.pointer(acquisition_status_ctype))
+        error_code = self._library.niDMM_ReadStatus(self._vi, ctypes.pointer(acquisition_backlog_ctype), ctypes.pointer(acquisition_status_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViInt32(acquisition_backlog_ctype.value), enums.AcquisitionStatus(acquisition_status_ctype.value)
 
@@ -2696,7 +2695,7 @@ class _SessionBase(object):
         '''
         waveform_array_ctype = (ctypes_types.ViReal64_ctype * array_size)()
         actual_number_of_points_ctype = ctypes_types.ViInt32_ctype(0)
-        error_code = self.library.niDMM_ReadWaveform(self.vi, maximum_time, array_size, ctypes.cast(waveform_array_ctype, ctypes.POINTER(ctypes_types.ViReal64_ctype)), ctypes.pointer(actual_number_of_points_ctype))
+        error_code = self._library.niDMM_ReadWaveform(self._vi, maximum_time, array_size, ctypes.cast(waveform_array_ctype, ctypes.POINTER(ctypes_types.ViReal64_ctype)), ctypes.pointer(actual_number_of_points_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return [python_types.ViReal64(waveform_array_ctype[i].value) for i in range(array_size)], python_types.ViInt32(actual_number_of_points_ctype.value)
 
@@ -2731,7 +2730,7 @@ class _SessionBase(object):
         warnings are returned. If you are not interested in the content of those
         warnings, you can call clear_interchange_warnings.
         '''
-        error_code = self.library.niDMM_ResetInterchangeCheck(self.vi)
+        error_code = self._library.niDMM_ResetInterchangeCheck(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -2743,7 +2742,7 @@ class _SessionBase(object):
         state necessary for the operation of NI-DMM. All user-defined default
         values associated with a logical name are applied after setting the DMM.
         '''
-        error_code = self.library.niDMM_ResetWithDefaults(self.vi)
+        error_code = self._library.niDMM_ResetWithDefaults(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -2758,7 +2757,7 @@ class _SessionBase(object):
         the call will be lost. All attributes will be set to their default
         values after the call returns.
         '''
-        error_code = self.library.niDMM_SelfCal(self.vi)
+        error_code = self._library.niDMM_SelfCal(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -2773,7 +2772,7 @@ class _SessionBase(object):
         can use this function to override the trigger source that you configured
         and trigger the device. The NI 4050 and NI 4060 are not supported.
         '''
-        error_code = self.library.niDMM_SendSoftwareTrigger(self.vi)
+        error_code = self._library.niDMM_SendSoftwareTrigger(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -2816,7 +2815,7 @@ class _SessionBase(object):
             attribute_id (int):Pass the ID of an attribute.
             attribute_value (bool):Pass the value that you want to set the attribute to.
         '''
-        error_code = self.library.niDMM_SetAttributeViBoolean(self.vi, channel_name.encode('ascii'), attribute_id, attribute_value)
+        error_code = self._library.niDMM_SetAttributeViBoolean(self._vi, channel_name.encode('ascii'), attribute_id, attribute_value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -2859,7 +2858,7 @@ class _SessionBase(object):
             attribute_id (int):Pass the ID of an attribute.
             attribute_value (int):Pass the value that you want to set the attribute to.
         '''
-        error_code = self.library.niDMM_SetAttributeViInt32(self.vi, channel_name.encode('ascii'), attribute_id, attribute_value)
+        error_code = self._library.niDMM_SetAttributeViInt32(self._vi, channel_name.encode('ascii'), attribute_id, attribute_value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -2902,7 +2901,7 @@ class _SessionBase(object):
             attribute_id (int):Pass the ID of an attribute.
             attribute_value (float):Pass the value that you want to set the attribute to.
         '''
-        error_code = self.library.niDMM_SetAttributeViReal64(self.vi, channel_name.encode('ascii'), attribute_id, attribute_value)
+        error_code = self._library.niDMM_SetAttributeViReal64(self._vi, channel_name.encode('ascii'), attribute_id, attribute_value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -2945,7 +2944,7 @@ class _SessionBase(object):
             attribute_id (int):Pass the ID of an attribute.
             attribute_value (str):Pass the value that you want to set the attribute to.
         '''
-        error_code = self.library.niDMM_SetAttributeViString(self.vi, channel_name.encode('ascii'), attribute_id, attribute_value.encode('ascii'))
+        error_code = self._library.niDMM_SetAttributeViString(self._vi, channel_name.encode('ascii'), attribute_id, attribute_value.encode('ascii'))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -2954,7 +2953,7 @@ class _SessionBase(object):
 
         Closes the specified session and deallocates resources that it reserved.
         '''
-        error_code = self.library.niDMM_close(self.vi)
+        error_code = self._library.niDMM_close(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -2976,7 +2975,7 @@ class _SessionBase(object):
         '''
         error_code_ctype = ctypes_types.ViStatus_ctype(0)
         error_message_ctype = ctypes_types.ViChar_ctype(0)
-        error_code = self.library.niDMM_error_query(self.vi, ctypes.pointer(error_code_ctype), ctypes.pointer(error_message_ctype))
+        error_code = self._library.niDMM_error_query(self._vi, ctypes.pointer(error_code_ctype), ctypes.pointer(error_message_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViStatus(error_code_ctype.value), python_types.ViChar(error_message_ctype.value)
 
@@ -2987,7 +2986,7 @@ class _SessionBase(object):
         to the instrument. The initialization commands set instrument settings
         to the state necessary for the operation of the instrument driver.
         '''
-        error_code = self.library.niDMM_reset(self.vi)
+        error_code = self._library.niDMM_reset(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -3009,7 +3008,7 @@ class _SessionBase(object):
         '''
         instrument_driver_revision_ctype = ctypes_types.ViChar_ctype(0)
         firmware_revision_ctype = ctypes_types.ViChar_ctype(0)
-        error_code = self.library.niDMM_revision_query(self.vi, ctypes.pointer(instrument_driver_revision_ctype), ctypes.pointer(firmware_revision_ctype))
+        error_code = self._library.niDMM_revision_query(self._vi, ctypes.pointer(instrument_driver_revision_ctype), ctypes.pointer(firmware_revision_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViChar(instrument_driver_revision_ctype.value), python_types.ViChar(firmware_revision_ctype.value)
 
@@ -3053,7 +3052,7 @@ class _SessionBase(object):
         '''
         self_test_result_ctype = ctypes_types.ViInt16_ctype(0)
         self_test_message_ctype = (ctypes_types.ViChar_ctype * 256)()
-        error_code = self.library.niDMM_self_test(self.vi, ctypes.pointer(self_test_result_ctype), ctypes.cast(self_test_message_ctype, ctypes.POINTER(ctypes_types.ViChar_ctype)))
+        error_code = self._library.niDMM_self_test(self._vi, ctypes.pointer(self_test_result_ctype), ctypes.cast(self_test_message_ctype, ctypes.POINTER(ctypes_types.ViChar_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViInt16(self_test_result_ctype.value), self_test_message_ctype.value.decode("ascii")
 
@@ -3063,7 +3062,7 @@ class _RepeatedCapability(_SessionBase):
 
     def __init__(self, vi, repeated_capability):
         super(_RepeatedCapability, self).__init__(repeated_capability)
-        self.vi = vi
+        self._vi = vi
         self._is_frozen = True
 
     def __enter__(self):
@@ -3079,8 +3078,8 @@ class Session(_SessionBase):
     def __init__(self, resource_name, id_query=False, reset_device=False, option_string=''):
         super(Session, self).__init__(repeated_capability='')
         # TODO(marcoskirsch): private members should start with _
-        self.vi = 0  # This must be set before calling _init_with_options.
-        self.vi = self._init_with_options(resource_name, id_query, reset_device, option_string)
+        self._vi = 0  # This must be set before calling _init_with_options().
+        self._vi = self._init_with_options(resource_name, id_query, reset_device, option_string)
         self._is_frozen = True
 
     def __enter__(self):
@@ -3091,7 +3090,7 @@ class Session(_SessionBase):
 
     def __getitem__(self, repeated_capability):
         '''Set/get properties or call methods with a repeated capability (i.e. channels)'''
-        return _RepeatedCapability(self.vi, repeated_capability)
+        return _RepeatedCapability(self._vi, repeated_capability)
 
     def initiate(self):
         return _Acquisition(self)
@@ -3102,6 +3101,6 @@ class Session(_SessionBase):
         except errors.Error:
             # TODO(marcoskirsch): This will occur when session is "stolen". Change to log instead
             print("Failed to close session.")
-        self.vi = 0
+        self._vi = 0
 
 

--- a/generated/nidmm/session.py
+++ b/generated/nidmm/session.py
@@ -3071,7 +3071,6 @@ class Session(_SessionBase):
 
     def __init__(self, resource_name, id_query=False, reset_device=False, option_string=''):
         super(Session, self).__init__(repeated_capability='')
-        # TODO(marcoskirsch): private members should start with _
         self._vi = 0  # This must be set before calling _init_with_options().
         self._vi = self._init_with_options(resource_name, id_query, reset_device, option_string)
         self._is_frozen = True

--- a/generated/nifake/session.py
+++ b/generated/nifake/session.py
@@ -536,7 +536,6 @@ class Session(_SessionBase):
 
     def __init__(self, resource_name, id_query=False, reset_device=False, option_string=''):
         super(Session, self).__init__(repeated_capability='')
-        # TODO(marcoskirsch): private members should start with _
         self._vi = 0  # This must be set before calling _init_with_options().
         self._vi = self._init_with_options(resource_name, id_query, reset_device, option_string)
         self._is_frozen = True

--- a/generated/nifake/session.py
+++ b/generated/nifake/session.py
@@ -12,14 +12,14 @@ from nifake import python_types
 
 class _Acquisition(object):
     def __init__(self, session):
-        self.session = session
+        self._session = session
 
     def __enter__(self):
-        self.session._initiate()
+        self._session._initiate()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.session._abort()
+        self._session._abort()
 
 
 class _SessionBase(object):
@@ -54,8 +54,7 @@ class _SessionBase(object):
     '''
 
     def __init__(self, repeated_capability):
-        # TODO(marcoskirsch): rename to _library.
-        self.library = library_singleton.get()
+        self._library = library_singleton.get()
         self._repeated_capability = repeated_capability
 
     def __setattr__(self, key, value):
@@ -92,7 +91,7 @@ class _SessionBase(object):
 
         Aborts a previously initiated thingie.
         '''
-        error_code = self.library.niFake_Abort(self.vi)
+        error_code = self._library.niFake_Abort(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -107,7 +106,7 @@ class _SessionBase(object):
             a_boolean (bool):Contains a boolean.
         '''
         a_boolean_ctype = ctypes_types.ViBoolean_ctype(0)
-        error_code = self.library.niFake_GetABoolean(self.vi, ctypes.pointer(a_boolean_ctype))
+        error_code = self._library.niFake_GetABoolean(self._vi, ctypes.pointer(a_boolean_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViBoolean(a_boolean_ctype.value)
 
@@ -122,7 +121,7 @@ class _SessionBase(object):
             a_number (int):Contains a number.
         '''
         a_number_ctype = ctypes_types.ViInt16_ctype(0)
-        error_code = self.library.niFake_GetANumber(self.vi, ctypes.pointer(a_number_ctype))
+        error_code = self._library.niFake_GetANumber(self._vi, ctypes.pointer(a_number_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViInt16(a_number_ctype.value)
 
@@ -135,7 +134,7 @@ class _SessionBase(object):
             a_string (int):String comes back here. Buffer must be 256 big.
         '''
         a_string_ctype = ctypes_types.ViChar_ctype(0)
-        error_code = self.library.niFake_GetAStringOfFixedMaximumSize(self.vi, ctypes.pointer(a_string_ctype))
+        error_code = self._library.niFake_GetAStringOfFixedMaximumSize(self._vi, ctypes.pointer(a_string_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViChar(a_string_ctype.value)
 
@@ -151,7 +150,7 @@ class _SessionBase(object):
             a_string (int):String comes back here. Buffer must be at least bufferSize big.
         '''
         a_string_ctype = (ctypes_types.ViChar_ctype * buffer_size)()
-        error_code = self.library.niFake_GetAStringWithSpecifiedMaximumSize(self.vi, ctypes.cast(a_string_ctype, ctypes.POINTER(ctypes_types.ViChar_ctype)), buffer_size)
+        error_code = self._library.niFake_GetAStringWithSpecifiedMaximumSize(self._vi, ctypes.cast(a_string_ctype, ctypes.POINTER(ctypes_types.ViChar_ctype)), buffer_size)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return a_string_ctype.value.decode("ascii")
 
@@ -168,7 +167,7 @@ class _SessionBase(object):
             attribute_value (bool):Returns the value of the attribute.
         '''
         attribute_value_ctype = ctypes_types.ViBoolean_ctype(0)
-        error_code = self.library.niFake_GetAttributeViBoolean(self.vi, channel_name.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
+        error_code = self._library.niFake_GetAttributeViBoolean(self._vi, channel_name.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViBoolean(attribute_value_ctype.value)
 
@@ -185,7 +184,7 @@ class _SessionBase(object):
             attribute_value (int):Returns the value of the attribute.
         '''
         attribute_value_ctype = ctypes_types.ViInt32_ctype(0)
-        error_code = self.library.niFake_GetAttributeViInt32(self.vi, channel_name.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
+        error_code = self._library.niFake_GetAttributeViInt32(self._vi, channel_name.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViInt32(attribute_value_ctype.value)
 
@@ -202,7 +201,7 @@ class _SessionBase(object):
             attribute_value (float):Returns the value of the attribute.
         '''
         attribute_value_ctype = ctypes_types.ViReal64_ctype(0)
-        error_code = self.library.niFake_GetAttributeViReal64(self.vi, channel_name.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
+        error_code = self._library.niFake_GetAttributeViReal64(self._vi, channel_name.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViReal64(attribute_value_ctype.value)
 
@@ -219,7 +218,7 @@ class _SessionBase(object):
             attribute_value (int):Returns the value of the attribute.
         '''
         attribute_value_ctype = ctypes_types.ViSession_ctype(0)
-        error_code = self.library.niFake_GetAttributeViSession(self.vi, channel_name.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
+        error_code = self._library.niFake_GetAttributeViSession(self._vi, channel_name.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViSession(attribute_value_ctype.value)
 
@@ -235,11 +234,11 @@ class _SessionBase(object):
         '''
         buffer_size = 0
         attribute_value_ctype = None
-        error_code = self.library.niFake_GetAttributeViString(self.vi, channel_name.encode('ascii'), attribute_id, buffer_size, attribute_value_ctype)
+        error_code = self._library.niFake_GetAttributeViString(self._vi, channel_name.encode('ascii'), attribute_id, buffer_size, attribute_value_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         buffer_size = error_code
         attribute_value_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), ctypes_types.ViString_ctype)
-        error_code = self.library.niFake_GetAttributeViString(self.vi, channel_name.encode('ascii'), attribute_id, buffer_size, attribute_value_ctype)
+        error_code = self._library.niFake_GetAttributeViString(self._vi, channel_name.encode('ascii'), attribute_id, buffer_size, attribute_value_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return attribute_value_ctype.value.decode("ascii")
 
@@ -268,7 +267,7 @@ class _SessionBase(object):
         '''
         a_quantity_ctype = ctypes_types.ViInt32_ctype(0)
         a_turtle_ctype = ctypes_types.ViInt16_ctype(0)
-        error_code = self.library.niFake_GetEnumValue(self.vi, ctypes.pointer(a_quantity_ctype), ctypes.pointer(a_turtle_ctype))
+        error_code = self._library.niFake_GetEnumValue(self._vi, ctypes.pointer(a_quantity_ctype), ctypes.pointer(a_turtle_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViInt32(a_quantity_ctype.value), enums.Turtle(a_turtle_ctype.value)
 
@@ -286,11 +285,11 @@ class _SessionBase(object):
         error_code_ctype = ctypes_types.ViStatus_ctype(0)
         buffer_size = 0
         description_ctype = None
-        error_code = self.library.niFake_GetError(self.vi, ctypes.pointer(error_code_ctype), buffer_size, description_ctype)
+        error_code = self._library.niFake_GetError(self._vi, ctypes.pointer(error_code_ctype), buffer_size, description_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=True)
         buffer_size = error_code
         description_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), ctypes_types.ViString_ctype)
-        error_code = self.library.niFake_GetError(self.vi, ctypes.pointer(error_code_ctype), buffer_size, description_ctype)
+        error_code = self._library.niFake_GetError(self._vi, ctypes.pointer(error_code_ctype), buffer_size, description_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return python_types.ViStatus(error_code_ctype.value), description_ctype.value.decode("ascii")
 
@@ -305,11 +304,11 @@ class _SessionBase(object):
         '''
         buffer_size = 0
         error_message_ctype = None
-        error_code = self.library.niFake_GetErrorMessage(self.vi, error_code, buffer_size, error_message_ctype)
+        error_code = self._library.niFake_GetErrorMessage(self._vi, error_code, buffer_size, error_message_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=True)
         buffer_size = error_code
         error_message_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), ctypes_types.ViString_ctype)
-        error_code = self.library.niFake_GetErrorMessage(self.vi, error_code, buffer_size, error_message_ctype)
+        error_code = self._library.niFake_GetErrorMessage(self._vi, error_code, buffer_size, error_message_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return error_message_ctype.value.decode("ascii")
 
@@ -342,7 +341,7 @@ class _SessionBase(object):
             vi (int):Returns a ViSession handle that you use.
         '''
         vi_ctype = ctypes_types.ViSession_ctype(0)
-        error_code = self.library.niFake_InitWithOptions(resource_name.encode('ascii'), id_query, reset_device, option_string.encode('ascii'), ctypes.pointer(vi_ctype))
+        error_code = self._library.niFake_InitWithOptions(resource_name.encode('ascii'), id_query, reset_device, option_string.encode('ascii'), ctypes.pointer(vi_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViSession(vi_ctype.value)
 
@@ -351,7 +350,7 @@ class _SessionBase(object):
 
         Initiates a thingie.
         '''
-        error_code = self.library.niFake_Initiate(self.vi)
+        error_code = self._library.niFake_Initiate(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -363,7 +362,7 @@ class _SessionBase(object):
         Args:
             a_number (int):Contains a number
         '''
-        error_code = self.library.niFake_OneInputFunction(self.vi, a_number)
+        error_code = self._library.niFake_OneInputFunction(self._vi, a_number)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -379,7 +378,7 @@ class _SessionBase(object):
             reading (float):The measured value.
         '''
         reading_ctype = ctypes_types.ViReal64_ctype(0)
-        error_code = self.library.niFake_Read(self.vi, maximum_time, ctypes.pointer(reading_ctype))
+        error_code = self._library.niFake_Read(self._vi, maximum_time, ctypes.pointer(reading_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViReal64(reading_ctype.value)
 
@@ -400,7 +399,7 @@ class _SessionBase(object):
         '''
         reading_array_ctype = (ctypes_types.ViReal64_ctype * array_size)()
         actual_number_of_points_ctype = ctypes_types.ViInt32_ctype(0)
-        error_code = self.library.niFake_ReadMultiPoint(self.vi, maximum_time, array_size, ctypes.cast(reading_array_ctype, ctypes.POINTER(ctypes_types.ViReal64_ctype)), ctypes.pointer(actual_number_of_points_ctype))
+        error_code = self._library.niFake_ReadMultiPoint(self._vi, maximum_time, array_size, ctypes.cast(reading_array_ctype, ctypes.POINTER(ctypes_types.ViReal64_ctype)), ctypes.pointer(actual_number_of_points_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return [python_types.ViReal64(reading_array_ctype[i].value) for i in range(array_size)], python_types.ViInt32(actual_number_of_points_ctype.value)
 
@@ -417,7 +416,7 @@ class _SessionBase(object):
         '''
         a_number_ctype = ctypes_types.ViInt16_ctype(0)
         a_string_ctype = ctypes_types.ViChar_ctype(0)
-        error_code = self.library.niFake_ReturnANumberAndAString(self.vi, ctypes.pointer(a_number_ctype), ctypes.pointer(a_string_ctype))
+        error_code = self._library.niFake_ReturnANumberAndAString(self._vi, ctypes.pointer(a_number_ctype), ctypes.pointer(a_string_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViInt16(a_number_ctype.value), python_types.ViChar(a_string_ctype.value)
 
@@ -431,7 +430,7 @@ class _SessionBase(object):
             attribute_id (int):Pass the ID of an attribute.
             attribute_value (bool):Pass the value that you want to set the attribute to.
         '''
-        error_code = self.library.niFake_SetAttributeViBoolean(self.vi, channel_name.encode('ascii'), attribute_id, attribute_value)
+        error_code = self._library.niFake_SetAttributeViBoolean(self._vi, channel_name.encode('ascii'), attribute_id, attribute_value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -445,7 +444,7 @@ class _SessionBase(object):
             attribute_id (int):Pass the ID of an attribute.
             attribute_value (int):Pass the value that you want to set the attribute to.
         '''
-        error_code = self.library.niFake_SetAttributeViInt32(self.vi, channel_name.encode('ascii'), attribute_id, attribute_value)
+        error_code = self._library.niFake_SetAttributeViInt32(self._vi, channel_name.encode('ascii'), attribute_id, attribute_value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -459,7 +458,7 @@ class _SessionBase(object):
             attribute_id (int):Pass the ID of an attribute.
             attribute_value (float):Pass the value that you want to set the attribute to.
         '''
-        error_code = self.library.niFake_SetAttributeViReal64(self.vi, channel_name.encode('ascii'), attribute_id, attribute_value)
+        error_code = self._library.niFake_SetAttributeViReal64(self._vi, channel_name.encode('ascii'), attribute_id, attribute_value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -473,7 +472,7 @@ class _SessionBase(object):
             attribute_id (int):Pass the ID of an attribute.
             attribute_value (int):Pass the value that you want to set the attribute to.
         '''
-        error_code = self.library.niFake_SetAttributeViSession(self.vi, channel_name.encode('ascii'), attribute_id, attribute_value)
+        error_code = self._library.niFake_SetAttributeViSession(self._vi, channel_name.encode('ascii'), attribute_id, attribute_value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -487,7 +486,7 @@ class _SessionBase(object):
             attribute_id (int):Pass the ID of an attribute.
             attribute_value (str):Pass the value that you want to set the attribute to.
         '''
-        error_code = self.library.niFake_SetAttributeViString(self.vi, channel_name.encode('ascii'), attribute_id, attribute_value.encode('ascii'))
+        error_code = self._library.niFake_SetAttributeViString(self._vi, channel_name.encode('ascii'), attribute_id, attribute_value.encode('ascii'))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -496,7 +495,7 @@ class _SessionBase(object):
 
         This function takes no parameters other than the session.
         '''
-        error_code = self.library.niFake_SimpleFunction(self.vi)
+        error_code = self._library.niFake_SimpleFunction(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -509,7 +508,7 @@ class _SessionBase(object):
             a_number (float):Contains a number
             a_string (int):Contains a string
         '''
-        error_code = self.library.niFake_TwoInputFunction(self.vi, a_number, a_string)
+        error_code = self._library.niFake_TwoInputFunction(self._vi, a_number, a_string)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -518,7 +517,7 @@ class _SessionBase(object):
 
         Closes the specified session and deallocates resources that it reserved.
         '''
-        error_code = self.library.niFake_close(self.vi)
+        error_code = self._library.niFake_close(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -528,7 +527,7 @@ class _RepeatedCapability(_SessionBase):
 
     def __init__(self, vi, repeated_capability):
         super(_RepeatedCapability, self).__init__(repeated_capability)
-        self.vi = vi
+        self._vi = vi
         self._is_frozen = True
 
     def __enter__(self):
@@ -544,8 +543,8 @@ class Session(_SessionBase):
     def __init__(self, resource_name, id_query=False, reset_device=False, option_string=''):
         super(Session, self).__init__(repeated_capability='')
         # TODO(marcoskirsch): private members should start with _
-        self.vi = 0  # This must be set before calling _init_with_options.
-        self.vi = self._init_with_options(resource_name, id_query, reset_device, option_string)
+        self._vi = 0  # This must be set before calling _init_with_options().
+        self._vi = self._init_with_options(resource_name, id_query, reset_device, option_string)
         self._is_frozen = True
 
     def __enter__(self):
@@ -556,7 +555,7 @@ class Session(_SessionBase):
 
     def __getitem__(self, repeated_capability):
         '''Set/get properties or call methods with a repeated capability (i.e. channels)'''
-        return _RepeatedCapability(self.vi, repeated_capability)
+        return _RepeatedCapability(self._vi, repeated_capability)
 
     def initiate(self):
         return _Acquisition(self)
@@ -567,6 +566,6 @@ class Session(_SessionBase):
         except errors.Error:
             # TODO(marcoskirsch): This will occur when session is "stolen". Change to log instead
             print("Failed to close session.")
-        self.vi = 0
+        self._vi = 0
 
 

--- a/generated/nifake/tests/test_session.py
+++ b/generated/nifake/tests/test_session.py
@@ -38,7 +38,7 @@ class TestSession(object):
 
         self.patched_library.niFake_close.side_effect = self.disallow_close
         session = nifake.Session('dev1')
-        assert session.vi == SESSION_NUM_FOR_TEST
+        assert session._vi == SESSION_NUM_FOR_TEST
         self.patched_library.niFake_InitWithOptions.assert_called_once_with(b'dev1', 0, False, b'', ANY)
         patched_errors.handle_error.assert_called_once_with(session, self.patched_library.niFake_InitWithOptions.return_value, ignore_warnings=False, is_error_handling=False)
 
@@ -46,7 +46,7 @@ class TestSession(object):
 
     def test_init_with_options_nondefault(self):
         session = nifake.Session('FakeDevice', True, True, 'Some string')
-        assert(session.vi == SESSION_NUM_FOR_TEST)
+        assert(session._vi == SESSION_NUM_FOR_TEST)
         self.patched_library.niFake_InitWithOptions.assert_called_once_with(b'FakeDevice', True, True, b'Some string', ANY)
 
     def test_error_on_init(self):
@@ -75,7 +75,7 @@ class TestSession(object):
 
     def test_session_context_manager(self):
         with nifake.Session('dev1') as session:
-            assert session.vi == SESSION_NUM_FOR_TEST
+            assert session._vi == SESSION_NUM_FOR_TEST
             self.patched_library.niFake_InitWithOptions.assert_called_once_with(b'dev1', 0, False, b'', ANY)
         self.patched_library.niFake_close.assert_called_once_with(SESSION_NUM_FOR_TEST)
 
@@ -168,9 +168,9 @@ class TestSession(object):
 
     def test_library_singleton(self):
         with nifake.Session('dev1') as session:
-            lib1 = session.library
+            lib1 = session._library
         with nifake.Session('dev2') as session:
-            lib2 = session.library
+            lib2 = session._library
         assert lib1 is lib2
 
     def test_one_input_function(self):

--- a/generated/nimodinst/tests/test_modinst.py
+++ b/generated/nimodinst/tests/test_modinst.py
@@ -54,7 +54,7 @@ class TestSession(object):
     def test_open(self):
         self.patched_library.niModInst_CloseInstalledDevicesSession.side_effect = self.disallow_close
         session = nimodinst.Session('')
-        assert(session.handle == SESSION_NUM_FOR_TEST)
+        assert(session._handle == SESSION_NUM_FOR_TEST)
         self.patched_library.niModInst_OpenInstalledDevicesSession.assert_called_once_with(b'', ANY, ANY)
 
     def test_close(self):
@@ -64,7 +64,7 @@ class TestSession(object):
 
     def test_context_manager(self):
         with nimodinst.Session('') as session:
-            assert(session.handle == SESSION_NUM_FOR_TEST)
+            assert(session._handle == SESSION_NUM_FOR_TEST)
             self.patched_library.niModInst_OpenInstalledDevicesSession.assert_called_once_with(b'', ANY, ANY)
         self.patched_library.niModInst_CloseInstalledDevicesSession.assert_called_once_with(SESSION_NUM_FOR_TEST)
 

--- a/generated/niswitch/session.py
+++ b/generated/niswitch/session.py
@@ -12,14 +12,14 @@ from niswitch import python_types
 
 class _Scan(object):
     def __init__(self, session):
-        self.session = session
+        self._session = session
 
     def __enter__(self):
-        self.session._initiate_scan()
+        self._session._initiate_scan()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.session._abort_scan()
+        self._session._abort_scan()
 
 
 class _SessionBase(object):
@@ -830,8 +830,7 @@ class _SessionBase(object):
     '''
 
     def __init__(self, repeated_capability):
-        # TODO(marcoskirsch): rename to _library.
-        self.library = library_singleton.get()
+        self._library = library_singleton.get()
         self._repeated_capability = repeated_capability
 
     def __setattr__(self, key, value):
@@ -870,7 +869,7 @@ class _SessionBase(object):
         _initiate_scan. If the switch module is not scanning,
         NISWITCH_ERROR_NO_SCAN_IN_PROGRESS error is returned.
         '''
-        error_code = self.library.niSwitch_AbortScan(self.vi)
+        error_code = self._library.niSwitch_AbortScan(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -915,7 +914,7 @@ class _SessionBase(object):
                 configuration channel and thus unavailable for external connections.
         '''
         path_capability_ctype = ctypes_types.ViInt32_ctype(0)
-        error_code = self.library.niSwitch_CanConnect(self.vi, channel1.encode('ascii'), channel2.encode('ascii'), ctypes.pointer(path_capability_ctype))
+        error_code = self._library.niSwitch_CanConnect(self._vi, channel1.encode('ascii'), channel2.encode('ascii'), ctypes.pointer(path_capability_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return enums.PathCapability(path_capability_ctype.value)
 
@@ -924,7 +923,7 @@ class _SessionBase(object):
 
         This function clears the list of current interchange warnings.
         '''
-        error_code = self.library.niSwitch_ClearInterchangeWarnings(self.vi)
+        error_code = self._library.niSwitch_ClearInterchangeWarnings(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -936,7 +935,7 @@ class _SessionBase(object):
         _initiate_scan. Use commit to arm triggers in a given
         order or to control when expensive hardware operations are performed.
         '''
-        error_code = self.library.niSwitch_Commit(self.vi)
+        error_code = self._library.niSwitch_Commit(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -964,7 +963,7 @@ class _SessionBase(object):
         '''
         if type(scan_mode) is not enums.ScanMode:
             raise TypeError('Parameter mode must be of type ' + str(enums.ScanMode))
-        error_code = self.library.niSwitch_ConfigureScanList(self.vi, scanlist.encode('ascii'), scan_mode.value)
+        error_code = self._library.niSwitch_ConfigureScanList(self._vi, scanlist.encode('ascii'), scan_mode.value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1005,7 +1004,7 @@ class _SessionBase(object):
             raise TypeError('Parameter mode must be of type ' + str(enums.TriggerInput))
         if type(scan_advanced_output) is not enums.ScanAdvancedOutput:
             raise TypeError('Parameter mode must be of type ' + str(enums.ScanAdvancedOutput))
-        error_code = self.library.niSwitch_ConfigureScanTrigger(self.vi, scan_delay, trigger_input.value, scan_advanced_output.value)
+        error_code = self._library.niSwitch_ConfigureScanTrigger(self._vi, scan_delay, trigger_input.value, scan_advanced_output.value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1041,7 +1040,7 @@ class _SessionBase(object):
                 valid channel names for the switch module. Examples of valid channel
                 names: ch0, com0, ab0, r1, c2, cjtemp Default value: None
         '''
-        error_code = self.library.niSwitch_Connect(self.vi, channel1.encode('ascii'), channel2.encode('ascii'))
+        error_code = self._library.niSwitch_Connect(self._vi, channel1.encode('ascii'), channel2.encode('ascii'))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1078,7 +1077,7 @@ class _SessionBase(object):
                 of a valid connection list: c0 -> r1, [c2 -> r2 -> c3] In this example,
                 r2 is a configuration channel. Default value: None
         '''
-        error_code = self.library.niSwitch_ConnectMultiple(self.vi, connection_list.encode('ascii'))
+        error_code = self._library.niSwitch_ConnectMultiple(self._vi, connection_list.encode('ascii'))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1089,7 +1088,7 @@ class _SessionBase(object):
         impact on the system to which it is connected. All channels are
         disconnected and any scan in progress is aborted.
         '''
-        error_code = self.library.niSwitch_Disable(self.vi)
+        error_code = self._library.niSwitch_Disable(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1111,7 +1110,7 @@ class _SessionBase(object):
                 valid channel names for the switch module. Examples of valid channel
                 names: ch0, com0, ab0, r1, c2, cjtemp Default value: None
         '''
-        error_code = self.library.niSwitch_Disconnect(self.vi, channel1.encode('ascii'), channel2.encode('ascii'))
+        error_code = self._library.niSwitch_Disconnect(self._vi, channel1.encode('ascii'), channel2.encode('ascii'))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1121,7 +1120,7 @@ class _SessionBase(object):
         Breaks all existing paths. If the switch module cannot break all paths,
         NISWITCH_WARN_PATH_REMAINS warning is returned.
         '''
-        error_code = self.library.niSwitch_DisconnectAll(self.vi)
+        error_code = self._library.niSwitch_DisconnectAll(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1143,7 +1142,7 @@ class _SessionBase(object):
                 r2 -> c3] In this example, r2 is a configuration channel. Default value:
                 None
         '''
-        error_code = self.library.niSwitch_DisconnectMultiple(self.vi, disconnection_list.encode('ascii'))
+        error_code = self._library.niSwitch_DisconnectMultiple(self._vi, disconnection_list.encode('ascii'))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1188,7 +1187,7 @@ class _SessionBase(object):
                 double-clicking on it or by selecting it and then pressing .
         '''
         attribute_value_ctype = ctypes_types.ViBoolean_ctype(0)
-        error_code = self.library.niSwitch_GetAttributeViBoolean(self.vi, channel_name.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
+        error_code = self._library.niSwitch_GetAttributeViBoolean(self._vi, channel_name.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViBoolean(attribute_value_ctype.value)
 
@@ -1233,7 +1232,7 @@ class _SessionBase(object):
                 double-clicking on it or by selecting it and then pressing .
         '''
         attribute_value_ctype = ctypes_types.ViInt32_ctype(0)
-        error_code = self.library.niSwitch_GetAttributeViInt32(self.vi, channel_name.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
+        error_code = self._library.niSwitch_GetAttributeViInt32(self._vi, channel_name.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViInt32(attribute_value_ctype.value)
 
@@ -1278,7 +1277,7 @@ class _SessionBase(object):
                 double-clicking on it or by selecting it and then pressing .
         '''
         attribute_value_ctype = ctypes_types.ViReal64_ctype(0)
-        error_code = self.library.niSwitch_GetAttributeViReal64(self.vi, channel_name.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
+        error_code = self._library.niSwitch_GetAttributeViReal64(self._vi, channel_name.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViReal64(attribute_value_ctype.value)
 
@@ -1339,11 +1338,11 @@ class _SessionBase(object):
         '''
         array_size = 0
         attribute_value_ctype = None
-        error_code = self.library.niSwitch_GetAttributeViString(self.vi, channel_name.encode('ascii'), attribute_id, array_size, attribute_value_ctype)
+        error_code = self._library.niSwitch_GetAttributeViString(self._vi, channel_name.encode('ascii'), attribute_id, array_size, attribute_value_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         array_size = error_code
         attribute_value_ctype = ctypes.cast(ctypes.create_string_buffer(array_size), ctypes_types.ViString_ctype)
-        error_code = self.library.niSwitch_GetAttributeViString(self.vi, channel_name.encode('ascii'), attribute_id, array_size, attribute_value_ctype)
+        error_code = self._library.niSwitch_GetAttributeViString(self._vi, channel_name.encode('ascii'), attribute_id, array_size, attribute_value_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return attribute_value_ctype.value.decode("ascii")
 
@@ -1372,11 +1371,11 @@ class _SessionBase(object):
         '''
         buffer_size = 0
         channel_name_buffer_ctype = None
-        error_code = self.library.niSwitch_GetChannelName(self.vi, index, buffer_size, channel_name_buffer_ctype)
+        error_code = self._library.niSwitch_GetChannelName(self._vi, index, buffer_size, channel_name_buffer_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         buffer_size = error_code
         channel_name_buffer_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), ctypes_types.ViString_ctype)
-        error_code = self.library.niSwitch_GetChannelName(self.vi, index, buffer_size, channel_name_buffer_ctype)
+        error_code = self._library.niSwitch_GetChannelName(self._vi, index, buffer_size, channel_name_buffer_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return channel_name_buffer_ctype.value.decode("ascii")
 
@@ -1418,11 +1417,11 @@ class _SessionBase(object):
         code_ctype = ctypes_types.ViStatus_ctype(0)
         buffer_size = 0
         description_ctype = None
-        error_code = self.library.niSwitch_GetError(self.vi, ctypes.pointer(code_ctype), buffer_size, description_ctype)
+        error_code = self._library.niSwitch_GetError(self._vi, ctypes.pointer(code_ctype), buffer_size, description_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         buffer_size = error_code
         description_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), ctypes_types.ViString_ctype)
-        error_code = self.library.niSwitch_GetError(self.vi, ctypes.pointer(code_ctype), buffer_size, description_ctype)
+        error_code = self._library.niSwitch_GetError(self._vi, ctypes.pointer(code_ctype), buffer_size, description_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViStatus(code_ctype.value), description_ctype.value.decode("ascii")
 
@@ -1463,11 +1462,11 @@ class _SessionBase(object):
         '''
         buffer_size = 0
         coercion_record_ctype = None
-        error_code = self.library.niSwitch_GetNextCoercionRecord(self.vi, buffer_size, coercion_record_ctype)
+        error_code = self._library.niSwitch_GetNextCoercionRecord(self._vi, buffer_size, coercion_record_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         buffer_size = error_code
         coercion_record_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), ctypes_types.ViString_ctype)
-        error_code = self.library.niSwitch_GetNextCoercionRecord(self.vi, buffer_size, coercion_record_ctype)
+        error_code = self._library.niSwitch_GetNextCoercionRecord(self._vi, buffer_size, coercion_record_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return coercion_record_ctype.value.decode("ascii")
 
@@ -1502,11 +1501,11 @@ class _SessionBase(object):
         '''
         buffer_size = 0
         interchange_warning_ctype = None
-        error_code = self.library.niSwitch_GetNextInterchangeWarning(self.vi, buffer_size, interchange_warning_ctype)
+        error_code = self._library.niSwitch_GetNextInterchangeWarning(self._vi, buffer_size, interchange_warning_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         buffer_size = error_code
         interchange_warning_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), ctypes_types.ViString_ctype)
-        error_code = self.library.niSwitch_GetNextInterchangeWarning(self.vi, buffer_size, interchange_warning_ctype)
+        error_code = self._library.niSwitch_GetNextInterchangeWarning(self._vi, buffer_size, interchange_warning_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return interchange_warning_ctype.value.decode("ascii")
 
@@ -1548,11 +1547,11 @@ class _SessionBase(object):
         '''
         buffer_size = 0
         path_ctype = None
-        error_code = self.library.niSwitch_GetPath(self.vi, channel1.encode('ascii'), channel2.encode('ascii'), buffer_size, path_ctype)
+        error_code = self._library.niSwitch_GetPath(self._vi, channel1.encode('ascii'), channel2.encode('ascii'), buffer_size, path_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         buffer_size = error_code
         path_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), ctypes_types.ViString_ctype)
-        error_code = self.library.niSwitch_GetPath(self.vi, channel1.encode('ascii'), channel2.encode('ascii'), buffer_size, path_ctype)
+        error_code = self._library.niSwitch_GetPath(self._vi, channel1.encode('ascii'), channel2.encode('ascii'), buffer_size, path_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return path_ctype.value.decode("ascii")
 
@@ -1574,7 +1573,7 @@ class _SessionBase(object):
             relay_count (int):The number of relay cycles.
         '''
         relay_count_ctype = ctypes_types.ViInt32_ctype(0)
-        error_code = self.library.niSwitch_GetRelayCount(self.vi, relay_name.encode('ascii'), ctypes.pointer(relay_count_ctype))
+        error_code = self._library.niSwitch_GetRelayCount(self._vi, relay_name.encode('ascii'), ctypes.pointer(relay_count_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViInt32(relay_count_ctype.value)
 
@@ -1603,11 +1602,11 @@ class _SessionBase(object):
         '''
         relay_name_buffer_size = 0
         relay_name_buffer_ctype = None
-        error_code = self.library.niSwitch_GetRelayName(self.vi, index, relay_name_buffer_size, relay_name_buffer_ctype)
+        error_code = self._library.niSwitch_GetRelayName(self._vi, index, relay_name_buffer_size, relay_name_buffer_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         relay_name_buffer_size = error_code
         relay_name_buffer_ctype = ctypes.cast(ctypes.create_string_buffer(relay_name_buffer_size), ctypes_types.ViString_ctype)
-        error_code = self.library.niSwitch_GetRelayName(self.vi, index, relay_name_buffer_size, relay_name_buffer_ctype)
+        error_code = self._library.niSwitch_GetRelayName(self._vi, index, relay_name_buffer_size, relay_name_buffer_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return relay_name_buffer_ctype.value.decode("ascii")
 
@@ -1627,7 +1626,7 @@ class _SessionBase(object):
                 NIWITCH_VAL_CLOSED 11
         '''
         relay_position_ctype = ctypes_types.ViInt32_ctype(0)
-        error_code = self.library.niSwitch_GetRelayPosition(self.vi, relay_name.encode('ascii'), ctypes.pointer(relay_position_ctype))
+        error_code = self._library.niSwitch_GetRelayPosition(self._vi, relay_name.encode('ascii'), ctypes.pointer(relay_position_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return enums.RelayPosition(relay_position_ctype.value)
 
@@ -1864,7 +1863,7 @@ class _SessionBase(object):
                 and used for all subsequent NI-SWITCH calls.
         '''
         vi_ctype = ctypes_types.ViSession_ctype(0)
-        error_code = self.library.niSwitch_InitWithTopology(resource_name.encode('ascii'), topology.encode('ascii'), simulate, reset_device, ctypes.pointer(vi_ctype))
+        error_code = self._library.niSwitch_InitWithTopology(resource_name.encode('ascii'), topology.encode('ascii'), simulate, reset_device, ctypes.pointer(vi_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViSession(vi_ctype.value)
 
@@ -1880,7 +1879,7 @@ class _SessionBase(object):
         scanning operation, To stop the scanning operation, call
         _abort_scan.
         '''
-        error_code = self.library.niSwitch_InitiateScan(self.vi)
+        error_code = self._library.niSwitch_InitiateScan(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1895,7 +1894,7 @@ class _SessionBase(object):
                 indicates that all created paths have not settled.
         '''
         is_debounced_ctype = ctypes_types.ViBoolean_ctype(0)
-        error_code = self.library.niSwitch_IsDebounced(self.vi, ctypes.pointer(is_debounced_ctype))
+        error_code = self._library.niSwitch_IsDebounced(self._vi, ctypes.pointer(is_debounced_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViBoolean(is_debounced_ctype.value)
 
@@ -1910,7 +1909,7 @@ class _SessionBase(object):
                 indicates that the switch device is idle.
         '''
         is_scanning_ctype = ctypes_types.ViBoolean_ctype(0)
-        error_code = self.library.niSwitch_IsScanning(self.vi, ctypes.pointer(is_scanning_ctype))
+        error_code = self._library.niSwitch_IsScanning(self._vi, ctypes.pointer(is_scanning_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViBoolean(is_scanning_ctype.value)
 
@@ -1934,7 +1933,7 @@ class _SessionBase(object):
         '''
         if type(relay_action) is not enums.RelayAction:
             raise TypeError('Parameter mode must be of type ' + str(enums.RelayAction))
-        error_code = self.library.niSwitch_RelayControl(self.vi, relay_name.encode('ascii'), relay_action.value)
+        error_code = self._library.niSwitch_RelayControl(self._vi, relay_name.encode('ascii'), relay_action.value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1968,7 +1967,7 @@ class _SessionBase(object):
         the content of those warnings, you can call the
         clear_interchange_warnings function.
         '''
-        error_code = self.library.niSwitch_ResetInterchangeCheck(self.vi)
+        error_code = self._library.niSwitch_ResetInterchangeCheck(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1980,7 +1979,7 @@ class _SessionBase(object):
         created without a logical name, this function is equivalent to
         reset.
         '''
-        error_code = self.library.niSwitch_ResetWithDefaults(self.vi)
+        error_code = self._library.niSwitch_ResetWithDefaults(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -2007,7 +2006,7 @@ class _SessionBase(object):
             raise TypeError('Parameter mode must be of type ' + str(enums.ScanAdvancedOutput))
         if type(scan_advanced_output_bus_line) is not enums.ScanAdvancedOutput:
             raise TypeError('Parameter mode must be of type ' + str(enums.ScanAdvancedOutput))
-        error_code = self.library.niSwitch_RouteScanAdvancedOutput(self.vi, scan_advanced_output_connector.value, scan_advanced_output_bus_line.value, invert)
+        error_code = self._library.niSwitch_RouteScanAdvancedOutput(self._vi, scan_advanced_output_connector.value, scan_advanced_output_bus_line.value, invert)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -2035,7 +2034,7 @@ class _SessionBase(object):
             raise TypeError('Parameter mode must be of type ' + str(enums.TriggerInput))
         if type(trigger_input_bus_line) is not enums.TriggerInput:
             raise TypeError('Parameter mode must be of type ' + str(enums.TriggerInput))
-        error_code = self.library.niSwitch_RouteTriggerInput(self.vi, trigger_input_connector.value, trigger_input_bus_line.value, invert)
+        error_code = self._library.niSwitch_RouteTriggerInput(self._vi, trigger_input_connector.value, trigger_input_bus_line.value, invert)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -2049,7 +2048,7 @@ class _SessionBase(object):
         a semi-colon (wait for trigger) until send_software_trigger is
         called.
         '''
-        error_code = self.library.niSwitch_SendSoftwareTrigger(self.vi)
+        error_code = self._library.niSwitch_SendSoftwareTrigger(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -2105,7 +2104,7 @@ class _SessionBase(object):
                 then pressing . Note: Some of the values might not be valid depending on
                 the current settings of the instrument session. Default Value: none
         '''
-        error_code = self.library.niSwitch_SetAttributeViBoolean(self.vi, channel_name.encode('ascii'), attribute_id, attribute_value)
+        error_code = self._library.niSwitch_SetAttributeViBoolean(self._vi, channel_name.encode('ascii'), attribute_id, attribute_value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -2161,7 +2160,7 @@ class _SessionBase(object):
                 then pressing . Note: Some of the values might not be valid depending on
                 the current settings of the instrument session. Default Value: none
         '''
-        error_code = self.library.niSwitch_SetAttributeViInt32(self.vi, channel_name.encode('ascii'), attribute_id, attribute_value)
+        error_code = self._library.niSwitch_SetAttributeViInt32(self._vi, channel_name.encode('ascii'), attribute_id, attribute_value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -2217,7 +2216,7 @@ class _SessionBase(object):
                 then pressing . Note: Some of the values might not be valid depending on
                 the current settings of the instrument session. Default Value: none
         '''
-        error_code = self.library.niSwitch_SetAttributeViReal64(self.vi, channel_name.encode('ascii'), attribute_id, attribute_value)
+        error_code = self._library.niSwitch_SetAttributeViReal64(self._vi, channel_name.encode('ascii'), attribute_id, attribute_value)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -2273,7 +2272,7 @@ class _SessionBase(object):
                 then pressing . Note: Some of the values might not be valid depending on
                 the current settings of the instrument session. Default Value: none
         '''
-        error_code = self.library.niSwitch_SetAttributeViString(self.vi, channel_name.encode('ascii'), attribute_id, attribute_value.encode('ascii'))
+        error_code = self._library.niSwitch_SetAttributeViString(self._vi, channel_name.encode('ascii'), attribute_id, attribute_value.encode('ascii'))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -2288,7 +2287,7 @@ class _SessionBase(object):
                 If VI_FALSE, the scan stops after one pass through the scan list.
                 Default value: VI_FALSE
         '''
-        error_code = self.library.niSwitch_SetContinuousScan(self.vi, continuous_scan)
+        error_code = self._library.niSwitch_SetContinuousScan(self._vi, continuous_scan)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -2308,7 +2307,7 @@ class _SessionBase(object):
                 configuration channel. Default value: None Obtain the path list for a
                 previously created path with get_path.
         '''
-        error_code = self.library.niSwitch_SetPath(self.vi, path_list.encode('ascii'))
+        error_code = self._library.niSwitch_SetPath(self._vi, path_list.encode('ascii'))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -2326,7 +2325,7 @@ class _SessionBase(object):
                 before all relays active or deactivate, a timeout error is returned.
                 Default Value:5000 ms
         '''
-        error_code = self.library.niSwitch_WaitForDebounce(self.vi, maximum_time_ms)
+        error_code = self._library.niSwitch_WaitForDebounce(self._vi, maximum_time_ms)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -2345,7 +2344,7 @@ class _SessionBase(object):
                 NISWITCH_ERROR_MAX_TIME_EXCEEDED error is returned. Default
                 Value:5000 ms
         '''
-        error_code = self.library.niSwitch_WaitForScanComplete(self.vi, maximum_time_ms)
+        error_code = self._library.niSwitch_WaitForScanComplete(self._vi, maximum_time_ms)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -2358,7 +2357,7 @@ class _SessionBase(object):
         _close, you cannot use the instrument driver again until you
         call init or init_with_options.
         '''
-        error_code = self.library.niSwitch_close(self.vi)
+        error_code = self._library.niSwitch_close(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -2379,7 +2378,7 @@ class _SessionBase(object):
         '''
         error_code_ctype = ctypes_types.ViInt32_ctype(0)
         error_message_ctype = (ctypes_types.ViChar_ctype * 256)()
-        error_code = self.library.niSwitch_error_query(self.vi, ctypes.pointer(error_code_ctype), ctypes.cast(error_message_ctype, ctypes.POINTER(ctypes_types.ViChar_ctype)))
+        error_code = self._library.niSwitch_error_query(self._vi, ctypes.pointer(error_code_ctype), ctypes.cast(error_message_ctype, ctypes.POINTER(ctypes_types.ViChar_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViInt32(error_code_ctype.value), error_message_ctype.value.decode("ascii")
 
@@ -2390,7 +2389,7 @@ class _SessionBase(object):
         at initialization. Configuration channel and source channel settings
         remain unchanged.
         '''
-        error_code = self.library.niSwitch_reset(self.vi)
+        error_code = self._library.niSwitch_reset(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -2406,7 +2405,7 @@ class _SessionBase(object):
         '''
         instrument_driver_revision_ctype = (ctypes_types.ViChar_ctype * 256)()
         firmware_revision_ctype = (ctypes_types.ViChar_ctype * 256)()
-        error_code = self.library.niSwitch_revision_query(self.vi, ctypes.cast(instrument_driver_revision_ctype, ctypes.POINTER(ctypes_types.ViChar_ctype)), ctypes.cast(firmware_revision_ctype, ctypes.POINTER(ctypes_types.ViChar_ctype)))
+        error_code = self._library.niSwitch_revision_query(self._vi, ctypes.cast(instrument_driver_revision_ctype, ctypes.POINTER(ctypes_types.ViChar_ctype)), ctypes.cast(firmware_revision_ctype, ctypes.POINTER(ctypes_types.ViChar_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return instrument_driver_revision_ctype.value.decode("ascii"), firmware_revision_ctype.value.decode("ascii")
 
@@ -2422,7 +2421,7 @@ class _SessionBase(object):
         '''
         self_test_result_ctype = ctypes_types.ViInt16_ctype(0)
         self_test_message_ctype = (ctypes_types.ViChar_ctype * 256)()
-        error_code = self.library.niSwitch_self_test(self.vi, ctypes.pointer(self_test_result_ctype), ctypes.cast(self_test_message_ctype, ctypes.POINTER(ctypes_types.ViChar_ctype)))
+        error_code = self._library.niSwitch_self_test(self._vi, ctypes.pointer(self_test_result_ctype), ctypes.cast(self_test_message_ctype, ctypes.POINTER(ctypes_types.ViChar_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return python_types.ViInt16(self_test_result_ctype.value), self_test_message_ctype.value.decode("ascii")
 
@@ -2432,7 +2431,7 @@ class _RepeatedCapability(_SessionBase):
 
     def __init__(self, vi, repeated_capability):
         super(_RepeatedCapability, self).__init__(repeated_capability)
-        self.vi = vi
+        self._vi = vi
         self._is_frozen = True
 
     def __enter__(self):
@@ -2448,8 +2447,8 @@ class Session(_SessionBase):
     def __init__(self, resource_name, topology='Configured Topology', simulate=False, reset_device=False):
         super(Session, self).__init__(repeated_capability='')
         # TODO(marcoskirsch): private members should start with _
-        self.vi = 0  # This must be set before calling _init_with_options.
-        self.vi = self.init_with_topology(resource_name, topology, simulate, reset_device)
+        self._vi = 0  # This must be set before calling init_with_topology().
+        self._vi = self.init_with_topology(resource_name, topology, simulate, reset_device)
         self._is_frozen = True
 
     def __enter__(self):
@@ -2460,7 +2459,7 @@ class Session(_SessionBase):
 
     def __getitem__(self, repeated_capability):
         '''Set/get properties or call methods with a repeated capability (i.e. channels)'''
-        return _RepeatedCapability(self.vi, repeated_capability)
+        return _RepeatedCapability(self._vi, repeated_capability)
 
     def initiate(self):
         return _Scan(self)
@@ -2471,6 +2470,6 @@ class Session(_SessionBase):
         except errors.Error:
             # TODO(marcoskirsch): This will occur when session is "stolen". Change to log instead
             print("Failed to close session.")
-        self.vi = 0
+        self._vi = 0
 
 

--- a/generated/niswitch/session.py
+++ b/generated/niswitch/session.py
@@ -2440,7 +2440,6 @@ class Session(_SessionBase):
 
     def __init__(self, resource_name, topology='Configured Topology', simulate=False, reset_device=False):
         super(Session, self).__init__(repeated_capability='')
-        # TODO(marcoskirsch): private members should start with _
         self._vi = 0  # This must be set before calling init_with_topology().
         self._vi = self.init_with_topology(resource_name, topology, simulate, reset_device)
         self._is_frozen = True

--- a/src/nifake/tests/test_session.py
+++ b/src/nifake/tests/test_session.py
@@ -38,7 +38,7 @@ class TestSession(object):
 
         self.patched_library.niFake_close.side_effect = self.disallow_close
         session = nifake.Session('dev1')
-        assert session.vi == SESSION_NUM_FOR_TEST
+        assert session._vi == SESSION_NUM_FOR_TEST
         self.patched_library.niFake_InitWithOptions.assert_called_once_with(b'dev1', 0, False, b'', ANY)
         patched_errors.handle_error.assert_called_once_with(session, self.patched_library.niFake_InitWithOptions.return_value, ignore_warnings=False, is_error_handling=False)
 
@@ -46,7 +46,7 @@ class TestSession(object):
 
     def test_init_with_options_nondefault(self):
         session = nifake.Session('FakeDevice', True, True, 'Some string')
-        assert(session.vi == SESSION_NUM_FOR_TEST)
+        assert(session._vi == SESSION_NUM_FOR_TEST)
         self.patched_library.niFake_InitWithOptions.assert_called_once_with(b'FakeDevice', True, True, b'Some string', ANY)
 
     def test_error_on_init(self):
@@ -75,7 +75,7 @@ class TestSession(object):
 
     def test_session_context_manager(self):
         with nifake.Session('dev1') as session:
-            assert session.vi == SESSION_NUM_FOR_TEST
+            assert session._vi == SESSION_NUM_FOR_TEST
             self.patched_library.niFake_InitWithOptions.assert_called_once_with(b'dev1', 0, False, b'', ANY)
         self.patched_library.niFake_close.assert_called_once_with(SESSION_NUM_FOR_TEST)
 
@@ -168,9 +168,9 @@ class TestSession(object):
 
     def test_library_singleton(self):
         with nifake.Session('dev1') as session:
-            lib1 = session.library
+            lib1 = session._library
         with nifake.Session('dev2') as session:
-            lib2 = session.library
+            lib2 = session._library
         assert lib1 is lib2
 
     def test_one_input_function(self):

--- a/src/nimodinst/templates/session.py.mako
+++ b/src/nimodinst/templates/session.py.mako
@@ -27,7 +27,7 @@ class AttributeViInt32(object):
         self._attribute_id = attribute_id
 
     def __getitem__(self, index):
-        return self._owner._get_installed_device_attribute_vi_int32(self._owner._handle, self._index, self._attribute_id)
+        return self._owner._get_installed_device_attribute_vi_int32(self._owner._${config['session_handle_parameter_name']}, self._index, self._attribute_id)
 
 
 class AttributeViString(object):
@@ -38,7 +38,7 @@ class AttributeViString(object):
         self._attribute_id = attribute_id
 
     def __getitem__(self, index):
-        return self._owner._get_installed_device_attribute_vi_string(self._owner._handle, self._index, self._attribute_id)
+        return self._owner._get_installed_device_attribute_vi_string(self._owner._${config['session_handle_parameter_name']}, self._index, self._attribute_id)
 
 
 class Device(object):
@@ -143,8 +143,8 @@ class Session(object):
 
     def close(self):
         # TODO(marcoskirsch): Should we raise an exception on double close? Look at what File does.
-        if(self._handle != 0):
-            self._close_installed_devices_session(self._handle)
+        if(self._${config['session_handle_parameter_name']} != 0):
+            self._close_installed_devices_session(self._${config['session_handle_parameter_name']})
             self._${config['session_handle_parameter_name']} = 0
 
     ''' These are code-generated '''

--- a/src/nimodinst/templates/session.py.mako
+++ b/src/nimodinst/templates/session.py.mako
@@ -27,7 +27,7 @@ class AttributeViInt32(object):
         self._attribute_id = attribute_id
 
     def __getitem__(self, index):
-        return self._owner._get_installed_device_attribute_vi_int32(self._owner.handle, self._index, self._attribute_id)
+        return self._owner._get_installed_device_attribute_vi_int32(self._owner._handle, self._index, self._attribute_id)
 
 
 class AttributeViString(object):
@@ -38,7 +38,7 @@ class AttributeViString(object):
         self._attribute_id = attribute_id
 
     def __getitem__(self, index):
-        return self._owner._get_installed_device_attribute_vi_string(self._owner.handle, self._index, self._attribute_id)
+        return self._owner._get_installed_device_attribute_vi_string(self._owner._handle, self._index, self._attribute_id)
 
 
 class Device(object):
@@ -77,11 +77,11 @@ class Session(object):
     _is_frozen = False
 
     def __init__(self, driver):
-        self.${config['session_handle_parameter_name']} = 0
-        self.item_count = 0
-        self.current_item = 0
-        self.library = library_singleton.get()
-        self.${config['session_handle_parameter_name']}, self.item_count = self._open_installed_devices_session(driver)
+        self._${config['session_handle_parameter_name']} = 0
+        self._item_count = 0
+        self._current_item = 0
+        self._library = library_singleton.get()
+        self._${config['session_handle_parameter_name']}, self._item_count = self._open_installed_devices_session(driver)
 
         self._is_frozen = True
 
@@ -104,35 +104,35 @@ class Session(object):
 
         Returns the error description.
         '''
-        # We hand-maintain the code that calls into self.library rather than leverage code-generation
+        # We hand-maintain the code that calls into self._library rather than leverage code-generation
         # because niModInst_GetExtendedErrorInfo() does not properly do the IVI-dance.
         # See https://github.com/ni/nimi-python/issues/166
         error_info_buffer_size = 0
         error_info_ctype = None
-        error_code = self.library.niModInst_GetExtendedErrorInfo(error_info_buffer_size, error_info_ctype)
+        error_code = self._library.niModInst_GetExtendedErrorInfo(error_info_buffer_size, error_info_ctype)
         if error_code <= 0:
             return "Failed to retrieve error description."
         error_info_buffer_size = error_code
         error_info_ctype = ctypes.create_string_buffer(error_info_buffer_size)
         # Note we don't look at the return value. This is intentional as niModInst returns the
         # original error code rather than 0 (VI_SUCCESS).
-        self.library.niModInst_GetExtendedErrorInfo(error_info_buffer_size, error_info_ctype)
+        self._library.niModInst_GetExtendedErrorInfo(error_info_buffer_size, error_info_ctype)
         return error_info_ctype.value.decode("ascii")
 
     # Iterator functions
     def __len__(self):
-        return self.item_count
+        return self._item_count
 
     def __iter__(self):
-        self.current_item = 0
+        self._current_item = 0
         return self
 
     def get_next(self):
-        if self.current_item + 1 > self.item_count:
+        if self._current_item + 1 > self._item_count:
             raise StopIteration
         else:
-            result = Device(self, self.current_item)
-            self.current_item += 1
+            result = Device(self, self._current_item)
+            self._current_item += 1
             return result
 
     def next(self):
@@ -143,9 +143,9 @@ class Session(object):
 
     def close(self):
         # TODO(marcoskirsch): Should we raise an exception on double close? Look at what File does.
-        if(self.handle != 0):
-            self._close_installed_devices_session(self.handle)
-            self.${config['session_handle_parameter_name']} = 0
+        if(self._handle != 0):
+            self._close_installed_devices_session(self._handle)
+            self._${config['session_handle_parameter_name']} = 0
 
     ''' These are code-generated '''
 % for func_name in sorted(functions):
@@ -166,17 +166,17 @@ class Session(object):
         ${helper.get_ctype_variable_declaration_snippet(output_parameter, parameters)}
 % endfor
 % if ivi_dance_parameter is None:
-        error_code = self.library.${c_function_prefix}${func_name}(${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_CALL, {'session_name': 'handle'})})
+        error_code = self._library.${c_function_prefix}${func_name}(${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_CALL, {'session_handle_parameter_name': '_handle'})})
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=${f['is_error_handling']})
         ${helper.get_method_return_snippet(f['parameters'])}
 % else:
         ${ivi_dance_size_parameter['python_name']} = 0
         ${ivi_dance_parameter['ctypes_variable_name']} = None
-        error_code = self.library.${c_function_prefix}${func_name}(${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_CALL, {'session_name': 'handle'})})
+        error_code = self._library.${c_function_prefix}${func_name}(${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_CALL, {'session_handle_parameter_name': '_handle'})})
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=${f['is_error_handling']})
         ${ivi_dance_size_parameter['python_name']} = error_code
         ${ivi_dance_parameter['ctypes_variable_name']} = ctypes.cast(ctypes.create_string_buffer(${ivi_dance_size_parameter['python_name']}), ctypes_types.${ivi_dance_parameter['ctypes_type']})
-        error_code = self.library.${c_function_prefix}${func_name}(${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_CALL, {'session_name': 'handle'})})
+        error_code = self._library.${c_function_prefix}${func_name}(${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_CALL, {'session_handle_parameter_name': '_handle'})})
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=${f['is_error_handling']})
         ${helper.get_method_return_snippet(f['parameters'])}
 % endif

--- a/src/nimodinst/templates/session.py.mako
+++ b/src/nimodinst/templates/session.py.mako
@@ -166,17 +166,17 @@ class Session(object):
         ${helper.get_ctype_variable_declaration_snippet(output_parameter, parameters)}
 % endfor
 % if ivi_dance_parameter is None:
-        error_code = self._library.${c_function_prefix}${func_name}(${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_CALL, {'session_handle_parameter_name': '_handle'})})
+        error_code = self._library.${c_function_prefix}${func_name}(${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_CALL, {'session_handle_parameter_name': '_' + config['session_handle_parameter_name']})})
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=${f['is_error_handling']})
         ${helper.get_method_return_snippet(f['parameters'])}
 % else:
         ${ivi_dance_size_parameter['python_name']} = 0
         ${ivi_dance_parameter['ctypes_variable_name']} = None
-        error_code = self._library.${c_function_prefix}${func_name}(${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_CALL, {'session_handle_parameter_name': '_handle'})})
+        error_code = self._library.${c_function_prefix}${func_name}(${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_CALL, {'session_handle_parameter_name': '_' + config['session_handle_parameter_name']})})
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=${f['is_error_handling']})
         ${ivi_dance_size_parameter['python_name']} = error_code
         ${ivi_dance_parameter['ctypes_variable_name']} = ctypes.cast(ctypes.create_string_buffer(${ivi_dance_size_parameter['python_name']}), ctypes_types.${ivi_dance_parameter['ctypes_type']})
-        error_code = self._library.${c_function_prefix}${func_name}(${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_CALL, {'session_handle_parameter_name': '_handle'})})
+        error_code = self._library.${c_function_prefix}${func_name}(${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_CALL, {'session_handle_parameter_name': '_' + config['session_handle_parameter_name']})})
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=${f['is_error_handling']})
         ${helper.get_method_return_snippet(f['parameters'])}
 % endif

--- a/src/nimodinst/tests/test_modinst.py
+++ b/src/nimodinst/tests/test_modinst.py
@@ -54,7 +54,7 @@ class TestSession(object):
     def test_open(self):
         self.patched_library.niModInst_CloseInstalledDevicesSession.side_effect = self.disallow_close
         session = nimodinst.Session('')
-        assert(session.handle == SESSION_NUM_FOR_TEST)
+        assert(session._handle == SESSION_NUM_FOR_TEST)
         self.patched_library.niModInst_OpenInstalledDevicesSession.assert_called_once_with(b'', ANY, ANY)
 
     def test_close(self):
@@ -64,7 +64,7 @@ class TestSession(object):
 
     def test_context_manager(self):
         with nimodinst.Session('') as session:
-            assert(session.handle == SESSION_NUM_FOR_TEST)
+            assert(session._handle == SESSION_NUM_FOR_TEST)
             self.patched_library.niModInst_OpenInstalledDevicesSession.assert_called_once_with(b'', ANY, ANY)
         self.patched_library.niModInst_CloseInstalledDevicesSession.assert_called_once_with(SESSION_NUM_FOR_TEST)
 


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md]

### What does this Pull Request accomplish?

* Fix #256 
* Adds underscore prefix to private members for consistency with PEP8 coding conventions
* Shrinks the "surface area" of API by signaling clients not to use those.
* Renames 'session_name' to 'session_handle_parameter_name' in ParamListType, consistent with config.py metadata.
* Renames 'name_to_use': 'library_call_name' in ParamListType to 'library_call_snippet', as it contains code not just a name.
* Fix a handful of locations where "vi" was still hardcoded, rather than use ${config['session_handle_parameter_name']}


### Why should this Pull Request be merged?

* Bug fixes
* Naming improvements

### What testing has been done?

tox
