### PR TITLE
Add unit test and NI-FAKE function that has enum parameter with default value

### DIFF
--- a/generated/nifake/library.py
+++ b/generated/nifake/library.py
@@ -18,6 +18,7 @@ class Library(object):
         self._func_lock = threading.Lock()
         # We cache the cfunc object from the ctypes.CDLL object
         self.niFake_Abort_cfunc = None
+        self.niFake_EnumInputFunctionWithDefaults_cfunc = None
         self.niFake_GetABoolean_cfunc = None
         self.niFake_GetANumber_cfunc = None
         self.niFake_GetAStringOfFixedMaximumSize_cfunc = None
@@ -58,6 +59,14 @@ class Library(object):
                 self.niFake_Abort_cfunc.argtypes = [ViSession_ctype]  # noqa: F405
                 self.niFake_Abort_cfunc.restype = nifake.python_types.ViStatus
         return self.niFake_Abort_cfunc(vi)
+
+    def niFake_EnumInputFunctionWithDefaults(self, vi, a_turtle):  # noqa: N802
+        with self._func_lock:
+            if self.niFake_EnumInputFunctionWithDefaults_cfunc is None:
+                self.niFake_EnumInputFunctionWithDefaults_cfunc = self._library.niFake_EnumInputFunctionWithDefaults
+                self.niFake_EnumInputFunctionWithDefaults_cfunc.argtypes = [ViSession_ctype, ViInt16_ctype]  # noqa: F405
+                self.niFake_EnumInputFunctionWithDefaults_cfunc.restype = nifake.python_types.ViStatus
+        return self.niFake_EnumInputFunctionWithDefaults_cfunc(vi, a_turtle)
 
     def niFake_GetABoolean(self, vi, a_boolean):  # noqa: N802
         with self._func_lock:

