### PR TITLE
Skip typos / bogus function names when converting to doc links

### DIFF
--- a/build/helper/documentation_helper.py
+++ b/build/helper/documentation_helper.py
@@ -215,7 +215,7 @@ def replace_func_python_name(f_match):
     '''callback function for regex sub command when link needed
 
     Args:
-        m (match object): Match object from the function substitution command
+        f_match (match object): Match object from the function substitution command
 
     Returns:
         str: rst link to function using python name
@@ -223,7 +223,10 @@ def replace_func_python_name(f_match):
     fname = "Unknown"
     if f_match:
         fname = f_match.group(1).replace('.', '').replace(',', '').replace('\\', '')
-        fname = config['functions'][fname]['python_name']
+        try:
+            fname = config['functions'][fname]['python_name']
+        except KeyError as e:
+            print('Warning: "{0}" not found in function metadata. Typo? Generated code will be funky!'.format(fname))
     else:
         print('Unknown function name: {0}'.format(f_match.group(1)))
         print(config['functions'])


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/<reponame>/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

When our code generator processes documentation strings from metadata,
it finds/replaces links to functions. If those links have typos
(typically but not always incorrect capitalization) it would normally
die with a KeyError. Now it prints a warning. This allows us to get a full list of these errors so we can fix in origin.

### Why should this Pull Request be merged?

Makes it easier to first onboard drivers with issues in its source metadata. In my case I ran into a lot of problems with NI-DCPower.

### What testing has been done?

I've been using this change successfully.