### PR TITLE
Adding additional system test to cover error_message

### DIFF
--- a/src/niswitch/system_tests/test_system_niswitch.py
+++ b/src/niswitch/system_tests/test_system_niswitch.py
@@ -160,5 +160,6 @@ def test_functions_disable(session):
 
 
 def test_error_message(session):
+    # Testing a private function, as there is no way to natively get to this function on a simulated session.
     message = session._error_message(-1074135027)
     assert message == 'IVI:  (Hex 0xBFFA000D) Attribute is read-only.'

--- a/src/niswitch/system_tests/test_system_niswitch.py
+++ b/src/niswitch/system_tests/test_system_niswitch.py
@@ -157,3 +157,7 @@ def test_functions_disable(session):
     session.connect(channel1, channel2)
     session.disable()   # expect no errors
     assert session.can_connect(channel1, channel2) == niswitch.PathCapability.PATH_AVAILABLE
+
+def test_error_message(session):
+    message = session._error_message(-1074135027)
+    assert message == 'IVI:  (Hex 0xBFFA000D) Attribute is read-only.'

--- a/src/niswitch/system_tests/test_system_niswitch.py
+++ b/src/niswitch/system_tests/test_system_niswitch.py
@@ -158,6 +158,7 @@ def test_functions_disable(session):
     session.disable()   # expect no errors
     assert session.can_connect(channel1, channel2) == niswitch.PathCapability.PATH_AVAILABLE
 
+
 def test_error_message(session):
     message = session._error_message(-1074135027)
     assert message == 'IVI:  (Hex 0xBFFA000D) Attribute is read-only.'


### PR DESCRIPTION
[x ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/<reponame>/blob/master/CONTRIBUTING.md).


### What does this Pull Request accomplish?

Adds system test to cover error_message which was previously not generated

### What testing has been done?

Ran system tests
