### PR TITLE
Improve RST unit tests

### DIFF
--- a/build/helper/documentation_helper.py
+++ b/build/helper/documentation_helper.py
@@ -470,9 +470,19 @@ def as_rest_table(data, header=True):
 
 # Unit Tests
 
+
 def _remove_trailing_whitespace(s):
-    '''Removes trailing whitespace in multi-line strings. https://stackoverflow.com/a/17350806/316875'''
+    '''Removes trailing whitespace and empty lines in multi-line strings. https://stackoverflow.com/a/17350806/316875'''
     return re.sub(r'\s+$', '', s, flags=re.M)
+
+
+def assert_rst_strings_are_equal(expected, actual):
+    '''Asserts rst formatted strings (multiline) are equal. Ignores trailing whitespace and empty lines.'''
+    expected = _remove_trailing_whitespace(expected).splitlines()
+    actual = _remove_trailing_whitespace(actual).splitlines()
+    assert len(expected) == len(actual), 'Strings have different number of non-empty lines.'
+    for expected_line, actual_line in zip(expected, actual):
+        assert expected_line == actual_line, 'Difference found:\n{0}\n{1}'.format(expected_line, actual_line)
 
 
 config = {
@@ -604,7 +614,7 @@ def test_get_function_rst():
 
     Returns the **ID** of selected Turtle Type.
 
-    
+
 
     .. note:: The RAPHAEL Turtles dont have an ID.
 
@@ -635,7 +645,7 @@ def test_get_function_rst():
 
             Returns the **ID** of selected turtle.
 
-            
+
 ''' # noqa
     assert_rst_strings_are_equal(actual_function_rst, expected_fuction_rst)
 
@@ -664,7 +674,7 @@ Args:
 
 Returns:
     turtle_id (float): Returns the **ID** of selected turtle.''' # noqa
-    assert expected_function_docstring == actual_function_docstring
+    assert_rst_strings_are_equal(expected_function_docstring, actual_function_docstring)
 
 
 def test_get_rst_header_snippet():
@@ -707,4 +717,4 @@ at maximum size I can handle"""
     +-------+-------------------------+---------------------------+
     | ipsum | this is a random strinf | Yes, I am a random string |
     +-------+-------------------------+---------------------------+""" # noqa
-    assert expected_documentation == actual_documentation
+    assert_rst_strings_are_equal(expected_documentation, actual_documentation)

--- a/build/helper/documentation_helper.py
+++ b/build/helper/documentation_helper.py
@@ -469,6 +469,12 @@ def as_rest_table(data, header=True):
 
 
 # Unit Tests
+
+def _remove_trailing_whitespace(s):
+    '''Removes trailing whitespace in multi-line strings. https://stackoverflow.com/a/17350806/316875'''
+    return re.sub(r'\s+$', '', s, flags=re.M)
+
+
 config = {
     'functions': {
         'GetTurtleID': {
@@ -631,7 +637,7 @@ def test_get_function_rst():
 
             
 ''' # noqa
-    assert actual_function_rst == expected_fuction_rst
+    assert _remove_trailing_whitespace(actual_function_rst) == _remove_trailing_whitespace(expected_fuction_rst)
 
 
 def test_get_function_docstring():

--- a/build/helper/documentation_helper.py
+++ b/build/helper/documentation_helper.py
@@ -122,6 +122,7 @@ def get_documentation_for_node_rst(node, config, indent=0):
     nd = node['documentation']
     doc += get_rst_admonition_snippet('caution', nd, config, indent)
     if 'description' in nd:
+        doc += '\n\n' + (' ' * indent) + get_indented_docstring_snippet(_fix_references(nd['description'], config, make_link=True), indent)
 
     doc += '\n\n' + (' ' * indent) + _get_rst_table_snippet(nd, config, indent)
     doc += get_rst_admonition_snippet('note', nd, config, indent)


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~

### What does this Pull Request accomplish?

* Makes string comparison in unit test pass when the strings differ only by trailing whitespace (RST doesn't care)
* Makes sting comparison in unit test pass when there are different blank strings (RST doesn't care)
* Improves errors in the assertions.

### List issues fixed by this Pull Request below, if any.

* Fix #442 

### What testing has been done?

tox
Made a test fail, looked at output.