### PR TITLE
 Rename ctypes_types.py to visatype.py

### DIFF
--- a/build/defines.mak
+++ b/build/defines.mak
@@ -60,7 +60,7 @@ DEFAULT_PY_FILES_TO_GENERATE := \
     __init__.py \
 
 DEFAULT_PY_FILES_TO_COPY := \
-    ctypes_types.py \
+    visatype.py \
 
 DEFAULT_RST_FILES_TO_GENERATE := \
     session.rst \

--- a/build/helper/codegen_helper.py
+++ b/build/helper/codegen_helper.py
@@ -205,17 +205,17 @@ def get_ctype_variable_declaration_snippet(parameter, parameters):
     snippet = parameter['ctypes_variable_name'] + ' = '
     if parameter['is_buffer']:
         if parameter['size']['mechanism'] == 'fixed':
-            snippet += '(' + 'ctypes_types.' + parameter['ctypes_type'] + ' * ' + str(parameter['size']['value']) + ')()'
+            snippet += '(' + 'visatype.' + parameter['ctypes_type'] + ' * ' + str(parameter['size']['value']) + ')()'
         elif parameter['size']['mechanism'] == 'ivi-dance':
             # TODO(marcoskirsch): remove.
             assert False, "THIS IS DEAD CODE!"
-            snippet += 'ctypes_types.' + parameter['ctypes_type'] + '(0)  # TODO(marcoskirsch): Do the IVI-dance!'
+            snippet += 'visatype.' + parameter['ctypes_type'] + '(0)  # TODO(marcoskirsch): Do the IVI-dance!'
         else:
             assert parameter['size']['mechanism'] == 'passed-in', parameter['size']['mechanism']
             size_parameter = find_size_parameter(parameter, parameters)
-            snippet += '(' + 'ctypes_types.' + parameter['ctypes_type'] + ' * ' + size_parameter['python_name'] + ')()'
+            snippet += '(' + 'visatype.' + parameter['ctypes_type'] + ' * ' + size_parameter['python_name'] + ')()'
     else:
-        snippet += 'ctypes_types.' + parameter['ctypes_type'] + '(0)'
+        snippet += 'visatype.' + parameter['ctypes_type'] + '(0)'
     return snippet
 
 

--- a/build/helper/metadata_add_all.py
+++ b/build/helper/metadata_add_all.py
@@ -105,7 +105,7 @@ def _add_library_method_call_snippet(parameter, session_handle_parameter_name):
         if parameter['size']['mechanism'] == 'ivi-dance':
             library_method_call_snippet = parameter['ctypes_variable_name']
         elif parameter['is_buffer']:
-            library_method_call_snippet = 'ctypes.cast(' + parameter['ctypes_variable_name'] + ', ctypes.POINTER(ctypes_types.' + parameter['ctypes_type'] + '))'
+            library_method_call_snippet = 'ctypes.cast(' + parameter['ctypes_variable_name'] + ', ctypes.POINTER(visatype.' + parameter['ctypes_type'] + '))'
         else:
             library_method_call_snippet = 'ctypes.pointer(' + (parameter['ctypes_variable_name']) + ')'
     parameter['library_method_call_snippet'] = library_method_call_snippet

--- a/build/templates/library.py.mako
+++ b/build/templates/library.py.mako
@@ -16,7 +16,7 @@ functions = helper.filter_codegen_functions(functions)
 import ctypes
 import threading
 
-from ${module_name}.ctypes_types import *  # noqa: F403,H303
+from ${module_name}.visatype import *  # noqa: F403,H303
 
 
 class Library(object):

--- a/build/templates/mock_helper.py.mako
+++ b/build/templates/mock_helper.py.mako
@@ -16,7 +16,7 @@ functions = helper.filter_codegen_functions(functions)
 
 import ctypes
 
-import ${module_name}.ctypes_types
+import ${module_name}.visatype
 
 
 class MockFunctionCallError(Exception):
@@ -76,8 +76,8 @@ ivi_dance_size_param = helper.find_size_parameter(ivi_dance_param, params)
             raise MockFunctionCallError("${c_function_prefix}${func_name}", param='${ivi_dance_param['name']}')
         if ${ivi_dance_size_param['python_name']} == 0:
             return len(self._defaults['${func_name}']['${ivi_dance_param['name']}'])
-        t = ${module_name}.ctypes_types.${ivi_dance_param['ctypes_type']}(self._defaults['${func_name}']['${ivi_dance_param['name']}'].encode('ascii'))
-        ${ivi_dance_param['python_name']}.value = ctypes.cast(t, ${module_name}.ctypes_types.${ivi_dance_param['ctypes_type']}).value
+        t = ${module_name}.visatype.${ivi_dance_param['ctypes_type']}(self._defaults['${func_name}']['${ivi_dance_param['name']}'].encode('ascii'))
+        ${ivi_dance_param['python_name']}.value = ctypes.cast(t, ${module_name}.visatype.${ivi_dance_param['ctypes_type']}).value
 %    endif
         return self._defaults['${func_name}']['return']
 

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -52,7 +52,7 @@ ${encoding_tag}
         error_code = self._library.${c_function_prefix}${f['name']}(${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_METHOD_CALL)})
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=${f['is_error_handling']})
         ${ivi_dance_size_parameter['python_name']} = error_code
-        ${ivi_dance_parameter['ctypes_variable_name']} = ctypes.cast(ctypes.create_string_buffer(${ivi_dance_size_parameter['python_name']}), ctypes_types.${ivi_dance_parameter['ctypes_type']})
+        ${ivi_dance_parameter['ctypes_variable_name']} = ctypes.cast(ctypes.create_string_buffer(${ivi_dance_size_parameter['python_name']}), visatype.${ivi_dance_parameter['ctypes_type']})
         error_code = self._library.${c_function_prefix}${f['name']}(${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_METHOD_CALL)})
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=${f['is_error_handling']})
         ${helper.get_method_return_snippet(parameters)}
@@ -61,10 +61,10 @@ ${encoding_tag}
 import ctypes
 
 from ${module_name} import attributes
-from ${module_name} import ctypes_types
 from ${module_name} import enums
 from ${module_name} import errors
 from ${module_name} import library_singleton
+from ${module_name} import visatype
 
 
 % if session_context_manager is not None:

--- a/build/templates/visatype.py
+++ b/build/templates/visatype.py
@@ -1,6 +1,11 @@
 import ctypes
 
 
+'''Definitions of the VISA types used by the C API of the driver runtime. These are subclases of ctypes types so can
+be used directly to call into the library.
+'''
+
+
 class ViStatus(ctypes.c_long):  # noqa: N801
     pass
 

--- a/generated/nidcpower/library.py
+++ b/generated/nidcpower/library.py
@@ -3,7 +3,7 @@
 import ctypes
 import threading
 
-from nidcpower.ctypes_types import *  # noqa: F403,H303
+from nidcpower.visatype import *  # noqa: F403,H303
 
 
 class Library(object):

--- a/generated/nidcpower/session.py
+++ b/generated/nidcpower/session.py
@@ -3,10 +3,10 @@
 import ctypes
 
 from nidcpower import attributes
-from nidcpower import ctypes_types
 from nidcpower import enums
 from nidcpower import errors
 from nidcpower import library_singleton
+from nidcpower import visatype
 
 
 class _Acquisition(object):
@@ -2599,10 +2599,10 @@ class _SessionBase(object):
             actual_count (int):Indicates the number of measured values actually retrieved from the
                 device.
         '''
-        voltage_measurements_ctype = ctypes_types.ViReal64(0)
-        current_measurements_ctype = ctypes_types.ViReal64(0)
-        in_compliance_ctype = ctypes_types.ViBoolean(0)
-        actual_count_ctype = ctypes_types.ViInt32(0)
+        voltage_measurements_ctype = visatype.ViReal64(0)
+        current_measurements_ctype = visatype.ViReal64(0)
+        in_compliance_ctype = visatype.ViBoolean(0)
+        actual_count_ctype = visatype.ViInt32(0)
         error_code = self._library.niDCPower_FetchMultiple(self._vi, self._repeated_capability.encode('ascii'), timeout, count, ctypes.pointer(voltage_measurements_ctype), ctypes.pointer(current_measurements_ctype), ctypes.pointer(in_compliance_ctype), ctypes.pointer(actual_count_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(voltage_measurements_ctype.value), float(current_measurements_ctype.value), bool(in_compliance_ctype.value), int(actual_count_ctype.value)
@@ -2654,7 +2654,7 @@ class _SessionBase(object):
                 pressing **Enter** on this control. Select a value by double-clicking on
                 it or by selecting it and then pressing **Enter**.
         '''
