### PR TITLE
Make visatypes "typedefs" rather than subclasses

### DIFF
--- a/build/helper/codegen_helper.py
+++ b/build/helper/codegen_helper.py
@@ -174,7 +174,7 @@ def _get_output_param_return_snippet(output_parameter, parameters):
             snippet = output_parameter['ctypes_variable_name'] + '.value.decode("ascii")'
         else:
             size_parameter = find_size_parameter(output_parameter, parameters)
-            snippet = '[' + return_type_snippet + output_parameter['ctypes_variable_name'] + '[i].value) for i in range(' + size_parameter['python_name'] + ')]'
+            snippet = '[' + return_type_snippet + output_parameter['ctypes_variable_name'] + '[i]) for i in range(' + size_parameter['python_name'] + ')]'
     else:
         snippet = return_type_snippet + output_parameter['ctypes_variable_name'] + '.value)'
 

--- a/build/templates/library.py.mako
+++ b/build/templates/library.py.mako
@@ -54,5 +54,5 @@ class Library(object):
                 self.${c_func_name}_cfunc = self._library.${c_func_name}
                 self.${c_func_name}_cfunc.argtypes = [${param_ctypes_library}]  # noqa: F405
                 self.${c_func_name}_cfunc.restype = ${f['returns']}  # noqa: F405
-        return self.${c_func_name}_cfunc(${param_names_library}).value
+        return self.${c_func_name}_cfunc(${param_names_library})
 % endfor

