### PR TITLE
Make enum value names fully qualified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Python Versioning](http://legacy.python.org/dev/pep
       # Sets sequence on channels 0 through 3
       session['0-3'].set_sequence(values, source_delays)
       ```
+    * Enum value documentation lists the fully qualified name - this is to allow easy copy/paste
   * #### Removed
 * #### NI-DMM
   * #### Added

--- a/build/templates/enums.rst.mako
+++ b/build/templates/enums.rst.mako
@@ -18,7 +18,7 @@ Enums used in ${driver_name}
 .. py:data:: ${enum_name}
     % for enum_value in enums[enum_name]['values']:
 
-    .. py:attribute:: ${enum_value['name']}
+    .. py:attribute:: ${module_name}.${enum_name}.${enum_value['name']}
 
 ${helper.get_documentation_for_node_rst(enum_value, config, indent=8)}
     % endfor

--- a/docs/nidcpower/enums.rst
+++ b/docs/nidcpower/enums.rst
@@ -9,7 +9,7 @@ Enums used in NI-DCPower
 
 .. py:data:: ApertureTimeUnits
 
-    .. py:attribute:: SECONDS
+    .. py:attribute:: nidcpower.ApertureTimeUnits.SECONDS
 
 
 
@@ -18,7 +18,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: POWER_LINE_CYCLES
+    .. py:attribute:: nidcpower.ApertureTimeUnits.POWER_LINE_CYCLES
 
 
 
@@ -30,7 +30,7 @@ Enums used in NI-DCPower
 
 .. py:data:: AutoZero
 
-    .. py:attribute:: OFF
+    .. py:attribute:: nidcpower.AutoZero.OFF
 
 
 
@@ -39,7 +39,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: ON
+    .. py:attribute:: nidcpower.AutoZero.ON
 
 
 
@@ -48,7 +48,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: ONCE
+    .. py:attribute:: nidcpower.AutoZero.ONCE
 
 
 
@@ -62,7 +62,7 @@ Enums used in NI-DCPower
 
 .. py:data:: CurrentLevelAutorange
 
-    .. py:attribute:: OFF
+    .. py:attribute:: nidcpower.CurrentLevelAutorange.OFF
 
 
 
@@ -71,7 +71,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: ON
+    .. py:attribute:: nidcpower.CurrentLevelAutorange.ON
 
 
 
@@ -83,7 +83,7 @@ Enums used in NI-DCPower
 
 .. py:data:: CurrentLimitAutorange
 
-    .. py:attribute:: OFF
+    .. py:attribute:: nidcpower.CurrentLimitAutorange.OFF
 
 
 
@@ -92,7 +92,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: ON
+    .. py:attribute:: nidcpower.CurrentLimitAutorange.ON
 
 
 
@@ -104,7 +104,7 @@ Enums used in NI-DCPower
 
 .. py:data:: CurrentLimitBehavior
 
-    .. py:attribute:: CURRENT_REGULATE
+    .. py:attribute:: nidcpower.CurrentLimitBehavior.CURRENT_REGULATE
 
 
 
@@ -113,7 +113,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: CURRENT_TRIP
+    .. py:attribute:: nidcpower.CurrentLimitBehavior.CURRENT_TRIP
 
 
 
@@ -125,7 +125,7 @@ Enums used in NI-DCPower
 
 .. py:data:: DCNoiseRejection
 
-    .. py:attribute:: SECOND_ORDER
+    .. py:attribute:: nidcpower.DCNoiseRejection.SECOND_ORDER
 
 
 
@@ -136,7 +136,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: NORMAL
+    .. py:attribute:: nidcpower.DCNoiseRejection.NORMAL
 
 
 
@@ -148,7 +148,7 @@ Enums used in NI-DCPower
 
 .. py:data:: DigitalEdge
 
-    .. py:attribute:: RISING
+    .. py:attribute:: nidcpower.DigitalEdge.RISING
 
 
 
@@ -157,7 +157,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: FALLING
+    .. py:attribute:: nidcpower.DigitalEdge.FALLING
 
 
 
@@ -169,7 +169,7 @@ Enums used in NI-DCPower
 
 .. py:data:: MeasureWhen
 
-    .. py:attribute:: AUTOMATICALLY_AFTER_SOURCE_COMPLETE
+    .. py:attribute:: nidcpower.MeasureWhen.AUTOMATICALLY_AFTER_SOURCE_COMPLETE
 
 
 
@@ -181,7 +181,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: ON_DEMAND
+    .. py:attribute:: nidcpower.MeasureWhen.ON_DEMAND
 
 
 
@@ -194,7 +194,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: ON_MEASURE_TRIGGER
+    .. py:attribute:: nidcpower.MeasureWhen.ON_MEASURE_TRIGGER
 
 
 
@@ -209,7 +209,7 @@ Enums used in NI-DCPower
 
 .. py:data:: OutputCapacitance
 
-    .. py:attribute:: LOW
+    .. py:attribute:: nidcpower.OutputCapacitance.LOW
 
 
 
@@ -218,7 +218,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: HIGH
+    .. py:attribute:: nidcpower.OutputCapacitance.HIGH
 
 
 
@@ -230,7 +230,7 @@ Enums used in NI-DCPower
 
 .. py:data:: OutputFunction
 
-    .. py:attribute:: DC_VOLTAGE
+    .. py:attribute:: nidcpower.OutputFunction.DC_VOLTAGE
 
 
 
@@ -239,7 +239,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: DC_CURRENT
+    .. py:attribute:: nidcpower.OutputFunction.DC_CURRENT
 
 
 
@@ -248,7 +248,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: PULSE_VOLTAGE
+    .. py:attribute:: nidcpower.OutputFunction.PULSE_VOLTAGE
 
 
 
@@ -257,7 +257,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: PULSE_CURRENT
+    .. py:attribute:: nidcpower.OutputFunction.PULSE_CURRENT
 
 
 
@@ -269,7 +269,7 @@ Enums used in NI-DCPower
 
 .. py:data:: Polarity
 
-    .. py:attribute:: ACTIVE_HIGH
+    .. py:attribute:: nidcpower.Polarity.ACTIVE_HIGH
 
 
 
@@ -279,7 +279,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: ACTIVE_LOW
+    .. py:attribute:: nidcpower.Polarity.ACTIVE_LOW
 
 
 
@@ -292,7 +292,7 @@ Enums used in NI-DCPower
 
 .. py:data:: PowerLineFrequency
 
-    .. py:attribute:: _50_HERTZ
+    .. py:attribute:: nidcpower.PowerLineFrequency._50_HERTZ
 
 
 
@@ -301,7 +301,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: _60_HERTZ
+    .. py:attribute:: nidcpower.PowerLineFrequency._60_HERTZ
 
 
 
@@ -313,7 +313,7 @@ Enums used in NI-DCPower
 
 .. py:data:: PowerSource
 
-    .. py:attribute:: INTERNAL
+    .. py:attribute:: nidcpower.PowerSource.INTERNAL
 
 
 
@@ -322,7 +322,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: AUXILIARY
+    .. py:attribute:: nidcpower.PowerSource.AUXILIARY
 
 
 
@@ -331,7 +331,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: AUTOMATIC
+    .. py:attribute:: nidcpower.PowerSource.AUTOMATIC
 
 
 
@@ -344,7 +344,7 @@ Enums used in NI-DCPower
 
 .. py:data:: PowerSourceInUse
 
-    .. py:attribute:: INTERNAL
+    .. py:attribute:: nidcpower.PowerSourceInUse.INTERNAL
 
 
 
@@ -353,7 +353,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: AUXILIARY
+    .. py:attribute:: nidcpower.PowerSourceInUse.AUXILIARY
 
 
 
@@ -368,7 +368,7 @@ Enums used in NI-DCPower
 
 .. py:data:: SelfCalibrationPersistence
 
-    .. py:attribute:: KEEP_IN_MEMORY
+    .. py:attribute:: nidcpower.SelfCalibrationPersistence.KEEP_IN_MEMORY
 
 
 
@@ -377,7 +377,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: WRITE_TO_EEPROM
+    .. py:attribute:: nidcpower.SelfCalibrationPersistence.WRITE_TO_EEPROM
 
 
 
@@ -391,7 +391,7 @@ Enums used in NI-DCPower
 
 .. py:data:: Sense
 
-    .. py:attribute:: LOCAL
+    .. py:attribute:: nidcpower.Sense.LOCAL
 
 
 
@@ -400,7 +400,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: REMOTE
+    .. py:attribute:: nidcpower.Sense.REMOTE
 
 
 
@@ -412,7 +412,7 @@ Enums used in NI-DCPower
 
 .. py:data:: SourceMode
 
-    .. py:attribute:: SINGLE_POINT
+    .. py:attribute:: nidcpower.SourceMode.SINGLE_POINT
 
 
 
@@ -421,7 +421,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: SEQUENCE
+    .. py:attribute:: nidcpower.SourceMode.SEQUENCE
 
 
 
@@ -434,7 +434,7 @@ Enums used in NI-DCPower
 
 .. py:data:: TransientResponse
 
-    .. py:attribute:: NORMAL
+    .. py:attribute:: nidcpower.TransientResponse.NORMAL
 
 
 
@@ -443,7 +443,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: FAST
+    .. py:attribute:: nidcpower.TransientResponse.FAST
 
 
 
@@ -452,7 +452,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: SLOW
+    .. py:attribute:: nidcpower.TransientResponse.SLOW
 
 
 
@@ -463,7 +463,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: CUSTOM
+    .. py:attribute:: nidcpower.TransientResponse.CUSTOM
 
 
 
@@ -487,7 +487,7 @@ Enums used in NI-DCPower
 
 .. py:data:: TriggerType
 
-    .. py:attribute:: NONE
+    .. py:attribute:: nidcpower.TriggerType.NONE
 
 
 
@@ -496,7 +496,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: DIGITAL_EDGE
+    .. py:attribute:: nidcpower.TriggerType.DIGITAL_EDGE
 
 
 
@@ -505,7 +505,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: SOFTWARE_EDGE
+    .. py:attribute:: nidcpower.TriggerType.SOFTWARE_EDGE
 
 
 
@@ -517,7 +517,7 @@ Enums used in NI-DCPower
 
 .. py:data:: VoltageLevelAutorange
 
-    .. py:attribute:: OFF
+    .. py:attribute:: nidcpower.VoltageLevelAutorange.OFF
 
 
 
@@ -526,7 +526,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: ON
+    .. py:attribute:: nidcpower.VoltageLevelAutorange.ON
 
 
 
@@ -538,7 +538,7 @@ Enums used in NI-DCPower
 
 .. py:data:: VoltageLimitAutorange
 
-    .. py:attribute:: OFF
+    .. py:attribute:: nidcpower.VoltageLimitAutorange.OFF
 
 
 
@@ -547,7 +547,7 @@ Enums used in NI-DCPower
         
 
 
-    .. py:attribute:: ON
+    .. py:attribute:: nidcpower.VoltageLimitAutorange.ON
 
 
 

--- a/docs/nidmm/enums.rst
+++ b/docs/nidmm/enums.rst
@@ -9,7 +9,7 @@ Enums used in NI-DMM
 
 .. py:data:: ADCCalibration
 
-    .. py:attribute:: AUTO
+    .. py:attribute:: nidmm.ADCCalibration.AUTO
 
 
 
@@ -19,7 +19,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: OFF
+    .. py:attribute:: nidmm.ADCCalibration.OFF
 
 
 
@@ -28,7 +28,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: ON
+    .. py:attribute:: nidmm.ADCCalibration.ON
 
 
 
@@ -41,7 +41,7 @@ Enums used in NI-DMM
 
 .. py:data:: AcquisitionStatus
 
-    .. py:attribute:: RUNNING
+    .. py:attribute:: nidmm.AcquisitionStatus.RUNNING
 
 
 
@@ -50,7 +50,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: FINISHED_WITH_BACKLOG
+    .. py:attribute:: nidmm.AcquisitionStatus.FINISHED_WITH_BACKLOG
 
 
 
@@ -59,7 +59,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: FINISHED_WITH_NO_BACKLOG
+    .. py:attribute:: nidmm.AcquisitionStatus.FINISHED_WITH_NO_BACKLOG
 
 
 
@@ -68,7 +68,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: PAUSED
+    .. py:attribute:: nidmm.AcquisitionStatus.PAUSED
 
 
 
@@ -77,7 +77,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: NO_ACQUISITION_IN_PROGRESS
+    .. py:attribute:: nidmm.AcquisitionStatus.NO_ACQUISITION_IN_PROGRESS
 
 
 
@@ -89,7 +89,7 @@ Enums used in NI-DMM
 
 .. py:data:: ApertureTimeUnits
 
-    .. py:attribute:: SECONDS
+    .. py:attribute:: nidmm.ApertureTimeUnits.SECONDS
 
 
 
@@ -98,7 +98,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: POWER_LINE_CYCLES
+    .. py:attribute:: nidmm.ApertureTimeUnits.POWER_LINE_CYCLES
 
 
 
@@ -110,7 +110,7 @@ Enums used in NI-DMM
 
 .. py:data:: AutoZero
 
-    .. py:attribute:: AUTO
+    .. py:attribute:: nidmm.AutoZero.AUTO
 
 
 
@@ -120,7 +120,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: OFF
+    .. py:attribute:: nidmm.AutoZero.OFF
 
 
 
@@ -129,7 +129,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: ON
+    .. py:attribute:: nidmm.AutoZero.ON
 
 
 
@@ -142,7 +142,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: ONCE
+    .. py:attribute:: nidmm.AutoZero.ONCE
 
 
 
@@ -157,7 +157,7 @@ Enums used in NI-DMM
 
 .. py:data:: CableCompensationType
 
-    .. py:attribute:: NONE
+    .. py:attribute:: nidmm.CableCompensationType.NONE
 
 
 
@@ -166,7 +166,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: OPEN
+    .. py:attribute:: nidmm.CableCompensationType.OPEN
 
 
 
@@ -175,7 +175,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: SHORT
+    .. py:attribute:: nidmm.CableCompensationType.SHORT
 
 
 
@@ -184,7 +184,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: OPEN_AND_SHORT
+    .. py:attribute:: nidmm.CableCompensationType.OPEN_AND_SHORT
 
 
 
@@ -196,7 +196,7 @@ Enums used in NI-DMM
 
 .. py:data:: CurrentSource
 
-    .. py:attribute:: _1_MICROAMP
+    .. py:attribute:: nidmm.CurrentSource._1_MICROAMP
 
 
 
@@ -205,7 +205,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _10_MICROAMP
+    .. py:attribute:: nidmm.CurrentSource._10_MICROAMP
 
 
 
@@ -214,7 +214,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _100_MICROAMP
+    .. py:attribute:: nidmm.CurrentSource._100_MICROAMP
 
 
 
@@ -223,7 +223,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _1_MILLIAMP
+    .. py:attribute:: nidmm.CurrentSource._1_MILLIAMP
 
 
 
@@ -235,7 +235,7 @@ Enums used in NI-DMM
 
 .. py:data:: DCBias
 
-    .. py:attribute:: DC_BIAS_OFF
+    .. py:attribute:: nidmm.DCBias.DC_BIAS_OFF
 
 
 
@@ -244,7 +244,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: DC_BIAS_ON
+    .. py:attribute:: nidmm.DCBias.DC_BIAS_ON
 
 
 
@@ -256,7 +256,7 @@ Enums used in NI-DMM
 
 .. py:data:: DCNoiseRejection
 
-    .. py:attribute:: AUTO
+    .. py:attribute:: nidmm.DCNoiseRejection.AUTO
 
 
 
@@ -266,7 +266,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: NORMAL
+    .. py:attribute:: nidmm.DCNoiseRejection.NORMAL
 
 
 
@@ -275,7 +275,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: SECOND_ORDER
+    .. py:attribute:: nidmm.DCNoiseRejection.SECOND_ORDER
 
 
 
@@ -286,7 +286,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: HIGH_ORDER
+    .. py:attribute:: nidmm.DCNoiseRejection.HIGH_ORDER
 
 
 
@@ -300,7 +300,7 @@ Enums used in NI-DMM
 
 .. py:data:: DigitsResolution
 
-    .. py:attribute:: _3_5
+    .. py:attribute:: nidmm.DigitsResolution._3_5
 
 
 
@@ -309,7 +309,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _4_5
+    .. py:attribute:: nidmm.DigitsResolution._4_5
 
 
 
@@ -318,7 +318,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _5_5
+    .. py:attribute:: nidmm.DigitsResolution._5_5
 
 
 
@@ -327,7 +327,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _6_5
+    .. py:attribute:: nidmm.DigitsResolution._6_5
 
 
 
@@ -336,7 +336,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _7_5
+    .. py:attribute:: nidmm.DigitsResolution._7_5
 
 
 
@@ -348,7 +348,7 @@ Enums used in NI-DMM
 
 .. py:data:: Function
 
-    .. py:attribute:: DC_VOLTS
+    .. py:attribute:: nidmm.Function.DC_VOLTS
 
 
 
@@ -357,7 +357,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: AC_VOLTS
+    .. py:attribute:: nidmm.Function.AC_VOLTS
 
 
 
@@ -366,7 +366,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: DC_CURRENT
+    .. py:attribute:: nidmm.Function.DC_CURRENT
 
 
 
@@ -375,7 +375,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: AC_CURRENT
+    .. py:attribute:: nidmm.Function.AC_CURRENT
 
 
 
@@ -384,7 +384,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _2_WIRE_RESISTANCE
+    .. py:attribute:: nidmm.Function._2_WIRE_RESISTANCE
 
 
 
@@ -393,7 +393,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _4_WIRE_RESISTANCE
+    .. py:attribute:: nidmm.Function._4_WIRE_RESISTANCE
 
 
 
@@ -402,7 +402,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: FREQUENCY
+    .. py:attribute:: nidmm.Function.FREQUENCY
 
 
 
@@ -411,7 +411,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: PERIOD
+    .. py:attribute:: nidmm.Function.PERIOD
 
 
 
@@ -420,7 +420,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: TEMPERATURE
+    .. py:attribute:: nidmm.Function.TEMPERATURE
 
 
 
@@ -429,7 +429,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _AC_VOLTS_DC_COUPLED
+    .. py:attribute:: nidmm.Function._AC_VOLTS_DC_COUPLED
 
 
 
@@ -438,7 +438,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: DIODE
+    .. py:attribute:: nidmm.Function.DIODE
 
 
 
@@ -447,7 +447,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: WAVEFORM_VOLTAGE
+    .. py:attribute:: nidmm.Function.WAVEFORM_VOLTAGE
 
 
 
@@ -456,7 +456,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _WAVEFORM_CURRENT
+    .. py:attribute:: nidmm.Function._WAVEFORM_CURRENT
 
 
 
@@ -465,7 +465,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: CAPACITANCE
+    .. py:attribute:: nidmm.Function.CAPACITANCE
 
 
 
@@ -474,7 +474,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: INDUCTANCE
+    .. py:attribute:: nidmm.Function.INDUCTANCE
 
 
 
@@ -486,7 +486,7 @@ Enums used in NI-DMM
 
 .. py:data:: InputResistance
 
-    .. py:attribute:: _1_M_OHM
+    .. py:attribute:: nidmm.InputResistance._1_M_OHM
 
 
 
@@ -495,7 +495,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _10_M_OHM
+    .. py:attribute:: nidmm.InputResistance._10_M_OHM
 
 
 
@@ -504,7 +504,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: GREATER_THAN_10_G_OHM
+    .. py:attribute:: nidmm.InputResistance.GREATER_THAN_10_G_OHM
 
 
 
@@ -516,7 +516,7 @@ Enums used in NI-DMM
 
 .. py:data:: LCCalculationModel
 
-    .. py:attribute:: AUTO
+    .. py:attribute:: nidmm.LCCalculationModel.AUTO
 
 
 
@@ -525,7 +525,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: SERIES
+    .. py:attribute:: nidmm.LCCalculationModel.SERIES
 
 
 
@@ -535,7 +535,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: PARALLEL
+    .. py:attribute:: nidmm.LCCalculationModel.PARALLEL
 
 
 
@@ -548,7 +548,7 @@ Enums used in NI-DMM
 
 .. py:data:: MeasurementCompleteDest
 
-    .. py:attribute:: NONE
+    .. py:attribute:: nidmm.MeasurementCompleteDest.NONE
 
 
 
@@ -557,7 +557,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: EXTERNAL
+    .. py:attribute:: nidmm.MeasurementCompleteDest.EXTERNAL
 
 
 
@@ -566,7 +566,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: TTL_0
+    .. py:attribute:: nidmm.MeasurementCompleteDest.TTL_0
 
 
 
@@ -575,7 +575,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: TTL_1
+    .. py:attribute:: nidmm.MeasurementCompleteDest.TTL_1
 
 
 
@@ -584,7 +584,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: TL_2
+    .. py:attribute:: nidmm.MeasurementCompleteDest.TL_2
 
 
 
@@ -593,7 +593,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: TTL_3
+    .. py:attribute:: nidmm.MeasurementCompleteDest.TTL_3
 
 
 
@@ -602,7 +602,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: TL_4
+    .. py:attribute:: nidmm.MeasurementCompleteDest.TL_4
 
 
 
@@ -611,7 +611,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: TTL_5
+    .. py:attribute:: nidmm.MeasurementCompleteDest.TTL_5
 
 
 
@@ -620,7 +620,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: TTL_6
+    .. py:attribute:: nidmm.MeasurementCompleteDest.TTL_6
 
 
 
@@ -629,7 +629,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: TTL_7
+    .. py:attribute:: nidmm.MeasurementCompleteDest.TTL_7
 
 
 
@@ -638,7 +638,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _LBR_TRIG_0
+    .. py:attribute:: nidmm.MeasurementCompleteDest._LBR_TRIG_0
 
 
 
@@ -650,7 +650,7 @@ Enums used in NI-DMM
 
 .. py:data:: MeasurementDestinationSlope
 
-    .. py:attribute:: POSITIVE
+    .. py:attribute:: nidmm.MeasurementDestinationSlope.POSITIVE
 
 
 
@@ -659,7 +659,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: NEGATIVE
+    .. py:attribute:: nidmm.MeasurementDestinationSlope.NEGATIVE
 
 
 
@@ -671,7 +671,7 @@ Enums used in NI-DMM
 
 .. py:data:: OffsetCompensatedOhms
 
-    .. py:attribute:: OFF
+    .. py:attribute:: nidmm.OffsetCompensatedOhms.OFF
 
 
 
@@ -680,7 +680,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: ON
+    .. py:attribute:: nidmm.OffsetCompensatedOhms.ON
 
 
 
@@ -692,7 +692,7 @@ Enums used in NI-DMM
 
 .. py:data:: OperationMode
 
-    .. py:attribute:: _IVIDMM_MODE
+    .. py:attribute:: nidmm.OperationMode._IVIDMM_MODE
 
 
 
@@ -704,7 +704,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: WAVEFORM_MODE
+    .. py:attribute:: nidmm.OperationMode.WAVEFORM_MODE
 
 
 
@@ -717,7 +717,7 @@ Enums used in NI-DMM
 
 .. py:data:: PowerlineFrequency
 
-    .. py:attribute:: _50_HZ
+    .. py:attribute:: nidmm.PowerlineFrequency._50_HZ
 
 
 
@@ -726,7 +726,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _60_HZ
+    .. py:attribute:: nidmm.PowerlineFrequency._60_HZ
 
 
 
@@ -738,7 +738,7 @@ Enums used in NI-DMM
 
 .. py:data:: RTDType
 
-    .. py:attribute:: CUSTOM
+    .. py:attribute:: nidmm.RTDType.CUSTOM
 
 
 
@@ -748,7 +748,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: PT_3750
+    .. py:attribute:: nidmm.RTDType.PT_3750
 
 
 
@@ -757,7 +757,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: PT_3851
+    .. py:attribute:: nidmm.RTDType.PT_3851
 
 
 
@@ -766,7 +766,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: PT_3911
+    .. py:attribute:: nidmm.RTDType.PT_3911
 
 
 
@@ -775,7 +775,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: PT_3916
+    .. py:attribute:: nidmm.RTDType.PT_3916
 
 
 
@@ -784,7 +784,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: PT_3920
+    .. py:attribute:: nidmm.RTDType.PT_3920
 
 
 
@@ -793,7 +793,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: PT_3928
+    .. py:attribute:: nidmm.RTDType.PT_3928
 
 
 
@@ -805,7 +805,7 @@ Enums used in NI-DMM
 
 .. py:data:: SampleTrigSlope
 
-    .. py:attribute:: POSITIVE
+    .. py:attribute:: nidmm.SampleTrigSlope.POSITIVE
 
 
 
@@ -814,7 +814,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: NEGATIVE
+    .. py:attribute:: nidmm.SampleTrigSlope.NEGATIVE
 
 
 
@@ -826,7 +826,7 @@ Enums used in NI-DMM
 
 .. py:data:: SampleTrigger
 
-    .. py:attribute:: IMMEDIATE
+    .. py:attribute:: nidmm.SampleTrigger.IMMEDIATE
 
 
 
@@ -835,7 +835,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _EXTERNAL
+    .. py:attribute:: nidmm.SampleTrigger._EXTERNAL
 
 
 
@@ -844,7 +844,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: SOFTWARE_TRIG
+    .. py:attribute:: nidmm.SampleTrigger.SOFTWARE_TRIG
 
 
 
@@ -854,7 +854,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: INTERVAL
+    .. py:attribute:: nidmm.SampleTrigger.INTERVAL
 
 
 
@@ -863,7 +863,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: TTL_0
+    .. py:attribute:: nidmm.SampleTrigger.TTL_0
 
 
 
@@ -872,7 +872,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: TTL_1
+    .. py:attribute:: nidmm.SampleTrigger.TTL_1
 
 
 
@@ -881,7 +881,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: TTL_2
+    .. py:attribute:: nidmm.SampleTrigger.TTL_2
 
 
 
@@ -890,7 +890,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _TTL_3
+    .. py:attribute:: nidmm.SampleTrigger._TTL_3
 
 
 
@@ -899,7 +899,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: TTL_4
+    .. py:attribute:: nidmm.SampleTrigger.TTL_4
 
 
 
@@ -908,7 +908,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: TTL_5
+    .. py:attribute:: nidmm.SampleTrigger.TTL_5
 
 
 
@@ -917,7 +917,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: TTL_6
+    .. py:attribute:: nidmm.SampleTrigger.TTL_6
 
 
 
@@ -926,7 +926,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: TTL_7
+    .. py:attribute:: nidmm.SampleTrigger.TTL_7
 
 
 
@@ -935,7 +935,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: PXI_STAR
+    .. py:attribute:: nidmm.SampleTrigger.PXI_STAR
 
 
 
@@ -944,7 +944,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: AUX_TRIG_1
+    .. py:attribute:: nidmm.SampleTrigger.AUX_TRIG_1
 
 
 
@@ -953,7 +953,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: LBR_TRIG_1
+    .. py:attribute:: nidmm.SampleTrigger.LBR_TRIG_1
 
 
 
@@ -965,7 +965,7 @@ Enums used in NI-DMM
 
 .. py:data:: ThermistorType
 
-    .. py:attribute:: CUSTOM
+    .. py:attribute:: nidmm.ThermistorType.CUSTOM
 
 
 
@@ -975,7 +975,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _44004
+    .. py:attribute:: nidmm.ThermistorType._44004
 
 
 
@@ -984,7 +984,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _44006
+    .. py:attribute:: nidmm.ThermistorType._44006
 
 
 
@@ -993,7 +993,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _44007
+    .. py:attribute:: nidmm.ThermistorType._44007
 
 
 
@@ -1005,7 +1005,7 @@ Enums used in NI-DMM
 
 .. py:data:: ThermocoupleReferenceJunctionType
 
-    .. py:attribute:: FIXED
+    .. py:attribute:: nidmm.ThermocoupleReferenceJunctionType.FIXED
 
 
 
@@ -1018,7 +1018,7 @@ Enums used in NI-DMM
 
 .. py:data:: ThermocoupleType
 
-    .. py:attribute:: B
+    .. py:attribute:: nidmm.ThermocoupleType.B
 
 
 
@@ -1027,7 +1027,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: E
+    .. py:attribute:: nidmm.ThermocoupleType.E
 
 
 
@@ -1036,7 +1036,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: J
+    .. py:attribute:: nidmm.ThermocoupleType.J
 
 
 
@@ -1045,7 +1045,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: K
+    .. py:attribute:: nidmm.ThermocoupleType.K
 
 
 
@@ -1054,7 +1054,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: N
+    .. py:attribute:: nidmm.ThermocoupleType.N
 
 
 
@@ -1063,7 +1063,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: R
+    .. py:attribute:: nidmm.ThermocoupleType.R
 
 
 
@@ -1072,7 +1072,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: S
+    .. py:attribute:: nidmm.ThermocoupleType.S
 
 
 
@@ -1081,7 +1081,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: T
+    .. py:attribute:: nidmm.ThermocoupleType.T
 
 
 
@@ -1093,7 +1093,7 @@ Enums used in NI-DMM
 
 .. py:data:: TransducerType
 
-    .. py:attribute:: THERMOCOUPLE
+    .. py:attribute:: nidmm.TransducerType.THERMOCOUPLE
 
 
 
@@ -1102,7 +1102,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: THERMISTOR
+    .. py:attribute:: nidmm.TransducerType.THERMISTOR
 
 
 
@@ -1111,7 +1111,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _2_WIRE_RTD
+    .. py:attribute:: nidmm.TransducerType._2_WIRE_RTD
 
 
 
@@ -1120,7 +1120,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _4_WIRE_RTD
+    .. py:attribute:: nidmm.TransducerType._4_WIRE_RTD
 
 
 
@@ -1132,7 +1132,7 @@ Enums used in NI-DMM
 
 .. py:data:: TriggerSlope
 
-    .. py:attribute:: POSITIVE
+    .. py:attribute:: nidmm.TriggerSlope.POSITIVE
 
 
 
@@ -1141,7 +1141,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: NEGATIVE
+    .. py:attribute:: nidmm.TriggerSlope.NEGATIVE
 
 
 
@@ -1153,7 +1153,7 @@ Enums used in NI-DMM
 
 .. py:data:: TriggerSource
 
-    .. py:attribute:: IMMEDIATE
+    .. py:attribute:: nidmm.TriggerSource.IMMEDIATE
 
 
 
@@ -1162,7 +1162,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: EXTERNAL
+    .. py:attribute:: nidmm.TriggerSource.EXTERNAL
 
 
 
@@ -1171,7 +1171,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: SOFTWARE_TRIG
+    .. py:attribute:: nidmm.TriggerSource.SOFTWARE_TRIG
 
 
 
@@ -1181,7 +1181,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _TTL_0
+    .. py:attribute:: nidmm.TriggerSource._TTL_0
 
 
 
@@ -1190,7 +1190,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: TTL_1
+    .. py:attribute:: nidmm.TriggerSource.TTL_1
 
 
 
@@ -1199,7 +1199,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: TTL_2
+    .. py:attribute:: nidmm.TriggerSource.TTL_2
 
 
 
@@ -1208,7 +1208,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _TTL_3
+    .. py:attribute:: nidmm.TriggerSource._TTL_3
 
 
 
@@ -1217,7 +1217,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: TTL_4
+    .. py:attribute:: nidmm.TriggerSource.TTL_4
 
 
 
@@ -1226,7 +1226,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: TTL_5
+    .. py:attribute:: nidmm.TriggerSource.TTL_5
 
 
 
@@ -1235,7 +1235,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: TTL_6
+    .. py:attribute:: nidmm.TriggerSource.TTL_6
 
 
 
@@ -1244,7 +1244,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _TTL_7
+    .. py:attribute:: nidmm.TriggerSource._TTL_7
 
 
 
@@ -1253,7 +1253,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: _PXI_STAR
+    .. py:attribute:: nidmm.TriggerSource._PXI_STAR
 
 
 
@@ -1262,7 +1262,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: AUX_TRIG_1
+    .. py:attribute:: nidmm.TriggerSource.AUX_TRIG_1
 
 
 
@@ -1271,7 +1271,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: LBR_TRIG_1
+    .. py:attribute:: nidmm.TriggerSource.LBR_TRIG_1
 
 
 
@@ -1283,7 +1283,7 @@ Enums used in NI-DMM
 
 .. py:data:: WaveformCoupling
 
-    .. py:attribute:: AC
+    .. py:attribute:: nidmm.WaveformCoupling.AC
 
 
 
@@ -1292,7 +1292,7 @@ Enums used in NI-DMM
         
 
 
-    .. py:attribute:: DC
+    .. py:attribute:: nidmm.WaveformCoupling.DC
 
 
 

--- a/docs/niswitch/enums.rst
+++ b/docs/niswitch/enums.rst
@@ -9,7 +9,7 @@ Enums used in NI-SWITCH
 
 .. py:data:: CabledModuleScanAdvancedBus
 
-    .. py:attribute:: NONE
+    .. py:attribute:: niswitch.CabledModuleScanAdvancedBus.NONE
 
 
 
@@ -18,7 +18,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG0
+    .. py:attribute:: niswitch.CabledModuleScanAdvancedBus.PXI_TRIG0
 
 
 
@@ -28,7 +28,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG1
+    .. py:attribute:: niswitch.CabledModuleScanAdvancedBus.PXI_TRIG1
 
 
 
@@ -38,7 +38,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG2
+    .. py:attribute:: niswitch.CabledModuleScanAdvancedBus.PXI_TRIG2
 
 
 
@@ -48,7 +48,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG3
+    .. py:attribute:: niswitch.CabledModuleScanAdvancedBus.PXI_TRIG3
 
 
 
@@ -58,7 +58,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG4
+    .. py:attribute:: niswitch.CabledModuleScanAdvancedBus.PXI_TRIG4
 
 
 
@@ -68,7 +68,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG5
+    .. py:attribute:: niswitch.CabledModuleScanAdvancedBus.PXI_TRIG5
 
 
 
@@ -78,7 +78,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG6
+    .. py:attribute:: niswitch.CabledModuleScanAdvancedBus.PXI_TRIG6
 
 
 
@@ -88,7 +88,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG7
+    .. py:attribute:: niswitch.CabledModuleScanAdvancedBus.PXI_TRIG7
 
 
 
@@ -101,7 +101,7 @@ Enums used in NI-SWITCH
 
 .. py:data:: CabledModuleTriggerBus
 
-    .. py:attribute:: NONE
+    .. py:attribute:: niswitch.CabledModuleTriggerBus.NONE
 
 
 
@@ -110,7 +110,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG0
+    .. py:attribute:: niswitch.CabledModuleTriggerBus.PXI_TRIG0
 
 
 
@@ -119,7 +119,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG1
+    .. py:attribute:: niswitch.CabledModuleTriggerBus.PXI_TRIG1
 
 
 
@@ -128,7 +128,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG2
+    .. py:attribute:: niswitch.CabledModuleTriggerBus.PXI_TRIG2
 
 
 
@@ -137,7 +137,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG3
+    .. py:attribute:: niswitch.CabledModuleTriggerBus.PXI_TRIG3
 
 
 
@@ -146,7 +146,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG4
+    .. py:attribute:: niswitch.CabledModuleTriggerBus.PXI_TRIG4
 
 
 
@@ -155,7 +155,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG5
+    .. py:attribute:: niswitch.CabledModuleTriggerBus.PXI_TRIG5
 
 
 
@@ -164,7 +164,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG6
+    .. py:attribute:: niswitch.CabledModuleTriggerBus.PXI_TRIG6
 
 
 
@@ -173,7 +173,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG7
+    .. py:attribute:: niswitch.CabledModuleTriggerBus.PXI_TRIG7
 
 
 
@@ -185,7 +185,7 @@ Enums used in NI-SWITCH
 
 .. py:data:: HandshakingInitiation
 
-    .. py:attribute:: MEASUREMENT_DEVICE_INITIATED
+    .. py:attribute:: niswitch.HandshakingInitiation.MEASUREMENT_DEVICE_INITIATED
 
 
 
@@ -204,7 +204,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: SWITCH_INITIATED
+    .. py:attribute:: niswitch.HandshakingInitiation.SWITCH_INITIATED
 
 
 
@@ -222,7 +222,7 @@ Enums used in NI-SWITCH
 
 .. py:data:: MasterSlaveScanAdvancedBus
 
-    .. py:attribute:: NONE
+    .. py:attribute:: niswitch.MasterSlaveScanAdvancedBus.NONE
 
 
 
@@ -231,7 +231,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG0
+    .. py:attribute:: niswitch.MasterSlaveScanAdvancedBus.PXI_TRIG0
 
 
 
@@ -241,7 +241,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG1
+    .. py:attribute:: niswitch.MasterSlaveScanAdvancedBus.PXI_TRIG1
 
 
 
@@ -251,7 +251,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG2
+    .. py:attribute:: niswitch.MasterSlaveScanAdvancedBus.PXI_TRIG2
 
 
 
@@ -261,7 +261,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG3
+    .. py:attribute:: niswitch.MasterSlaveScanAdvancedBus.PXI_TRIG3
 
 
 
@@ -271,7 +271,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG4
+    .. py:attribute:: niswitch.MasterSlaveScanAdvancedBus.PXI_TRIG4
 
 
 
@@ -281,7 +281,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG5
+    .. py:attribute:: niswitch.MasterSlaveScanAdvancedBus.PXI_TRIG5
 
 
 
@@ -291,7 +291,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG6
+    .. py:attribute:: niswitch.MasterSlaveScanAdvancedBus.PXI_TRIG6
 
 
 
@@ -301,7 +301,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG7
+    .. py:attribute:: niswitch.MasterSlaveScanAdvancedBus.PXI_TRIG7
 
 
 
@@ -314,7 +314,7 @@ Enums used in NI-SWITCH
 
 .. py:data:: MasterSlaveTriggerBus
 
-    .. py:attribute:: NONE
+    .. py:attribute:: niswitch.MasterSlaveTriggerBus.NONE
 
 
 
@@ -323,7 +323,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG0
+    .. py:attribute:: niswitch.MasterSlaveTriggerBus.PXI_TRIG0
 
 
 
@@ -333,7 +333,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG1
+    .. py:attribute:: niswitch.MasterSlaveTriggerBus.PXI_TRIG1
 
 
 
@@ -343,7 +343,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG2
+    .. py:attribute:: niswitch.MasterSlaveTriggerBus.PXI_TRIG2
 
 
 
@@ -353,7 +353,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG3
+    .. py:attribute:: niswitch.MasterSlaveTriggerBus.PXI_TRIG3
 
 
 
@@ -363,7 +363,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG4
+    .. py:attribute:: niswitch.MasterSlaveTriggerBus.PXI_TRIG4
 
 
 
@@ -373,7 +373,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG5
+    .. py:attribute:: niswitch.MasterSlaveTriggerBus.PXI_TRIG5
 
 
 
@@ -383,7 +383,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG6
+    .. py:attribute:: niswitch.MasterSlaveTriggerBus.PXI_TRIG6
 
 
 
@@ -393,7 +393,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG7
+    .. py:attribute:: niswitch.MasterSlaveTriggerBus.PXI_TRIG7
 
 
 
@@ -406,7 +406,7 @@ Enums used in NI-SWITCH
 
 .. py:data:: PathCapability
 
-    .. py:attribute:: PATH_AVAILABLE
+    .. py:attribute:: niswitch.PathCapability.PATH_AVAILABLE
 
 
 
@@ -415,7 +415,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PATH_EXISTS
+    .. py:attribute:: niswitch.PathCapability.PATH_EXISTS
 
 
 
@@ -424,7 +424,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PATH_UNSUPPORTED
+    .. py:attribute:: niswitch.PathCapability.PATH_UNSUPPORTED
 
 
 
@@ -433,7 +433,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: RESOURCE_IN_USE
+    .. py:attribute:: niswitch.PathCapability.RESOURCE_IN_USE
 
 
 
@@ -442,7 +442,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: SOURCE_CONFLICT
+    .. py:attribute:: niswitch.PathCapability.SOURCE_CONFLICT
 
 
 
@@ -451,7 +451,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: CHANNEL_NOT_AVAILABLE
+    .. py:attribute:: niswitch.PathCapability.CHANNEL_NOT_AVAILABLE
 
 
 
@@ -463,7 +463,7 @@ Enums used in NI-SWITCH
 
 .. py:data:: RelayAction
 
-    .. py:attribute:: OPEN_RELAY
+    .. py:attribute:: niswitch.RelayAction.OPEN_RELAY
 
 
 
@@ -472,7 +472,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: CLOSE_RELAY
+    .. py:attribute:: niswitch.RelayAction.CLOSE_RELAY
 
 
 
@@ -484,7 +484,7 @@ Enums used in NI-SWITCH
 
 .. py:data:: RelayPosition
 
-    .. py:attribute:: OPEN
+    .. py:attribute:: niswitch.RelayPosition.OPEN
 
 
 
@@ -493,7 +493,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: CLOSED
+    .. py:attribute:: niswitch.RelayPosition.CLOSED
 
 
 
@@ -505,7 +505,7 @@ Enums used in NI-SWITCH
 
 .. py:data:: ScanAdvancedOutput
 
-    .. py:attribute:: NONE
+    .. py:attribute:: niswitch.ScanAdvancedOutput.NONE
 
 
 
@@ -514,7 +514,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: EXTERNAL
+    .. py:attribute:: niswitch.ScanAdvancedOutput.EXTERNAL
 
 
 
@@ -524,7 +524,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG0
+    .. py:attribute:: niswitch.ScanAdvancedOutput.PXI_TRIG0
 
 
 
@@ -534,7 +534,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG1
+    .. py:attribute:: niswitch.ScanAdvancedOutput.PXI_TRIG1
 
 
 
@@ -544,7 +544,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG2
+    .. py:attribute:: niswitch.ScanAdvancedOutput.PXI_TRIG2
 
 
 
@@ -554,7 +554,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG3
+    .. py:attribute:: niswitch.ScanAdvancedOutput.PXI_TRIG3
 
 
 
@@ -564,7 +564,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG4
+    .. py:attribute:: niswitch.ScanAdvancedOutput.PXI_TRIG4
 
 
 
@@ -574,7 +574,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG5
+    .. py:attribute:: niswitch.ScanAdvancedOutput.PXI_TRIG5
 
 
 
@@ -584,7 +584,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG6
+    .. py:attribute:: niswitch.ScanAdvancedOutput.PXI_TRIG6
 
 
 
@@ -594,7 +594,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG7
+    .. py:attribute:: niswitch.ScanAdvancedOutput.PXI_TRIG7
 
 
 
@@ -604,7 +604,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_STAR
+    .. py:attribute:: niswitch.ScanAdvancedOutput.PXI_STAR
 
 
 
@@ -614,7 +614,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR
+    .. py:attribute:: niswitch.ScanAdvancedOutput.REARCONNECTOR
 
 
 
@@ -624,7 +624,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR
+    .. py:attribute:: niswitch.ScanAdvancedOutput.FRONTCONNECTOR
 
 
 
@@ -634,7 +634,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR_MODULE1
+    .. py:attribute:: niswitch.ScanAdvancedOutput.REARCONNECTOR_MODULE1
 
 
 
@@ -644,7 +644,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR_MODULE2
+    .. py:attribute:: niswitch.ScanAdvancedOutput.REARCONNECTOR_MODULE2
 
 
 
@@ -654,7 +654,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR_MODULE3
+    .. py:attribute:: niswitch.ScanAdvancedOutput.REARCONNECTOR_MODULE3
 
 
 
@@ -664,7 +664,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR_MODULE4
+    .. py:attribute:: niswitch.ScanAdvancedOutput.REARCONNECTOR_MODULE4
 
 
 
@@ -674,7 +674,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR_MODULE5
+    .. py:attribute:: niswitch.ScanAdvancedOutput.REARCONNECTOR_MODULE5
 
 
 
@@ -684,7 +684,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR_MODULE6
+    .. py:attribute:: niswitch.ScanAdvancedOutput.REARCONNECTOR_MODULE6
 
 
 
@@ -694,7 +694,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR_MODULE7
+    .. py:attribute:: niswitch.ScanAdvancedOutput.REARCONNECTOR_MODULE7
 
 
 
@@ -704,7 +704,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR_MODULE8
+    .. py:attribute:: niswitch.ScanAdvancedOutput.REARCONNECTOR_MODULE8
 
 
 
@@ -714,7 +714,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR_MODULE9
+    .. py:attribute:: niswitch.ScanAdvancedOutput.REARCONNECTOR_MODULE9
 
 
 
@@ -724,7 +724,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR_MODULE10
+    .. py:attribute:: niswitch.ScanAdvancedOutput.REARCONNECTOR_MODULE10
 
 
 
@@ -734,7 +734,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR_MODULE11
+    .. py:attribute:: niswitch.ScanAdvancedOutput.REARCONNECTOR_MODULE11
 
 
 
@@ -744,7 +744,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR_MODULE12
+    .. py:attribute:: niswitch.ScanAdvancedOutput.REARCONNECTOR_MODULE12
 
 
 
@@ -754,7 +754,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR_MODULE1
+    .. py:attribute:: niswitch.ScanAdvancedOutput.FRONTCONNECTOR_MODULE1
 
 
 
@@ -764,7 +764,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR_MODULE2
+    .. py:attribute:: niswitch.ScanAdvancedOutput.FRONTCONNECTOR_MODULE2
 
 
 
@@ -774,7 +774,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR_MODULE3
+    .. py:attribute:: niswitch.ScanAdvancedOutput.FRONTCONNECTOR_MODULE3
 
 
 
@@ -784,7 +784,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR_MODULE4
+    .. py:attribute:: niswitch.ScanAdvancedOutput.FRONTCONNECTOR_MODULE4
 
 
 
@@ -794,7 +794,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR_MODULE5
+    .. py:attribute:: niswitch.ScanAdvancedOutput.FRONTCONNECTOR_MODULE5
 
 
 
@@ -804,7 +804,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR_MODULE6
+    .. py:attribute:: niswitch.ScanAdvancedOutput.FRONTCONNECTOR_MODULE6
 
 
 
@@ -814,7 +814,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR_MODULE7
+    .. py:attribute:: niswitch.ScanAdvancedOutput.FRONTCONNECTOR_MODULE7
 
 
 
@@ -824,7 +824,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR_MODULE8
+    .. py:attribute:: niswitch.ScanAdvancedOutput.FRONTCONNECTOR_MODULE8
 
 
 
@@ -834,7 +834,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR_MODULE9
+    .. py:attribute:: niswitch.ScanAdvancedOutput.FRONTCONNECTOR_MODULE9
 
 
 
@@ -844,7 +844,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR_MODULE10
+    .. py:attribute:: niswitch.ScanAdvancedOutput.FRONTCONNECTOR_MODULE10
 
 
 
@@ -854,7 +854,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR_MODULE11
+    .. py:attribute:: niswitch.ScanAdvancedOutput.FRONTCONNECTOR_MODULE11
 
 
 
@@ -864,7 +864,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR_MODULE12
+    .. py:attribute:: niswitch.ScanAdvancedOutput.FRONTCONNECTOR_MODULE12
 
 
 
@@ -877,7 +877,7 @@ Enums used in NI-SWITCH
 
 .. py:data:: ScanAdvancedPolarity
 
-    .. py:attribute:: RISING_EDGE
+    .. py:attribute:: niswitch.ScanAdvancedPolarity.RISING_EDGE
 
 
 
@@ -886,7 +886,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FALLING_EDGE
+    .. py:attribute:: niswitch.ScanAdvancedPolarity.FALLING_EDGE
 
 
 
@@ -898,7 +898,7 @@ Enums used in NI-SWITCH
 
 .. py:data:: ScanMode
 
-    .. py:attribute:: NONE
+    .. py:attribute:: niswitch.ScanMode.NONE
 
 
 
@@ -907,7 +907,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: BREAK_BEFORE_MAKE
+    .. py:attribute:: niswitch.ScanMode.BREAK_BEFORE_MAKE
 
 
 
@@ -917,7 +917,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: BREAK_AFTER_MAKE
+    .. py:attribute:: niswitch.ScanMode.BREAK_AFTER_MAKE
 
 
 
@@ -930,7 +930,7 @@ Enums used in NI-SWITCH
 
 .. py:data:: TriggerInput
 
-    .. py:attribute:: IMMEDIATE
+    .. py:attribute:: niswitch.TriggerInput.IMMEDIATE
 
 
 
@@ -940,7 +940,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: EXTERNAL
+    .. py:attribute:: niswitch.TriggerInput.EXTERNAL
 
 
 
@@ -951,7 +951,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: SW_TRIG_FUNC
+    .. py:attribute:: niswitch.TriggerInput.SW_TRIG_FUNC
 
 
 
@@ -962,7 +962,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG0
+    .. py:attribute:: niswitch.TriggerInput.PXI_TRIG0
 
 
 
@@ -972,7 +972,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG1
+    .. py:attribute:: niswitch.TriggerInput.PXI_TRIG1
 
 
 
@@ -982,7 +982,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG2
+    .. py:attribute:: niswitch.TriggerInput.PXI_TRIG2
 
 
 
@@ -992,7 +992,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG3
+    .. py:attribute:: niswitch.TriggerInput.PXI_TRIG3
 
 
 
@@ -1002,7 +1002,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG4
+    .. py:attribute:: niswitch.TriggerInput.PXI_TRIG4
 
 
 
@@ -1012,7 +1012,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG5
+    .. py:attribute:: niswitch.TriggerInput.PXI_TRIG5
 
 
 
@@ -1022,7 +1022,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG6
+    .. py:attribute:: niswitch.TriggerInput.PXI_TRIG6
 
 
 
@@ -1032,7 +1032,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_TRIG7
+    .. py:attribute:: niswitch.TriggerInput.PXI_TRIG7
 
 
 
@@ -1042,7 +1042,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: PXI_STAR
+    .. py:attribute:: niswitch.TriggerInput.PXI_STAR
 
 
 
@@ -1052,7 +1052,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR
+    .. py:attribute:: niswitch.TriggerInput.REARCONNECTOR
 
 
 
@@ -1062,7 +1062,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR
+    .. py:attribute:: niswitch.TriggerInput.FRONTCONNECTOR
 
 
 
@@ -1072,7 +1072,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR_MODULE1
+    .. py:attribute:: niswitch.TriggerInput.REARCONNECTOR_MODULE1
 
 
 
@@ -1082,7 +1082,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR_MODULE2
+    .. py:attribute:: niswitch.TriggerInput.REARCONNECTOR_MODULE2
 
 
 
@@ -1092,7 +1092,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR_MODULE3
+    .. py:attribute:: niswitch.TriggerInput.REARCONNECTOR_MODULE3
 
 
 
@@ -1102,7 +1102,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR_MODULE4
+    .. py:attribute:: niswitch.TriggerInput.REARCONNECTOR_MODULE4
 
 
 
@@ -1112,7 +1112,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR_MODULE5
+    .. py:attribute:: niswitch.TriggerInput.REARCONNECTOR_MODULE5
 
 
 
@@ -1122,7 +1122,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR_MODULE6
+    .. py:attribute:: niswitch.TriggerInput.REARCONNECTOR_MODULE6
 
 
 
@@ -1132,7 +1132,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR_MODULE7
+    .. py:attribute:: niswitch.TriggerInput.REARCONNECTOR_MODULE7
 
 
 
@@ -1142,7 +1142,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR_MODULE8
+    .. py:attribute:: niswitch.TriggerInput.REARCONNECTOR_MODULE8
 
 
 
@@ -1152,7 +1152,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR_MODULE9
+    .. py:attribute:: niswitch.TriggerInput.REARCONNECTOR_MODULE9
 
 
 
@@ -1162,7 +1162,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR_MODULE10
+    .. py:attribute:: niswitch.TriggerInput.REARCONNECTOR_MODULE10
 
 
 
@@ -1172,7 +1172,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR_MODULE11
+    .. py:attribute:: niswitch.TriggerInput.REARCONNECTOR_MODULE11
 
 
 
@@ -1182,7 +1182,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: REARCONNECTOR_MODULE12
+    .. py:attribute:: niswitch.TriggerInput.REARCONNECTOR_MODULE12
 
 
 
@@ -1192,7 +1192,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR_MODULE1
+    .. py:attribute:: niswitch.TriggerInput.FRONTCONNECTOR_MODULE1
 
 
 
@@ -1202,7 +1202,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR_MODULE2
+    .. py:attribute:: niswitch.TriggerInput.FRONTCONNECTOR_MODULE2
 
 
 
@@ -1212,7 +1212,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR_MODULE3
+    .. py:attribute:: niswitch.TriggerInput.FRONTCONNECTOR_MODULE3
 
 
 
@@ -1222,7 +1222,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR_MODULE4
+    .. py:attribute:: niswitch.TriggerInput.FRONTCONNECTOR_MODULE4
 
 
 
@@ -1232,7 +1232,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR_MODULE5
+    .. py:attribute:: niswitch.TriggerInput.FRONTCONNECTOR_MODULE5
 
 
 
@@ -1242,7 +1242,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR_MODULE6
+    .. py:attribute:: niswitch.TriggerInput.FRONTCONNECTOR_MODULE6
 
 
 
@@ -1252,7 +1252,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR_MODULE7
+    .. py:attribute:: niswitch.TriggerInput.FRONTCONNECTOR_MODULE7
 
 
 
@@ -1262,7 +1262,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR_MODULE8
+    .. py:attribute:: niswitch.TriggerInput.FRONTCONNECTOR_MODULE8
 
 
 
@@ -1272,7 +1272,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR_MODULE9
+    .. py:attribute:: niswitch.TriggerInput.FRONTCONNECTOR_MODULE9
 
 
 
@@ -1282,7 +1282,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR_MODULE10
+    .. py:attribute:: niswitch.TriggerInput.FRONTCONNECTOR_MODULE10
 
 
 
@@ -1292,7 +1292,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR_MODULE11
+    .. py:attribute:: niswitch.TriggerInput.FRONTCONNECTOR_MODULE11
 
 
 
@@ -1302,7 +1302,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FRONTCONNECTOR_MODULE12
+    .. py:attribute:: niswitch.TriggerInput.FRONTCONNECTOR_MODULE12
 
 
 
@@ -1315,7 +1315,7 @@ Enums used in NI-SWITCH
 
 .. py:data:: TriggerInputPolarity
 
-    .. py:attribute:: RISING_EDGE
+    .. py:attribute:: niswitch.TriggerInputPolarity.RISING_EDGE
 
 
 
@@ -1324,7 +1324,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: FALLING_EDGE
+    .. py:attribute:: niswitch.TriggerInputPolarity.FALLING_EDGE
 
 
 
@@ -1336,7 +1336,7 @@ Enums used in NI-SWITCH
 
 .. py:data:: TriggerMode
 
-    .. py:attribute:: SINGLE
+    .. py:attribute:: niswitch.TriggerMode.SINGLE
 
 
 
@@ -1345,7 +1345,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: MASTER
+    .. py:attribute:: niswitch.TriggerMode.MASTER
 
 
 
@@ -1354,7 +1354,7 @@ Enums used in NI-SWITCH
         
 
 
-    .. py:attribute:: SLAVE
+    .. py:attribute:: niswitch.TriggerMode.SLAVE
 
 
 


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/<reponame>/blob/master/CONTRIBUTING.md).
[X] I've updated [CHANGELOG.md](https://github.com/ni/<reponame>/blob/master/CHANGELOG.md) if applicable.
### What does this Pull Request accomplish?
* Make the enum value name in documentation fully qualified
  * This allows easy copy/paste 
### List issues fixed by this Pull Request below, if any.
* Fix #395 

### What testing has been done?
* Travis
* System tests
* Visual inspection of generated documentation