### PR TITLE
Use the actual function name and then lookup python name

### DIFF
--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -18,8 +18,8 @@ ${encoding_tag}
     session_context_manager = None
     if 'task' in config['context_manager_name']:
         session_context_manager = '_' + config['context_manager_name']['task'].title()
-        session_context_manager_initiate = '_' + config['context_manager_name']['initiate']
-        session_context_manager_abort = '_' + config['context_manager_name']['abort']
+        session_context_manager_initiate = functions[config['context_manager_name']['initiate_function']]['python_name']
+        session_context_manager_abort = functions[config['context_manager_name']['abort_function']]['python_name']
 %>\
 <%def name="render_method(f)">\
 <%

--- a/src/nidmm/metadata/config.py
+++ b/src/nidmm/metadata/config.py
@@ -18,8 +18,8 @@ config = {
     },
     'context_manager_name': {
         'task': 'acquisition',
-        'initiate': 'initiate',
-        'abort': 'abort',
+        'initiate_function': 'Initiate',
+        'abort_function': 'Abort',
     },
     'init_function': 'InitWithOptions',
 }

--- a/src/nifake/metadata/config.py
+++ b/src/nifake/metadata/config.py
@@ -18,8 +18,8 @@ config = {
     },
     'context_manager_name': {
         'task': 'acquisition',
-        'initiate': 'initiate',
-        'abort': 'abort',
+        'initiate_function': 'Initiate',
+        'abort_function': 'Abort',
     },
     'init_function': 'InitWithOptions',
 }

--- a/src/niswitch/metadata/config.py
+++ b/src/niswitch/metadata/config.py
@@ -18,8 +18,8 @@ config = {
     },
     'context_manager_name': {
         'task': 'scan',
-        'initiate': 'initiate_scan',
-        'abort': 'abort_scan',
+        'initiate_function': 'InitiateScan',
+        'abort_function': 'AbortScan',
     },
     'init_function': 'InitWithTopology',
 }


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md]
~~[ ] I've updated [CHANGELOG.md](https://github.com/ni/<reponame>/blob/master/CHANGELOG.md) if applicable.~~
### What does this Pull Request accomplish?
* Use C name to lookup context manager actions method names to use
* Rename keys to add '_function' to be clear that it is the function name

### List issues fixed by this Pull Request below, if any.
* Fix #350 

### What testing has been done?
* Travis & System tests