--- a/generated/nifake/session.py
+++ b/generated/nifake/session.py
@@ -95,6 +95,30 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
+    def enum_input_function_with_defaults(self, a_turtle=enums.Turtle.LEONARDO):
+        '''enum_input_function_with_defaults
+
+        This function takes one parameter other than the session, which happens to be an enum and has a default value defined in functions_addon.
+
+        Args:
+            a_turtle (enums.Turtle):Indicates a ninja turtle
+
+                +---+---------------+
+                | 0 | Leonardo      |
+                +---+---------------+
+                | 1 | Donatello     |
+                +---+---------------+
+                | 2 | Raphael       |
+                +---+---------------+
+                | 3 | Mich elangelo |
+                +---+---------------+
+        '''
+        if type(a_turtle) is not enums.Turtle:
+            raise TypeError('Parameter mode must be of type ' + str(enums.Turtle))
+        error_code = self._library.niFake_EnumInputFunctionWithDefaults(self._vi, a_turtle.value)
+        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
+        return
+
     def get_a_boolean(self):
         '''get_a_boolean
 

--- a/generated/nifake/tests/mock_helper.py
+++ b/generated/nifake/tests/mock_helper.py
@@ -21,6 +21,8 @@ class SideEffectsHelper(object):
         self._defaults = {}
         self._defaults['Abort'] = {}
         self._defaults['Abort']['return'] = 0
+        self._defaults['EnumInputFunctionWithDefaults'] = {}
+        self._defaults['EnumInputFunctionWithDefaults']['return'] = 0
         self._defaults['GetABoolean'] = {}
         self._defaults['GetABoolean']['return'] = 0
         self._defaults['GetABoolean']['aBoolean'] = None
@@ -104,6 +106,11 @@ class SideEffectsHelper(object):
         if self._defaults['Abort']['return'] != 0:
             return self._defaults['Abort']['return']
         return self._defaults['Abort']['return']
+
+    def niFake_EnumInputFunctionWithDefaults(self, vi, a_turtle):  # noqa: N802
+        if self._defaults['EnumInputFunctionWithDefaults']['return'] != 0:
+            return self._defaults['EnumInputFunctionWithDefaults']['return']
+        return self._defaults['EnumInputFunctionWithDefaults']['return']
 
     def niFake_GetABoolean(self, vi, a_boolean):  # noqa: N802
         if self._defaults['GetABoolean']['return'] != 0:
@@ -308,6 +315,8 @@ class SideEffectsHelper(object):
     def set_side_effects_and_return_values(self, mock_library):
         mock_library.niFake_Abort.side_effect = MockFunctionCallError("niFake_Abort")
         mock_library.niFake_Abort.return_value = nifake.python_types.ViStatus(0)
+        mock_library.niFake_EnumInputFunctionWithDefaults.side_effect = MockFunctionCallError("niFake_EnumInputFunctionWithDefaults")
+        mock_library.niFake_EnumInputFunctionWithDefaults.return_value = nifake.python_types.ViStatus(0)
         mock_library.niFake_GetABoolean.side_effect = MockFunctionCallError("niFake_GetABoolean")
         mock_library.niFake_GetABoolean.return_value = nifake.python_types.ViStatus(0)
         mock_library.niFake_GetANumber.side_effect = MockFunctionCallError("niFake_GetANumber")

--- a/generated/nifake/tests/test_session.py
+++ b/generated/nifake/tests/test_session.py
@@ -469,3 +469,12 @@ class TestSession(object):
                 assert e.code == test_error_code
                 assert e.description == 'Failed to retrieve error description.'
 
+    def test_enum_input_function_with_defaults(self):
+        test_turtle = nifake.Turtle.DONATELLO
+        self.patched_library.niFake_EnumInputFunctionWithDefaults.side_effect = self.side_effects_helper.niFake_EnumInputFunctionWithDefaults
+        with nifake.Session('dev1') as session:
+            session.enum_input_function_with_defaults()
+            session.enum_input_function_with_defaults(test_turtle)
+            from mock import call
+            calls = [call(SESSION_NUM_FOR_TEST, 0), call(SESSION_NUM_FOR_TEST, 1)]  # 0 is the value of the default of nifake.Turtle.LEONARDO, 1 is the value of nifake.Turtle.DONATELLO
+            self.patched_library.niFake_EnumInputFunctionWithDefaults.assert_has_calls(calls)

--- a/src/nifake/metadata/functions.py
+++ b/src/nifake/metadata/functions.py
@@ -1136,6 +1136,34 @@ functions = {
         },
     },
 
+    'EnumInputFunctionWithDefaults': {
+        'codegen_method': 'public',
+        'returns': 'ViStatus',
+        'parameters': [
+            {
+                'direction': 'in',
+                'enum': None,
+                'name': 'vi',
+                'type': 'ViSession',
+                'documentation': {
+                    'description': 'Identifies a particular instrument session. You obtain the **vi**',
+                },
+            },
+            {
+                'direction': 'in',
+                'enum': 'Turtle',
+                'name': 'aTurtle',
+                'type': 'ViInt16',
+                'documentation': {
+                    'description': 'Indicates a ninja turtle',
+                    'table_body': [['0', 'Leonardo'], ['1', 'Donatello'], ['2', 'Raphael'], ['3', 'Mich elangelo']],
+                },
+            },
+        ],
+        'documentation': {
+            'description': 'This function takes one parameter other than the session, which happens to be an enum and has a default value defined in functions_addon.',
+        },
+    },
     #TODO(marcoskirsch): Lots more cases to add:
     #     Returning arrays (not strings) through all 3 mechanisms
     #     Returning strings using ivi-dance

--- a/src/nifake/metadata/functions_addon.py
+++ b/src/nifake/metadata/functions_addon.py
@@ -19,7 +19,8 @@ functions_codegen_method = {
 
 # Attach the given parameter to the given enum from enums.py
 functions_enums = {
-    'GetEnumValue':                 { 'parameters': { 2: { 'enum': 'Turtle',    }, }, },
+    'GetEnumValue':                     { 'parameters': { 2: { 'enum': 'Turtle',    }, }, },
+    'EnumInputFunctionWithDefaults':    { 'parameters': { 1: { 'enum': 'Turtle',    }, }, },
 }
 
 # TODO(texasaggie97) can we get rid of this now that we are code generating the ivi-dance method of buffer retrieval? Issue #259
@@ -65,8 +66,9 @@ functions_is_error_handling = {
 
 # Default values for method parameters
 function_default_value = {
-    'InitWithOptions':  { 'parameters': { 1: { 'default_value': False, },
-                                          2: { 'default_value': False, },
-                                          3: { 'default_value': '', }, }, },
+    'InitWithOptions':                 { 'parameters': { 1: { 'default_value': False, },
+                                                         2: { 'default_value': False, },
+                                                         3: { 'default_value': '', }, }, },
+    'EnumInputFunctionWithDefaults':   { 'parameters': { 1: { 'default_value': 'enums.Turtle.LEONARDO', }, }, },
 }
 

--- a/src/nifake/tests/test_session.py
+++ b/src/nifake/tests/test_session.py
@@ -469,3 +469,12 @@ class TestSession(object):
                 assert e.code == test_error_code
                 assert e.description == 'Failed to retrieve error description.'
 
+    def test_enum_input_function_with_defaults(self):
+        test_turtle = nifake.Turtle.DONATELLO
+        self.patched_library.niFake_EnumInputFunctionWithDefaults.side_effect = self.side_effects_helper.niFake_EnumInputFunctionWithDefaults
+        with nifake.Session('dev1') as session:
+            session.enum_input_function_with_defaults()
+            session.enum_input_function_with_defaults(test_turtle)
+            from mock import call
+            calls = [call(SESSION_NUM_FOR_TEST, 0), call(SESSION_NUM_FOR_TEST, 1)]  # 0 is the value of the default of nifake.Turtle.LEONARDO, 1 is the value of nifake.Turtle.DONATELLO
+            self.patched_library.niFake_EnumInputFunctionWithDefaults.assert_has_calls(calls)


### PR DESCRIPTION
[x ] This contribution adheres to [CONTRIBUTING.md]

### What does this Pull Request accomplish?

Add unit test and niFAKE function that has enums that are default

### Why should this Pull Request be merged?

Increases build coverage. Handling default values of type enum was added recently to the codegenerator but not tested in NI-FAKE.

### What testing has been done?

Built and ran unit tests and flake8