### PR TITLE
Add ViInt64 to code-generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Python Versioning](http://legacy.python.org/dev/pep
 ## [Unreleased]
 * #### ALL
   * #### Added
+    * Support for ViInt64 (64-bit integers)
   * #### Changed
     * Modified how methods with repeated capabilities are invoked. There's no longer (for example) a "channel_name" input. Instead:
       ```python

--- a/build/templates/ctypes_types.py
+++ b/build/templates/ctypes_types.py
@@ -32,6 +32,8 @@ class ViInt16_ctype(ctypes.c_short):  # noqa: N801
 class ViUInt16_ctype(ctypes.c_ushort):  # noqa: N801
     pass
 
+class ViInt64_ctype(ctypes.c_longlong):  # noqa: N801
+    pass
 
 class ViString_ctype(ctypes.c_char_p):  # noqa: N801
     pass

--- a/build/templates/ctypes_types.py
+++ b/build/templates/ctypes_types.py
@@ -36,6 +36,7 @@ class ViUInt16_ctype(ctypes.c_ushort):  # noqa: N801
 class ViInt64_ctype(ctypes.c_longlong):  # noqa: N801
     pass
 
+
 class ViString_ctype(ctypes.c_char_p):  # noqa: N801
     pass
 

--- a/build/templates/ctypes_types.py
+++ b/build/templates/ctypes_types.py
@@ -32,6 +32,7 @@ class ViInt16_ctype(ctypes.c_short):  # noqa: N801
 class ViUInt16_ctype(ctypes.c_ushort):  # noqa: N801
     pass
 
+
 class ViInt64_ctype(ctypes.c_longlong):  # noqa: N801
     pass
 

--- a/build/templates/python_types.py
+++ b/build/templates/python_types.py
@@ -40,7 +40,6 @@ class ViUInt16(int):
         return int(val)
 
 
-# TODO(marcoskirsch): See issue #379, int may not be large enough in some cases.
 class ViInt64(int):
     def __new__(cls, val=0):
         return int(val)

--- a/build/templates/python_types.py
+++ b/build/templates/python_types.py
@@ -40,6 +40,12 @@ class ViUInt16(int):
         return int(val)
 
 
+# TODO(marcoskirsch): See issue #379, int may not be large enough in some cases.
+class ViInt64(int):
+    def __new__(cls, val=0):
+        return int(val)
+
+
 class ViString(str):
     def __new__(cls, val=0):
         return str(val)

--- a/generated/nidmm/ctypes_types.py
+++ b/generated/nidmm/ctypes_types.py
@@ -33,6 +33,10 @@ class ViUInt16_ctype(ctypes.c_ushort):  # noqa: N801
     pass
 
 
+class ViInt64_ctype(ctypes.c_longlong):  # noqa: N801
+    pass
+
+
 class ViString_ctype(ctypes.c_char_p):  # noqa: N801
     pass
 

--- a/generated/nidmm/python_types.py
+++ b/generated/nidmm/python_types.py
@@ -40,7 +40,6 @@ class ViUInt16(int):
         return int(val)
 
 
-# TODO(marcoskirsch): See issue #379, int may not be large enough in some cases.
 class ViInt64(int):
     def __new__(cls, val=0):
         return int(val)

--- a/generated/nidmm/python_types.py
+++ b/generated/nidmm/python_types.py
@@ -40,6 +40,12 @@ class ViUInt16(int):
         return int(val)
 
 
+# TODO(marcoskirsch): See issue #379, int may not be large enough in some cases.
+class ViInt64(int):
+    def __new__(cls, val=0):
+        return int(val)
+
+
 class ViString(str):
     def __new__(cls, val=0):
         return str(val)

--- a/generated/nifake/ctypes_types.py
+++ b/generated/nifake/ctypes_types.py
@@ -33,6 +33,10 @@ class ViUInt16_ctype(ctypes.c_ushort):  # noqa: N801
     pass
 
 
+class ViInt64_ctype(ctypes.c_longlong):  # noqa: N801
+    pass
+
+
 class ViString_ctype(ctypes.c_char_p):  # noqa: N801
     pass
 

--- a/generated/nifake/library.py
+++ b/generated/nifake/library.py
@@ -45,6 +45,7 @@ class Library(object):
         self.niFake_SetAttributeViString_cfunc = None
         self.niFake_SimpleFunction_cfunc = None
         self.niFake_TwoInputFunction_cfunc = None
+        self.niFake_Use64BitNumber_cfunc = None
         self.niFake_close_cfunc = None
 
         if library_type == 'windll':
@@ -276,6 +277,14 @@ class Library(object):
                 self.niFake_TwoInputFunction_cfunc.argtypes = [ViSession_ctype, ViReal64_ctype, ViChar_ctype]  # noqa: F405
                 self.niFake_TwoInputFunction_cfunc.restype = nifake.python_types.ViStatus
         return self.niFake_TwoInputFunction_cfunc(vi, a_number, a_string)
+
+    def niFake_Use64BitNumber(self, vi, input, output):  # noqa: N802
+        with self._func_lock:
+            if self.niFake_Use64BitNumber_cfunc is None:
+                self.niFake_Use64BitNumber_cfunc = self._library.niFake_Use64BitNumber
+                self.niFake_Use64BitNumber_cfunc.argtypes = [ViSession_ctype, ViInt64_ctype, ctypes.POINTER(ViInt64_ctype)]  # noqa: F405
+                self.niFake_Use64BitNumber_cfunc.restype = nifake.python_types.ViStatus
+        return self.niFake_Use64BitNumber_cfunc(vi, input, output)
 
     def niFake_close(self, vi):  # noqa: N802
         with self._func_lock:

--- a/generated/nifake/python_types.py
+++ b/generated/nifake/python_types.py
@@ -40,7 +40,6 @@ class ViUInt16(int):
         return int(val)
 
 
-# TODO(marcoskirsch): See issue #379, int may not be large enough in some cases.
 class ViInt64(int):
     def __new__(cls, val=0):
         return int(val)

--- a/generated/nifake/python_types.py
+++ b/generated/nifake/python_types.py
@@ -40,6 +40,12 @@ class ViUInt16(int):
         return int(val)
 
 
+# TODO(marcoskirsch): See issue #379, int may not be large enough in some cases.
+class ViInt64(int):
+    def __new__(cls, val=0):
+        return int(val)
+
+
 class ViString(str):
     def __new__(cls, val=0):
         return str(val)

--- a/generated/nifake/session.py
+++ b/generated/nifake/session.py
@@ -595,6 +595,24 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
+    def use64_bit_number(self, input):
+        '''use64_bit_number
+
+        Returns a number and a string.
+
+        Note: This function rules!
+
+        Args:
+            input (int):A big number on its way in.
+
+        Returns:
+            output (int):A big number on its way out.
+        '''
+        output_ctype = ctypes_types.ViInt64_ctype(0)
+        error_code = self._library.niFake_Use64BitNumber(self._vi, input, ctypes.pointer(output_ctype))
+        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
+        return python_types.ViInt64(output_ctype.value)
+
     def _close(self):
         '''_close
 

--- a/generated/nifake/tests/mock_helper.py
+++ b/generated/nifake/tests/mock_helper.py
@@ -96,6 +96,9 @@ class SideEffectsHelper(object):
         self._defaults['SimpleFunction']['return'] = 0
         self._defaults['TwoInputFunction'] = {}
         self._defaults['TwoInputFunction']['return'] = 0
+        self._defaults['Use64BitNumber'] = {}
+        self._defaults['Use64BitNumber']['return'] = 0
+        self._defaults['Use64BitNumber']['output'] = None
         self._defaults['close'] = {}
         self._defaults['close']['return'] = 0
 
@@ -317,6 +320,14 @@ class SideEffectsHelper(object):
             return self._defaults['TwoInputFunction']['return']
         return self._defaults['TwoInputFunction']['return']
 
+    def niFake_Use64BitNumber(self, vi, input, output):  # noqa: N802
+        if self._defaults['Use64BitNumber']['return'] != 0:
+            return self._defaults['Use64BitNumber']['return']
+        if self._defaults['Use64BitNumber']['output'] is None:
+            raise MockFunctionCallError("niFake_Use64BitNumber", param='output')
+        output.contents.value = self._defaults['Use64BitNumber']['output']
+        return self._defaults['Use64BitNumber']['return']
+
     def niFake_close(self, vi):  # noqa: N802
         if self._defaults['close']['return'] != 0:
             return self._defaults['close']['return']
@@ -380,5 +391,7 @@ class SideEffectsHelper(object):
         mock_library.niFake_SimpleFunction.return_value = nifake.python_types.ViStatus(0)
         mock_library.niFake_TwoInputFunction.side_effect = MockFunctionCallError("niFake_TwoInputFunction")
         mock_library.niFake_TwoInputFunction.return_value = nifake.python_types.ViStatus(0)
+        mock_library.niFake_Use64BitNumber.side_effect = MockFunctionCallError("niFake_Use64BitNumber")
+        mock_library.niFake_Use64BitNumber.return_value = nifake.python_types.ViStatus(0)
         mock_library.niFake_close.side_effect = MockFunctionCallError("niFake_close")
         mock_library.niFake_close.return_value = nifake.python_types.ViStatus(0)

--- a/generated/nifake/tests/test_session.py
+++ b/generated/nifake/tests/test_session.py
@@ -180,6 +180,15 @@ class TestSession(object):
             session.one_input_function(test_number)
             self.patched_library.niFake_OneInputFunction.assert_called_once_with(SESSION_NUM_FOR_TEST, test_number)
 
+    def test_vi_int_64_function(self):
+        input_value = 1099511627776  # 2^40
+        output_value = 2199023255552  # 2^41
+        self.patched_library.niFake_Use64BitNumber.side_effect = self.side_effects_helper.niFake_Use64BitNumber
+        self.side_effects_helper['Use64BitNumber']['output'] = output_value
+        with nifake.Session('dev1') as session:
+            assert session.use64_bit_number(input_value) == output_value
+            self.patched_library.niFake_Use64BitNumber.assert_called_once_with(SESSION_NUM_FOR_TEST, input_value, ANY)
+
     def test_two_input_function(self):
         test_number = 1.5
         test_string = 'test'

--- a/generated/nimodinst/ctypes_types.py
+++ b/generated/nimodinst/ctypes_types.py
@@ -33,6 +33,10 @@ class ViUInt16_ctype(ctypes.c_ushort):  # noqa: N801
     pass
 
 
+class ViInt64_ctype(ctypes.c_longlong):  # noqa: N801
+    pass
+
+
 class ViString_ctype(ctypes.c_char_p):  # noqa: N801
     pass
 

--- a/generated/nimodinst/python_types.py
+++ b/generated/nimodinst/python_types.py
@@ -40,7 +40,6 @@ class ViUInt16(int):
         return int(val)
 
 
-# TODO(marcoskirsch): See issue #379, int may not be large enough in some cases.
 class ViInt64(int):
     def __new__(cls, val=0):
         return int(val)

--- a/generated/nimodinst/python_types.py
+++ b/generated/nimodinst/python_types.py
@@ -40,6 +40,12 @@ class ViUInt16(int):
         return int(val)
 
 
+# TODO(marcoskirsch): See issue #379, int may not be large enough in some cases.
+class ViInt64(int):
+    def __new__(cls, val=0):
+        return int(val)
+
+
 class ViString(str):
     def __new__(cls, val=0):
         return str(val)

--- a/generated/niswitch/ctypes_types.py
+++ b/generated/niswitch/ctypes_types.py
@@ -33,6 +33,10 @@ class ViUInt16_ctype(ctypes.c_ushort):  # noqa: N801
     pass
 
 
+class ViInt64_ctype(ctypes.c_longlong):  # noqa: N801
+    pass
+
+
 class ViString_ctype(ctypes.c_char_p):  # noqa: N801
     pass
 

--- a/generated/niswitch/python_types.py
+++ b/generated/niswitch/python_types.py
@@ -40,7 +40,6 @@ class ViUInt16(int):
         return int(val)
 
 
-# TODO(marcoskirsch): See issue #379, int may not be large enough in some cases.
 class ViInt64(int):
     def __new__(cls, val=0):
         return int(val)

--- a/generated/niswitch/python_types.py
+++ b/generated/niswitch/python_types.py
@@ -40,6 +40,12 @@ class ViUInt16(int):
         return int(val)
 
 
+# TODO(marcoskirsch): See issue #379, int may not be large enough in some cases.
+class ViInt64(int):
+    def __new__(cls, val=0):
+        return int(val)
+
+
 class ViString(str):
     def __new__(cls, val=0):
         return str(val)

--- a/src/nifake/metadata/functions.py
+++ b/src/nifake/metadata/functions.py
@@ -1002,6 +1002,44 @@ functions = {
         },
     },
 
+    'Use64BitNumber': {
+        'codegen_method': 'public',
+        'returns': 'ViStatus',
+        'parameters': [
+            {
+                'direction': 'in',
+                'enum': None,
+                'name': 'vi',
+                'type': 'ViSession',
+                'documentation': {
+                    'description': 'Identifies a particular instrument session.',
+                },
+            },
+            {
+                'direction': 'in',
+                'enum': None,
+                'name': 'input',
+                'type': 'ViInt64',
+                'documentation': {
+                    'description': 'A big number on its way in.',
+                },
+            },
+            {
+                'direction': 'out',
+                'enum': None,
+                'name': 'output',
+                'type': 'ViInt64',
+                'documentation': {
+                    'description': 'A big number on its way out.',
+                },
+            },
+        ],
+        'documentation': {
+            'description': 'Returns a number and a string.',
+            'note': 'This function rules!',
+        },
+    },
+
     'Read': {
         'codegen_method': 'public',
         'returns': 'ViStatus',

--- a/src/nifake/tests/test_session.py
+++ b/src/nifake/tests/test_session.py
@@ -180,6 +180,15 @@ class TestSession(object):
             session.one_input_function(test_number)
             self.patched_library.niFake_OneInputFunction.assert_called_once_with(SESSION_NUM_FOR_TEST, test_number)
 
+    def test_vi_int_64_function(self):
+        input_value = 1099511627776  # 2^40
+        output_value = 2199023255552  # 2^41
+        self.patched_library.niFake_Use64BitNumber.side_effect = self.side_effects_helper.niFake_Use64BitNumber
+        self.side_effects_helper['Use64BitNumber']['output'] = output_value
+        with nifake.Session('dev1') as session:
+            assert session.use64_bit_number(input_value) == output_value
+            self.patched_library.niFake_Use64BitNumber.assert_called_once_with(SESSION_NUM_FOR_TEST, input_value, ANY)
+
     def test_two_input_function(self):
         test_number = 1.5
         test_string = 'test'


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md]

[X] I've updated [CHANGELOG.md](https://github.com/ni/<reponame>/blob/master/CHANGELOG.md) if applicable.

### What does this Pull Request accomplish?

Adds support for ViInt64 type. This is needed by APIs that will be added (example NI-DCPower).

### What testing has been done?

Added a test function and a unit test to NI-FAKE.