### PR TITLE
Add 'len' mechanism for buffers 

### DIFF
--- a/build/helper/__init__.py
+++ b/build/helper/__init__.py
@@ -24,6 +24,7 @@ from build.helper.metadata_filters import filter_codegen_functions  # noqa: F401
 from build.helper.metadata_filters import filter_enum_parameters  # noqa: F401
 from build.helper.metadata_filters import filter_input_parameters  # noqa: F401
 from build.helper.metadata_filters import filter_ivi_dance_parameter  # noqa: F401
+from build.helper.metadata_filters import filter_len_parameter  # noqa: F401
 from build.helper.metadata_filters import filter_output_parameters  # noqa: F401
 
 from build.helper.metadata_find import find_size_parameter  # noqa: F401

--- a/build/helper/codegen_helper.py
+++ b/build/helper/codegen_helper.py
@@ -1,4 +1,5 @@
 from .metadata_filters import filter_ivi_dance_parameter
+from .metadata_filters import filter_len_parameter
 from .metadata_find import find_size_parameter
 from enum import Enum
 import pprint
@@ -33,7 +34,7 @@ _parameterUsageOptions[ParameterUsageOptions.SESSION_METHOD_DECLARATION] = {
     'skip_session_handle': True,
     'skip_input_parameters': False,
     'skip_output_parameters': True,
-    'skip_ivi_dance_size_parameter': True,
+    'skip_size_parameter': True,
     'reordered_for_default_values': True,
     'name_to_use': 'python_name_with_default',
     'skip_repeated_capability_parameter': True,
@@ -43,7 +44,7 @@ _parameterUsageOptions[ParameterUsageOptions.SESSION_METHOD_CALL] = {
     'skip_session_handle': True,
     'skip_input_parameters': False,
     'skip_output_parameters': True,
-    'skip_ivi_dance_size_parameter': True,
+    'skip_size_parameter': True,
     'reordered_for_default_values': True,
     'name_to_use': 'python_name',
     'skip_repeated_capability_parameter': True,
@@ -53,7 +54,7 @@ _parameterUsageOptions[ParameterUsageOptions.DOCUMENTATION_SESSION_METHOD] = {
     'skip_session_handle': True,
     'skip_input_parameters': False,
     'skip_output_parameters': True,
-    'skip_ivi_dance_size_parameter': True,
+    'skip_size_parameter': True,
     'reordered_for_default_values': True,
     'name_to_use': 'python_name_with_doc_default',
     'skip_repeated_capability_parameter': True,
@@ -63,7 +64,7 @@ _parameterUsageOptions[ParameterUsageOptions.CTYPES_CALL] = {
     'skip_session_handle': False,
     'skip_input_parameters': False,
     'skip_output_parameters': False,
-    'skip_ivi_dance_size_parameter': False,
+    'skip_size_parameter': False,
     'reordered_for_default_values': False,
     'name_to_use': 'python_name',
     'skip_repeated_capability_parameter': False,
@@ -73,7 +74,7 @@ _parameterUsageOptions[ParameterUsageOptions.LIBRARY_METHOD_CALL] = {
     'skip_session_handle': False,
     'skip_input_parameters': False,
     'skip_output_parameters': False,
-    'skip_ivi_dance_size_parameter': False,
+    'skip_size_parameter': False,
     'reordered_for_default_values': False,
     'name_to_use': 'library_method_call_snippet',
     'skip_repeated_capability_parameter': False,
@@ -83,7 +84,7 @@ _parameterUsageOptions[ParameterUsageOptions.CTYPES_ARGTYPES] = {
     'skip_session_handle': False,
     'skip_input_parameters': False,
     'skip_output_parameters': False,
-    'skip_ivi_dance_size_parameter': False,
+    'skip_size_parameter': False,
     'reordered_for_default_values': False,
     'name_to_use': 'ctypes_type_library_call',
     'skip_repeated_capability_parameter': False,
@@ -93,7 +94,7 @@ _parameterUsageOptions[ParameterUsageOptions.LIBRARY_METHOD_DECLARATION] = {
     'skip_session_handle': False,
     'skip_input_parameters': False,
     'skip_output_parameters': False,
-    'skip_ivi_dance_size_parameter': False,
+    'skip_size_parameter': False,
     'reordered_for_default_values': False,
     'name_to_use': 'python_name',
     'skip_repeated_capability_parameter': False,
@@ -113,14 +114,17 @@ def filter_parameters(function, parameter_usage_options):
     parameters_to_use = []
 
     # Filter based on options
-    ivi_dance_size_parameter = find_size_parameter(filter_ivi_dance_parameter(function['parameters']), function['parameters'])
+    # Find the size parameter - we are assuming there can only be one, eother from mechanism == 'ivi-dance' or mechanism == 'len'
+    size_parameter = find_size_parameter(filter_ivi_dance_parameter(function['parameters']), function['parameters'])
+    if size_parameter is None:
+        size_parameter = find_size_parameter(filter_len_parameter(function['parameters']), function['parameters'])
     for x in function['parameters']:
         skip = False
         if x['direction'] == 'out' and options_to_use['skip_output_parameters']:
             skip = True
         if x['direction'] == 'in' and options_to_use['skip_input_parameters']:
             skip = True
-        if x == ivi_dance_size_parameter and options_to_use['skip_ivi_dance_size_parameter']:
+        if x == size_parameter and options_to_use['skip_size_parameter']:
             skip = True
         if x['is_session_handle'] is True and options_to_use['skip_session_handle']:
             skip = True

--- a/build/helper/codegen_helper.py
+++ b/build/helper/codegen_helper.py
@@ -114,7 +114,7 @@ def filter_parameters(function, parameter_usage_options):
     parameters_to_use = []
 
     # Filter based on options
-    # Find the size parameter - we are assuming there can only be one, eother from mechanism == 'ivi-dance' or mechanism == 'len'
+    # Find the size parameter - we are assuming there can only be one, other from mechanism == 'ivi-dance' or mechanism == 'len'
     size_parameter = find_size_parameter(filter_ivi_dance_parameter(function['parameters']), function['parameters'])
     if size_parameter is None:
         size_parameter = find_size_parameter(filter_len_parameter(function['parameters']), function['parameters'])

--- a/build/helper/metadata_filters.py
+++ b/build/helper/metadata_filters.py
@@ -21,15 +21,25 @@ def filter_enum_parameters(parameters):
     return [x for x in parameters if x['enum'] is not None]
 
 
-def filter_ivi_dance_parameter(parameters):
-    '''Returns the ivi-dance parameter of a session method if there is one. This is the parameter whose size is determined at runtime.'''
-    param = [x for x in parameters if x['size']['mechanism'] == 'ivi-dance']
-    assert len(param) <= 1, '{0} ivi-dance parameters. No more than one is allowed'.format(len(param))
+def filter_size_parameter(parameters, mechanism, direction=None):
+    param = [x for x in parameters if x['size']['mechanism'] == mechanism]
+    assert len(param) <= 1, '{0} {1} parameters. No more than one is allowed'.format(len(param), mechanism)
     if len(param) == 0:
         return None
-    assert param[0]['direction'] == 'out', "ivi-dance parameter must have 'direction':'out'. Check your metadata."
-    assert param[0]['is_buffer'], "ivi-dance parameter must have 'is_buffer':True. Check your metadata."
+    if direction is not None:
+        assert param[0]['direction'] == direction, "{0} parameter must have 'direction':'out'. Check your metadata.".format(mechanism)
+    assert param[0]['is_buffer'], "{0} parameter must have 'is_buffer':True. Check your metadata.".format(mechanism)
     return param[0]
+
+
+def filter_ivi_dance_parameter(parameters):
+    '''Returns the ivi-dance parameter of a session method if there is one. This is the parameter whose size is determined at runtime.'''
+    return filter_size_parameter(parameters, 'ivi-dance', 'out')
+
+
+def filter_len_parameter(parameters):
+    '''Returns the len parameter of a session method if there is one. This is the parameter whose size is determined at runtime.'''
+    return filter_size_parameter(parameters, 'len')
 
 
 

--- a/build/helper/metadata_filters.py
+++ b/build/helper/metadata_filters.py
@@ -21,25 +21,35 @@ def filter_enum_parameters(parameters):
     return [x for x in parameters if x['enum'] is not None]
 
 
-def filter_size_parameter(parameters, mechanism, direction=None):
+def _filter_size_parameter(parameters, mechanism, direction):
+    '''Returns the parameter what matches the given mechanism
+
+    Args:
+        paramaters: Parameters from function
+        mechanism: which mechanism we are looking for
+        direction: optional, will be used to verify the direction of the found parameter
+
+    Returns:
+        Parameter that matches the mechanism
+    '''
     param = [x for x in parameters if x['size']['mechanism'] == mechanism]
     assert len(param) <= 1, '{0} {1} parameters. No more than one is allowed'.format(len(param), mechanism)
     if len(param) == 0:
         return None
     if direction is not None:
-        assert param[0]['direction'] == direction, "{0} parameter must have 'direction':'out'. Check your metadata.".format(mechanism)
+        assert param[0]['direction'] == direction, "{0} parameter must have 'direction':'{1}'. Check your metadata.".format(mechanism, direction)
     assert param[0]['is_buffer'], "{0} parameter must have 'is_buffer':True. Check your metadata.".format(mechanism)
     return param[0]
 
 
 def filter_ivi_dance_parameter(parameters):
     '''Returns the ivi-dance parameter of a session method if there is one. This is the parameter whose size is determined at runtime.'''
-    return filter_size_parameter(parameters, 'ivi-dance', 'out')
+    return _filter_size_parameter(parameters, 'ivi-dance', 'out')
 
 
 def filter_len_parameter(parameters):
     '''Returns the len parameter of a session method if there is one. This is the parameter whose size is determined at runtime.'''
-    return filter_size_parameter(parameters, 'len')
+    return _filter_size_parameter(parameters, 'len', 'in')
 
 
 

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -32,6 +32,7 @@ ${encoding_tag}
     ivi_dance_size_parameter = helper.find_size_parameter(ivi_dance_parameter, parameters)
     len_parameter = helper.filter_len_parameter(parameters)
     len_size_parameter = helper.find_size_parameter(len_parameter, parameters)
+    assert ivi_dance_size_parameter is None or len_size_parameter is None
 %>\
     def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
         '''${f['python_name']}

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -52,6 +52,8 @@ ${encoding_tag}
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=${f['is_error_handling']})
         ${ivi_dance_size_parameter['python_name']} = error_code
         ${ivi_dance_parameter['ctypes_variable_name']} = (visatype.${ivi_dance_parameter['ctypes_type']} * ${ivi_dance_size_parameter['python_name']})()
+% elif len_parameter is not None:
+        ${len_size_parameter['python_name']} = len(${len_parameter['python_name']})
 % endif
         error_code = self._library.${c_function_prefix}${f['name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.LIBRARY_METHOD_CALL)})
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=${f['is_error_handling']})

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -30,6 +30,8 @@ ${encoding_tag}
     enum_input_parameters = helper.filter_enum_parameters(helper.filter_input_parameters(parameters))
     ivi_dance_parameter = helper.filter_ivi_dance_parameter(parameters)
     ivi_dance_size_parameter = helper.find_size_parameter(ivi_dance_parameter, parameters)
+    len_parameter = helper.filter_len_parameter(parameters)
+    len_size_parameter = helper.find_size_parameter(len_parameter, parameters)
 %>\
     def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
         '''${f['python_name']}

--- a/generated/nifake/session.py
+++ b/generated/nifake/session.py
@@ -285,7 +285,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def array_input_function(self, number_of_elements, an_array):
+    def array_input_function(self, an_array):
         '''array_input_function
 
         This function takes an array parameter.
@@ -294,6 +294,7 @@ class Session(_SessionBase):
             number_of_elements (int): Number of elements in the array.
             an_array (list of float): Contains an array of float numbers
         '''
+        number_of_elements = len(an_array)
         error_code = self._library.niFake_ArrayInputFunction(self._vi, number_of_elements, an_array)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return

--- a/generated/nifake/tests/test_session.py
+++ b/generated/nifake/tests/test_session.py
@@ -582,5 +582,5 @@ class TestSession(object):
         test_array_size = len(test_array)
         self.patched_library.niFake_ArrayInputFunction.side_effect = self.side_effects_helper.niFake_ArrayInputFunction
         with nifake.Session('dev1') as session:
-            session.array_input_function(test_array_size, test_array)
+            session.array_input_function(test_array)
             self.patched_library.niFake_ArrayInputFunction.assert_called_once_with(SESSION_NUM_FOR_TEST, test_array_size, test_array)

--- a/src/nifake/metadata/functions_addon.py
+++ b/src/nifake/metadata/functions_addon.py
@@ -47,7 +47,7 @@ functions_buffer_info = {
                                                                3: { 'is_buffer': True, }, }, },
     '.etAttribute.+':                        { 'parameters': { 1: { 'is_buffer': True, }, }, },
     'error_message':                         { 'parameters': { 2: { 'size': {'mechanism':'fixed', 'value':256}, }, }, }, # From documentation
-    'ArrayInputFunction':                    { 'parameters': { 2: { 'size': {'mechanism':'passed-in', 'value':'numberOfElements'}, }, }, },
+    'ArrayInputFunction':                    { 'parameters': { 2: { 'size': {'mechanism':'len', 'value':'numberOfElements'}, }, }, },
 }
 
 # These are functions we mark as "error_handling":True. The generator uses this information to

--- a/src/nifake/tests/test_session.py
+++ b/src/nifake/tests/test_session.py
@@ -582,5 +582,5 @@ class TestSession(object):
         test_array_size = len(test_array)
         self.patched_library.niFake_ArrayInputFunction.side_effect = self.side_effects_helper.niFake_ArrayInputFunction
         with nifake.Session('dev1') as session:
-            session.array_input_function(test_array_size, test_array)
+            session.array_input_function(test_array)
             self.patched_library.niFake_ArrayInputFunction.assert_called_once_with(SESSION_NUM_FOR_TEST, test_array_size, test_array)


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
~~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
### What does this Pull Request accomplish?
* Add 'len' mechanism for buffer length code generation
  * metadata looks like
    ```
        'ArrayInputFunction': { 'parameters': { 2: { 'size': {'mechanism':'len', 'value':'numberOfElements'}, }, }, },
    ```
  * This mechanism will set the size parameter to the length of the buffer parameter
* Created new filter function
  * Moved common filter code into shared function
* Changed 'skip_ivi_dance_size_parameter' to 'skip_size_parameter' in `ParameterUsageOptions`
  * More generic
### List issues fixed by this Pull Request below, if any.
* Fix #440 

### What testing has been done?
* Travis
* System tests