--- a/build/templates/visatype.py
+++ b/build/templates/visatype.py
@@ -6,69 +6,19 @@ be used directly to call into the library.
 '''
 
 
-class ViStatus(ctypes.c_long):  # noqa: N801
-    pass
+ViStatus = ctypes.c_long
+ViRsrc = ctypes.c_char_p
+ViSession = ctypes.c_ulong
+ViChar = ctypes.c_char
+ViUInt32 = ctypes.c_ulong
+ViInt32 = ctypes.c_long
+ViInt16 = ctypes.c_short
+ViUInt16 = ctypes.c_ushort
+ViInt64 = ctypes.c_longlong
+ViString = ctypes.c_char_p
+ViAttr = ctypes.c_long
+ViConstString = ViString
+ViBoolean = ctypes.c_ushort
+ViReal32 = ctypes.c_float
+ViReal64 = ctypes.c_double
 
-
-class ViRsrc(ctypes.c_char_p):  # noqa: N801
-    pass
-
-
-class ViSession(ctypes.c_ulong):  # noqa: N801
-    pass
-
-
-class ViChar(ctypes.c_char):  # noqa: N801
-    pass
-
-
-class ViUInt32(ctypes.c_ulong):  # noqa: N801
-    pass
-
-
-class ViInt32(ctypes.c_long):  # noqa: N801
-    pass
-
-
-class ViInt16(ctypes.c_short):  # noqa: N801
-    pass
-
-
-class ViUInt16(ctypes.c_ushort):  # noqa: N801
-    pass
-
-
-class ViInt64(ctypes.c_longlong):  # noqa: N801
-    pass
-
-
-class ViString(ctypes.c_char_p):  # noqa: N801
-    pass
-
-
-class ViAttr(ctypes.c_long):  # noqa: N801
-    pass
-
-
-class ViConstString(ViString):  # noqa: N801
-    @property
-    def value(self):  # Makes 'value' readonly
-        return super(ViConstString, ViString).value
-
-
-class ViBoolean(ctypes.c_ushort):  # noqa: N801
-    @classmethod
-    def from_param(cls, param):
-        return ctypes.c_uint16(1) if bool(param) else ctypes.c_uint16(0)
-
-
-class ViReal32(ctypes.c_float):  # noqa: N801
-    @classmethod
-    def from_param(cls, param):
-        return ctypes.c_float(param)
-
-
-class ViReal64(ctypes.c_double):  # noqa: N801
-    @classmethod
-    def from_param(cls, param):
-        return ctypes.c_double(param)

--- a/generated/nidcpower/library.py
+++ b/generated/nidcpower/library.py
@@ -76,7 +76,7 @@ class Library(object):
                 self.niDCPower_Abort_cfunc = self._library.niDCPower_Abort
                 self.niDCPower_Abort_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_Abort_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_Abort_cfunc(vi).value
+        return self.niDCPower_Abort_cfunc(vi)
 
     def niDCPower_Commit(self, vi):  # noqa: N802
         with self._func_lock:
@@ -84,7 +84,7 @@ class Library(object):
                 self.niDCPower_Commit_cfunc = self._library.niDCPower_Commit
                 self.niDCPower_Commit_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_Commit_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_Commit_cfunc(vi).value
+        return self.niDCPower_Commit_cfunc(vi)
 
     def niDCPower_ConfigureApertureTime(self, vi, channel_name, aperture_time, units):  # noqa: N802
         with self._func_lock:
@@ -92,7 +92,7 @@ class Library(object):
                 self.niDCPower_ConfigureApertureTime_cfunc = self._library.niDCPower_ConfigureApertureTime
                 self.niDCPower_ConfigureApertureTime_cfunc.argtypes = [ViSession, ViChar, ViReal64, ViInt32]  # noqa: F405
                 self.niDCPower_ConfigureApertureTime_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_ConfigureApertureTime_cfunc(vi, channel_name, aperture_time, units).value
+        return self.niDCPower_ConfigureApertureTime_cfunc(vi, channel_name, aperture_time, units)
 
     def niDCPower_ConfigureDigitalEdgeMeasureTrigger(self, vi, input_terminal, edge):  # noqa: N802
         with self._func_lock:
@@ -100,7 +100,7 @@ class Library(object):
                 self.niDCPower_ConfigureDigitalEdgeMeasureTrigger_cfunc = self._library.niDCPower_ConfigureDigitalEdgeMeasureTrigger
                 self.niDCPower_ConfigureDigitalEdgeMeasureTrigger_cfunc.argtypes = [ViSession, ViChar, ViInt32]  # noqa: F405
                 self.niDCPower_ConfigureDigitalEdgeMeasureTrigger_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_ConfigureDigitalEdgeMeasureTrigger_cfunc(vi, input_terminal, edge).value
+        return self.niDCPower_ConfigureDigitalEdgeMeasureTrigger_cfunc(vi, input_terminal, edge)
 
     def niDCPower_ConfigureDigitalEdgePulseTrigger(self, vi, input_terminal, edge):  # noqa: N802
         with self._func_lock:
@@ -108,7 +108,7 @@ class Library(object):
                 self.niDCPower_ConfigureDigitalEdgePulseTrigger_cfunc = self._library.niDCPower_ConfigureDigitalEdgePulseTrigger
                 self.niDCPower_ConfigureDigitalEdgePulseTrigger_cfunc.argtypes = [ViSession, ViChar, ViInt32]  # noqa: F405
                 self.niDCPower_ConfigureDigitalEdgePulseTrigger_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_ConfigureDigitalEdgePulseTrigger_cfunc(vi, input_terminal, edge).value
+        return self.niDCPower_ConfigureDigitalEdgePulseTrigger_cfunc(vi, input_terminal, edge)
 
     def niDCPower_ConfigureDigitalEdgeSequenceAdvanceTrigger(self, vi, input_terminal, edge):  # noqa: N802
         with self._func_lock:
@@ -116,7 +116,7 @@ class Library(object):
                 self.niDCPower_ConfigureDigitalEdgeSequenceAdvanceTrigger_cfunc = self._library.niDCPower_ConfigureDigitalEdgeSequenceAdvanceTrigger
                 self.niDCPower_ConfigureDigitalEdgeSequenceAdvanceTrigger_cfunc.argtypes = [ViSession, ViChar, ViInt32]  # noqa: F405
                 self.niDCPower_ConfigureDigitalEdgeSequenceAdvanceTrigger_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_ConfigureDigitalEdgeSequenceAdvanceTrigger_cfunc(vi, input_terminal, edge).value
+        return self.niDCPower_ConfigureDigitalEdgeSequenceAdvanceTrigger_cfunc(vi, input_terminal, edge)
 
     def niDCPower_ConfigureDigitalEdgeSourceTrigger(self, vi, input_terminal, edge):  # noqa: N802
         with self._func_lock:
@@ -124,7 +124,7 @@ class Library(object):
                 self.niDCPower_ConfigureDigitalEdgeSourceTrigger_cfunc = self._library.niDCPower_ConfigureDigitalEdgeSourceTrigger
                 self.niDCPower_ConfigureDigitalEdgeSourceTrigger_cfunc.argtypes = [ViSession, ViChar, ViInt32]  # noqa: F405
                 self.niDCPower_ConfigureDigitalEdgeSourceTrigger_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_ConfigureDigitalEdgeSourceTrigger_cfunc(vi, input_terminal, edge).value
+        return self.niDCPower_ConfigureDigitalEdgeSourceTrigger_cfunc(vi, input_terminal, edge)
 
     def niDCPower_ConfigureDigitalEdgeStartTrigger(self, vi, input_terminal, edge):  # noqa: N802
         with self._func_lock:
@@ -132,7 +132,7 @@ class Library(object):
                 self.niDCPower_ConfigureDigitalEdgeStartTrigger_cfunc = self._library.niDCPower_ConfigureDigitalEdgeStartTrigger
                 self.niDCPower_ConfigureDigitalEdgeStartTrigger_cfunc.argtypes = [ViSession, ViChar, ViInt32]  # noqa: F405
                 self.niDCPower_ConfigureDigitalEdgeStartTrigger_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_ConfigureDigitalEdgeStartTrigger_cfunc(vi, input_terminal, edge).value
+        return self.niDCPower_ConfigureDigitalEdgeStartTrigger_cfunc(vi, input_terminal, edge)
 
     def niDCPower_CreateAdvancedSequence(self, vi, sequence_name, attribute_id_count, attribute_ids, set_as_active_sequence):  # noqa: N802
         with self._func_lock:
@@ -140,7 +140,7 @@ class Library(object):
                 self.niDCPower_CreateAdvancedSequence_cfunc = self._library.niDCPower_CreateAdvancedSequence
                 self.niDCPower_CreateAdvancedSequence_cfunc.argtypes = [ViSession, ViConstString, ViInt32, ViInt32, ViBoolean]  # noqa: F405
                 self.niDCPower_CreateAdvancedSequence_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_CreateAdvancedSequence_cfunc(vi, sequence_name, attribute_id_count, attribute_ids, set_as_active_sequence).value
+        return self.niDCPower_CreateAdvancedSequence_cfunc(vi, sequence_name, attribute_id_count, attribute_ids, set_as_active_sequence)
 
     def niDCPower_CreateAdvancedSequenceStep(self, vi, set_as_active_step):  # noqa: N802
         with self._func_lock:
@@ -148,7 +148,7 @@ class Library(object):
                 self.niDCPower_CreateAdvancedSequenceStep_cfunc = self._library.niDCPower_CreateAdvancedSequenceStep
                 self.niDCPower_CreateAdvancedSequenceStep_cfunc.argtypes = [ViSession, ViBoolean]  # noqa: F405
                 self.niDCPower_CreateAdvancedSequenceStep_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_CreateAdvancedSequenceStep_cfunc(vi, set_as_active_step).value
+        return self.niDCPower_CreateAdvancedSequenceStep_cfunc(vi, set_as_active_step)
 
     def niDCPower_DeleteAdvancedSequence(self, vi, sequence_name):  # noqa: N802
         with self._func_lock:
@@ -156,7 +156,7 @@ class Library(object):
                 self.niDCPower_DeleteAdvancedSequence_cfunc = self._library.niDCPower_DeleteAdvancedSequence
                 self.niDCPower_DeleteAdvancedSequence_cfunc.argtypes = [ViSession, ViConstString]  # noqa: F405
                 self.niDCPower_DeleteAdvancedSequence_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_DeleteAdvancedSequence_cfunc(vi, sequence_name).value
+        return self.niDCPower_DeleteAdvancedSequence_cfunc(vi, sequence_name)
 
     def niDCPower_Disable(self, vi):  # noqa: N802
         with self._func_lock:
@@ -164,7 +164,7 @@ class Library(object):
                 self.niDCPower_Disable_cfunc = self._library.niDCPower_Disable
                 self.niDCPower_Disable_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_Disable_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_Disable_cfunc(vi).value
+        return self.niDCPower_Disable_cfunc(vi)
 
     def niDCPower_ExportSignal(self, vi, signal, signal_identifier, output_terminal):  # noqa: N802
         with self._func_lock:
@@ -172,7 +172,7 @@ class Library(object):
                 self.niDCPower_ExportSignal_cfunc = self._library.niDCPower_ExportSignal
                 self.niDCPower_ExportSignal_cfunc.argtypes = [ViSession, ViInt32, ViChar, ViChar]  # noqa: F405
                 self.niDCPower_ExportSignal_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_ExportSignal_cfunc(vi, signal, signal_identifier, output_terminal).value
+        return self.niDCPower_ExportSignal_cfunc(vi, signal, signal_identifier, output_terminal)
 
     def niDCPower_FetchMultiple(self, vi, channel_name, timeout, count, voltage_measurements, current_measurements, in_compliance, actual_count):  # noqa: N802
         with self._func_lock:
@@ -180,7 +180,7 @@ class Library(object):
                 self.niDCPower_FetchMultiple_cfunc = self._library.niDCPower_FetchMultiple
                 self.niDCPower_FetchMultiple_cfunc.argtypes = [ViSession, ViChar, ViReal64, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViBoolean), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDCPower_FetchMultiple_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_FetchMultiple_cfunc(vi, channel_name, timeout, count, voltage_measurements, current_measurements, in_compliance, actual_count).value
+        return self.niDCPower_FetchMultiple_cfunc(vi, channel_name, timeout, count, voltage_measurements, current_measurements, in_compliance, actual_count)
 
     def niDCPower_GetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -188,7 +188,7 @@ class Library(object):
                 self.niDCPower_GetAttributeViBoolean_cfunc = self._library.niDCPower_GetAttributeViBoolean
                 self.niDCPower_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ViChar, ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDCPower_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_GetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niDCPower_GetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niDCPower_GetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -196,7 +196,7 @@ class Library(object):
                 self.niDCPower_GetAttributeViInt32_cfunc = self._library.niDCPower_GetAttributeViInt32
                 self.niDCPower_GetAttributeViInt32_cfunc.argtypes = [ViSession, ViChar, ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDCPower_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_GetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niDCPower_GetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niDCPower_GetAttributeViInt64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -204,7 +204,7 @@ class Library(object):
                 self.niDCPower_GetAttributeViInt64_cfunc = self._library.niDCPower_GetAttributeViInt64
                 self.niDCPower_GetAttributeViInt64_cfunc.argtypes = [ViSession, ViChar, ViAttr, ctypes.POINTER(ViInt64)]  # noqa: F405
                 self.niDCPower_GetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_GetAttributeViInt64_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niDCPower_GetAttributeViInt64_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niDCPower_GetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -212,7 +212,7 @@ class Library(object):
                 self.niDCPower_GetAttributeViReal64_cfunc = self._library.niDCPower_GetAttributeViReal64
                 self.niDCPower_GetAttributeViReal64_cfunc.argtypes = [ViSession, ViChar, ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_GetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niDCPower_GetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niDCPower_GetAttributeViString(self, vi, channel_name, attribute_id, buffer_size, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -220,7 +220,7 @@ class Library(object):
                 self.niDCPower_GetAttributeViString_cfunc = self._library.niDCPower_GetAttributeViString
                 self.niDCPower_GetAttributeViString_cfunc.argtypes = [ViSession, ViChar, ViAttr, ViInt32, ViString]  # noqa: F405
                 self.niDCPower_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_GetAttributeViString_cfunc(vi, channel_name, attribute_id, buffer_size, attribute_value).value
+        return self.niDCPower_GetAttributeViString_cfunc(vi, channel_name, attribute_id, buffer_size, attribute_value)
 
     def niDCPower_GetError(self, vi, code, buffer_size, description):  # noqa: N802
         with self._func_lock:
@@ -228,7 +228,7 @@ class Library(object):
                 self.niDCPower_GetError_cfunc = self._library.niDCPower_GetError
                 self.niDCPower_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ViString]  # noqa: F405
                 self.niDCPower_GetError_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_GetError_cfunc(vi, code, buffer_size, description).value
+        return self.niDCPower_GetError_cfunc(vi, code, buffer_size, description)
 
     def niDCPower_GetSelfCalLastDateAndTime(self, vi, year, month, day, hour, minute):  # noqa: N802
         with self._func_lock:
@@ -236,7 +236,7 @@ class Library(object):
                 self.niDCPower_GetSelfCalLastDateAndTime_cfunc = self._library.niDCPower_GetSelfCalLastDateAndTime
                 self.niDCPower_GetSelfCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDCPower_GetSelfCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_GetSelfCalLastDateAndTime_cfunc(vi, year, month, day, hour, minute).value
+        return self.niDCPower_GetSelfCalLastDateAndTime_cfunc(vi, year, month, day, hour, minute)
 
     def niDCPower_GetSelfCalLastTemp(self, vi, temperature):  # noqa: N802
         with self._func_lock:
@@ -244,7 +244,7 @@ class Library(object):
                 self.niDCPower_GetSelfCalLastTemp_cfunc = self._library.niDCPower_GetSelfCalLastTemp
                 self.niDCPower_GetSelfCalLastTemp_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_GetSelfCalLastTemp_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_GetSelfCalLastTemp_cfunc(vi, temperature).value
+        return self.niDCPower_GetSelfCalLastTemp_cfunc(vi, temperature)
 
     def niDCPower_InitializeWithChannels(self, resource_name, channels, reset, option_string, vi):  # noqa: N802
         with self._func_lock:
@@ -252,7 +252,7 @@ class Library(object):
                 self.niDCPower_InitializeWithChannels_cfunc = self._library.niDCPower_InitializeWithChannels
                 self.niDCPower_InitializeWithChannels_cfunc.argtypes = [ViRsrc, ViChar, ViBoolean, ViChar, ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niDCPower_InitializeWithChannels_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_InitializeWithChannels_cfunc(resource_name, channels, reset, option_string, vi).value
+        return self.niDCPower_InitializeWithChannels_cfunc(resource_name, channels, reset, option_string, vi)
 
     def niDCPower_Initiate(self, vi):  # noqa: N802
         with self._func_lock:
@@ -260,7 +260,7 @@ class Library(object):
                 self.niDCPower_Initiate_cfunc = self._library.niDCPower_Initiate
                 self.niDCPower_Initiate_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_Initiate_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_Initiate_cfunc(vi).value
+        return self.niDCPower_Initiate_cfunc(vi)
 
     def niDCPower_Measure(self, vi, channel_name, measurement_type, measurement):  # noqa: N802
         with self._func_lock:
@@ -268,7 +268,7 @@ class Library(object):
                 self.niDCPower_Measure_cfunc = self._library.niDCPower_Measure
                 self.niDCPower_Measure_cfunc.argtypes = [ViSession, ViChar, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_Measure_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_Measure_cfunc(vi, channel_name, measurement_type, measurement).value
+        return self.niDCPower_Measure_cfunc(vi, channel_name, measurement_type, measurement)
 
     def niDCPower_MeasureMultiple(self, vi, channel_name, voltage_measurements, current_measurements):  # noqa: N802
         with self._func_lock:
@@ -276,7 +276,7 @@ class Library(object):
                 self.niDCPower_MeasureMultiple_cfunc = self._library.niDCPower_MeasureMultiple
                 self.niDCPower_MeasureMultiple_cfunc.argtypes = [ViSession, ViChar, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_MeasureMultiple_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_MeasureMultiple_cfunc(vi, channel_name, voltage_measurements, current_measurements).value
+        return self.niDCPower_MeasureMultiple_cfunc(vi, channel_name, voltage_measurements, current_measurements)
 
     def niDCPower_QueryInCompliance(self, vi, channel_name, in_compliance):  # noqa: N802
         with self._func_lock:
@@ -284,7 +284,7 @@ class Library(object):
                 self.niDCPower_QueryInCompliance_cfunc = self._library.niDCPower_QueryInCompliance
                 self.niDCPower_QueryInCompliance_cfunc.argtypes = [ViSession, ViChar, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDCPower_QueryInCompliance_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_QueryInCompliance_cfunc(vi, channel_name, in_compliance).value
+        return self.niDCPower_QueryInCompliance_cfunc(vi, channel_name, in_compliance)
 
     def niDCPower_QueryMaxCurrentLimit(self, vi, channel_name, voltage_level, max_current_limit):  # noqa: N802
         with self._func_lock:
@@ -292,7 +292,7 @@ class Library(object):
                 self.niDCPower_QueryMaxCurrentLimit_cfunc = self._library.niDCPower_QueryMaxCurrentLimit
                 self.niDCPower_QueryMaxCurrentLimit_cfunc.argtypes = [ViSession, ViChar, ViReal64, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_QueryMaxCurrentLimit_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_QueryMaxCurrentLimit_cfunc(vi, channel_name, voltage_level, max_current_limit).value
+        return self.niDCPower_QueryMaxCurrentLimit_cfunc(vi, channel_name, voltage_level, max_current_limit)
 
     def niDCPower_QueryMaxVoltageLevel(self, vi, channel_name, current_limit, max_voltage_level):  # noqa: N802
         with self._func_lock:
@@ -300,7 +300,7 @@ class Library(object):
                 self.niDCPower_QueryMaxVoltageLevel_cfunc = self._library.niDCPower_QueryMaxVoltageLevel
                 self.niDCPower_QueryMaxVoltageLevel_cfunc.argtypes = [ViSession, ViChar, ViReal64, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_QueryMaxVoltageLevel_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_QueryMaxVoltageLevel_cfunc(vi, channel_name, current_limit, max_voltage_level).value
+        return self.niDCPower_QueryMaxVoltageLevel_cfunc(vi, channel_name, current_limit, max_voltage_level)
 
     def niDCPower_QueryMinCurrentLimit(self, vi, channel_name, voltage_level, min_current_limit):  # noqa: N802
         with self._func_lock:
@@ -308,7 +308,7 @@ class Library(object):
                 self.niDCPower_QueryMinCurrentLimit_cfunc = self._library.niDCPower_QueryMinCurrentLimit
                 self.niDCPower_QueryMinCurrentLimit_cfunc.argtypes = [ViSession, ViChar, ViReal64, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_QueryMinCurrentLimit_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_QueryMinCurrentLimit_cfunc(vi, channel_name, voltage_level, min_current_limit).value
+        return self.niDCPower_QueryMinCurrentLimit_cfunc(vi, channel_name, voltage_level, min_current_limit)
 
     def niDCPower_QueryOutputState(self, vi, channel_name, output_state, in_state):  # noqa: N802
         with self._func_lock:
@@ -316,7 +316,7 @@ class Library(object):
                 self.niDCPower_QueryOutputState_cfunc = self._library.niDCPower_QueryOutputState
                 self.niDCPower_QueryOutputState_cfunc.argtypes = [ViSession, ViChar, ViInt32, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDCPower_QueryOutputState_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_QueryOutputState_cfunc(vi, channel_name, output_state, in_state).value
+        return self.niDCPower_QueryOutputState_cfunc(vi, channel_name, output_state, in_state)
 
     def niDCPower_ReadCurrentTemperature(self, vi, temperature):  # noqa: N802
         with self._func_lock:
@@ -324,7 +324,7 @@ class Library(object):
                 self.niDCPower_ReadCurrentTemperature_cfunc = self._library.niDCPower_ReadCurrentTemperature
                 self.niDCPower_ReadCurrentTemperature_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_ReadCurrentTemperature_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_ReadCurrentTemperature_cfunc(vi, temperature).value
+        return self.niDCPower_ReadCurrentTemperature_cfunc(vi, temperature)
 
     def niDCPower_ResetDevice(self, vi):  # noqa: N802
         with self._func_lock:
@@ -332,7 +332,7 @@ class Library(object):
                 self.niDCPower_ResetDevice_cfunc = self._library.niDCPower_ResetDevice
                 self.niDCPower_ResetDevice_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_ResetDevice_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_ResetDevice_cfunc(vi).value
+        return self.niDCPower_ResetDevice_cfunc(vi)
 
     def niDCPower_ResetWithDefaults(self, vi):  # noqa: N802
         with self._func_lock:
@@ -340,7 +340,7 @@ class Library(object):
                 self.niDCPower_ResetWithDefaults_cfunc = self._library.niDCPower_ResetWithDefaults
                 self.niDCPower_ResetWithDefaults_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_ResetWithDefaults_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_ResetWithDefaults_cfunc(vi).value
+        return self.niDCPower_ResetWithDefaults_cfunc(vi)
 
     def niDCPower_SendSoftwareEdgeTrigger(self, vi, trigger):  # noqa: N802
         with self._func_lock:
@@ -348,7 +348,7 @@ class Library(object):
                 self.niDCPower_SendSoftwareEdgeTrigger_cfunc = self._library.niDCPower_SendSoftwareEdgeTrigger
                 self.niDCPower_SendSoftwareEdgeTrigger_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niDCPower_SendSoftwareEdgeTrigger_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_SendSoftwareEdgeTrigger_cfunc(vi, trigger).value
+        return self.niDCPower_SendSoftwareEdgeTrigger_cfunc(vi, trigger)
 
     def niDCPower_SetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -356,7 +356,7 @@ class Library(object):
                 self.niDCPower_SetAttributeViBoolean_cfunc = self._library.niDCPower_SetAttributeViBoolean
                 self.niDCPower_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ViChar, ViAttr, ViBoolean]  # noqa: F405
                 self.niDCPower_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_SetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niDCPower_SetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niDCPower_SetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -364,7 +364,7 @@ class Library(object):
                 self.niDCPower_SetAttributeViInt32_cfunc = self._library.niDCPower_SetAttributeViInt32
                 self.niDCPower_SetAttributeViInt32_cfunc.argtypes = [ViSession, ViChar, ViAttr, ViInt32]  # noqa: F405
                 self.niDCPower_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_SetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niDCPower_SetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niDCPower_SetAttributeViInt64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -372,7 +372,7 @@ class Library(object):
                 self.niDCPower_SetAttributeViInt64_cfunc = self._library.niDCPower_SetAttributeViInt64
                 self.niDCPower_SetAttributeViInt64_cfunc.argtypes = [ViSession, ViChar, ViAttr, ViInt64]  # noqa: F405
                 self.niDCPower_SetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_SetAttributeViInt64_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niDCPower_SetAttributeViInt64_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niDCPower_SetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -380,7 +380,7 @@ class Library(object):
                 self.niDCPower_SetAttributeViReal64_cfunc = self._library.niDCPower_SetAttributeViReal64
                 self.niDCPower_SetAttributeViReal64_cfunc.argtypes = [ViSession, ViChar, ViAttr, ViReal64]  # noqa: F405
                 self.niDCPower_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_SetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niDCPower_SetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niDCPower_SetAttributeViString(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -388,7 +388,7 @@ class Library(object):
                 self.niDCPower_SetAttributeViString_cfunc = self._library.niDCPower_SetAttributeViString
                 self.niDCPower_SetAttributeViString_cfunc.argtypes = [ViSession, ViChar, ViAttr, ViString]  # noqa: F405
                 self.niDCPower_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_SetAttributeViString_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niDCPower_SetAttributeViString_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niDCPower_SetSequence(self, vi, channel_name, values, source_delays, size):  # noqa: N802
         with self._func_lock:
@@ -396,7 +396,7 @@ class Library(object):
                 self.niDCPower_SetSequence_cfunc = self._library.niDCPower_SetSequence
                 self.niDCPower_SetSequence_cfunc.argtypes = [ViSession, ViChar, ViReal64, ViReal64, ViUInt32]  # noqa: F405
                 self.niDCPower_SetSequence_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_SetSequence_cfunc(vi, channel_name, values, source_delays, size).value
+        return self.niDCPower_SetSequence_cfunc(vi, channel_name, values, source_delays, size)
 
     def niDCPower_WaitForEvent(self, vi, event_id, timeout):  # noqa: N802
         with self._func_lock:
@@ -404,7 +404,7 @@ class Library(object):
                 self.niDCPower_WaitForEvent_cfunc = self._library.niDCPower_WaitForEvent
                 self.niDCPower_WaitForEvent_cfunc.argtypes = [ViSession, ViInt32, ViReal64]  # noqa: F405
                 self.niDCPower_WaitForEvent_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_WaitForEvent_cfunc(vi, event_id, timeout).value
+        return self.niDCPower_WaitForEvent_cfunc(vi, event_id, timeout)
 
     def niDCPower_close(self, vi):  # noqa: N802
         with self._func_lock:
@@ -412,7 +412,7 @@ class Library(object):
                 self.niDCPower_close_cfunc = self._library.niDCPower_close
                 self.niDCPower_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_close_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_close_cfunc(vi).value
+        return self.niDCPower_close_cfunc(vi)
 
     def niDCPower_error_message(self, vi, error_code, error_message):  # noqa: N802
         with self._func_lock:
@@ -420,7 +420,7 @@ class Library(object):
                 self.niDCPower_error_message_cfunc = self._library.niDCPower_error_message
                 self.niDCPower_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_error_message_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_error_message_cfunc(vi, error_code, error_message).value
+        return self.niDCPower_error_message_cfunc(vi, error_code, error_message)
 
     def niDCPower_reset(self, vi):  # noqa: N802
         with self._func_lock:
@@ -428,7 +428,7 @@ class Library(object):
                 self.niDCPower_reset_cfunc = self._library.niDCPower_reset
                 self.niDCPower_reset_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_reset_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_reset_cfunc(vi).value
+        return self.niDCPower_reset_cfunc(vi)
 
     def niDCPower_revision_query(self, vi, instrument_driver_revision, firmware_revision):  # noqa: N802
         with self._func_lock:
@@ -436,7 +436,7 @@ class Library(object):
                 self.niDCPower_revision_query_cfunc = self._library.niDCPower_revision_query
                 self.niDCPower_revision_query_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_revision_query_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_revision_query_cfunc(vi, instrument_driver_revision, firmware_revision).value
+        return self.niDCPower_revision_query_cfunc(vi, instrument_driver_revision, firmware_revision)
 
     def niDCPower_self_test(self, vi, self_test_result, self_test_message):  # noqa: N802
         with self._func_lock:
@@ -444,4 +444,4 @@ class Library(object):
                 self.niDCPower_self_test_cfunc = self._library.niDCPower_self_test
                 self.niDCPower_self_test_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_self_test_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDCPower_self_test_cfunc(vi, self_test_result, self_test_message).value
+        return self.niDCPower_self_test_cfunc(vi, self_test_result, self_test_message)

--- a/generated/nidcpower/visatype.py
+++ b/generated/nidcpower/visatype.py
@@ -6,69 +6,19 @@ be used directly to call into the library.
 '''
 
 