-        attribute_value_ctype = ctypes_types.ViBoolean(0)
+        attribute_value_ctype = visatype.ViBoolean(0)
         error_code = self._library.niDCPower_GetAttributeViBoolean(self._vi, self._repeated_capability.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return bool(attribute_value_ctype.value)
@@ -2706,7 +2706,7 @@ class _SessionBase(object):
                 pressing **Enter** on this control. Select a value by double-clicking on
                 it or by selecting it and then pressing **Enter**.
         '''
-        attribute_value_ctype = ctypes_types.ViInt32(0)
+        attribute_value_ctype = visatype.ViInt32(0)
         error_code = self._library.niDCPower_GetAttributeViInt32(self._vi, self._repeated_capability.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(attribute_value_ctype.value)
@@ -2758,7 +2758,7 @@ class _SessionBase(object):
                 pressing **Enter** on this control. Select a value by double-clicking on
                 it or by selecting it and then pressing **Enter**.
         '''
-        attribute_value_ctype = ctypes_types.ViInt64(0)
+        attribute_value_ctype = visatype.ViInt64(0)
         error_code = self._library.niDCPower_GetAttributeViInt64(self._vi, self._repeated_capability.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(attribute_value_ctype.value)
@@ -2810,7 +2810,7 @@ class _SessionBase(object):
                 pressing **Enter** on this control. Select a value by double-clicking on
                 it or by selecting it and then pressing **Enter**.
         '''
-        attribute_value_ctype = ctypes_types.ViReal64(0)
+        attribute_value_ctype = visatype.ViReal64(0)
         error_code = self._library.niDCPower_GetAttributeViReal64(self._vi, self._repeated_capability.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(attribute_value_ctype.value)
@@ -2871,7 +2871,7 @@ class _SessionBase(object):
         error_code = self._library.niDCPower_GetAttributeViString(self._vi, self._repeated_capability.encode('ascii'), attribute_id, buffer_size, attribute_value_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         buffer_size = error_code
-        attribute_value_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), ctypes_types.ViString)
+        attribute_value_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), visatype.ViString)
         error_code = self._library.niDCPower_GetAttributeViString(self._vi, self._repeated_capability.encode('ascii'), attribute_id, buffer_size, attribute_value_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return attribute_value_ctype.value.decode("ascii")
@@ -2907,7 +2907,7 @@ class _SessionBase(object):
             measurement (float):Returns the value of the measurement, either in volts for voltage or
                 amps for current.
         '''
-        measurement_ctype = ctypes_types.ViReal64(0)
+        measurement_ctype = visatype.ViReal64(0)
         error_code = self._library.niDCPower_Measure(self._vi, self._repeated_capability.encode('ascii'), measurement_type, ctypes.pointer(measurement_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(measurement_ctype.value)
@@ -2944,8 +2944,8 @@ class _SessionBase(object):
                 **channelName**. Ensure that sufficient space has been allocated for the
                 returned array.
         '''
-        voltage_measurements_ctype = ctypes_types.ViReal64(0)
-        current_measurements_ctype = ctypes_types.ViReal64(0)
+        voltage_measurements_ctype = visatype.ViReal64(0)
+        current_measurements_ctype = visatype.ViReal64(0)
         error_code = self._library.niDCPower_MeasureMultiple(self._vi, self._repeated_capability.encode('ascii'), ctypes.pointer(voltage_measurements_ctype), ctypes.pointer(current_measurements_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(voltage_measurements_ctype.value), float(current_measurements_ctype.value)
@@ -2991,7 +2991,7 @@ class _SessionBase(object):
         Returns:
             in_compliance (bool):Returns whether the device output channel is in compliance.
         '''
-        in_compliance_ctype = ctypes_types.ViBoolean(0)
+        in_compliance_ctype = visatype.ViBoolean(0)
         error_code = self._library.niDCPower_QueryInCompliance(self._vi, self._repeated_capability.encode('ascii'), ctypes.pointer(in_compliance_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return bool(in_compliance_ctype.value)
@@ -3015,7 +3015,7 @@ class _SessionBase(object):
             max_current_limit (float):Returns the maximum current limit that can be set with the specified
                 **voltageLevel**.
         '''
-        max_current_limit_ctype = ctypes_types.ViReal64(0)
+        max_current_limit_ctype = visatype.ViReal64(0)
         error_code = self._library.niDCPower_QueryMaxCurrentLimit(self._vi, self._repeated_capability.encode('ascii'), voltage_level, ctypes.pointer(max_current_limit_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(max_current_limit_ctype.value)
@@ -3039,7 +3039,7 @@ class _SessionBase(object):
             max_voltage_level (float):Returns the maximum voltage level that can be set on an output channel
                 with the specified **currentLimit**.
         '''
-        max_voltage_level_ctype = ctypes_types.ViReal64(0)
+        max_voltage_level_ctype = visatype.ViReal64(0)
         error_code = self._library.niDCPower_QueryMaxVoltageLevel(self._vi, self._repeated_capability.encode('ascii'), current_limit, ctypes.pointer(max_voltage_level_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(max_voltage_level_ctype.value)
@@ -3063,7 +3063,7 @@ class _SessionBase(object):
             min_current_limit (float):Returns the minimum current limit that can be set on an output channel
                 with the specified **voltageLevel**.
         '''
-        min_current_limit_ctype = ctypes_types.ViReal64(0)
+        min_current_limit_ctype = visatype.ViReal64(0)
         error_code = self._library.niDCPower_QueryMinCurrentLimit(self._vi, self._repeated_capability.encode('ascii'), voltage_level, ctypes.pointer(min_current_limit_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(min_current_limit_ctype.value)
@@ -3097,7 +3097,7 @@ class _SessionBase(object):
             in_state (bool):Returns whether the device output channel is in the specified output
                 state.
         '''
-        in_state_ctype = ctypes_types.ViBoolean(0)
+        in_state_ctype = visatype.ViBoolean(0)
         error_code = self._library.niDCPower_QueryOutputState(self._vi, self._repeated_capability.encode('ascii'), output_state, ctypes.pointer(in_state_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return bool(in_state_ctype.value)
@@ -4084,13 +4084,13 @@ class Session(_SessionBase):
         Returns:
             code (int):Returns the error code for the session or execution thread.
         '''
-        code_ctype = ctypes_types.ViStatus(0)
+        code_ctype = visatype.ViStatus(0)
         buffer_size = 0
         description_ctype = None
         error_code = self._library.niDCPower_GetError(self._vi, ctypes.pointer(code_ctype), buffer_size, description_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=True)
         buffer_size = error_code
-        description_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), ctypes_types.ViString)
+        description_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), visatype.ViString)
         error_code = self._library.niDCPower_GetError(self._vi, ctypes.pointer(code_ctype), buffer_size, description_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return int(code_ctype.value), description_ctype.value.decode("ascii")
@@ -4125,11 +4125,11 @@ class Session(_SessionBase):
                 calibrated.
             minute (int):Returns the **minute** in which the device was last calibrated.
         '''
-        year_ctype = ctypes_types.ViInt32(0)
-        month_ctype = ctypes_types.ViInt32(0)
-        day_ctype = ctypes_types.ViInt32(0)
-        hour_ctype = ctypes_types.ViInt32(0)
-        minute_ctype = ctypes_types.ViInt32(0)
+        year_ctype = visatype.ViInt32(0)
+        month_ctype = visatype.ViInt32(0)
+        day_ctype = visatype.ViInt32(0)
+        hour_ctype = visatype.ViInt32(0)
+        minute_ctype = visatype.ViInt32(0)
         error_code = self._library.niDCPower_GetSelfCalLastDateAndTime(self._vi, ctypes.pointer(year_ctype), ctypes.pointer(month_ctype), ctypes.pointer(day_ctype), ctypes.pointer(hour_ctype), ctypes.pointer(minute_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(year_ctype.value), int(month_ctype.value), int(day_ctype.value), int(hour_ctype.value), int(minute_ctype.value)
@@ -4160,7 +4160,7 @@ class Session(_SessionBase):
             temperature (float):Returns the onboard **temperature** of the device, in degrees Celsius,
                 during the oldest successful calibration.
         '''
-        temperature_ctype = ctypes_types.ViReal64(0)
+        temperature_ctype = visatype.ViReal64(0)
         error_code = self._library.niDCPower_GetSelfCalLastTemp(self._vi, ctypes.pointer(temperature_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(temperature_ctype.value)
@@ -4237,7 +4237,7 @@ class Session(_SessionBase):
             vi (int):Returns a session handle that you use to identify the device in all
                 subsequent NI-DCPower function calls.
         '''
-        vi_ctype = ctypes_types.ViSession(0)
+        vi_ctype = visatype.ViSession(0)
         error_code = self._library.niDCPower_InitializeWithChannels(resource_name.encode('ascii'), channels, reset, option_string, ctypes.pointer(vi_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(vi_ctype.value)
@@ -4277,7 +4277,7 @@ class Session(_SessionBase):
         Returns:
             temperature (float):Returns the onboard **temperature**, in degrees Celsius, of the device.
         '''
-        temperature_ctype = ctypes_types.ViReal64(0)
+        temperature_ctype = visatype.ViReal64(0)
         error_code = self._library.niDCPower_ReadCurrentTemperature(self._vi, ctypes.pointer(temperature_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(temperature_ctype.value)
@@ -4453,8 +4453,8 @@ class Session(_SessionBase):
                 code you specify.
                 You must pass a ViChar array with at least 256 bytes.
         '''
-        error_message_ctype = (ctypes_types.ViChar * 256)()
-        error_code = self._library.niDCPower_error_message(self._vi, error_code, ctypes.cast(error_message_ctype, ctypes.POINTER(ctypes_types.ViChar)))
+        error_message_ctype = (visatype.ViChar * 256)()
+        error_code = self._library.niDCPower_error_message(self._vi, error_code, ctypes.cast(error_message_ctype, ctypes.POINTER(visatype.ViChar)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return error_message_ctype.value.decode("ascii")
 
@@ -4487,8 +4487,8 @@ class Session(_SessionBase):
             firmware_revision (int):Returns firmware revision information for the device you are using. The
                 size of this array must be at least 256 bytes.
         '''
-        instrument_driver_revision_ctype = ctypes_types.ViChar(0)
-        firmware_revision_ctype = ctypes_types.ViChar(0)
+        instrument_driver_revision_ctype = visatype.ViChar(0)
+        firmware_revision_ctype = visatype.ViChar(0)
         error_code = self._library.niDCPower_revision_query(self._vi, ctypes.pointer(instrument_driver_revision_ctype), ctypes.pointer(firmware_revision_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(instrument_driver_revision_ctype.value), int(firmware_revision_ctype.value)
@@ -4517,9 +4517,9 @@ class Session(_SessionBase):
             self_test_message (int):Returns the self-test result message. The size of this array must be at
                 least 256 bytes.
         '''
-        self_test_result_ctype = ctypes_types.ViInt16(0)
-        self_test_message_ctype = (ctypes_types.ViChar * 256)()
-        error_code = self._library.niDCPower_self_test(self._vi, ctypes.pointer(self_test_result_ctype), ctypes.cast(self_test_message_ctype, ctypes.POINTER(ctypes_types.ViChar)))
+        self_test_result_ctype = visatype.ViInt16(0)
+        self_test_message_ctype = (visatype.ViChar * 256)()
+        error_code = self._library.niDCPower_self_test(self._vi, ctypes.pointer(self_test_result_ctype), ctypes.cast(self_test_message_ctype, ctypes.POINTER(visatype.ViChar)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(self_test_result_ctype.value), self_test_message_ctype.value.decode("ascii")
 

--- a/generated/nidcpower/tests/mock_helper.py
+++ b/generated/nidcpower/tests/mock_helper.py
@@ -2,7 +2,7 @@
 
 import ctypes
 
-import nidcpower.ctypes_types
+import nidcpower.visatype
 
 
 class MockFunctionCallError(Exception):
@@ -272,8 +272,8 @@ class SideEffectsHelper(object):
             raise MockFunctionCallError("niDCPower_GetAttributeViString", param='attributeValue')
         if buffer_size == 0:
             return len(self._defaults['GetAttributeViString']['attributeValue'])
-        t = nidcpower.ctypes_types.ViString(self._defaults['GetAttributeViString']['attributeValue'].encode('ascii'))
-        attribute_value.value = ctypes.cast(t, nidcpower.ctypes_types.ViString).value
+        t = nidcpower.visatype.ViString(self._defaults['GetAttributeViString']['attributeValue'].encode('ascii'))
+        attribute_value.value = ctypes.cast(t, nidcpower.visatype.ViString).value
         return self._defaults['GetAttributeViString']['return']
 
     def niDCPower_GetError(self, vi, code, buffer_size, description):  # noqa: N802
@@ -286,8 +286,8 @@ class SideEffectsHelper(object):
             raise MockFunctionCallError("niDCPower_GetError", param='Description')
         if buffer_size == 0:
             return len(self._defaults['GetError']['Description'])
-        t = nidcpower.ctypes_types.ViString(self._defaults['GetError']['Description'].encode('ascii'))
-        description.value = ctypes.cast(t, nidcpower.ctypes_types.ViString).value
+        t = nidcpower.visatype.ViString(self._defaults['GetError']['Description'].encode('ascii'))
+        description.value = ctypes.cast(t, nidcpower.visatype.ViString).value
         return self._defaults['GetError']['return']
 
     def niDCPower_GetSelfCalLastDateAndTime(self, vi, year, month, day, hour, minute):  # noqa: N802

--- a/generated/nidcpower/visatype.py
+++ b/generated/nidcpower/visatype.py
@@ -1,6 +1,11 @@
 import ctypes
 
 
+'''Definitions of the VISA types used by the C API of the driver runtime. These are subclases of ctypes types so can
+be used directly to call into the library.
+'''
+
+
 class ViStatus(ctypes.c_long):  # noqa: N801
     pass
 

--- a/generated/nidmm/library.py
+++ b/generated/nidmm/library.py
@@ -3,7 +3,7 @@
 import ctypes
 import threading
 
-from nidmm.ctypes_types import *  # noqa: F403,H303
+from nidmm.visatype import *  # noqa: F403,H303
 
 
 class Library(object):

--- a/generated/nidmm/session.py
+++ b/generated/nidmm/session.py
@@ -3,10 +3,10 @@
 import ctypes
 
 from nidmm import attributes
-from nidmm import ctypes_types
 from nidmm import enums
 from nidmm import errors
 from nidmm import library_singleton
+from nidmm import visatype
 
 
 class _Acquisition(object):
@@ -831,7 +831,7 @@ class _SessionBase(object):
             attribute_value (bool):Returns the current value of the attribute. Pass the address of a
                 ViBoolean variable.
         '''
-        attribute_value_ctype = ctypes_types.ViBoolean(0)
+        attribute_value_ctype = visatype.ViBoolean(0)
         error_code = self._library.niDMM_GetAttributeViBoolean(self._vi, self._repeated_capability.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return bool(attribute_value_ctype.value)
@@ -863,7 +863,7 @@ class _SessionBase(object):
             attribute_value (int):Returns the current value of the attribute. Pass the address of a
                 ViInt32 variable.
         '''
-        attribute_value_ctype = ctypes_types.ViInt32(0)
+        attribute_value_ctype = visatype.ViInt32(0)
         error_code = self._library.niDMM_GetAttributeViInt32(self._vi, self._repeated_capability.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(attribute_value_ctype.value)
@@ -895,7 +895,7 @@ class _SessionBase(object):
             attribute_value (float):Returns the current value of the attribute. Pass the address of a
                 ViReal64 variable.
         '''
-        attribute_value_ctype = ctypes_types.ViReal64(0)
+        attribute_value_ctype = visatype.ViReal64(0)
         error_code = self._library.niDMM_GetAttributeViReal64(self._vi, self._repeated_capability.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(attribute_value_ctype.value)
@@ -945,7 +945,7 @@ class _SessionBase(object):
         error_code = self._library.niDMM_GetAttributeViString(self._vi, self._repeated_capability.encode('ascii'), attribute_id, buffer_size, attribute_value_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         buffer_size = error_code
-        attribute_value_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), ctypes_types.ViString)
+        attribute_value_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), visatype.ViString)
         error_code = self._library.niDMM_GetAttributeViString(self._vi, self._repeated_capability.encode('ascii'), attribute_id, buffer_size, attribute_value_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return attribute_value_ctype.value.decode("ascii")
@@ -2032,7 +2032,7 @@ class Session(_SessionBase):
         Returns:
             reading (float):The measured value returned from the DMM.
         '''
-        reading_ctype = ctypes_types.ViReal64(0)
+        reading_ctype = visatype.ViReal64(0)
         error_code = self._library.niDMM_Fetch(self._vi, maximum_time, ctypes.pointer(reading_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(reading_ctype.value)
@@ -2073,9 +2073,9 @@ class Session(_SessionBase):
                 specify for the **Array_Size** parameter.
             actual_number_of_points (int):Indicates the number of measured values actually retrieved from the DMM.
         '''
-        reading_array_ctype = (ctypes_types.ViReal64 * array_size)()
-        actual_number_of_points_ctype = ctypes_types.ViInt32(0)
-        error_code = self._library.niDMM_FetchMultiPoint(self._vi, maximum_time, array_size, ctypes.cast(reading_array_ctype, ctypes.POINTER(ctypes_types.ViReal64)), ctypes.pointer(actual_number_of_points_ctype))
+        reading_array_ctype = (visatype.ViReal64 * array_size)()
+        actual_number_of_points_ctype = visatype.ViInt32(0)
+        error_code = self._library.niDMM_FetchMultiPoint(self._vi, maximum_time, array_size, ctypes.cast(reading_array_ctype, ctypes.POINTER(visatype.ViReal64)), ctypes.pointer(actual_number_of_points_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return [float(reading_array_ctype[i].value) for i in range(array_size)], int(actual_number_of_points_ctype.value)
 
@@ -2107,9 +2107,9 @@ class Session(_SessionBase):
                 data type.
             actual_number_of_points (int):Indicates the number of measured values actually retrieved from the DMM.
         '''
-        waveform_array_ctype = (ctypes_types.ViReal64 * array_size)()
-        actual_number_of_points_ctype = ctypes_types.ViInt32(0)
-        error_code = self._library.niDMM_FetchWaveform(self._vi, maximum_time, array_size, ctypes.cast(waveform_array_ctype, ctypes.POINTER(ctypes_types.ViReal64)), ctypes.pointer(actual_number_of_points_ctype))
+        waveform_array_ctype = (visatype.ViReal64 * array_size)()
+        actual_number_of_points_ctype = visatype.ViInt32(0)
+        error_code = self._library.niDMM_FetchWaveform(self._vi, maximum_time, array_size, ctypes.cast(waveform_array_ctype, ctypes.POINTER(visatype.ViReal64)), ctypes.pointer(actual_number_of_points_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return [float(waveform_array_ctype[i].value) for i in range(array_size)], int(actual_number_of_points_ctype.value)
 
@@ -2149,8 +2149,8 @@ class Session(_SessionBase):
                 | NIDMM_VAL_POWER_LINE_CYCLES | 1 | Powerline Cycles |
                 +-----------------------------+---+------------------+
         '''
-        aperture_time_ctype = ctypes_types.ViReal64(0)
-        aperture_time_units_ctype = ctypes_types.ViInt32(0)
+        aperture_time_ctype = visatype.ViReal64(0)
+        aperture_time_units_ctype = visatype.ViInt32(0)
         error_code = self._library.niDMM_GetApertureTimeInfo(self._vi, ctypes.pointer(aperture_time_ctype), ctypes.pointer(aperture_time_units_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(aperture_time_ctype.value), enums.ApertureTimeUnits(aperture_time_units_ctype.value)
@@ -2166,7 +2166,7 @@ class Session(_SessionBase):
                 the AUTO_RANGE_VALUE attribute. The units of the returned
                 value depend on the function.
         '''
-        actual_range_ctype = ctypes_types.ViReal64(0)
+        actual_range_ctype = visatype.ViReal64(0)
         error_code = self._library.niDMM_GetAutoRangeValue(self._vi, ctypes.pointer(actual_range_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(actual_range_ctype.value)
@@ -2197,11 +2197,11 @@ class Session(_SessionBase):
             hour (int):Indicates the **hour** of the last calibration.
             minute (int):Indicates the **minute** of the last calibration.
         '''
-        month_ctype = ctypes_types.ViInt32(0)
-        day_ctype = ctypes_types.ViInt32(0)
-        year_ctype = ctypes_types.ViInt32(0)
-        hour_ctype = ctypes_types.ViInt32(0)
-        minute_ctype = ctypes_types.ViInt32(0)
+        month_ctype = visatype.ViInt32(0)
+        day_ctype = visatype.ViInt32(0)
+        year_ctype = visatype.ViInt32(0)
+        hour_ctype = visatype.ViInt32(0)
+        minute_ctype = visatype.ViInt32(0)
         error_code = self._library.niDMM_GetCalDateAndTime(self._vi, cal_type, ctypes.pointer(month_ctype), ctypes.pointer(day_ctype), ctypes.pointer(year_ctype), ctypes.pointer(hour_ctype), ctypes.pointer(minute_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(month_ctype.value), int(day_ctype.value), int(year_ctype.value), int(hour_ctype.value), int(minute_ctype.value)
@@ -2219,7 +2219,7 @@ class Session(_SessionBase):
         Returns:
             temperature (float):Returns the current **temperature** of the device.
         '''
-        temperature_ctype = ctypes_types.ViReal64(0)
+        temperature_ctype = visatype.ViReal64(0)
         error_code = self._library.niDMM_GetDevTemp(self._vi, options.encode('ascii'), ctypes.pointer(temperature_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(temperature_ctype.value)
@@ -2253,13 +2253,13 @@ class Session(_SessionBase):
                 pass 0 for the **Buffer_Size**, you can pass VI_NULL for this
                 parameter.
         '''
-        error_code_ctype = ctypes_types.ViStatus(0)
+        error_code_ctype = visatype.ViStatus(0)
         buffer_size = 0
         description_ctype = None
         error_code = self._library.niDMM_GetError(self._vi, ctypes.pointer(error_code_ctype), buffer_size, description_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=True)
         buffer_size = error_code
-        description_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), ctypes_types.ViString)
+        description_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), visatype.ViString)
         error_code = self._library.niDMM_GetError(self._vi, ctypes.pointer(error_code_ctype), buffer_size, description_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return int(error_code_ctype.value), description_ctype.value.decode("ascii")
@@ -2286,7 +2286,7 @@ class Session(_SessionBase):
         Returns:
             temperature (float):Returns the **temperature** during the last calibration.
         '''
-        temperature_ctype = ctypes_types.ViReal64(0)
+        temperature_ctype = visatype.ViReal64(0)
         error_code = self._library.niDMM_GetLastCalTemp(self._vi, cal_type, ctypes.pointer(temperature_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(temperature_ctype.value)
@@ -2309,7 +2309,7 @@ class Session(_SessionBase):
                 Time required for internal measurements, such as
                 AUTO_ZERO, is included.
         '''
-        period_ctype = ctypes_types.ViReal64(0)
+        period_ctype = visatype.ViReal64(0)
         error_code = self._library.niDMM_GetMeasurementPeriod(self._vi, ctypes.pointer(period_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(period_ctype.value)
@@ -2330,7 +2330,7 @@ class Session(_SessionBase):
                 | VI_FALSE | 0 | The DMM that you are using cannot perform self-calibration. |
                 +----------+---+-------------------------------------------------------------+
         '''
-        self_cal_supported_ctype = ctypes_types.ViBoolean(0)
+        self_cal_supported_ctype = visatype.ViBoolean(0)
         error_code = self._library.niDMM_GetSelfCalSupported(self._vi, ctypes.pointer(self_cal_supported_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return bool(self_cal_supported_ctype.value)
@@ -2431,7 +2431,7 @@ class Session(_SessionBase):
             vi (int):Returns a ViSession handle that you use to identify the instrument in
                 all subsequent instrument driver function calls.
         '''
-        vi_ctype = ctypes_types.ViSession(0)
+        vi_ctype = visatype.ViSession(0)
         error_code = self._library.niDMM_InitWithOptions(resource_name.encode('ascii'), id_query, reset_device, option_string.encode('ascii'), ctypes.pointer(vi_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(vi_ctype.value)
@@ -2468,8 +2468,8 @@ class Session(_SessionBase):
             susceptance (float):**susceptance** is the measured value of open cable compensation
                 **susceptance**.
         '''
-        conductance_ctype = ctypes_types.ViReal64(0)
-        susceptance_ctype = ctypes_types.ViReal64(0)
+        conductance_ctype = visatype.ViReal64(0)
+        susceptance_ctype = visatype.ViReal64(0)
         error_code = self._library.niDMM_PerformOpenCableComp(self._vi, ctypes.pointer(conductance_ctype), ctypes.pointer(susceptance_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(conductance_ctype.value), float(susceptance_ctype.value)
@@ -2492,8 +2492,8 @@ class Session(_SessionBase):
             reactance (float):**reactance** is the measured value of short cable compensation
                 **reactance**.
         '''
-        resistance_ctype = ctypes_types.ViReal64(0)
-        reactance_ctype = ctypes_types.ViReal64(0)
+        resistance_ctype = visatype.ViReal64(0)
+        reactance_ctype = visatype.ViReal64(0)
         error_code = self._library.niDMM_PerformShortCableComp(self._vi, ctypes.pointer(resistance_ctype), ctypes.pointer(reactance_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(resistance_ctype.value), float(reactance_ctype.value)
@@ -2518,7 +2518,7 @@ class Session(_SessionBase):
         Returns:
             reading (float):The measured value returned from the DMM.
         '''
-        reading_ctype = ctypes_types.ViReal64(0)
+        reading_ctype = visatype.ViReal64(0)
         error_code = self._library.niDMM_Read(self._vi, maximum_time, ctypes.pointer(reading_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(reading_ctype.value)
@@ -2558,9 +2558,9 @@ class Session(_SessionBase):
                 specify for the **Array_Size** parameter.
             actual_number_of_points (int):Indicates the number of measured values actually retrieved from the DMM.
         '''
-        reading_array_ctype = (ctypes_types.ViReal64 * array_size)()
-        actual_number_of_points_ctype = ctypes_types.ViInt32(0)
-        error_code = self._library.niDMM_ReadMultiPoint(self._vi, maximum_time, array_size, ctypes.cast(reading_array_ctype, ctypes.POINTER(ctypes_types.ViReal64)), ctypes.pointer(actual_number_of_points_ctype))
+        reading_array_ctype = (visatype.ViReal64 * array_size)()
+        actual_number_of_points_ctype = visatype.ViInt32(0)
+        error_code = self._library.niDMM_ReadMultiPoint(self._vi, maximum_time, array_size, ctypes.cast(reading_array_ctype, ctypes.POINTER(visatype.ViReal64)), ctypes.pointer(actual_number_of_points_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return [float(reading_array_ctype[i].value) for i in range(array_size)], int(actual_number_of_points_ctype.value)
 
@@ -2599,8 +2599,8 @@ class Session(_SessionBase):
                 | 4 | No acquisition in progress |
                 +---+----------------------------+
         '''
-        acquisition_backlog_ctype = ctypes_types.ViInt32(0)
-        acquisition_status_ctype = ctypes_types.ViInt16(0)
+        acquisition_backlog_ctype = visatype.ViInt32(0)
+        acquisition_status_ctype = visatype.ViInt16(0)
         error_code = self._library.niDMM_ReadStatus(self._vi, ctypes.pointer(acquisition_backlog_ctype), ctypes.pointer(acquisition_status_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(acquisition_backlog_ctype.value), enums.AcquisitionStatus(acquisition_status_ctype.value)
@@ -2638,9 +2638,9 @@ class Session(_SessionBase):
                 specify for the **Array_Size** parameter.
             actual_number_of_points (int):Indicates the number of measured values actually retrieved from the DMM.
         '''
-        waveform_array_ctype = (ctypes_types.ViReal64 * array_size)()
-        actual_number_of_points_ctype = ctypes_types.ViInt32(0)
-        error_code = self._library.niDMM_ReadWaveform(self._vi, maximum_time, array_size, ctypes.cast(waveform_array_ctype, ctypes.POINTER(ctypes_types.ViReal64)), ctypes.pointer(actual_number_of_points_ctype))
+        waveform_array_ctype = (visatype.ViReal64 * array_size)()
+        actual_number_of_points_ctype = visatype.ViInt32(0)
+        error_code = self._library.niDMM_ReadWaveform(self._vi, maximum_time, array_size, ctypes.cast(waveform_array_ctype, ctypes.POINTER(visatype.ViReal64)), ctypes.pointer(actual_number_of_points_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return [float(waveform_array_ctype[i].value) for i in range(array_size)], int(actual_number_of_points_ctype.value)
 
@@ -2708,8 +2708,8 @@ class Session(_SessionBase):
         Returns:
             error_message (int):The error information formatted into a string.
         '''
-        error_message_ctype = (ctypes_types.ViChar * 256)()
-        error_code = self._library.niDMM_error_message(self._vi, error_code, ctypes.cast(error_message_ctype, ctypes.POINTER(ctypes_types.ViChar)))
+        error_message_ctype = (visatype.ViChar * 256)()
+        error_code = self._library.niDMM_error_message(self._vi, error_code, ctypes.cast(error_message_ctype, ctypes.POINTER(visatype.ViChar)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return error_message_ctype.value.decode("ascii")
 
@@ -2740,8 +2740,8 @@ class Session(_SessionBase):
 
                 Note: The array must contain at least 256 elements ViChar[256].
         '''
-        instrument_driver_revision_ctype = ctypes_types.ViChar(0)
-        firmware_revision_ctype = ctypes_types.ViChar(0)
+        instrument_driver_revision_ctype = visatype.ViChar(0)
+        firmware_revision_ctype = visatype.ViChar(0)
         error_code = self._library.niDMM_revision_query(self._vi, ctypes.pointer(instrument_driver_revision_ctype), ctypes.pointer(firmware_revision_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(instrument_driver_revision_ctype.value), int(firmware_revision_ctype.value)
@@ -2784,9 +2784,9 @@ class Session(_SessionBase):
                 returned for a self-test failure is NIDMM_ERROR_SELF_TEST_FAILURE.
                 This error code indicates that the DMM should be repaired.
         '''
-        self_test_result_ctype = ctypes_types.ViInt16(0)
-        self_test_message_ctype = (ctypes_types.ViChar * 256)()
-        error_code = self._library.niDMM_self_test(self._vi, ctypes.pointer(self_test_result_ctype), ctypes.cast(self_test_message_ctype, ctypes.POINTER(ctypes_types.ViChar)))
+        self_test_result_ctype = visatype.ViInt16(0)
+        self_test_message_ctype = (visatype.ViChar * 256)()
+        error_code = self._library.niDMM_self_test(self._vi, ctypes.pointer(self_test_result_ctype), ctypes.cast(self_test_message_ctype, ctypes.POINTER(visatype.ViChar)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(self_test_result_ctype.value), self_test_message_ctype.value.decode("ascii")
 

--- a/generated/nidmm/tests/mock_helper.py
+++ b/generated/nidmm/tests/mock_helper.py
@@ -2,7 +2,7 @@
 
 import ctypes
 
-import nidmm.ctypes_types
+import nidmm.visatype
 
 
 class MockFunctionCallError(Exception):
@@ -410,8 +410,8 @@ class SideEffectsHelper(object):
             raise MockFunctionCallError("niDMM_GetAttributeViString", param='attributeValue')
         if buffer_size == 0:
             return len(self._defaults['GetAttributeViString']['attributeValue'])
-        t = nidmm.ctypes_types.ViString(self._defaults['GetAttributeViString']['attributeValue'].encode('ascii'))
-        attribute_value.value = ctypes.cast(t, nidmm.ctypes_types.ViString).value
+        t = nidmm.visatype.ViString(self._defaults['GetAttributeViString']['attributeValue'].encode('ascii'))
+        attribute_value.value = ctypes.cast(t, nidmm.visatype.ViString).value
         return self._defaults['GetAttributeViString']['return']
 
     def niDMM_GetAutoRangeValue(self, vi, actual_range):  # noqa: N802
@@ -460,8 +460,8 @@ class SideEffectsHelper(object):
             raise MockFunctionCallError("niDMM_GetError", param='description')
         if buffer_size == 0:
             return len(self._defaults['GetError']['description'])
-        t = nidmm.ctypes_types.ViString(self._defaults['GetError']['description'].encode('ascii'))
-        description.value = ctypes.cast(t, nidmm.ctypes_types.ViString).value
+        t = nidmm.visatype.ViString(self._defaults['GetError']['description'].encode('ascii'))
+        description.value = ctypes.cast(t, nidmm.visatype.ViString).value
         return self._defaults['GetError']['return']
 
     def niDMM_GetLastCalTemp(self, vi, cal_type, temperature):  # noqa: N802

--- a/generated/nidmm/visatype.py
+++ b/generated/nidmm/visatype.py
@@ -1,6 +1,11 @@
 import ctypes
 
 
+'''Definitions of the VISA types used by the C API of the driver runtime. These are subclases of ctypes types so can
+be used directly to call into the library.
+'''
+
+
 class ViStatus(ctypes.c_long):  # noqa: N801
     pass
 

--- a/generated/nifake/library.py
+++ b/generated/nifake/library.py
@@ -3,7 +3,7 @@
 import ctypes
 import threading
 
-from nifake.ctypes_types import *  # noqa: F403,H303
+from nifake.visatype import *  # noqa: F403,H303
 
 
 class Library(object):

--- a/generated/nifake/session.py
+++ b/generated/nifake/session.py
@@ -3,10 +3,10 @@
 import ctypes
 
 from nifake import attributes
-from nifake import ctypes_types
 from nifake import enums
 from nifake import errors
 from nifake import library_singleton
+from nifake import visatype
 
 
 class _Acquisition(object):
@@ -101,7 +101,7 @@ class _SessionBase(object):
         Returns:
             attribute_value (bool):Returns the value of the attribute.
         '''
-        attribute_value_ctype = ctypes_types.ViBoolean(0)
+        attribute_value_ctype = visatype.ViBoolean(0)
         error_code = self._library.niFake_GetAttributeViBoolean(self._vi, self._repeated_capability.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return bool(attribute_value_ctype.value)
@@ -118,7 +118,7 @@ class _SessionBase(object):
         Returns:
             attribute_value (int):Returns the value of the attribute.
         '''
-        attribute_value_ctype = ctypes_types.ViInt32(0)
+        attribute_value_ctype = visatype.ViInt32(0)
         error_code = self._library.niFake_GetAttributeViInt32(self._vi, self._repeated_capability.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(attribute_value_ctype.value)
@@ -135,7 +135,7 @@ class _SessionBase(object):
         Returns:
             attribute_value (float):Returns the value of the attribute.
         '''
-        attribute_value_ctype = ctypes_types.ViReal64(0)
+        attribute_value_ctype = visatype.ViReal64(0)
         error_code = self._library.niFake_GetAttributeViReal64(self._vi, self._repeated_capability.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(attribute_value_ctype.value)
@@ -152,7 +152,7 @@ class _SessionBase(object):
         Returns:
             attribute_value (int):Returns the value of the attribute.
         '''
-        attribute_value_ctype = ctypes_types.ViSession(0)
+        attribute_value_ctype = visatype.ViSession(0)
         error_code = self._library.niFake_GetAttributeViSession(self._vi, self._repeated_capability.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(attribute_value_ctype.value)
@@ -172,7 +172,7 @@ class _SessionBase(object):
         error_code = self._library.niFake_GetAttributeViString(self._vi, self._repeated_capability.encode('ascii'), attribute_id, buffer_size, attribute_value_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         buffer_size = error_code
-        attribute_value_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), ctypes_types.ViString)
+        attribute_value_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), visatype.ViString)
         error_code = self._library.niFake_GetAttributeViString(self._vi, self._repeated_capability.encode('ascii'), attribute_id, buffer_size, attribute_value_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return attribute_value_ctype.value.decode("ascii")
@@ -189,7 +189,7 @@ class _SessionBase(object):
         Returns:
             reading (float):The measured value.
         '''
-        reading_ctype = ctypes_types.ViReal64(0)
+        reading_ctype = visatype.ViReal64(0)
         error_code = self._library.niFake_ReadFromChannel(self._vi, self._repeated_capability.encode('ascii'), maximum_time, ctypes.pointer(reading_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(reading_ctype.value)
@@ -349,7 +349,7 @@ class Session(_SessionBase):
         Returns:
             a_boolean (bool):Contains a boolean.
         '''
-        a_boolean_ctype = ctypes_types.ViBoolean(0)
+        a_boolean_ctype = visatype.ViBoolean(0)
         error_code = self._library.niFake_GetABoolean(self._vi, ctypes.pointer(a_boolean_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return bool(a_boolean_ctype.value)
@@ -364,7 +364,7 @@ class Session(_SessionBase):
         Returns:
             a_number (int):Contains a number.
         '''
-        a_number_ctype = ctypes_types.ViInt16(0)
+        a_number_ctype = visatype.ViInt16(0)
         error_code = self._library.niFake_GetANumber(self._vi, ctypes.pointer(a_number_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(a_number_ctype.value)
@@ -377,7 +377,7 @@ class Session(_SessionBase):
         Returns:
             a_string (int):String comes back here. Buffer must be 256 big.
         '''
-        a_string_ctype = ctypes_types.ViChar(0)
+        a_string_ctype = visatype.ViChar(0)
         error_code = self._library.niFake_GetAStringOfFixedMaximumSize(self._vi, ctypes.pointer(a_string_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(a_string_ctype.value)
@@ -393,8 +393,8 @@ class Session(_SessionBase):
         Returns:
             a_string (int):String comes back here. Buffer must be at least bufferSize big.
         '''
-        a_string_ctype = (ctypes_types.ViChar * buffer_size)()
-        error_code = self._library.niFake_GetAStringWithSpecifiedMaximumSize(self._vi, ctypes.cast(a_string_ctype, ctypes.POINTER(ctypes_types.ViChar)), buffer_size)
+        a_string_ctype = (visatype.ViChar * buffer_size)()
+        error_code = self._library.niFake_GetAStringWithSpecifiedMaximumSize(self._vi, ctypes.cast(a_string_ctype, ctypes.POINTER(visatype.ViChar)), buffer_size)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return a_string_ctype.value.decode("ascii")
 
@@ -421,8 +421,8 @@ class Session(_SessionBase):
                 | 3 | Mich elangelo |
                 +---+---------------+
         '''
-        a_quantity_ctype = ctypes_types.ViInt32(0)
-        a_turtle_ctype = ctypes_types.ViInt16(0)
+        a_quantity_ctype = visatype.ViInt32(0)
+        a_turtle_ctype = visatype.ViInt16(0)
         error_code = self._library.niFake_GetEnumValue(self._vi, ctypes.pointer(a_quantity_ctype), ctypes.pointer(a_turtle_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(a_quantity_ctype.value), enums.Turtle(a_turtle_ctype.value)
@@ -438,13 +438,13 @@ class Session(_SessionBase):
         Returns:
             error_code (int):Returns errorCode for the session. If you pass 0 for bufferSize, you can pass VI_NULL for this.
         '''
-        error_code_ctype = ctypes_types.ViStatus(0)
+        error_code_ctype = visatype.ViStatus(0)
         buffer_size = 0
         description_ctype = None
         error_code = self._library.niFake_GetError(self._vi, ctypes.pointer(error_code_ctype), buffer_size, description_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=True)
         buffer_size = error_code
-        description_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), ctypes_types.ViString)
+        description_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), visatype.ViString)
         error_code = self._library.niFake_GetError(self._vi, ctypes.pointer(error_code_ctype), buffer_size, description_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return int(error_code_ctype.value), description_ctype.value.decode("ascii")
@@ -477,7 +477,7 @@ class Session(_SessionBase):
         Returns:
             vi (int):Returns a ViSession handle that you use.
         '''
-        vi_ctype = ctypes_types.ViSession(0)
+        vi_ctype = visatype.ViSession(0)
         error_code = self._library.niFake_InitWithOptions(resource_name.encode('ascii'), id_query, reset_device, option_string.encode('ascii'), ctypes.pointer(vi_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(vi_ctype.value)
@@ -514,7 +514,7 @@ class Session(_SessionBase):
         Returns:
             reading (float):The measured value.
         '''
-        reading_ctype = ctypes_types.ViReal64(0)
+        reading_ctype = visatype.ViReal64(0)
         error_code = self._library.niFake_Read(self._vi, maximum_time, ctypes.pointer(reading_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(reading_ctype.value)
@@ -534,9 +534,9 @@ class Session(_SessionBase):
                 Note: The size must be at least arraySize.
             actual_number_of_points (int):Indicates the number of measured values actually retrieved.
         '''
-        reading_array_ctype = (ctypes_types.ViReal64 * array_size)()
-        actual_number_of_points_ctype = ctypes_types.ViInt32(0)
-        error_code = self._library.niFake_ReadMultiPoint(self._vi, maximum_time, array_size, ctypes.cast(reading_array_ctype, ctypes.POINTER(ctypes_types.ViReal64)), ctypes.pointer(actual_number_of_points_ctype))
+        reading_array_ctype = (visatype.ViReal64 * array_size)()
+        actual_number_of_points_ctype = visatype.ViInt32(0)
+        error_code = self._library.niFake_ReadMultiPoint(self._vi, maximum_time, array_size, ctypes.cast(reading_array_ctype, ctypes.POINTER(visatype.ViReal64)), ctypes.pointer(actual_number_of_points_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return [float(reading_array_ctype[i].value) for i in range(array_size)], int(actual_number_of_points_ctype.value)
 
@@ -551,8 +551,8 @@ class Session(_SessionBase):
             a_number (int):Contains a number.
             a_string (int):Contains a string.
         '''
-        a_number_ctype = ctypes_types.ViInt16(0)
-        a_string_ctype = ctypes_types.ViChar(0)
+        a_number_ctype = visatype.ViInt16(0)
+        a_string_ctype = visatype.ViChar(0)
         error_code = self._library.niFake_ReturnANumberAndAString(self._vi, ctypes.pointer(a_number_ctype), ctypes.pointer(a_string_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(a_number_ctype.value), int(a_string_ctype.value)
@@ -592,7 +592,7 @@ class Session(_SessionBase):
         Returns:
             output (int):A big number on its way out.
         '''
-        output_ctype = ctypes_types.ViInt64(0)
+        output_ctype = visatype.ViInt64(0)
         error_code = self._library.niFake_Use64BitNumber(self._vi, input, ctypes.pointer(output_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(output_ctype.value)
@@ -617,8 +617,8 @@ class Session(_SessionBase):
         Returns:
             error_message (int):The error information formatted into a string.
         '''
-        error_message_ctype = (ctypes_types.ViChar * 256)()
-        error_code = self._library.niFake_error_message(self._vi, error_code, ctypes.cast(error_message_ctype, ctypes.POINTER(ctypes_types.ViChar)))
+        error_message_ctype = (visatype.ViChar * 256)()
+        error_code = self._library.niFake_error_message(self._vi, error_code, ctypes.cast(error_message_ctype, ctypes.POINTER(visatype.ViChar)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return error_message_ctype.value.decode("ascii")
 

--- a/generated/nifake/tests/mock_helper.py
+++ b/generated/nifake/tests/mock_helper.py
@@ -2,7 +2,7 @@
 
 import ctypes
 
-import nifake.ctypes_types
+import nifake.visatype
 
 
 class MockFunctionCallError(Exception):
@@ -188,8 +188,8 @@ class SideEffectsHelper(object):
             raise MockFunctionCallError("niFake_GetAttributeViString", param='attributeValue')
         if buffer_size == 0:
             return len(self._defaults['GetAttributeViString']['attributeValue'])
-        t = nifake.ctypes_types.ViString(self._defaults['GetAttributeViString']['attributeValue'].encode('ascii'))
-        attribute_value.value = ctypes.cast(t, nifake.ctypes_types.ViString).value
+        t = nifake.visatype.ViString(self._defaults['GetAttributeViString']['attributeValue'].encode('ascii'))
+        attribute_value.value = ctypes.cast(t, nifake.visatype.ViString).value
         return self._defaults['GetAttributeViString']['return']
 
     def niFake_GetEnumValue(self, vi, a_quantity, a_turtle):  # noqa: N802
@@ -213,8 +213,8 @@ class SideEffectsHelper(object):
             raise MockFunctionCallError("niFake_GetError", param='description')
         if buffer_size == 0:
             return len(self._defaults['GetError']['description'])
-        t = nifake.ctypes_types.ViString(self._defaults['GetError']['description'].encode('ascii'))
-        description.value = ctypes.cast(t, nifake.ctypes_types.ViString).value
+        t = nifake.visatype.ViString(self._defaults['GetError']['description'].encode('ascii'))
+        description.value = ctypes.cast(t, nifake.visatype.ViString).value
         return self._defaults['GetError']['return']
 
     def niFake_InitWithOptions(self, resource_name, id_query, reset_device, option_string, vi):  # noqa: N802

--- a/generated/nifake/visatype.py
+++ b/generated/nifake/visatype.py
@@ -1,6 +1,11 @@
 import ctypes
 
 
+'''Definitions of the VISA types used by the C API of the driver runtime. These are subclases of ctypes types so can
+be used directly to call into the library.
+'''
+
+
 class ViStatus(ctypes.c_long):  # noqa: N801
     pass
 

--- a/generated/nimodinst/library.py
+++ b/generated/nimodinst/library.py
@@ -3,7 +3,7 @@
 import ctypes
 import threading
 
-from nimodinst.ctypes_types import *  # noqa: F403,H303
+from nimodinst.visatype import *  # noqa: F403,H303
 
 
 class Library(object):

--- a/generated/nimodinst/session.py
+++ b/generated/nimodinst/session.py
@@ -1,9 +1,9 @@
 # This file was generated
 
 import ctypes
-from nimodinst import ctypes_types
 from nimodinst import errors
 from nimodinst import library_singleton
+from nimodinst import visatype
 
 
 class AttributeViInt32(object):
@@ -175,13 +175,13 @@ class Session(object):
         error_code = self._library.niModInst_GetExtendedErrorInfo(error_info_buffer_size, error_info_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=True)
         error_info_buffer_size = error_code
-        error_info_ctype = ctypes.cast(ctypes.create_string_buffer(error_info_buffer_size), ctypes_types.ViString)
+        error_info_ctype = ctypes.cast(ctypes.create_string_buffer(error_info_buffer_size), visatype.ViString)
         error_code = self._library.niModInst_GetExtendedErrorInfo(error_info_buffer_size, error_info_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return error_info_ctype.value.decode("ascii")
 
     def _get_installed_device_attribute_vi_int32(self, handle, index, attribute_id):
-        attribute_value_ctype = ctypes_types.ViInt32(0)
+        attribute_value_ctype = visatype.ViInt32(0)
         error_code = self._library.niModInst_GetInstalledDeviceAttributeViInt32(self._handle, index, attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(attribute_value_ctype.value)
@@ -192,14 +192,14 @@ class Session(object):
         error_code = self._library.niModInst_GetInstalledDeviceAttributeViString(self._handle, index, attribute_id, attribute_value_buffer_size, attribute_value_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         attribute_value_buffer_size = error_code
-        attribute_value_ctype = ctypes.cast(ctypes.create_string_buffer(attribute_value_buffer_size), ctypes_types.ViString)
+        attribute_value_ctype = ctypes.cast(ctypes.create_string_buffer(attribute_value_buffer_size), visatype.ViString)
         error_code = self._library.niModInst_GetInstalledDeviceAttributeViString(self._handle, index, attribute_id, attribute_value_buffer_size, attribute_value_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return attribute_value_ctype.value.decode("ascii")
 
     def _open_installed_devices_session(self, driver):
-        handle_ctype = ctypes_types.ViSession(0)
-        device_count_ctype = ctypes_types.ViInt32(0)
+        handle_ctype = visatype.ViSession(0)
+        device_count_ctype = visatype.ViInt32(0)
         error_code = self._library.niModInst_OpenInstalledDevicesSession(driver.encode('ascii'), ctypes.pointer(handle_ctype), ctypes.pointer(device_count_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(handle_ctype.value), int(device_count_ctype.value)

--- a/generated/nimodinst/tests/mock_helper.py
+++ b/generated/nimodinst/tests/mock_helper.py
@@ -2,7 +2,7 @@
 
 import ctypes
 
-import nimodinst.ctypes_types
+import nimodinst.visatype
 
 
 class MockFunctionCallError(Exception):
@@ -52,8 +52,8 @@ class SideEffectsHelper(object):
             raise MockFunctionCallError("niModInst_GetExtendedErrorInfo", param='errorInfo')
         if error_info_buffer_size == 0:
             return len(self._defaults['GetExtendedErrorInfo']['errorInfo'])
-        t = nimodinst.ctypes_types.ViString(self._defaults['GetExtendedErrorInfo']['errorInfo'].encode('ascii'))
-        error_info.value = ctypes.cast(t, nimodinst.ctypes_types.ViString).value
+        t = nimodinst.visatype.ViString(self._defaults['GetExtendedErrorInfo']['errorInfo'].encode('ascii'))
+        error_info.value = ctypes.cast(t, nimodinst.visatype.ViString).value
         return self._defaults['GetExtendedErrorInfo']['return']
 
     def niModInst_GetInstalledDeviceAttributeViInt32(self, handle, index, attribute_id, attribute_value):  # noqa: N802
@@ -71,8 +71,8 @@ class SideEffectsHelper(object):
             raise MockFunctionCallError("niModInst_GetInstalledDeviceAttributeViString", param='attributeValue')
         if attribute_value_buffer_size == 0:
             return len(self._defaults['GetInstalledDeviceAttributeViString']['attributeValue'])
-        t = nimodinst.ctypes_types.ViString(self._defaults['GetInstalledDeviceAttributeViString']['attributeValue'].encode('ascii'))
-        attribute_value.value = ctypes.cast(t, nimodinst.ctypes_types.ViString).value
+        t = nimodinst.visatype.ViString(self._defaults['GetInstalledDeviceAttributeViString']['attributeValue'].encode('ascii'))
+        attribute_value.value = ctypes.cast(t, nimodinst.visatype.ViString).value
         return self._defaults['GetInstalledDeviceAttributeViString']['return']
 
     def niModInst_OpenInstalledDevicesSession(self, driver, handle, device_count):  # noqa: N802

--- a/generated/nimodinst/tests/test_modinst.py
+++ b/generated/nimodinst/tests/test_modinst.py
@@ -39,8 +39,8 @@ class TestSession(object):
     def niModInst_GetInstalledDeviceAttributeViString_looping(self, handle, index, attribute_id, attribute_value_buffer_size, attribute_value):  # noqa: N802
         if attribute_value_buffer_size == 0:
             return (len(self.string_vals_device_looping[self.iteration_device_looping]))
-        t = nimodinst.ctypes_types.ViString(self.string_vals_device_looping[self.iteration_device_looping].encode('ascii'))
-        attribute_value.value = ctypes.cast(t, nimodinst.ctypes_types.ViString).value
+        t = nimodinst.visatype.ViString(self.string_vals_device_looping[self.iteration_device_looping].encode('ascii'))
+        attribute_value.value = ctypes.cast(t, nimodinst.visatype.ViString).value
         self.iteration_device_looping += 1
         return 0
 

--- a/generated/nimodinst/visatype.py
+++ b/generated/nimodinst/visatype.py
@@ -1,6 +1,11 @@
 import ctypes
 
 
+'''Definitions of the VISA types used by the C API of the driver runtime. These are subclases of ctypes types so can
+be used directly to call into the library.
+'''
+
+
 class ViStatus(ctypes.c_long):  # noqa: N801
     pass
 

--- a/generated/niswitch/library.py
+++ b/generated/niswitch/library.py
@@ -3,7 +3,7 @@
 import ctypes
 import threading
 
-from niswitch.ctypes_types import *  # noqa: F403,H303
+from niswitch.visatype import *  # noqa: F403,H303
 
 
 class Library(object):

--- a/generated/niswitch/session.py
+++ b/generated/niswitch/session.py
@@ -3,10 +3,10 @@
 import ctypes
 
 from niswitch import attributes
-from niswitch import ctypes_types
 from niswitch import enums
 from niswitch import errors
 from niswitch import library_singleton
+from niswitch import visatype
 
 
 class _Scan(object):
@@ -901,7 +901,7 @@ class _SessionBase(object):
                 list of the constants by pressing on this control. Select a value by
                 double-clicking on it or by selecting it and then pressing .
         '''
-        attribute_value_ctype = ctypes_types.ViBoolean(0)
+        attribute_value_ctype = visatype.ViBoolean(0)
         error_code = self._library.niSwitch_GetAttributeViBoolean(self._vi, self._repeated_capability.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return bool(attribute_value_ctype.value)
@@ -946,7 +946,7 @@ class _SessionBase(object):
                 list of the constants by pressing on this control. Select a value by
                 double-clicking on it or by selecting it and then pressing .
         '''
-        attribute_value_ctype = ctypes_types.ViInt32(0)
+        attribute_value_ctype = visatype.ViInt32(0)
         error_code = self._library.niSwitch_GetAttributeViInt32(self._vi, self._repeated_capability.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(attribute_value_ctype.value)
@@ -991,7 +991,7 @@ class _SessionBase(object):
                 list of the constants by pressing on this control. Select a value by
                 double-clicking on it or by selecting it and then pressing .
         '''
-        attribute_value_ctype = ctypes_types.ViReal64(0)
+        attribute_value_ctype = visatype.ViReal64(0)
         error_code = self._library.niSwitch_GetAttributeViReal64(self._vi, self._repeated_capability.encode('ascii'), attribute_id, ctypes.pointer(attribute_value_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(attribute_value_ctype.value)
@@ -1056,7 +1056,7 @@ class _SessionBase(object):
         error_code = self._library.niSwitch_GetAttributeViString(self._vi, self._repeated_capability.encode('ascii'), attribute_id, array_size, attribute_value_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         array_size = error_code
-        attribute_value_ctype = ctypes.cast(ctypes.create_string_buffer(array_size), ctypes_types.ViString)
+        attribute_value_ctype = ctypes.cast(ctypes.create_string_buffer(array_size), visatype.ViString)
         error_code = self._library.niSwitch_GetAttributeViString(self._vi, self._repeated_capability.encode('ascii'), attribute_id, array_size, attribute_value_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return attribute_value_ctype.value.decode("ascii")
@@ -1378,7 +1378,7 @@ class Session(_SessionBase):
                 create a path between the two channels because one of the channels is a
                 configuration channel and thus unavailable for external connections.
         '''
-        path_capability_ctype = ctypes_types.ViInt32(0)
+        path_capability_ctype = visatype.ViInt32(0)
         error_code = self._library.niSwitch_CanConnect(self._vi, channel1.encode('ascii'), channel2.encode('ascii'), ctypes.pointer(path_capability_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return enums.PathCapability(path_capability_ctype.value)
@@ -1630,7 +1630,7 @@ class Session(_SessionBase):
         error_code = self._library.niSwitch_GetChannelName(self._vi, index, buffer_size, channel_name_buffer_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         buffer_size = error_code
-        channel_name_buffer_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), ctypes_types.ViString)
+        channel_name_buffer_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), visatype.ViString)
         error_code = self._library.niSwitch_GetChannelName(self._vi, index, buffer_size, channel_name_buffer_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return channel_name_buffer_ctype.value.decode("ascii")
@@ -1670,13 +1670,13 @@ class Session(_SessionBase):
             code (int):Returns the error code for the session or execution thread. If you pass
                 0 for the Buffer Size, you can pass VI_NULL for this parameter.
         '''
-        code_ctype = ctypes_types.ViStatus(0)
+        code_ctype = visatype.ViStatus(0)
         buffer_size = 0
         description_ctype = None
         error_code = self._library.niSwitch_GetError(self._vi, ctypes.pointer(code_ctype), buffer_size, description_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=True)
         buffer_size = error_code
-        description_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), ctypes_types.ViString)
+        description_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), visatype.ViString)
         error_code = self._library.niSwitch_GetError(self._vi, ctypes.pointer(code_ctype), buffer_size, description_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return int(code_ctype.value), description_ctype.value.decode("ascii")
@@ -1722,7 +1722,7 @@ class Session(_SessionBase):
         error_code = self._library.niSwitch_GetPath(self._vi, channel1.encode('ascii'), channel2.encode('ascii'), buffer_size, path_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         buffer_size = error_code
-        path_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), ctypes_types.ViString)
+        path_ctype = ctypes.cast(ctypes.create_string_buffer(buffer_size), visatype.ViString)
         error_code = self._library.niSwitch_GetPath(self._vi, channel1.encode('ascii'), channel2.encode('ascii'), buffer_size, path_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return path_ctype.value.decode("ascii")
@@ -1744,7 +1744,7 @@ class Session(_SessionBase):
         Returns:
             relay_count (int):The number of relay cycles.
         '''
-        relay_count_ctype = ctypes_types.ViInt32(0)
+        relay_count_ctype = visatype.ViInt32(0)
         error_code = self._library.niSwitch_GetRelayCount(self._vi, relay_name.encode('ascii'), ctypes.pointer(relay_count_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(relay_count_ctype.value)
@@ -1777,7 +1777,7 @@ class Session(_SessionBase):
         error_code = self._library.niSwitch_GetRelayName(self._vi, index, relay_name_buffer_size, relay_name_buffer_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         relay_name_buffer_size = error_code
-        relay_name_buffer_ctype = ctypes.cast(ctypes.create_string_buffer(relay_name_buffer_size), ctypes_types.ViString)
+        relay_name_buffer_ctype = ctypes.cast(ctypes.create_string_buffer(relay_name_buffer_size), visatype.ViString)
         error_code = self._library.niSwitch_GetRelayName(self._vi, index, relay_name_buffer_size, relay_name_buffer_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return relay_name_buffer_ctype.value.decode("ascii")
@@ -1797,7 +1797,7 @@ class Session(_SessionBase):
             relay_position (enums.RelayPosition):Indicates whether the relay is open or closed. NISWITCH_VAL_OPEN 10
                 NIWITCH_VAL_CLOSED 11
         '''
-        relay_position_ctype = ctypes_types.ViInt32(0)
+        relay_position_ctype = visatype.ViInt32(0)
         error_code = self._library.niSwitch_GetRelayPosition(self._vi, relay_name.encode('ascii'), ctypes.pointer(relay_position_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return enums.RelayPosition(relay_position_ctype.value)
@@ -2034,7 +2034,7 @@ class Session(_SessionBase):
                 init_with_topology, init_with_options, or init
                 and used for all subsequent NI-SWITCH calls.
         '''
-        vi_ctype = ctypes_types.ViSession(0)
+        vi_ctype = visatype.ViSession(0)
         error_code = self._library.niSwitch_InitWithTopology(resource_name.encode('ascii'), topology.encode('ascii'), simulate, reset_device, ctypes.pointer(vi_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(vi_ctype.value)
@@ -2065,7 +2065,7 @@ class Session(_SessionBase):
             is_debounced (bool):VI_TRUE indicates that all created paths have settled. VI_FALSE
                 indicates that all created paths have not settled.
         '''
-        is_debounced_ctype = ctypes_types.ViBoolean(0)
+        is_debounced_ctype = visatype.ViBoolean(0)
         error_code = self._library.niSwitch_IsDebounced(self._vi, ctypes.pointer(is_debounced_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return bool(is_debounced_ctype.value)
@@ -2080,7 +2080,7 @@ class Session(_SessionBase):
                 VI_TRUE indicates that the switch device is scanning. VI_FALSE
                 indicates that the switch device is idle.
         '''
-        is_scanning_ctype = ctypes_types.ViBoolean(0)
+        is_scanning_ctype = visatype.ViBoolean(0)
         error_code = self._library.niSwitch_IsScanning(self._vi, ctypes.pointer(is_scanning_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return bool(is_scanning_ctype.value)
@@ -2291,8 +2291,8 @@ class Session(_SessionBase):
             error_message (int):The error information formatted into a string. You must pass a ViChar
                 array with at least 256 bytes.
         '''
-        error_message_ctype = (ctypes_types.ViChar * 256)()
-        error_code = self._library.niSwitch_error_message(self._vi, error_code, ctypes.cast(error_message_ctype, ctypes.POINTER(ctypes_types.ViChar)))
+        error_message_ctype = (visatype.ViChar * 256)()
+        error_code = self._library.niSwitch_error_message(self._vi, error_code, ctypes.cast(error_message_ctype, ctypes.POINTER(visatype.ViChar)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return error_message_ctype.value.decode("ascii")
 
@@ -2317,9 +2317,9 @@ class Session(_SessionBase):
                 pass a ViChar array with at least 256 bytes.
             firmware_revision (int):Currently unsupported.
         '''
-        instrument_driver_revision_ctype = (ctypes_types.ViChar * 256)()
-        firmware_revision_ctype = (ctypes_types.ViChar * 256)()
-        error_code = self._library.niSwitch_revision_query(self._vi, ctypes.cast(instrument_driver_revision_ctype, ctypes.POINTER(ctypes_types.ViChar)), ctypes.cast(firmware_revision_ctype, ctypes.POINTER(ctypes_types.ViChar)))
+        instrument_driver_revision_ctype = (visatype.ViChar * 256)()
+        firmware_revision_ctype = (visatype.ViChar * 256)()
+        error_code = self._library.niSwitch_revision_query(self._vi, ctypes.cast(instrument_driver_revision_ctype, ctypes.POINTER(visatype.ViChar)), ctypes.cast(firmware_revision_ctype, ctypes.POINTER(visatype.ViChar)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return instrument_driver_revision_ctype.value.decode("ascii"), firmware_revision_ctype.value.decode("ascii")
 
@@ -2333,9 +2333,9 @@ class Session(_SessionBase):
             self_test_message (int):Self-test response string from the switch device. You must pass a ViChar
                 array with at least 256 bytes.
         '''
-        self_test_result_ctype = ctypes_types.ViInt16(0)
-        self_test_message_ctype = (ctypes_types.ViChar * 256)()
-        error_code = self._library.niSwitch_self_test(self._vi, ctypes.pointer(self_test_result_ctype), ctypes.cast(self_test_message_ctype, ctypes.POINTER(ctypes_types.ViChar)))
+        self_test_result_ctype = visatype.ViInt16(0)
+        self_test_message_ctype = (visatype.ViChar * 256)()
+        error_code = self._library.niSwitch_self_test(self._vi, ctypes.pointer(self_test_result_ctype), ctypes.cast(self_test_message_ctype, ctypes.POINTER(visatype.ViChar)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(self_test_result_ctype.value), self_test_message_ctype.value.decode("ascii")
 

--- a/generated/niswitch/tests/mock_helper.py
+++ b/generated/niswitch/tests/mock_helper.py
@@ -2,7 +2,7 @@
 
 import ctypes
 
-import niswitch.ctypes_types
+import niswitch.visatype
 
 
 class MockFunctionCallError(Exception):
@@ -220,8 +220,8 @@ class SideEffectsHelper(object):
             raise MockFunctionCallError("niSwitch_GetAttributeViString", param='attributeValue')
         if array_size == 0:
             return len(self._defaults['GetAttributeViString']['attributeValue'])
-        t = niswitch.ctypes_types.ViString(self._defaults['GetAttributeViString']['attributeValue'].encode('ascii'))
-        attribute_value.value = ctypes.cast(t, niswitch.ctypes_types.ViString).value
+        t = niswitch.visatype.ViString(self._defaults['GetAttributeViString']['attributeValue'].encode('ascii'))
+        attribute_value.value = ctypes.cast(t, niswitch.visatype.ViString).value
         return self._defaults['GetAttributeViString']['return']
 
     def niSwitch_GetChannelName(self, vi, index, buffer_size, channel_name_buffer):  # noqa: N802
@@ -231,8 +231,8 @@ class SideEffectsHelper(object):
             raise MockFunctionCallError("niSwitch_GetChannelName", param='channelNameBuffer')
         if buffer_size == 0:
             return len(self._defaults['GetChannelName']['channelNameBuffer'])
-        t = niswitch.ctypes_types.ViString(self._defaults['GetChannelName']['channelNameBuffer'].encode('ascii'))
-        channel_name_buffer.value = ctypes.cast(t, niswitch.ctypes_types.ViString).value
+        t = niswitch.visatype.ViString(self._defaults['GetChannelName']['channelNameBuffer'].encode('ascii'))
+        channel_name_buffer.value = ctypes.cast(t, niswitch.visatype.ViString).value
         return self._defaults['GetChannelName']['return']
 
     def niSwitch_GetError(self, vi, code, buffer_size, description):  # noqa: N802
@@ -245,8 +245,8 @@ class SideEffectsHelper(object):
             raise MockFunctionCallError("niSwitch_GetError", param='Description')
         if buffer_size == 0:
             return len(self._defaults['GetError']['Description'])
-        t = niswitch.ctypes_types.ViString(self._defaults['GetError']['Description'].encode('ascii'))
-        description.value = ctypes.cast(t, niswitch.ctypes_types.ViString).value
+        t = niswitch.visatype.ViString(self._defaults['GetError']['Description'].encode('ascii'))
+        description.value = ctypes.cast(t, niswitch.visatype.ViString).value
         return self._defaults['GetError']['return']
 
     def niSwitch_GetPath(self, vi, channel1, channel2, buffer_size, path):  # noqa: N802
@@ -256,8 +256,8 @@ class SideEffectsHelper(object):
             raise MockFunctionCallError("niSwitch_GetPath", param='Path')
         if buffer_size == 0:
             return len(self._defaults['GetPath']['Path'])
-        t = niswitch.ctypes_types.ViString(self._defaults['GetPath']['Path'].encode('ascii'))
-        path.value = ctypes.cast(t, niswitch.ctypes_types.ViString).value
+        t = niswitch.visatype.ViString(self._defaults['GetPath']['Path'].encode('ascii'))
+        path.value = ctypes.cast(t, niswitch.visatype.ViString).value
         return self._defaults['GetPath']['return']
 
     def niSwitch_GetRelayCount(self, vi, relay_name, relay_count):  # noqa: N802
@@ -275,8 +275,8 @@ class SideEffectsHelper(object):
             raise MockFunctionCallError("niSwitch_GetRelayName", param='relayNameBuffer')
         if relay_name_buffer_size == 0:
             return len(self._defaults['GetRelayName']['relayNameBuffer'])
-        t = niswitch.ctypes_types.ViString(self._defaults['GetRelayName']['relayNameBuffer'].encode('ascii'))
-        relay_name_buffer.value = ctypes.cast(t, niswitch.ctypes_types.ViString).value
+        t = niswitch.visatype.ViString(self._defaults['GetRelayName']['relayNameBuffer'].encode('ascii'))
+        relay_name_buffer.value = ctypes.cast(t, niswitch.visatype.ViString).value
         return self._defaults['GetRelayName']['return']
 
     def niSwitch_GetRelayPosition(self, vi, relay_name, relay_position):  # noqa: N802

--- a/generated/niswitch/visatype.py
+++ b/generated/niswitch/visatype.py
@@ -1,6 +1,11 @@
 import ctypes
 
 
+'''Definitions of the VISA types used by the C API of the driver runtime. These are subclases of ctypes types so can
+be used directly to call into the library.
+'''
+
+
 class ViStatus(ctypes.c_long):  # noqa: N801
     pass
 

--- a/src/nimodinst/templates/session.py.mako
+++ b/src/nimodinst/templates/session.py.mako
@@ -13,9 +13,9 @@
 %>\
 
 import ctypes
-from ${module_name} import ctypes_types
 from ${module_name} import errors
 from ${module_name} import library_singleton
+from ${module_name} import visatype
 
 
 class AttributeViInt32(object):
@@ -174,7 +174,7 @@ class Session(object):
         error_code = self._library.${c_function_prefix}${func_name}(${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_METHOD_CALL, {'session_handle_parameter_name': '_' + config['session_handle_parameter_name']})})
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=${f['is_error_handling']})
         ${ivi_dance_size_parameter['python_name']} = error_code
-        ${ivi_dance_parameter['ctypes_variable_name']} = ctypes.cast(ctypes.create_string_buffer(${ivi_dance_size_parameter['python_name']}), ctypes_types.${ivi_dance_parameter['ctypes_type']})
+        ${ivi_dance_parameter['ctypes_variable_name']} = ctypes.cast(ctypes.create_string_buffer(${ivi_dance_size_parameter['python_name']}), visatype.${ivi_dance_parameter['ctypes_type']})
         error_code = self._library.${c_function_prefix}${func_name}(${helper.get_params_snippet(f, helper.ParamListType.LIBRARY_METHOD_CALL, {'session_handle_parameter_name': '_' + config['session_handle_parameter_name']})})
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=${f['is_error_handling']})
         ${helper.get_method_return_snippet(f['parameters'])}

--- a/src/nimodinst/tests/test_modinst.py
+++ b/src/nimodinst/tests/test_modinst.py
@@ -39,8 +39,8 @@ class TestSession(object):
     def niModInst_GetInstalledDeviceAttributeViString_looping(self, handle, index, attribute_id, attribute_value_buffer_size, attribute_value):  # noqa: N802
         if attribute_value_buffer_size == 0:
             return (len(self.string_vals_device_looping[self.iteration_device_looping]))
-        t = nimodinst.ctypes_types.ViString(self.string_vals_device_looping[self.iteration_device_looping].encode('ascii'))
-        attribute_value.value = ctypes.cast(t, nimodinst.ctypes_types.ViString).value
+        t = nimodinst.visatype.ViString(self.string_vals_device_looping[self.iteration_device_looping].encode('ascii'))
+        attribute_value.value = ctypes.cast(t, nimodinst.visatype.ViString).value
         self.iteration_device_looping += 1
         return 0
 


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md]

~~[ ] I've updated [CHANGELOG.md](https://github.com/ni/<reponame>/blob/master/CHANGELOG.md) if applicable.~~

### What does this Pull Request accomplish?

Renames ctypes_types.py -> visatype.py

The logic behind this is that visatype.py contains types with names identical to those in visatype.h that ships with VISA and is used by Modular Instruments drivers. They are ctypes types and are binary compatible too.

This should make the code simpler to follow, is the intention.

### List issues fixed by this Pull Request below, if any.

N/A

### What testing has been done?

tox