-class ViStatus(ctypes.c_long):  # noqa: N801
-    pass
+ViStatus = ctypes.c_long
+ViRsrc = ctypes.c_char_p
+ViSession = ctypes.c_ulong
+ViChar = ctypes.c_char
+ViUInt32 = ctypes.c_ulong
+ViInt32 = ctypes.c_long
+ViInt16 = ctypes.c_short
+ViUInt16 = ctypes.c_ushort
+ViInt64 = ctypes.c_longlong
+ViString = ctypes.c_char_p
+ViAttr = ctypes.c_long
+ViConstString = ViString
+ViBoolean = ctypes.c_ushort
+ViReal32 = ctypes.c_float
+ViReal64 = ctypes.c_double
 
-
-class ViRsrc(ctypes.c_char_p):  # noqa: N801
-    pass
-
-
-class ViSession(ctypes.c_ulong):  # noqa: N801
-    pass
-
-
-class ViChar(ctypes.c_char):  # noqa: N801
-    pass
-
-
-class ViUInt32(ctypes.c_ulong):  # noqa: N801
-    pass
-
-
-class ViInt32(ctypes.c_long):  # noqa: N801
-    pass
-
-
-class ViInt16(ctypes.c_short):  # noqa: N801
-    pass
-
-
-class ViUInt16(ctypes.c_ushort):  # noqa: N801
-    pass
-
-
-class ViInt64(ctypes.c_longlong):  # noqa: N801
-    pass
-
-
-class ViString(ctypes.c_char_p):  # noqa: N801
-    pass
-
-
-class ViAttr(ctypes.c_long):  # noqa: N801
-    pass
-
-
-class ViConstString(ViString):  # noqa: N801
-    @property
-    def value(self):  # Makes 'value' readonly
-        return super(ViConstString, ViString).value
-
-
-class ViBoolean(ctypes.c_ushort):  # noqa: N801
-    @classmethod
-    def from_param(cls, param):
-        return ctypes.c_uint16(1) if bool(param) else ctypes.c_uint16(0)
-
-
-class ViReal32(ctypes.c_float):  # noqa: N801
-    @classmethod
-    def from_param(cls, param):
-        return ctypes.c_float(param)
-
-
-class ViReal64(ctypes.c_double):  # noqa: N801
-    @classmethod
-    def from_param(cls, param):
-        return ctypes.c_double(param)

--- a/generated/nidmm/library.py
+++ b/generated/nidmm/library.py
@@ -79,7 +79,7 @@ class Library(object):
                 self.niDMM_Abort_cfunc = self._library.niDMM_Abort
                 self.niDMM_Abort_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_Abort_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_Abort_cfunc(vi).value
+        return self.niDMM_Abort_cfunc(vi)
 
     def niDMM_ConfigureACBandwidth(self, vi, ac_minimum_frequency_hz, ac_maximum_frequency_hz):  # noqa: N802
         with self._func_lock:
@@ -87,7 +87,7 @@ class Library(object):
                 self.niDMM_ConfigureACBandwidth_cfunc = self._library.niDMM_ConfigureACBandwidth
                 self.niDMM_ConfigureACBandwidth_cfunc.argtypes = [ViSession, ViReal64, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureACBandwidth_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_ConfigureACBandwidth_cfunc(vi, ac_minimum_frequency_hz, ac_maximum_frequency_hz).value
+        return self.niDMM_ConfigureACBandwidth_cfunc(vi, ac_minimum_frequency_hz, ac_maximum_frequency_hz)
 
     def niDMM_ConfigureMeasurementAbsolute(self, vi, measurement_function, range, resolution_absolute):  # noqa: N802
         with self._func_lock:
@@ -95,7 +95,7 @@ class Library(object):
                 self.niDMM_ConfigureMeasurementAbsolute_cfunc = self._library.niDMM_ConfigureMeasurementAbsolute
                 self.niDMM_ConfigureMeasurementAbsolute_cfunc.argtypes = [ViSession, ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureMeasurementAbsolute_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_ConfigureMeasurementAbsolute_cfunc(vi, measurement_function, range, resolution_absolute).value
+        return self.niDMM_ConfigureMeasurementAbsolute_cfunc(vi, measurement_function, range, resolution_absolute)
 
     def niDMM_ConfigureMeasurementDigits(self, vi, measurement_function, range, resolution_digits):  # noqa: N802
         with self._func_lock:
@@ -103,7 +103,7 @@ class Library(object):
                 self.niDMM_ConfigureMeasurementDigits_cfunc = self._library.niDMM_ConfigureMeasurementDigits
                 self.niDMM_ConfigureMeasurementDigits_cfunc.argtypes = [ViSession, ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureMeasurementDigits_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_ConfigureMeasurementDigits_cfunc(vi, measurement_function, range, resolution_digits).value
+        return self.niDMM_ConfigureMeasurementDigits_cfunc(vi, measurement_function, range, resolution_digits)
 
     def niDMM_ConfigureMultiPoint(self, vi, trigger_count, sample_count, sample_trigger, sample_interval):  # noqa: N802
         with self._func_lock:
@@ -111,7 +111,7 @@ class Library(object):
                 self.niDMM_ConfigureMultiPoint_cfunc = self._library.niDMM_ConfigureMultiPoint
                 self.niDMM_ConfigureMultiPoint_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ViInt32, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureMultiPoint_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_ConfigureMultiPoint_cfunc(vi, trigger_count, sample_count, sample_trigger, sample_interval).value
+        return self.niDMM_ConfigureMultiPoint_cfunc(vi, trigger_count, sample_count, sample_trigger, sample_interval)
 
     def niDMM_ConfigureOpenCableCompValues(self, vi, conductance, susceptance):  # noqa: N802
         with self._func_lock:
@@ -119,7 +119,7 @@ class Library(object):
                 self.niDMM_ConfigureOpenCableCompValues_cfunc = self._library.niDMM_ConfigureOpenCableCompValues
                 self.niDMM_ConfigureOpenCableCompValues_cfunc.argtypes = [ViSession, ViReal64, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureOpenCableCompValues_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_ConfigureOpenCableCompValues_cfunc(vi, conductance, susceptance).value
+        return self.niDMM_ConfigureOpenCableCompValues_cfunc(vi, conductance, susceptance)
 
     def niDMM_ConfigurePowerLineFrequency(self, vi, power_line_frequency_hz):  # noqa: N802
         with self._func_lock:
@@ -127,7 +127,7 @@ class Library(object):
                 self.niDMM_ConfigurePowerLineFrequency_cfunc = self._library.niDMM_ConfigurePowerLineFrequency
                 self.niDMM_ConfigurePowerLineFrequency_cfunc.argtypes = [ViSession, ViReal64]  # noqa: F405
                 self.niDMM_ConfigurePowerLineFrequency_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_ConfigurePowerLineFrequency_cfunc(vi, power_line_frequency_hz).value
+        return self.niDMM_ConfigurePowerLineFrequency_cfunc(vi, power_line_frequency_hz)
 
     def niDMM_ConfigureRTDCustom(self, vi, rtd_a, rtd_b, rtd_c):  # noqa: N802
         with self._func_lock:
@@ -135,7 +135,7 @@ class Library(object):
                 self.niDMM_ConfigureRTDCustom_cfunc = self._library.niDMM_ConfigureRTDCustom
                 self.niDMM_ConfigureRTDCustom_cfunc.argtypes = [ViSession, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureRTDCustom_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_ConfigureRTDCustom_cfunc(vi, rtd_a, rtd_b, rtd_c).value
+        return self.niDMM_ConfigureRTDCustom_cfunc(vi, rtd_a, rtd_b, rtd_c)
 
     def niDMM_ConfigureRTDType(self, vi, rtd_type, rtd_resistance):  # noqa: N802
         with self._func_lock:
@@ -143,7 +143,7 @@ class Library(object):
                 self.niDMM_ConfigureRTDType_cfunc = self._library.niDMM_ConfigureRTDType
                 self.niDMM_ConfigureRTDType_cfunc.argtypes = [ViSession, ViInt32, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureRTDType_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_ConfigureRTDType_cfunc(vi, rtd_type, rtd_resistance).value
+        return self.niDMM_ConfigureRTDType_cfunc(vi, rtd_type, rtd_resistance)
 
     def niDMM_ConfigureShortCableCompValues(self, vi, resistance, reactance):  # noqa: N802
         with self._func_lock:
@@ -151,7 +151,7 @@ class Library(object):
                 self.niDMM_ConfigureShortCableCompValues_cfunc = self._library.niDMM_ConfigureShortCableCompValues
                 self.niDMM_ConfigureShortCableCompValues_cfunc.argtypes = [ViSession, ViReal64, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureShortCableCompValues_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_ConfigureShortCableCompValues_cfunc(vi, resistance, reactance).value
+        return self.niDMM_ConfigureShortCableCompValues_cfunc(vi, resistance, reactance)
 
     def niDMM_ConfigureThermistorCustom(self, vi, thermistor_a, thermistor_b, thermistor_c):  # noqa: N802
         with self._func_lock:
@@ -159,7 +159,7 @@ class Library(object):
                 self.niDMM_ConfigureThermistorCustom_cfunc = self._library.niDMM_ConfigureThermistorCustom
                 self.niDMM_ConfigureThermistorCustom_cfunc.argtypes = [ViSession, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureThermistorCustom_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_ConfigureThermistorCustom_cfunc(vi, thermistor_a, thermistor_b, thermistor_c).value
+        return self.niDMM_ConfigureThermistorCustom_cfunc(vi, thermistor_a, thermistor_b, thermistor_c)
 
     def niDMM_ConfigureThermocouple(self, vi, thermocouple_type, reference_junction_type):  # noqa: N802
         with self._func_lock:
@@ -167,7 +167,7 @@ class Library(object):
                 self.niDMM_ConfigureThermocouple_cfunc = self._library.niDMM_ConfigureThermocouple
                 self.niDMM_ConfigureThermocouple_cfunc.argtypes = [ViSession, ViInt32, ViInt32]  # noqa: F405
                 self.niDMM_ConfigureThermocouple_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_ConfigureThermocouple_cfunc(vi, thermocouple_type, reference_junction_type).value
+        return self.niDMM_ConfigureThermocouple_cfunc(vi, thermocouple_type, reference_junction_type)
 
     def niDMM_ConfigureTrigger(self, vi, trigger_source, trigger_delay):  # noqa: N802
         with self._func_lock:
@@ -175,7 +175,7 @@ class Library(object):
                 self.niDMM_ConfigureTrigger_cfunc = self._library.niDMM_ConfigureTrigger
                 self.niDMM_ConfigureTrigger_cfunc.argtypes = [ViSession, ViInt32, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureTrigger_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_ConfigureTrigger_cfunc(vi, trigger_source, trigger_delay).value
+        return self.niDMM_ConfigureTrigger_cfunc(vi, trigger_source, trigger_delay)
 
     def niDMM_ConfigureWaveformAcquisition(self, vi, measurement_function, range, rate, waveform_points):  # noqa: N802
         with self._func_lock:
@@ -183,7 +183,7 @@ class Library(object):
                 self.niDMM_ConfigureWaveformAcquisition_cfunc = self._library.niDMM_ConfigureWaveformAcquisition
                 self.niDMM_ConfigureWaveformAcquisition_cfunc.argtypes = [ViSession, ViInt32, ViReal64, ViReal64, ViInt32]  # noqa: F405
                 self.niDMM_ConfigureWaveformAcquisition_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_ConfigureWaveformAcquisition_cfunc(vi, measurement_function, range, rate, waveform_points).value
+        return self.niDMM_ConfigureWaveformAcquisition_cfunc(vi, measurement_function, range, rate, waveform_points)
 
     def niDMM_Disable(self, vi):  # noqa: N802
         with self._func_lock:
@@ -191,7 +191,7 @@ class Library(object):
                 self.niDMM_Disable_cfunc = self._library.niDMM_Disable
                 self.niDMM_Disable_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_Disable_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_Disable_cfunc(vi).value
+        return self.niDMM_Disable_cfunc(vi)
 
     def niDMM_Fetch(self, vi, maximum_time, reading):  # noqa: N802
         with self._func_lock:
@@ -199,7 +199,7 @@ class Library(object):
                 self.niDMM_Fetch_cfunc = self._library.niDMM_Fetch
                 self.niDMM_Fetch_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_Fetch_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_Fetch_cfunc(vi, maximum_time, reading).value
+        return self.niDMM_Fetch_cfunc(vi, maximum_time, reading)
 
     def niDMM_FetchMultiPoint(self, vi, maximum_time, array_size, reading_array, actual_number_of_points):  # noqa: N802
         with self._func_lock:
@@ -207,7 +207,7 @@ class Library(object):
                 self.niDMM_FetchMultiPoint_cfunc = self._library.niDMM_FetchMultiPoint
                 self.niDMM_FetchMultiPoint_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_FetchMultiPoint_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_FetchMultiPoint_cfunc(vi, maximum_time, array_size, reading_array, actual_number_of_points).value
+        return self.niDMM_FetchMultiPoint_cfunc(vi, maximum_time, array_size, reading_array, actual_number_of_points)
 
     def niDMM_FetchWaveform(self, vi, maximum_time, array_size, waveform_array, actual_number_of_points):  # noqa: N802
         with self._func_lock:
@@ -215,7 +215,7 @@ class Library(object):
                 self.niDMM_FetchWaveform_cfunc = self._library.niDMM_FetchWaveform
                 self.niDMM_FetchWaveform_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_FetchWaveform_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_FetchWaveform_cfunc(vi, maximum_time, array_size, waveform_array, actual_number_of_points).value
+        return self.niDMM_FetchWaveform_cfunc(vi, maximum_time, array_size, waveform_array, actual_number_of_points)
 
     def niDMM_GetApertureTimeInfo(self, vi, aperture_time, aperture_time_units):  # noqa: N802
         with self._func_lock:
@@ -223,7 +223,7 @@ class Library(object):
                 self.niDMM_GetApertureTimeInfo_cfunc = self._library.niDMM_GetApertureTimeInfo
                 self.niDMM_GetApertureTimeInfo_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_GetApertureTimeInfo_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_GetApertureTimeInfo_cfunc(vi, aperture_time, aperture_time_units).value
+        return self.niDMM_GetApertureTimeInfo_cfunc(vi, aperture_time, aperture_time_units)
 
     def niDMM_GetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -231,7 +231,7 @@ class Library(object):
                 self.niDMM_GetAttributeViBoolean_cfunc = self._library.niDMM_GetAttributeViBoolean
                 self.niDMM_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDMM_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_GetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niDMM_GetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niDMM_GetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -239,7 +239,7 @@ class Library(object):
                 self.niDMM_GetAttributeViInt32_cfunc = self._library.niDMM_GetAttributeViInt32
                 self.niDMM_GetAttributeViInt32_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_GetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niDMM_GetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niDMM_GetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -247,7 +247,7 @@ class Library(object):
                 self.niDMM_GetAttributeViReal64_cfunc = self._library.niDMM_GetAttributeViReal64
                 self.niDMM_GetAttributeViReal64_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_GetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niDMM_GetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niDMM_GetAttributeViString(self, vi, channel_name, attribute_id, buffer_size, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -255,7 +255,7 @@ class Library(object):
                 self.niDMM_GetAttributeViString_cfunc = self._library.niDMM_GetAttributeViString
                 self.niDMM_GetAttributeViString_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ViInt32, ViString]  # noqa: F405
                 self.niDMM_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_GetAttributeViString_cfunc(vi, channel_name, attribute_id, buffer_size, attribute_value).value
+        return self.niDMM_GetAttributeViString_cfunc(vi, channel_name, attribute_id, buffer_size, attribute_value)
 
     def niDMM_GetAutoRangeValue(self, vi, actual_range):  # noqa: N802
         with self._func_lock:
@@ -263,7 +263,7 @@ class Library(object):
                 self.niDMM_GetAutoRangeValue_cfunc = self._library.niDMM_GetAutoRangeValue
                 self.niDMM_GetAutoRangeValue_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_GetAutoRangeValue_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_GetAutoRangeValue_cfunc(vi, actual_range).value
+        return self.niDMM_GetAutoRangeValue_cfunc(vi, actual_range)
 
     def niDMM_GetCalDateAndTime(self, vi, cal_type, month, day, year, hour, minute):  # noqa: N802
         with self._func_lock:
@@ -271,7 +271,7 @@ class Library(object):
                 self.niDMM_GetCalDateAndTime_cfunc = self._library.niDMM_GetCalDateAndTime
                 self.niDMM_GetCalDateAndTime_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_GetCalDateAndTime_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_GetCalDateAndTime_cfunc(vi, cal_type, month, day, year, hour, minute).value
+        return self.niDMM_GetCalDateAndTime_cfunc(vi, cal_type, month, day, year, hour, minute)
 
     def niDMM_GetDevTemp(self, vi, options, temperature):  # noqa: N802
         with self._func_lock:
@@ -279,7 +279,7 @@ class Library(object):
                 self.niDMM_GetDevTemp_cfunc = self._library.niDMM_GetDevTemp
                 self.niDMM_GetDevTemp_cfunc.argtypes = [ViSession, ViString, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_GetDevTemp_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_GetDevTemp_cfunc(vi, options, temperature).value
+        return self.niDMM_GetDevTemp_cfunc(vi, options, temperature)
 
     def niDMM_GetError(self, vi, error_code, buffer_size, description):  # noqa: N802
         with self._func_lock:
@@ -287,7 +287,7 @@ class Library(object):
                 self.niDMM_GetError_cfunc = self._library.niDMM_GetError
                 self.niDMM_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ViString]  # noqa: F405
                 self.niDMM_GetError_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_GetError_cfunc(vi, error_code, buffer_size, description).value
+        return self.niDMM_GetError_cfunc(vi, error_code, buffer_size, description)
 
     def niDMM_GetLastCalTemp(self, vi, cal_type, temperature):  # noqa: N802
         with self._func_lock:
@@ -295,7 +295,7 @@ class Library(object):
                 self.niDMM_GetLastCalTemp_cfunc = self._library.niDMM_GetLastCalTemp
                 self.niDMM_GetLastCalTemp_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_GetLastCalTemp_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_GetLastCalTemp_cfunc(vi, cal_type, temperature).value
+        return self.niDMM_GetLastCalTemp_cfunc(vi, cal_type, temperature)
 
     def niDMM_GetMeasurementPeriod(self, vi, period):  # noqa: N802
         with self._func_lock:
@@ -303,7 +303,7 @@ class Library(object):
                 self.niDMM_GetMeasurementPeriod_cfunc = self._library.niDMM_GetMeasurementPeriod
                 self.niDMM_GetMeasurementPeriod_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_GetMeasurementPeriod_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_GetMeasurementPeriod_cfunc(vi, period).value
+        return self.niDMM_GetMeasurementPeriod_cfunc(vi, period)
 
     def niDMM_GetSelfCalSupported(self, vi, self_cal_supported):  # noqa: N802
         with self._func_lock:
@@ -311,7 +311,7 @@ class Library(object):
                 self.niDMM_GetSelfCalSupported_cfunc = self._library.niDMM_GetSelfCalSupported
                 self.niDMM_GetSelfCalSupported_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDMM_GetSelfCalSupported_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_GetSelfCalSupported_cfunc(vi, self_cal_supported).value
+        return self.niDMM_GetSelfCalSupported_cfunc(vi, self_cal_supported)
 
     def niDMM_InitWithOptions(self, resource_name, id_query, reset_device, option_string, vi):  # noqa: N802
         with self._func_lock:
@@ -319,7 +319,7 @@ class Library(object):
                 self.niDMM_InitWithOptions_cfunc = self._library.niDMM_InitWithOptions
                 self.niDMM_InitWithOptions_cfunc.argtypes = [ViString, ViBoolean, ViBoolean, ViString, ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niDMM_InitWithOptions_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_InitWithOptions_cfunc(resource_name, id_query, reset_device, option_string, vi).value
+        return self.niDMM_InitWithOptions_cfunc(resource_name, id_query, reset_device, option_string, vi)
 
     def niDMM_Initiate(self, vi):  # noqa: N802
         with self._func_lock:
@@ -327,7 +327,7 @@ class Library(object):
                 self.niDMM_Initiate_cfunc = self._library.niDMM_Initiate
                 self.niDMM_Initiate_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_Initiate_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_Initiate_cfunc(vi).value
+        return self.niDMM_Initiate_cfunc(vi)
 
     def niDMM_PerformOpenCableComp(self, vi, conductance, susceptance):  # noqa: N802
         with self._func_lock:
@@ -335,7 +335,7 @@ class Library(object):
                 self.niDMM_PerformOpenCableComp_cfunc = self._library.niDMM_PerformOpenCableComp
                 self.niDMM_PerformOpenCableComp_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_PerformOpenCableComp_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_PerformOpenCableComp_cfunc(vi, conductance, susceptance).value
+        return self.niDMM_PerformOpenCableComp_cfunc(vi, conductance, susceptance)
 
     def niDMM_PerformShortCableComp(self, vi, resistance, reactance):  # noqa: N802
         with self._func_lock:
@@ -343,7 +343,7 @@ class Library(object):
                 self.niDMM_PerformShortCableComp_cfunc = self._library.niDMM_PerformShortCableComp
                 self.niDMM_PerformShortCableComp_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_PerformShortCableComp_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_PerformShortCableComp_cfunc(vi, resistance, reactance).value
+        return self.niDMM_PerformShortCableComp_cfunc(vi, resistance, reactance)
 
     def niDMM_Read(self, vi, maximum_time, reading):  # noqa: N802
         with self._func_lock:
@@ -351,7 +351,7 @@ class Library(object):
                 self.niDMM_Read_cfunc = self._library.niDMM_Read
                 self.niDMM_Read_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_Read_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_Read_cfunc(vi, maximum_time, reading).value
+        return self.niDMM_Read_cfunc(vi, maximum_time, reading)
 
     def niDMM_ReadMultiPoint(self, vi, maximum_time, array_size, reading_array, actual_number_of_points):  # noqa: N802
         with self._func_lock:
@@ -359,7 +359,7 @@ class Library(object):
                 self.niDMM_ReadMultiPoint_cfunc = self._library.niDMM_ReadMultiPoint
                 self.niDMM_ReadMultiPoint_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_ReadMultiPoint_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_ReadMultiPoint_cfunc(vi, maximum_time, array_size, reading_array, actual_number_of_points).value
+        return self.niDMM_ReadMultiPoint_cfunc(vi, maximum_time, array_size, reading_array, actual_number_of_points)
 
     def niDMM_ReadStatus(self, vi, acquisition_backlog, acquisition_status):  # noqa: N802
         with self._func_lock:
@@ -367,7 +367,7 @@ class Library(object):
                 self.niDMM_ReadStatus_cfunc = self._library.niDMM_ReadStatus
                 self.niDMM_ReadStatus_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt16)]  # noqa: F405
                 self.niDMM_ReadStatus_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_ReadStatus_cfunc(vi, acquisition_backlog, acquisition_status).value
+        return self.niDMM_ReadStatus_cfunc(vi, acquisition_backlog, acquisition_status)
 
     def niDMM_ReadWaveform(self, vi, maximum_time, array_size, waveform_array, actual_number_of_points):  # noqa: N802
         with self._func_lock:
@@ -375,7 +375,7 @@ class Library(object):
                 self.niDMM_ReadWaveform_cfunc = self._library.niDMM_ReadWaveform
                 self.niDMM_ReadWaveform_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_ReadWaveform_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_ReadWaveform_cfunc(vi, maximum_time, array_size, waveform_array, actual_number_of_points).value
+        return self.niDMM_ReadWaveform_cfunc(vi, maximum_time, array_size, waveform_array, actual_number_of_points)
 
     def niDMM_ResetWithDefaults(self, vi):  # noqa: N802
         with self._func_lock:
@@ -383,7 +383,7 @@ class Library(object):
                 self.niDMM_ResetWithDefaults_cfunc = self._library.niDMM_ResetWithDefaults
                 self.niDMM_ResetWithDefaults_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_ResetWithDefaults_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_ResetWithDefaults_cfunc(vi).value
+        return self.niDMM_ResetWithDefaults_cfunc(vi)
 
     def niDMM_SelfCal(self, vi):  # noqa: N802
         with self._func_lock:
@@ -391,7 +391,7 @@ class Library(object):
                 self.niDMM_SelfCal_cfunc = self._library.niDMM_SelfCal
                 self.niDMM_SelfCal_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_SelfCal_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_SelfCal_cfunc(vi).value
+        return self.niDMM_SelfCal_cfunc(vi)
 
     def niDMM_SendSoftwareTrigger(self, vi):  # noqa: N802
         with self._func_lock:
@@ -399,7 +399,7 @@ class Library(object):
                 self.niDMM_SendSoftwareTrigger_cfunc = self._library.niDMM_SendSoftwareTrigger
                 self.niDMM_SendSoftwareTrigger_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_SendSoftwareTrigger_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_SendSoftwareTrigger_cfunc(vi).value
+        return self.niDMM_SendSoftwareTrigger_cfunc(vi)
 
     def niDMM_SetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -407,7 +407,7 @@ class Library(object):
                 self.niDMM_SetAttributeViBoolean_cfunc = self._library.niDMM_SetAttributeViBoolean
                 self.niDMM_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ViBoolean]  # noqa: F405
                 self.niDMM_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_SetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niDMM_SetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niDMM_SetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -415,7 +415,7 @@ class Library(object):
                 self.niDMM_SetAttributeViInt32_cfunc = self._library.niDMM_SetAttributeViInt32
                 self.niDMM_SetAttributeViInt32_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ViInt32]  # noqa: F405
                 self.niDMM_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_SetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niDMM_SetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niDMM_SetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -423,7 +423,7 @@ class Library(object):
                 self.niDMM_SetAttributeViReal64_cfunc = self._library.niDMM_SetAttributeViReal64
                 self.niDMM_SetAttributeViReal64_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ViReal64]  # noqa: F405
                 self.niDMM_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_SetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niDMM_SetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niDMM_SetAttributeViString(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -431,7 +431,7 @@ class Library(object):
                 self.niDMM_SetAttributeViString_cfunc = self._library.niDMM_SetAttributeViString
                 self.niDMM_SetAttributeViString_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ViString]  # noqa: F405
                 self.niDMM_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_SetAttributeViString_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niDMM_SetAttributeViString_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niDMM_close(self, vi):  # noqa: N802
         with self._func_lock:
@@ -439,7 +439,7 @@ class Library(object):
                 self.niDMM_close_cfunc = self._library.niDMM_close
                 self.niDMM_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_close_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_close_cfunc(vi).value
+        return self.niDMM_close_cfunc(vi)
 
     def niDMM_error_message(self, vi, error_code, error_message):  # noqa: N802
         with self._func_lock:
@@ -447,7 +447,7 @@ class Library(object):
                 self.niDMM_error_message_cfunc = self._library.niDMM_error_message
                 self.niDMM_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDMM_error_message_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_error_message_cfunc(vi, error_code, error_message).value
+        return self.niDMM_error_message_cfunc(vi, error_code, error_message)
 
     def niDMM_reset(self, vi):  # noqa: N802
         with self._func_lock:
@@ -455,7 +455,7 @@ class Library(object):
                 self.niDMM_reset_cfunc = self._library.niDMM_reset
                 self.niDMM_reset_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_reset_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_reset_cfunc(vi).value
+        return self.niDMM_reset_cfunc(vi)
 
     def niDMM_revision_query(self, vi, instrument_driver_revision, firmware_revision):  # noqa: N802
         with self._func_lock:
@@ -463,7 +463,7 @@ class Library(object):
                 self.niDMM_revision_query_cfunc = self._library.niDMM_revision_query
                 self.niDMM_revision_query_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDMM_revision_query_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_revision_query_cfunc(vi, instrument_driver_revision, firmware_revision).value
+        return self.niDMM_revision_query_cfunc(vi, instrument_driver_revision, firmware_revision)
 
     def niDMM_self_test(self, vi, self_test_result, self_test_message):  # noqa: N802
         with self._func_lock:
@@ -471,4 +471,4 @@ class Library(object):
                 self.niDMM_self_test_cfunc = self._library.niDMM_self_test
                 self.niDMM_self_test_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDMM_self_test_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDMM_self_test_cfunc(vi, self_test_result, self_test_message).value
+        return self.niDMM_self_test_cfunc(vi, self_test_result, self_test_message)

--- a/generated/nidmm/session.py
+++ b/generated/nidmm/session.py
@@ -1688,7 +1688,7 @@ class Session(_SessionBase):
         actual_number_of_points_ctype = visatype.ViInt32(0)
         error_code = self._library.niDMM_FetchMultiPoint(self._vi, maximum_time, array_size, ctypes.cast(reading_array_ctype, ctypes.POINTER(visatype.ViReal64)), ctypes.pointer(actual_number_of_points_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return [float(reading_array_ctype[i].value) for i in range(array_size)], int(actual_number_of_points_ctype.value)
+        return [float(reading_array_ctype[i]) for i in range(array_size)], int(actual_number_of_points_ctype.value)
 
     def fetch_waveform(self, array_size, maximum_time=-1):
         '''fetch_waveform
@@ -1722,7 +1722,7 @@ class Session(_SessionBase):
         actual_number_of_points_ctype = visatype.ViInt32(0)
         error_code = self._library.niDMM_FetchWaveform(self._vi, maximum_time, array_size, ctypes.cast(waveform_array_ctype, ctypes.POINTER(visatype.ViReal64)), ctypes.pointer(actual_number_of_points_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return [float(waveform_array_ctype[i].value) for i in range(array_size)], int(actual_number_of_points_ctype.value)
+        return [float(waveform_array_ctype[i]) for i in range(array_size)], int(actual_number_of_points_ctype.value)
 
     def get_aperture_time_info(self):
         '''get_aperture_time_info
@@ -2173,7 +2173,7 @@ class Session(_SessionBase):
         actual_number_of_points_ctype = visatype.ViInt32(0)
         error_code = self._library.niDMM_ReadMultiPoint(self._vi, maximum_time, array_size, ctypes.cast(reading_array_ctype, ctypes.POINTER(visatype.ViReal64)), ctypes.pointer(actual_number_of_points_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return [float(reading_array_ctype[i].value) for i in range(array_size)], int(actual_number_of_points_ctype.value)
+        return [float(reading_array_ctype[i]) for i in range(array_size)], int(actual_number_of_points_ctype.value)
 
     def read_status(self):
         '''read_status
@@ -2253,7 +2253,7 @@ class Session(_SessionBase):
         actual_number_of_points_ctype = visatype.ViInt32(0)
         error_code = self._library.niDMM_ReadWaveform(self._vi, maximum_time, array_size, ctypes.cast(waveform_array_ctype, ctypes.POINTER(visatype.ViReal64)), ctypes.pointer(actual_number_of_points_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return [float(waveform_array_ctype[i].value) for i in range(array_size)], int(actual_number_of_points_ctype.value)
+        return [float(waveform_array_ctype[i]) for i in range(array_size)], int(actual_number_of_points_ctype.value)
 
     def reset_with_defaults(self):
         '''reset_with_defaults

--- a/generated/nidmm/visatype.py
+++ b/generated/nidmm/visatype.py
@@ -6,69 +6,19 @@ be used directly to call into the library.
 '''
 
 
-class ViStatus(ctypes.c_long):  # noqa: N801
-    pass
+ViStatus = ctypes.c_long
+ViRsrc = ctypes.c_char_p
+ViSession = ctypes.c_ulong
+ViChar = ctypes.c_char
+ViUInt32 = ctypes.c_ulong
+ViInt32 = ctypes.c_long
+ViInt16 = ctypes.c_short
+ViUInt16 = ctypes.c_ushort
+ViInt64 = ctypes.c_longlong
+ViString = ctypes.c_char_p
+ViAttr = ctypes.c_long
+ViConstString = ViString
+ViBoolean = ctypes.c_ushort
+ViReal32 = ctypes.c_float
+ViReal64 = ctypes.c_double
 
-
-class ViRsrc(ctypes.c_char_p):  # noqa: N801
-    pass
-
-
-class ViSession(ctypes.c_ulong):  # noqa: N801
-    pass
-
-
-class ViChar(ctypes.c_char):  # noqa: N801
-    pass
-
-
-class ViUInt32(ctypes.c_ulong):  # noqa: N801
-    pass
-
-
-class ViInt32(ctypes.c_long):  # noqa: N801
-    pass
-
-
-class ViInt16(ctypes.c_short):  # noqa: N801
-    pass
-
-
-class ViUInt16(ctypes.c_ushort):  # noqa: N801
-    pass
-
-
-class ViInt64(ctypes.c_longlong):  # noqa: N801
-    pass
-
-
-class ViString(ctypes.c_char_p):  # noqa: N801
-    pass
-
-
-class ViAttr(ctypes.c_long):  # noqa: N801
-    pass
-
-
-class ViConstString(ViString):  # noqa: N801
-    @property
-    def value(self):  # Makes 'value' readonly
-        return super(ViConstString, ViString).value
-
-
-class ViBoolean(ctypes.c_ushort):  # noqa: N801
-    @classmethod
-    def from_param(cls, param):
-        return ctypes.c_uint16(1) if bool(param) else ctypes.c_uint16(0)
-
-
-class ViReal32(ctypes.c_float):  # noqa: N801
-    @classmethod
-    def from_param(cls, param):
-        return ctypes.c_float(param)
-
-
-class ViReal64(ctypes.c_double):  # noqa: N801
-    @classmethod
-    def from_param(cls, param):
-        return ctypes.c_double(param)

--- a/generated/nifake/library.py
+++ b/generated/nifake/library.py
@@ -59,7 +59,7 @@ class Library(object):
                 self.niFake_Abort_cfunc = self._library.niFake_Abort
                 self.niFake_Abort_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFake_Abort_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_Abort_cfunc(vi).value
+        return self.niFake_Abort_cfunc(vi)
 
     def niFake_EnumInputFunctionWithDefaults(self, vi, a_turtle):  # noqa: N802
         with self._func_lock:
@@ -67,7 +67,7 @@ class Library(object):
                 self.niFake_EnumInputFunctionWithDefaults_cfunc = self._library.niFake_EnumInputFunctionWithDefaults
                 self.niFake_EnumInputFunctionWithDefaults_cfunc.argtypes = [ViSession, ViInt16]  # noqa: F405
                 self.niFake_EnumInputFunctionWithDefaults_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_EnumInputFunctionWithDefaults_cfunc(vi, a_turtle).value
+        return self.niFake_EnumInputFunctionWithDefaults_cfunc(vi, a_turtle)
 
     def niFake_GetABoolean(self, vi, a_boolean):  # noqa: N802
         with self._func_lock:
@@ -75,7 +75,7 @@ class Library(object):
                 self.niFake_GetABoolean_cfunc = self._library.niFake_GetABoolean
                 self.niFake_GetABoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFake_GetABoolean_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_GetABoolean_cfunc(vi, a_boolean).value
+        return self.niFake_GetABoolean_cfunc(vi, a_boolean)
 
     def niFake_GetANumber(self, vi, a_number):  # noqa: N802
         with self._func_lock:
@@ -83,7 +83,7 @@ class Library(object):
                 self.niFake_GetANumber_cfunc = self._library.niFake_GetANumber
                 self.niFake_GetANumber_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16)]  # noqa: F405
                 self.niFake_GetANumber_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_GetANumber_cfunc(vi, a_number).value
+        return self.niFake_GetANumber_cfunc(vi, a_number)
 
     def niFake_GetAStringOfFixedMaximumSize(self, vi, a_string):  # noqa: N802
         with self._func_lock:
@@ -91,7 +91,7 @@ class Library(object):
                 self.niFake_GetAStringOfFixedMaximumSize_cfunc = self._library.niFake_GetAStringOfFixedMaximumSize
                 self.niFake_GetAStringOfFixedMaximumSize_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_GetAStringOfFixedMaximumSize_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_GetAStringOfFixedMaximumSize_cfunc(vi, a_string).value
+        return self.niFake_GetAStringOfFixedMaximumSize_cfunc(vi, a_string)
 
     def niFake_GetAStringWithSpecifiedMaximumSize(self, vi, a_string, buffer_size):  # noqa: N802
         with self._func_lock:
@@ -99,7 +99,7 @@ class Library(object):
                 self.niFake_GetAStringWithSpecifiedMaximumSize_cfunc = self._library.niFake_GetAStringWithSpecifiedMaximumSize
                 self.niFake_GetAStringWithSpecifiedMaximumSize_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niFake_GetAStringWithSpecifiedMaximumSize_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_GetAStringWithSpecifiedMaximumSize_cfunc(vi, a_string, buffer_size).value
+        return self.niFake_GetAStringWithSpecifiedMaximumSize_cfunc(vi, a_string, buffer_size)
 
     def niFake_GetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -107,7 +107,7 @@ class Library(object):
                 self.niFake_GetAttributeViBoolean_cfunc = self._library.niFake_GetAttributeViBoolean
                 self.niFake_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFake_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_GetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niFake_GetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niFake_GetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -115,7 +115,7 @@ class Library(object):
                 self.niFake_GetAttributeViInt32_cfunc = self._library.niFake_GetAttributeViInt32
                 self.niFake_GetAttributeViInt32_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFake_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_GetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niFake_GetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niFake_GetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -123,7 +123,7 @@ class Library(object):
                 self.niFake_GetAttributeViReal64_cfunc = self._library.niFake_GetAttributeViReal64
                 self.niFake_GetAttributeViReal64_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_GetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niFake_GetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niFake_GetAttributeViSession(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -131,7 +131,7 @@ class Library(object):
                 self.niFake_GetAttributeViSession_cfunc = self._library.niFake_GetAttributeViSession
                 self.niFake_GetAttributeViSession_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niFake_GetAttributeViSession_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_GetAttributeViSession_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niFake_GetAttributeViSession_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niFake_GetAttributeViString(self, vi, channel_name, attribute_id, buffer_size, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -139,7 +139,7 @@ class Library(object):
                 self.niFake_GetAttributeViString_cfunc = self._library.niFake_GetAttributeViString
                 self.niFake_GetAttributeViString_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ViInt32, ViString]  # noqa: F405
                 self.niFake_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_GetAttributeViString_cfunc(vi, channel_name, attribute_id, buffer_size, attribute_value).value
+        return self.niFake_GetAttributeViString_cfunc(vi, channel_name, attribute_id, buffer_size, attribute_value)
 
     def niFake_GetEnumValue(self, vi, a_quantity, a_turtle):  # noqa: N802
         with self._func_lock:
@@ -147,7 +147,7 @@ class Library(object):
                 self.niFake_GetEnumValue_cfunc = self._library.niFake_GetEnumValue
                 self.niFake_GetEnumValue_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt16)]  # noqa: F405
                 self.niFake_GetEnumValue_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_GetEnumValue_cfunc(vi, a_quantity, a_turtle).value
+        return self.niFake_GetEnumValue_cfunc(vi, a_quantity, a_turtle)
 
     def niFake_GetError(self, vi, error_code, buffer_size, description):  # noqa: N802
         with self._func_lock:
@@ -155,7 +155,7 @@ class Library(object):
                 self.niFake_GetError_cfunc = self._library.niFake_GetError
                 self.niFake_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ViString]  # noqa: F405
                 self.niFake_GetError_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_GetError_cfunc(vi, error_code, buffer_size, description).value
+        return self.niFake_GetError_cfunc(vi, error_code, buffer_size, description)
 
     def niFake_InitWithOptions(self, resource_name, id_query, reset_device, option_string, vi):  # noqa: N802
         with self._func_lock:
@@ -163,7 +163,7 @@ class Library(object):
                 self.niFake_InitWithOptions_cfunc = self._library.niFake_InitWithOptions
                 self.niFake_InitWithOptions_cfunc.argtypes = [ViString, ViBoolean, ViBoolean, ViString, ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niFake_InitWithOptions_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_InitWithOptions_cfunc(resource_name, id_query, reset_device, option_string, vi).value
+        return self.niFake_InitWithOptions_cfunc(resource_name, id_query, reset_device, option_string, vi)
 
     def niFake_Initiate(self, vi):  # noqa: N802
         with self._func_lock:
@@ -171,7 +171,7 @@ class Library(object):
                 self.niFake_Initiate_cfunc = self._library.niFake_Initiate
                 self.niFake_Initiate_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFake_Initiate_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_Initiate_cfunc(vi).value
+        return self.niFake_Initiate_cfunc(vi)
 
     def niFake_OneInputFunction(self, vi, a_number):  # noqa: N802
         with self._func_lock:
@@ -179,7 +179,7 @@ class Library(object):
                 self.niFake_OneInputFunction_cfunc = self._library.niFake_OneInputFunction
                 self.niFake_OneInputFunction_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niFake_OneInputFunction_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_OneInputFunction_cfunc(vi, a_number).value
+        return self.niFake_OneInputFunction_cfunc(vi, a_number)
 
     def niFake_Read(self, vi, maximum_time, reading):  # noqa: N802
         with self._func_lock:
@@ -187,7 +187,7 @@ class Library(object):
                 self.niFake_Read_cfunc = self._library.niFake_Read
                 self.niFake_Read_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_Read_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_Read_cfunc(vi, maximum_time, reading).value
+        return self.niFake_Read_cfunc(vi, maximum_time, reading)
 
     def niFake_ReadFromChannel(self, vi, channel_name, maximum_time, reading):  # noqa: N802
         with self._func_lock:
@@ -195,7 +195,7 @@ class Library(object):
                 self.niFake_ReadFromChannel_cfunc = self._library.niFake_ReadFromChannel
                 self.niFake_ReadFromChannel_cfunc.argtypes = [ViSession, ViConstString, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_ReadFromChannel_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_ReadFromChannel_cfunc(vi, channel_name, maximum_time, reading).value
+        return self.niFake_ReadFromChannel_cfunc(vi, channel_name, maximum_time, reading)
 
     def niFake_ReadMultiPoint(self, vi, maximum_time, array_size, reading_array, actual_number_of_points):  # noqa: N802
         with self._func_lock:
@@ -203,7 +203,7 @@ class Library(object):
                 self.niFake_ReadMultiPoint_cfunc = self._library.niFake_ReadMultiPoint
                 self.niFake_ReadMultiPoint_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFake_ReadMultiPoint_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_ReadMultiPoint_cfunc(vi, maximum_time, array_size, reading_array, actual_number_of_points).value
+        return self.niFake_ReadMultiPoint_cfunc(vi, maximum_time, array_size, reading_array, actual_number_of_points)
 
     def niFake_ReturnANumberAndAString(self, vi, a_number, a_string):  # noqa: N802
         with self._func_lock:
@@ -211,7 +211,7 @@ class Library(object):
                 self.niFake_ReturnANumberAndAString_cfunc = self._library.niFake_ReturnANumberAndAString
                 self.niFake_ReturnANumberAndAString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_ReturnANumberAndAString_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_ReturnANumberAndAString_cfunc(vi, a_number, a_string).value
+        return self.niFake_ReturnANumberAndAString_cfunc(vi, a_number, a_string)
 
     def niFake_SetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -219,7 +219,7 @@ class Library(object):
                 self.niFake_SetAttributeViBoolean_cfunc = self._library.niFake_SetAttributeViBoolean
                 self.niFake_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ViBoolean]  # noqa: F405
                 self.niFake_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_SetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niFake_SetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niFake_SetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -227,7 +227,7 @@ class Library(object):
                 self.niFake_SetAttributeViInt32_cfunc = self._library.niFake_SetAttributeViInt32
                 self.niFake_SetAttributeViInt32_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ViInt32]  # noqa: F405
                 self.niFake_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_SetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niFake_SetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niFake_SetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -235,7 +235,7 @@ class Library(object):
                 self.niFake_SetAttributeViReal64_cfunc = self._library.niFake_SetAttributeViReal64
                 self.niFake_SetAttributeViReal64_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ViReal64]  # noqa: F405
                 self.niFake_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_SetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niFake_SetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niFake_SetAttributeViSession(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -243,7 +243,7 @@ class Library(object):
                 self.niFake_SetAttributeViSession_cfunc = self._library.niFake_SetAttributeViSession
                 self.niFake_SetAttributeViSession_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ViSession]  # noqa: F405
                 self.niFake_SetAttributeViSession_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_SetAttributeViSession_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niFake_SetAttributeViSession_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niFake_SetAttributeViString(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -251,7 +251,7 @@ class Library(object):
                 self.niFake_SetAttributeViString_cfunc = self._library.niFake_SetAttributeViString
                 self.niFake_SetAttributeViString_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ViString]  # noqa: F405
                 self.niFake_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_SetAttributeViString_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niFake_SetAttributeViString_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niFake_SimpleFunction(self, vi):  # noqa: N802
         with self._func_lock:
@@ -259,7 +259,7 @@ class Library(object):
                 self.niFake_SimpleFunction_cfunc = self._library.niFake_SimpleFunction
                 self.niFake_SimpleFunction_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFake_SimpleFunction_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_SimpleFunction_cfunc(vi).value
+        return self.niFake_SimpleFunction_cfunc(vi)
 
     def niFake_TwoInputFunction(self, vi, a_number, a_string):  # noqa: N802
         with self._func_lock:
@@ -267,7 +267,7 @@ class Library(object):
                 self.niFake_TwoInputFunction_cfunc = self._library.niFake_TwoInputFunction
                 self.niFake_TwoInputFunction_cfunc.argtypes = [ViSession, ViReal64, ViChar]  # noqa: F405
                 self.niFake_TwoInputFunction_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_TwoInputFunction_cfunc(vi, a_number, a_string).value
+        return self.niFake_TwoInputFunction_cfunc(vi, a_number, a_string)
 
     def niFake_Use64BitNumber(self, vi, input, output):  # noqa: N802
         with self._func_lock:
@@ -275,7 +275,7 @@ class Library(object):
                 self.niFake_Use64BitNumber_cfunc = self._library.niFake_Use64BitNumber
                 self.niFake_Use64BitNumber_cfunc.argtypes = [ViSession, ViInt64, ctypes.POINTER(ViInt64)]  # noqa: F405
                 self.niFake_Use64BitNumber_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_Use64BitNumber_cfunc(vi, input, output).value
+        return self.niFake_Use64BitNumber_cfunc(vi, input, output)
 
     def niFake_close(self, vi):  # noqa: N802
         with self._func_lock:
@@ -283,7 +283,7 @@ class Library(object):
                 self.niFake_close_cfunc = self._library.niFake_close
                 self.niFake_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFake_close_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_close_cfunc(vi).value
+        return self.niFake_close_cfunc(vi)
 
     def niFake_error_message(self, vi, error_code, error_message):  # noqa: N802
         with self._func_lock:
@@ -291,4 +291,4 @@ class Library(object):
                 self.niFake_error_message_cfunc = self._library.niFake_error_message
                 self.niFake_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_error_message_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_error_message_cfunc(vi, error_code, error_message).value
+        return self.niFake_error_message_cfunc(vi, error_code, error_message)

--- a/generated/nifake/session.py
+++ b/generated/nifake/session.py
@@ -538,7 +538,7 @@ class Session(_SessionBase):
         actual_number_of_points_ctype = visatype.ViInt32(0)
         error_code = self._library.niFake_ReadMultiPoint(self._vi, maximum_time, array_size, ctypes.cast(reading_array_ctype, ctypes.POINTER(visatype.ViReal64)), ctypes.pointer(actual_number_of_points_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return [float(reading_array_ctype[i].value) for i in range(array_size)], int(actual_number_of_points_ctype.value)
+        return [float(reading_array_ctype[i]) for i in range(array_size)], int(actual_number_of_points_ctype.value)
 
     def return_a_number_and_a_string(self):
         '''return_a_number_and_a_string

--- a/generated/nifake/visatype.py
+++ b/generated/nifake/visatype.py
@@ -6,69 +6,19 @@ be used directly to call into the library.
 '''
 
 
-class ViStatus(ctypes.c_long):  # noqa: N801
-    pass
+ViStatus = ctypes.c_long
+ViRsrc = ctypes.c_char_p
+ViSession = ctypes.c_ulong
+ViChar = ctypes.c_char
+ViUInt32 = ctypes.c_ulong
+ViInt32 = ctypes.c_long
+ViInt16 = ctypes.c_short
+ViUInt16 = ctypes.c_ushort
+ViInt64 = ctypes.c_longlong
+ViString = ctypes.c_char_p
+ViAttr = ctypes.c_long
+ViConstString = ViString
+ViBoolean = ctypes.c_ushort
+ViReal32 = ctypes.c_float
+ViReal64 = ctypes.c_double
 
-
-class ViRsrc(ctypes.c_char_p):  # noqa: N801
-    pass
-
-
-class ViSession(ctypes.c_ulong):  # noqa: N801
-    pass
-
-
-class ViChar(ctypes.c_char):  # noqa: N801
-    pass
-
-
-class ViUInt32(ctypes.c_ulong):  # noqa: N801
-    pass
-
-
-class ViInt32(ctypes.c_long):  # noqa: N801
-    pass
-
-
-class ViInt16(ctypes.c_short):  # noqa: N801
-    pass
-
-
-class ViUInt16(ctypes.c_ushort):  # noqa: N801
-    pass
-
-
-class ViInt64(ctypes.c_longlong):  # noqa: N801
-    pass
-
-
-class ViString(ctypes.c_char_p):  # noqa: N801
-    pass
-
-
-class ViAttr(ctypes.c_long):  # noqa: N801
-    pass
-
-
-class ViConstString(ViString):  # noqa: N801
-    @property
-    def value(self):  # Makes 'value' readonly
-        return super(ViConstString, ViString).value
-
-
-class ViBoolean(ctypes.c_ushort):  # noqa: N801
-    @classmethod
-    def from_param(cls, param):
-        return ctypes.c_uint16(1) if bool(param) else ctypes.c_uint16(0)
-
-
-class ViReal32(ctypes.c_float):  # noqa: N801
-    @classmethod
-    def from_param(cls, param):
-        return ctypes.c_float(param)
-
-
-class ViReal64(ctypes.c_double):  # noqa: N801
-    @classmethod
-    def from_param(cls, param):
-        return ctypes.c_double(param)

--- a/generated/nimodinst/library.py
+++ b/generated/nimodinst/library.py
@@ -34,7 +34,7 @@ class Library(object):
                 self.niModInst_CloseInstalledDevicesSession_cfunc = self._library.niModInst_CloseInstalledDevicesSession
                 self.niModInst_CloseInstalledDevicesSession_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niModInst_CloseInstalledDevicesSession_cfunc.restype = ViStatus  # noqa: F405
-        return self.niModInst_CloseInstalledDevicesSession_cfunc(handle).value
+        return self.niModInst_CloseInstalledDevicesSession_cfunc(handle)
 
     def niModInst_GetExtendedErrorInfo(self, error_info_buffer_size, error_info):  # noqa: N802
         with self._func_lock:
@@ -42,7 +42,7 @@ class Library(object):
                 self.niModInst_GetExtendedErrorInfo_cfunc = self._library.niModInst_GetExtendedErrorInfo
                 self.niModInst_GetExtendedErrorInfo_cfunc.argtypes = [ViInt32, ViString]  # noqa: F405
                 self.niModInst_GetExtendedErrorInfo_cfunc.restype = ViStatus  # noqa: F405
-        return self.niModInst_GetExtendedErrorInfo_cfunc(error_info_buffer_size, error_info).value
+        return self.niModInst_GetExtendedErrorInfo_cfunc(error_info_buffer_size, error_info)
 
     def niModInst_GetInstalledDeviceAttributeViInt32(self, handle, index, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -50,7 +50,7 @@ class Library(object):
                 self.niModInst_GetInstalledDeviceAttributeViInt32_cfunc = self._library.niModInst_GetInstalledDeviceAttributeViInt32
                 self.niModInst_GetInstalledDeviceAttributeViInt32_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niModInst_GetInstalledDeviceAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
-        return self.niModInst_GetInstalledDeviceAttributeViInt32_cfunc(handle, index, attribute_id, attribute_value).value
+        return self.niModInst_GetInstalledDeviceAttributeViInt32_cfunc(handle, index, attribute_id, attribute_value)
 
     def niModInst_GetInstalledDeviceAttributeViString(self, handle, index, attribute_id, attribute_value_buffer_size, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -58,7 +58,7 @@ class Library(object):
                 self.niModInst_GetInstalledDeviceAttributeViString_cfunc = self._library.niModInst_GetInstalledDeviceAttributeViString
                 self.niModInst_GetInstalledDeviceAttributeViString_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ViInt32, ViString]  # noqa: F405
                 self.niModInst_GetInstalledDeviceAttributeViString_cfunc.restype = ViStatus  # noqa: F405
-        return self.niModInst_GetInstalledDeviceAttributeViString_cfunc(handle, index, attribute_id, attribute_value_buffer_size, attribute_value).value
+        return self.niModInst_GetInstalledDeviceAttributeViString_cfunc(handle, index, attribute_id, attribute_value_buffer_size, attribute_value)
 
     def niModInst_OpenInstalledDevicesSession(self, driver, handle, device_count):  # noqa: N802
         with self._func_lock:
@@ -66,4 +66,4 @@ class Library(object):
                 self.niModInst_OpenInstalledDevicesSession_cfunc = self._library.niModInst_OpenInstalledDevicesSession
                 self.niModInst_OpenInstalledDevicesSession_cfunc.argtypes = [ViConstString, ctypes.POINTER(ViSession), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niModInst_OpenInstalledDevicesSession_cfunc.restype = ViStatus  # noqa: F405
-        return self.niModInst_OpenInstalledDevicesSession_cfunc(driver, handle, device_count).value
+        return self.niModInst_OpenInstalledDevicesSession_cfunc(driver, handle, device_count)

--- a/generated/nimodinst/visatype.py
+++ b/generated/nimodinst/visatype.py
@@ -6,69 +6,19 @@ be used directly to call into the library.
 '''
 
 
-class ViStatus(ctypes.c_long):  # noqa: N801
-    pass
+ViStatus = ctypes.c_long
+ViRsrc = ctypes.c_char_p
+ViSession = ctypes.c_ulong
+ViChar = ctypes.c_char
+ViUInt32 = ctypes.c_ulong
+ViInt32 = ctypes.c_long
+ViInt16 = ctypes.c_short
+ViUInt16 = ctypes.c_ushort
+ViInt64 = ctypes.c_longlong
+ViString = ctypes.c_char_p
+ViAttr = ctypes.c_long
+ViConstString = ViString
+ViBoolean = ctypes.c_ushort
+ViReal32 = ctypes.c_float
+ViReal64 = ctypes.c_double
 
-
-class ViRsrc(ctypes.c_char_p):  # noqa: N801
-    pass
-
-
-class ViSession(ctypes.c_ulong):  # noqa: N801
-    pass
-
-
-class ViChar(ctypes.c_char):  # noqa: N801
-    pass
-
-
-class ViUInt32(ctypes.c_ulong):  # noqa: N801
-    pass
-
-
-class ViInt32(ctypes.c_long):  # noqa: N801
-    pass
-
-
-class ViInt16(ctypes.c_short):  # noqa: N801
-    pass
-
-
-class ViUInt16(ctypes.c_ushort):  # noqa: N801
-    pass
-
-
-class ViInt64(ctypes.c_longlong):  # noqa: N801
-    pass
-
-
-class ViString(ctypes.c_char_p):  # noqa: N801
-    pass
-
-
-class ViAttr(ctypes.c_long):  # noqa: N801
-    pass
-
-
-class ViConstString(ViString):  # noqa: N801
-    @property
-    def value(self):  # Makes 'value' readonly
-        return super(ViConstString, ViString).value
-
-
-class ViBoolean(ctypes.c_ushort):  # noqa: N801
-    @classmethod
-    def from_param(cls, param):
-        return ctypes.c_uint16(1) if bool(param) else ctypes.c_uint16(0)
-
-
-class ViReal32(ctypes.c_float):  # noqa: N801
-    @classmethod
-    def from_param(cls, param):
-        return ctypes.c_float(param)
-
-
-class ViReal64(ctypes.c_double):  # noqa: N801
-    @classmethod
-    def from_param(cls, param):
-        return ctypes.c_double(param)

--- a/generated/niswitch/library.py
+++ b/generated/niswitch/library.py
@@ -72,7 +72,7 @@ class Library(object):
                 self.niSwitch_AbortScan_cfunc = self._library.niSwitch_AbortScan
                 self.niSwitch_AbortScan_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_AbortScan_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_AbortScan_cfunc(vi).value
+        return self.niSwitch_AbortScan_cfunc(vi)
 
     def niSwitch_CanConnect(self, vi, channel1, channel2, path_capability):  # noqa: N802
         with self._func_lock:
@@ -80,7 +80,7 @@ class Library(object):
                 self.niSwitch_CanConnect_cfunc = self._library.niSwitch_CanConnect
                 self.niSwitch_CanConnect_cfunc.argtypes = [ViSession, ViConstString, ViConstString, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSwitch_CanConnect_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_CanConnect_cfunc(vi, channel1, channel2, path_capability).value
+        return self.niSwitch_CanConnect_cfunc(vi, channel1, channel2, path_capability)
 
     def niSwitch_Commit(self, vi):  # noqa: N802
         with self._func_lock:
@@ -88,7 +88,7 @@ class Library(object):
                 self.niSwitch_Commit_cfunc = self._library.niSwitch_Commit
                 self.niSwitch_Commit_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_Commit_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_Commit_cfunc(vi).value
+        return self.niSwitch_Commit_cfunc(vi)
 
     def niSwitch_ConfigureScanList(self, vi, scanlist, scan_mode):  # noqa: N802
         with self._func_lock:
@@ -96,7 +96,7 @@ class Library(object):
                 self.niSwitch_ConfigureScanList_cfunc = self._library.niSwitch_ConfigureScanList
                 self.niSwitch_ConfigureScanList_cfunc.argtypes = [ViSession, ViConstString, ViInt32]  # noqa: F405
                 self.niSwitch_ConfigureScanList_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_ConfigureScanList_cfunc(vi, scanlist, scan_mode).value
+        return self.niSwitch_ConfigureScanList_cfunc(vi, scanlist, scan_mode)
 
     def niSwitch_ConfigureScanTrigger(self, vi, scan_delay, trigger_input, scan_advanced_output):  # noqa: N802
         with self._func_lock:
@@ -104,7 +104,7 @@ class Library(object):
                 self.niSwitch_ConfigureScanTrigger_cfunc = self._library.niSwitch_ConfigureScanTrigger
                 self.niSwitch_ConfigureScanTrigger_cfunc.argtypes = [ViSession, ViReal64, ViInt32, ViInt32]  # noqa: F405
                 self.niSwitch_ConfigureScanTrigger_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_ConfigureScanTrigger_cfunc(vi, scan_delay, trigger_input, scan_advanced_output).value
+        return self.niSwitch_ConfigureScanTrigger_cfunc(vi, scan_delay, trigger_input, scan_advanced_output)
 
     def niSwitch_Connect(self, vi, channel1, channel2):  # noqa: N802
         with self._func_lock:
@@ -112,7 +112,7 @@ class Library(object):
                 self.niSwitch_Connect_cfunc = self._library.niSwitch_Connect
                 self.niSwitch_Connect_cfunc.argtypes = [ViSession, ViConstString, ViConstString]  # noqa: F405
                 self.niSwitch_Connect_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_Connect_cfunc(vi, channel1, channel2).value
+        return self.niSwitch_Connect_cfunc(vi, channel1, channel2)
 
     def niSwitch_ConnectMultiple(self, vi, connection_list):  # noqa: N802
         with self._func_lock:
@@ -120,7 +120,7 @@ class Library(object):
                 self.niSwitch_ConnectMultiple_cfunc = self._library.niSwitch_ConnectMultiple
                 self.niSwitch_ConnectMultiple_cfunc.argtypes = [ViSession, ViConstString]  # noqa: F405
                 self.niSwitch_ConnectMultiple_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_ConnectMultiple_cfunc(vi, connection_list).value
+        return self.niSwitch_ConnectMultiple_cfunc(vi, connection_list)
 
     def niSwitch_Disable(self, vi):  # noqa: N802
         with self._func_lock:
@@ -128,7 +128,7 @@ class Library(object):
                 self.niSwitch_Disable_cfunc = self._library.niSwitch_Disable
                 self.niSwitch_Disable_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_Disable_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_Disable_cfunc(vi).value
+        return self.niSwitch_Disable_cfunc(vi)
 
     def niSwitch_Disconnect(self, vi, channel1, channel2):  # noqa: N802
         with self._func_lock:
@@ -136,7 +136,7 @@ class Library(object):
                 self.niSwitch_Disconnect_cfunc = self._library.niSwitch_Disconnect
                 self.niSwitch_Disconnect_cfunc.argtypes = [ViSession, ViConstString, ViConstString]  # noqa: F405
                 self.niSwitch_Disconnect_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_Disconnect_cfunc(vi, channel1, channel2).value
+        return self.niSwitch_Disconnect_cfunc(vi, channel1, channel2)
 
     def niSwitch_DisconnectAll(self, vi):  # noqa: N802
         with self._func_lock:
@@ -144,7 +144,7 @@ class Library(object):
                 self.niSwitch_DisconnectAll_cfunc = self._library.niSwitch_DisconnectAll
                 self.niSwitch_DisconnectAll_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_DisconnectAll_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_DisconnectAll_cfunc(vi).value
+        return self.niSwitch_DisconnectAll_cfunc(vi)
 
     def niSwitch_DisconnectMultiple(self, vi, disconnection_list):  # noqa: N802
         with self._func_lock:
@@ -152,7 +152,7 @@ class Library(object):
                 self.niSwitch_DisconnectMultiple_cfunc = self._library.niSwitch_DisconnectMultiple
                 self.niSwitch_DisconnectMultiple_cfunc.argtypes = [ViSession, ViConstString]  # noqa: F405
                 self.niSwitch_DisconnectMultiple_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_DisconnectMultiple_cfunc(vi, disconnection_list).value
+        return self.niSwitch_DisconnectMultiple_cfunc(vi, disconnection_list)
 
     def niSwitch_GetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -160,7 +160,7 @@ class Library(object):
                 self.niSwitch_GetAttributeViBoolean_cfunc = self._library.niSwitch_GetAttributeViBoolean
                 self.niSwitch_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niSwitch_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_GetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niSwitch_GetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niSwitch_GetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -168,7 +168,7 @@ class Library(object):
                 self.niSwitch_GetAttributeViInt32_cfunc = self._library.niSwitch_GetAttributeViInt32
                 self.niSwitch_GetAttributeViInt32_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSwitch_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_GetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niSwitch_GetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niSwitch_GetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -176,7 +176,7 @@ class Library(object):
                 self.niSwitch_GetAttributeViReal64_cfunc = self._library.niSwitch_GetAttributeViReal64
                 self.niSwitch_GetAttributeViReal64_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niSwitch_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_GetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niSwitch_GetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niSwitch_GetAttributeViString(self, vi, channel_name, attribute_id, array_size, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -184,7 +184,7 @@ class Library(object):
                 self.niSwitch_GetAttributeViString_cfunc = self._library.niSwitch_GetAttributeViString
                 self.niSwitch_GetAttributeViString_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ViInt32, ViString]  # noqa: F405
                 self.niSwitch_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_GetAttributeViString_cfunc(vi, channel_name, attribute_id, array_size, attribute_value).value
+        return self.niSwitch_GetAttributeViString_cfunc(vi, channel_name, attribute_id, array_size, attribute_value)
 
     def niSwitch_GetChannelName(self, vi, index, buffer_size, channel_name_buffer):  # noqa: N802
         with self._func_lock:
@@ -192,7 +192,7 @@ class Library(object):
                 self.niSwitch_GetChannelName_cfunc = self._library.niSwitch_GetChannelName
                 self.niSwitch_GetChannelName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ViString]  # noqa: F405
                 self.niSwitch_GetChannelName_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_GetChannelName_cfunc(vi, index, buffer_size, channel_name_buffer).value
+        return self.niSwitch_GetChannelName_cfunc(vi, index, buffer_size, channel_name_buffer)
 
     def niSwitch_GetError(self, vi, code, buffer_size, description):  # noqa: N802
         with self._func_lock:
@@ -200,7 +200,7 @@ class Library(object):
                 self.niSwitch_GetError_cfunc = self._library.niSwitch_GetError
                 self.niSwitch_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ViString]  # noqa: F405
                 self.niSwitch_GetError_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_GetError_cfunc(vi, code, buffer_size, description).value
+        return self.niSwitch_GetError_cfunc(vi, code, buffer_size, description)
 
     def niSwitch_GetPath(self, vi, channel1, channel2, buffer_size, path):  # noqa: N802
         with self._func_lock:
@@ -208,7 +208,7 @@ class Library(object):
                 self.niSwitch_GetPath_cfunc = self._library.niSwitch_GetPath
                 self.niSwitch_GetPath_cfunc.argtypes = [ViSession, ViConstString, ViConstString, ViInt32, ViString]  # noqa: F405
                 self.niSwitch_GetPath_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_GetPath_cfunc(vi, channel1, channel2, buffer_size, path).value
+        return self.niSwitch_GetPath_cfunc(vi, channel1, channel2, buffer_size, path)
 
     def niSwitch_GetRelayCount(self, vi, relay_name, relay_count):  # noqa: N802
         with self._func_lock:
@@ -216,7 +216,7 @@ class Library(object):
                 self.niSwitch_GetRelayCount_cfunc = self._library.niSwitch_GetRelayCount
                 self.niSwitch_GetRelayCount_cfunc.argtypes = [ViSession, ViConstString, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSwitch_GetRelayCount_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_GetRelayCount_cfunc(vi, relay_name, relay_count).value
+        return self.niSwitch_GetRelayCount_cfunc(vi, relay_name, relay_count)
 
     def niSwitch_GetRelayName(self, vi, index, relay_name_buffer_size, relay_name_buffer):  # noqa: N802
         with self._func_lock:
@@ -224,7 +224,7 @@ class Library(object):
                 self.niSwitch_GetRelayName_cfunc = self._library.niSwitch_GetRelayName
                 self.niSwitch_GetRelayName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ViString]  # noqa: F405
                 self.niSwitch_GetRelayName_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_GetRelayName_cfunc(vi, index, relay_name_buffer_size, relay_name_buffer).value
+        return self.niSwitch_GetRelayName_cfunc(vi, index, relay_name_buffer_size, relay_name_buffer)
 
     def niSwitch_GetRelayPosition(self, vi, relay_name, relay_position):  # noqa: N802
         with self._func_lock:
@@ -232,7 +232,7 @@ class Library(object):
                 self.niSwitch_GetRelayPosition_cfunc = self._library.niSwitch_GetRelayPosition
                 self.niSwitch_GetRelayPosition_cfunc.argtypes = [ViSession, ViConstString, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSwitch_GetRelayPosition_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_GetRelayPosition_cfunc(vi, relay_name, relay_position).value
+        return self.niSwitch_GetRelayPosition_cfunc(vi, relay_name, relay_position)
 
     def niSwitch_InitWithTopology(self, resource_name, topology, simulate, reset_device, vi):  # noqa: N802
         with self._func_lock:
@@ -240,7 +240,7 @@ class Library(object):
                 self.niSwitch_InitWithTopology_cfunc = self._library.niSwitch_InitWithTopology
                 self.niSwitch_InitWithTopology_cfunc.argtypes = [ViRsrc, ViConstString, ViBoolean, ViBoolean, ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niSwitch_InitWithTopology_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_InitWithTopology_cfunc(resource_name, topology, simulate, reset_device, vi).value
+        return self.niSwitch_InitWithTopology_cfunc(resource_name, topology, simulate, reset_device, vi)
 
     def niSwitch_InitiateScan(self, vi):  # noqa: N802
         with self._func_lock:
@@ -248,7 +248,7 @@ class Library(object):
                 self.niSwitch_InitiateScan_cfunc = self._library.niSwitch_InitiateScan
                 self.niSwitch_InitiateScan_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_InitiateScan_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_InitiateScan_cfunc(vi).value
+        return self.niSwitch_InitiateScan_cfunc(vi)
 
     def niSwitch_IsDebounced(self, vi, is_debounced):  # noqa: N802
         with self._func_lock:
@@ -256,7 +256,7 @@ class Library(object):
                 self.niSwitch_IsDebounced_cfunc = self._library.niSwitch_IsDebounced
                 self.niSwitch_IsDebounced_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niSwitch_IsDebounced_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_IsDebounced_cfunc(vi, is_debounced).value
+        return self.niSwitch_IsDebounced_cfunc(vi, is_debounced)
 
     def niSwitch_IsScanning(self, vi, is_scanning):  # noqa: N802
         with self._func_lock:
@@ -264,7 +264,7 @@ class Library(object):
                 self.niSwitch_IsScanning_cfunc = self._library.niSwitch_IsScanning
                 self.niSwitch_IsScanning_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niSwitch_IsScanning_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_IsScanning_cfunc(vi, is_scanning).value
+        return self.niSwitch_IsScanning_cfunc(vi, is_scanning)
 
     def niSwitch_RelayControl(self, vi, relay_name, relay_action):  # noqa: N802
         with self._func_lock:
@@ -272,7 +272,7 @@ class Library(object):
                 self.niSwitch_RelayControl_cfunc = self._library.niSwitch_RelayControl
                 self.niSwitch_RelayControl_cfunc.argtypes = [ViSession, ViConstString, ViInt32]  # noqa: F405
                 self.niSwitch_RelayControl_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_RelayControl_cfunc(vi, relay_name, relay_action).value
+        return self.niSwitch_RelayControl_cfunc(vi, relay_name, relay_action)
 
     def niSwitch_ResetWithDefaults(self, vi):  # noqa: N802
         with self._func_lock:
@@ -280,7 +280,7 @@ class Library(object):
                 self.niSwitch_ResetWithDefaults_cfunc = self._library.niSwitch_ResetWithDefaults
                 self.niSwitch_ResetWithDefaults_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_ResetWithDefaults_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_ResetWithDefaults_cfunc(vi).value
+        return self.niSwitch_ResetWithDefaults_cfunc(vi)
 
     def niSwitch_RouteScanAdvancedOutput(self, vi, scan_advanced_output_connector, scan_advanced_output_bus_line, invert):  # noqa: N802
         with self._func_lock:
@@ -288,7 +288,7 @@ class Library(object):
                 self.niSwitch_RouteScanAdvancedOutput_cfunc = self._library.niSwitch_RouteScanAdvancedOutput
                 self.niSwitch_RouteScanAdvancedOutput_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ViBoolean]  # noqa: F405
                 self.niSwitch_RouteScanAdvancedOutput_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_RouteScanAdvancedOutput_cfunc(vi, scan_advanced_output_connector, scan_advanced_output_bus_line, invert).value
+        return self.niSwitch_RouteScanAdvancedOutput_cfunc(vi, scan_advanced_output_connector, scan_advanced_output_bus_line, invert)
 
     def niSwitch_RouteTriggerInput(self, vi, trigger_input_connector, trigger_input_bus_line, invert):  # noqa: N802
         with self._func_lock:
@@ -296,7 +296,7 @@ class Library(object):
                 self.niSwitch_RouteTriggerInput_cfunc = self._library.niSwitch_RouteTriggerInput
                 self.niSwitch_RouteTriggerInput_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ViBoolean]  # noqa: F405
                 self.niSwitch_RouteTriggerInput_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_RouteTriggerInput_cfunc(vi, trigger_input_connector, trigger_input_bus_line, invert).value
+        return self.niSwitch_RouteTriggerInput_cfunc(vi, trigger_input_connector, trigger_input_bus_line, invert)
 
     def niSwitch_SendSoftwareTrigger(self, vi):  # noqa: N802
         with self._func_lock:
@@ -304,7 +304,7 @@ class Library(object):
                 self.niSwitch_SendSoftwareTrigger_cfunc = self._library.niSwitch_SendSoftwareTrigger
                 self.niSwitch_SendSoftwareTrigger_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_SendSoftwareTrigger_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_SendSoftwareTrigger_cfunc(vi).value
+        return self.niSwitch_SendSoftwareTrigger_cfunc(vi)
 
     def niSwitch_SetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -312,7 +312,7 @@ class Library(object):
                 self.niSwitch_SetAttributeViBoolean_cfunc = self._library.niSwitch_SetAttributeViBoolean
                 self.niSwitch_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ViBoolean]  # noqa: F405
                 self.niSwitch_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_SetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niSwitch_SetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niSwitch_SetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -320,7 +320,7 @@ class Library(object):
                 self.niSwitch_SetAttributeViInt32_cfunc = self._library.niSwitch_SetAttributeViInt32
                 self.niSwitch_SetAttributeViInt32_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ViInt32]  # noqa: F405
                 self.niSwitch_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_SetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niSwitch_SetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niSwitch_SetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -328,7 +328,7 @@ class Library(object):
                 self.niSwitch_SetAttributeViReal64_cfunc = self._library.niSwitch_SetAttributeViReal64
                 self.niSwitch_SetAttributeViReal64_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ViReal64]  # noqa: F405
                 self.niSwitch_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_SetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niSwitch_SetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niSwitch_SetAttributeViString(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
@@ -336,7 +336,7 @@ class Library(object):
                 self.niSwitch_SetAttributeViString_cfunc = self._library.niSwitch_SetAttributeViString
                 self.niSwitch_SetAttributeViString_cfunc.argtypes = [ViSession, ViConstString, ViAttr, ViString]  # noqa: F405
                 self.niSwitch_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_SetAttributeViString_cfunc(vi, channel_name, attribute_id, attribute_value).value
+        return self.niSwitch_SetAttributeViString_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niSwitch_SetContinuousScan(self, vi, continuous_scan):  # noqa: N802
         with self._func_lock:
@@ -344,7 +344,7 @@ class Library(object):
                 self.niSwitch_SetContinuousScan_cfunc = self._library.niSwitch_SetContinuousScan
                 self.niSwitch_SetContinuousScan_cfunc.argtypes = [ViSession, ViBoolean]  # noqa: F405
                 self.niSwitch_SetContinuousScan_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_SetContinuousScan_cfunc(vi, continuous_scan).value
+        return self.niSwitch_SetContinuousScan_cfunc(vi, continuous_scan)
 
     def niSwitch_SetPath(self, vi, path_list):  # noqa: N802
         with self._func_lock:
@@ -352,7 +352,7 @@ class Library(object):
                 self.niSwitch_SetPath_cfunc = self._library.niSwitch_SetPath
                 self.niSwitch_SetPath_cfunc.argtypes = [ViSession, ViConstString]  # noqa: F405
                 self.niSwitch_SetPath_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_SetPath_cfunc(vi, path_list).value
+        return self.niSwitch_SetPath_cfunc(vi, path_list)
 
     def niSwitch_WaitForDebounce(self, vi, maximum_time_ms):  # noqa: N802
         with self._func_lock:
@@ -360,7 +360,7 @@ class Library(object):
                 self.niSwitch_WaitForDebounce_cfunc = self._library.niSwitch_WaitForDebounce
                 self.niSwitch_WaitForDebounce_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niSwitch_WaitForDebounce_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_WaitForDebounce_cfunc(vi, maximum_time_ms).value
+        return self.niSwitch_WaitForDebounce_cfunc(vi, maximum_time_ms)
 
     def niSwitch_WaitForScanComplete(self, vi, maximum_time_ms):  # noqa: N802
         with self._func_lock:
@@ -368,7 +368,7 @@ class Library(object):
                 self.niSwitch_WaitForScanComplete_cfunc = self._library.niSwitch_WaitForScanComplete
                 self.niSwitch_WaitForScanComplete_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niSwitch_WaitForScanComplete_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_WaitForScanComplete_cfunc(vi, maximum_time_ms).value
+        return self.niSwitch_WaitForScanComplete_cfunc(vi, maximum_time_ms)
 
     def niSwitch_close(self, vi):  # noqa: N802
         with self._func_lock:
@@ -376,7 +376,7 @@ class Library(object):
                 self.niSwitch_close_cfunc = self._library.niSwitch_close
                 self.niSwitch_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_close_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_close_cfunc(vi).value
+        return self.niSwitch_close_cfunc(vi)
 
     def niSwitch_error_message(self, vi, error_code, error_message):  # noqa: N802
         with self._func_lock:
@@ -384,7 +384,7 @@ class Library(object):
                 self.niSwitch_error_message_cfunc = self._library.niSwitch_error_message
                 self.niSwitch_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_error_message_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_error_message_cfunc(vi, error_code, error_message).value
+        return self.niSwitch_error_message_cfunc(vi, error_code, error_message)
 
     def niSwitch_reset(self, vi):  # noqa: N802
         with self._func_lock:
@@ -392,7 +392,7 @@ class Library(object):
                 self.niSwitch_reset_cfunc = self._library.niSwitch_reset
                 self.niSwitch_reset_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_reset_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_reset_cfunc(vi).value
+        return self.niSwitch_reset_cfunc(vi)
 
     def niSwitch_revision_query(self, vi, instrument_driver_revision, firmware_revision):  # noqa: N802
         with self._func_lock:
@@ -400,7 +400,7 @@ class Library(object):
                 self.niSwitch_revision_query_cfunc = self._library.niSwitch_revision_query
                 self.niSwitch_revision_query_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_revision_query_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_revision_query_cfunc(vi, instrument_driver_revision, firmware_revision).value
+        return self.niSwitch_revision_query_cfunc(vi, instrument_driver_revision, firmware_revision)
 
     def niSwitch_self_test(self, vi, self_test_result, self_test_message):  # noqa: N802
         with self._func_lock:
@@ -408,4 +408,4 @@ class Library(object):
                 self.niSwitch_self_test_cfunc = self._library.niSwitch_self_test
                 self.niSwitch_self_test_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_self_test_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_self_test_cfunc(vi, self_test_result, self_test_message).value
+        return self.niSwitch_self_test_cfunc(vi, self_test_result, self_test_message)

--- a/generated/niswitch/visatype.py
+++ b/generated/niswitch/visatype.py
@@ -6,69 +6,19 @@ be used directly to call into the library.
 '''
 
 
-class ViStatus(ctypes.c_long):  # noqa: N801
-    pass
+ViStatus = ctypes.c_long
+ViRsrc = ctypes.c_char_p
+ViSession = ctypes.c_ulong
+ViChar = ctypes.c_char
+ViUInt32 = ctypes.c_ulong
+ViInt32 = ctypes.c_long
+ViInt16 = ctypes.c_short
+ViUInt16 = ctypes.c_ushort
+ViInt64 = ctypes.c_longlong
+ViString = ctypes.c_char_p
+ViAttr = ctypes.c_long
+ViConstString = ViString
+ViBoolean = ctypes.c_ushort
+ViReal32 = ctypes.c_float
+ViReal64 = ctypes.c_double
 
-
-class ViRsrc(ctypes.c_char_p):  # noqa: N801
-    pass
-
-
-class ViSession(ctypes.c_ulong):  # noqa: N801
-    pass
-
-
-class ViChar(ctypes.c_char):  # noqa: N801
-    pass
-
-
-class ViUInt32(ctypes.c_ulong):  # noqa: N801
-    pass
-
-
-class ViInt32(ctypes.c_long):  # noqa: N801
-    pass
-
-
-class ViInt16(ctypes.c_short):  # noqa: N801
-    pass
-
-
-class ViUInt16(ctypes.c_ushort):  # noqa: N801
-    pass
-
-
-class ViInt64(ctypes.c_longlong):  # noqa: N801
-    pass
-
-
-class ViString(ctypes.c_char_p):  # noqa: N801
-    pass
-
-
-class ViAttr(ctypes.c_long):  # noqa: N801
-    pass
-
-
-class ViConstString(ViString):  # noqa: N801
-    @property
-    def value(self):  # Makes 'value' readonly
-        return super(ViConstString, ViString).value
-
-
-class ViBoolean(ctypes.c_ushort):  # noqa: N801
-    @classmethod
-    def from_param(cls, param):
-        return ctypes.c_uint16(1) if bool(param) else ctypes.c_uint16(0)
-
-
-class ViReal32(ctypes.c_float):  # noqa: N801
-    @classmethod
-    def from_param(cls, param):
-        return ctypes.c_float(param)
-
-
-class ViReal64(ctypes.c_double):  # noqa: N801
-    @classmethod
-    def from_param(cls, param):
-        return ctypes.c_double(param)


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md]
~~[ ] I've updated [CHANGELOG.md](https://github.com/ni/<reponame>/blob/master/CHANGELOG.md) if applicable.~~
### What does this Pull Request accomplish?
* Make visatypes "typedefs" rather than subclasses
  * This is done as setting them equal to the ctype instead of a class that inherits from ctypes

### List issues fixed by this Pull Request below, if any.
N/A

### What testing has been done?
* Travis
* System tests