### PR TITLE
Moving todos and functions to relevant category in unit test file.

### DIFF
--- a/generated/nifake/tests/test_session.py
+++ b/generated/nifake/tests/test_session.py
@@ -72,14 +72,14 @@ class TestSession(object):
         session.close()
         self.patched_library.niFake_close.assert_called_once_with(SESSION_NUM_FOR_TEST)
 
-    # TODO(marcoskirsch): This should test that when close errors it raises.
-    # def test_close_errors(self):
-
     def test_session_context_manager(self):
         with nifake.Session('dev1') as session:
             assert type(session) == nifake.Session
             self.patched_library.niFake_InitWithOptions.assert_called_once_with(b'dev1', 0, False, b'', ANY)
         self.patched_library.niFake_close.assert_called_once_with(SESSION_NUM_FOR_TEST)
+
+    # TODO(marcoskirsch): This should test that when close errors it raises.
+    # def test_close_errors(self):
 
     # TODO(marcoskirsch): This should test that when init errors it raises.
     # def test_session_context_manager_error_on_init
@@ -135,9 +135,6 @@ class TestSession(object):
             assert isinstance(test_result, int)
             assert test_result == test_number
             self.patched_library.niFake_GetANumber.assert_called_once_with(SESSION_NUM_FOR_TEST, ANY)
-
-    # TODO(marcoskirsch):
-    # def test_multiple_outputs of different types
 
     def test_invalid_method_call_not_enough_parameters(self):
         self.patched_library.niFake_GetAStringWithSpecifiedMaximumSize.side_effect = self.side_effects_helper.niFake_GetAStringWithSpecifiedMaximumSize
@@ -216,41 +213,6 @@ class TestSession(object):
             self.patched_library.niFake_Abort.assert_called_once_with(SESSION_NUM_FOR_TEST)
         self.patched_library.niFake_close.assert_called_once_with(SESSION_NUM_FOR_TEST)
 
-    def test_cannot_add_properties_to_session(self):
-        with nifake.Session('dev1') as session:
-            try:
-                session.nonexistent_property = 5
-                assert False
-            except TypeError as e:
-                pass
-            try:
-                value = session.nonexistent_property  # noqa: F841
-                assert False
-            except AttributeError as e:
-                pass
-
-    # Retrieving buffers and strings
-
-    # TODO(marcoskirsch):
-    # def test_get_string_ivi_dance(self)
-
-    def test_get_string_ivi_dance_error(self):
-        test_error_code = -1234
-        test_error_desc = "ascending order"
-        self.patched_library.niFake_GetAttributeViString.side_effect = self.side_effects_helper.niFake_GetAttributeViString
-        self.side_effects_helper['GetAttributeViString']['attributeValue'] = 'Testing is fun?'
-        self.side_effects_helper['GetAttributeViString']['return'] = test_error_code
-        self.patched_library.niFake_GetError.side_effect = self.side_effects_helper.niFake_GetError
-        self.side_effects_helper['GetError']['errorCode'] = test_error_code
-        self.side_effects_helper['GetError']['description'] = test_error_desc
-        with nifake.Session('dev1') as session:
-            try:
-                session.read_write_string
-                assert False
-            except nifake.Error as e:
-                assert e.code == test_error_code
-                assert e.description == test_error_desc
-
     def test_single_point_read(self):
         test_maximum_time = 10
         test_reading = 5
@@ -271,7 +233,119 @@ class TestSession(object):
         with nifake.Session('dev1') as session:
             assert math.isnan(session.read(test_maximum_time))
 
-    # TODO(marcoskirsch): Other variations: multi-point/waveform with ViReal64 and ViInt16 * 3 mechanisms
+    def test_enum_input_function_with_defaults(self):
+        test_turtle = nifake.Turtle.DONATELLO
+        self.patched_library.niFake_EnumInputFunctionWithDefaults.side_effect = self.side_effects_helper.niFake_EnumInputFunctionWithDefaults
+        with nifake.Session('dev1') as session:
+            session.enum_input_function_with_defaults()
+            session.enum_input_function_with_defaults(test_turtle)
+            from mock import call
+            calls = [call(SESSION_NUM_FOR_TEST, 0), call(SESSION_NUM_FOR_TEST, 1)]  # 0 is the value of the default of nifake.Turtle.LEONARDO, 1 is the value of nifake.Turtle.DONATELLO
+            self.patched_library.niFake_EnumInputFunctionWithDefaults.assert_has_calls(calls)
+
+    def test_multipoint_read(self):
+        test_maximum_time = 1000
+        test_reading_array = [1.0, 0.1, 42, .42]
+        test_actual_number_of_points = len(test_reading_array)
+        self.patched_library.niFake_ReadMultiPoint.side_effect = self.side_effects_helper.niFake_ReadMultiPoint
+        self.side_effects_helper['ReadMultiPoint']['readingArray'] = test_reading_array
+        self.side_effects_helper['ReadMultiPoint']['actualNumberOfPoints'] = test_actual_number_of_points
+        with nifake.Session('dev1') as session:
+            measurements, points = session.read_multi_point(test_maximum_time, len(test_reading_array))
+            assert len(measurements) == test_actual_number_of_points
+            assert points == test_actual_number_of_points
+            assert measurements == test_reading_array
+            from mock import call
+            calls = [call(SESSION_NUM_FOR_TEST, test_maximum_time, len(test_reading_array), ANY, ANY)]
+            self.patched_library.niFake_ReadMultiPoint.assert_has_calls(calls)
+            assert self.patched_library.niFake_ReadMultiPoint.call_count == 1
+
+    def test_array_input_function(self):
+        test_array = [1, 2, 3, 4]
+        test_array_size = len(test_array)
+        self.patched_library.niFake_ArrayInputFunction.side_effect = self.side_effects_helper.niFake_ArrayInputFunction
+        with nifake.Session('dev1') as session:
+            session.array_input_function(test_array)
+            self.patched_library.niFake_ArrayInputFunction.assert_called_once_with(SESSION_NUM_FOR_TEST, test_array_size, test_array)
+
+    '''
+    # TODO(bhaswath): Enable test once issue 320 is fixed
+    def test_read_with_warning(self):
+        test_maximum_time = 10
+        test_reading = float('nan')
+        test_error_code = 42
+        test_error_desc = "The answer to the ultimate question, only positive"
+        self.patched_library.niFake_Read.side_effect = self.side_effects_helper.niFake_Read
+        self.side_effects_helper['Read']['return'] = test_error_code
+        self.side_effects_helper['Read']['reading'] = test_reading
+        self.patched_library.niFake_GetError.side_effect = self.side_effects_helper.niFake_GetError
+        self.side_effects_helper['GetError']['errorCode'] = test_error_code
+        self.side_effects_helper['GetError']['description'] = test_error_desc
+        with nifake.Session('dev1') as session:
+            with warnings.catch_warnings(record=True) as w:
+                assert test_reading == session.read(test_maximum_time)
+                assert len(w) == 1
+                assert issubclass(w[0].category, nifake.NifakeWarning)
+                assert test_error_desc in str(w[0].message)
+    '''
+
+    # TODO(marcoskirsch): Other read variations: waveform with ViReal64 and ViInt16 * 3 mechanisms
+
+    # TODO(marcoskirsch):
+    # def test_multiple_outputs of different types
+
+    # Retrieving buffers and strings
+
+    def test_get_string_ivi_dance_error(self):
+        test_error_code = -1234
+        test_error_desc = "ascending order"
+        self.patched_library.niFake_GetAttributeViString.side_effect = self.side_effects_helper.niFake_GetAttributeViString
+        self.side_effects_helper['GetAttributeViString']['attributeValue'] = 'Testing is fun?'
+        self.side_effects_helper['GetAttributeViString']['return'] = test_error_code
+        self.patched_library.niFake_GetError.side_effect = self.side_effects_helper.niFake_GetError
+        self.side_effects_helper['GetError']['errorCode'] = test_error_code
+        self.side_effects_helper['GetError']['description'] = test_error_desc
+        with nifake.Session('dev1') as session:
+            try:
+                session.read_write_string
+                assert False
+            except nifake.Error as e:
+                assert e.code == test_error_code
+                assert e.description == test_error_desc
+
+    def test_get_a_string_with_specified_maximum_size(self):
+        single_character_string = 'a'
+        self.patched_library.niFake_GetAStringWithSpecifiedMaximumSize.side_effect = self.side_effects_helper.niFake_GetAStringWithSpecifiedMaximumSize
+        self.side_effects_helper['GetAStringWithSpecifiedMaximumSize']['aString'] = single_character_string
+        with nifake.Session('dev1') as session:
+            buffer_size = 19
+            string_with_specified_buffer = session.get_a_string_with_specified_maximum_size(buffer_size)
+            assert(string_with_specified_buffer == single_character_string)
+            self.patched_library.niFake_GetAStringWithSpecifiedMaximumSize.assert_called_once_with(SESSION_NUM_FOR_TEST, ANY, ANY)
+
+    def test_get_a_string_of_fixed_maximum_size(self):
+        fixed_buffer_string = "this method will return fixed buffer string"
+        self.patched_library.niFake_GetAStringOfFixedMaximumSize.side_effect = self.side_effects_helper.niFake_GetAStringOfFixedMaximumSize
+        self.side_effects_helper['GetAStringOfFixedMaximumSize']['aString'] = fixed_buffer_string
+        with nifake.Session('dev1') as session:
+            returned_string = session.get_a_string_of_fixed_maximum_size()
+            assert (returned_string == fixed_buffer_string)
+            self.patched_library.niFake_GetAStringOfFixedMaximumSize.assert_called_once_with(SESSION_NUM_FOR_TEST, ANY)
+
+    def test_return_a_number_and_a_string(self):
+        test_string = "this string"
+        test_number = 13
+        self.patched_library.niFake_ReturnANumberAndAString.side_effect = self.side_effects_helper.niFake_ReturnANumberAndAString
+        self.side_effects_helper['ReturnANumberAndAString']['aString'] = test_string
+        self.side_effects_helper['ReturnANumberAndAString']['aNumber'] = test_number
+        with nifake.Session('dev1') as session:
+            returned_number, returned_string = session.return_a_number_and_a_string()
+            assert (returned_string == test_string)
+            assert (returned_number == test_number)
+            self.patched_library.niFake_ReturnANumberAndAString.assert_called_once_with(SESSION_NUM_FOR_TEST, ANY, ANY)
+
+    # TODO(marcoskirsch):
+    # def test_get_string_ivi_dance(self)
 
     # Repeated Capabilities
 
@@ -322,10 +396,6 @@ class TestSession(object):
             session.read_write_integer = test_number
             self.patched_library.niFake_SetAttributeViInt32.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', attribute_id, test_number)
 
-    # TODO(marcoskirsch)
-    # def test_get_attribute_int64(self):
-    # def test_set_attribute_int64(self):
-
     def test_get_attribute_real64(self):
         self.patched_library.niFake_GetAttributeViReal64.side_effect = self.side_effects_helper.niFake_GetAttributeViReal64
         test_number = 1.5
@@ -353,12 +423,28 @@ class TestSession(object):
             self.patched_library.niFake_GetAttributeViString.assert_has_calls(calls)
             assert self.patched_library.niFake_GetAttributeViString.call_count == 2
 
+    def test_set_vi_string_attribute(self):
+        self.patched_library.niFake_SetAttributeViString.side_effect = self.side_effects_helper.niFake_SetAttributeViString
+        attribute_id = 1000002
+        attrib_string = 'This is test string'
+        with nifake.Session('dev1') as session:
+            session.read_write_string = attrib_string
+            self.patched_library.niFake_SetAttributeViString.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', attribute_id, b'This is test string')
+
     def test_get_attribute_boolean(self):
         self.patched_library.niFake_GetAttributeViBoolean.side_effect = self.side_effects_helper.niFake_GetAttributeViBoolean
         self.side_effects_helper['GetAttributeViBoolean']['attributeValue'] = 1
         with nifake.Session('dev1') as session:
             assert session.read_write_bool
             self.patched_library.niFake_GetAttributeViBoolean.assert_called_once_with(SESSION_NUM_FOR_TEST, b"", 1000000, ANY)
+
+    def test_set_bool_attribute(self):
+        self.patched_library.niFake_SetAttributeViBoolean.side_effect = self.side_effects_helper.niFake_SetAttributeViBoolean
+        attribute_id = 1000000
+        attrib_bool = True
+        with nifake.Session('dev1') as session:
+            session.read_write_bool = attrib_bool
+            self.patched_library.niFake_SetAttributeViBoolean.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', attribute_id, 1)
 
     def test_get_attribute_enum_int32(self):
         self.patched_library.niFake_GetAttributeViInt32.side_effect = self.side_effects_helper.niFake_GetAttributeViInt32
@@ -375,13 +461,6 @@ class TestSession(object):
             session.read_write_color = enum_value
             attribute_id = 1000003
             self.patched_library.niFake_SetAttributeViInt32.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', attribute_id, enum_value.value)
-
-    def test_set_enum_attribute_int32_bad_type(self):
-        with nifake.Session('dev1') as session:
-            try:
-                session.read_write_color = 5
-            except TypeError as e:
-                assert str(e) == 'must be nifake.Color not int'
 
     def test_get_attribute_enum_real64(self):
         self.patched_library.niFake_GetAttributeViReal64.side_effect = self.side_effects_helper.niFake_GetAttributeViReal64
@@ -400,7 +479,7 @@ class TestSession(object):
             attribute_id = 1000005
             self.patched_library.niFake_SetAttributeViReal64.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', attribute_id, enum_value.value)
 
-    def test_get_attribute_channel_int32(self):
+    def test_get_attribute_channel(self):
         self.patched_library.niFake_GetAttributeViInt32.side_effect = self.side_effects_helper.niFake_GetAttributeViInt32
         test_number = 100
         self.side_effects_helper['GetAttributeViInt32']['attributeValue'] = test_number
@@ -409,13 +488,17 @@ class TestSession(object):
             assert(attr_int == test_number)
             self.patched_library.niFake_GetAttributeViInt32.assert_called_once_with(SESSION_NUM_FOR_TEST, b'0,1', 1000004, ANY)
 
-    def test_set_attribute_channel_real64(self):
+    def test_set_attribute_channel(self):
         self.patched_library.niFake_SetAttributeViReal64.side_effect = self.side_effects_helper.niFake_SetAttributeViReal64
         attribute_id = 1000001
         test_number = 0.001
         with nifake.Session('dev1') as session:
             session['0-24'].read_write_double = test_number
             self.patched_library.niFake_SetAttributeViReal64.assert_called_once_with(SESSION_NUM_FOR_TEST, b'0-24', attribute_id, test_number)
+
+    # TODO(marcoskirsch)
+    # def test_get_attribute_int64(self):
+    # def test_set_attribute_int64(self):
 
     def test_set_attribute_error(self):
         test_error_code = -1
@@ -451,6 +534,26 @@ class TestSession(object):
                 assert e.code == test_error_code
                 assert e.description == test_error_desc
 
+    def test_add_properties_to_session_error(self):
+        with nifake.Session('dev1') as session:
+            try:
+                session.nonexistent_property = 5
+                assert False
+            except TypeError as e:
+                pass
+            try:
+                value = session.nonexistent_property  # noqa: F841
+                assert False
+            except AttributeError as e:
+                pass
+
+    def test_set_enum_attribute_int32_error(self):
+        with nifake.Session('dev1') as session:
+            try:
+                session.read_write_color = 5
+            except TypeError as e:
+                assert str(e) == 'must be nifake.Color not int'
+
     # Error descriptions
 
     def test_get_error_and_error_message_returns_error(self):
@@ -470,88 +573,6 @@ class TestSession(object):
             except nifake.Error as e:
                 assert e.code == test_error_code
                 assert e.description == 'Failed to retrieve error description.'
-
-    def test_enum_input_function_with_defaults(self):
-        test_turtle = nifake.Turtle.DONATELLO
-        self.patched_library.niFake_EnumInputFunctionWithDefaults.side_effect = self.side_effects_helper.niFake_EnumInputFunctionWithDefaults
-        with nifake.Session('dev1') as session:
-            session.enum_input_function_with_defaults()
-            session.enum_input_function_with_defaults(test_turtle)
-            from mock import call
-            calls = [call(SESSION_NUM_FOR_TEST, 0), call(SESSION_NUM_FOR_TEST, 1)]  # 0 is the value of the default of nifake.Turtle.LEONARDO, 1 is the value of nifake.Turtle.DONATELLO
-            self.patched_library.niFake_EnumInputFunctionWithDefaults.assert_has_calls(calls)
-
-    def test_set_bool_attribute(self):
-        self.patched_library.niFake_SetAttributeViBoolean.side_effect = self.side_effects_helper.niFake_SetAttributeViBoolean
-        attribute_id = 1000000
-        attrib_bool = True
-        with nifake.Session('dev1') as session:
-            session.read_write_bool = attrib_bool
-            self.patched_library.niFake_SetAttributeViBoolean.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', attribute_id, 1)
-
-    def test_set_vi_string_attribute(self):
-        self.patched_library.niFake_SetAttributeViString.side_effect = self.side_effects_helper.niFake_SetAttributeViString
-        attribute_id = 1000002
-        attrib_string = 'This is test string'
-        with nifake.Session('dev1') as session:
-            session.read_write_string = attrib_string
-            self.patched_library.niFake_SetAttributeViString.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', attribute_id, b'This is test string')
-
-    def test_multipoint_read(self):
-        test_maximum_time = 1000
-        test_reading_array = [1.0, 0.1, 42, .42]
-        test_actual_number_of_points = len(test_reading_array)
-        self.patched_library.niFake_ReadMultiPoint.side_effect = self.side_effects_helper.niFake_ReadMultiPoint
-        self.side_effects_helper['ReadMultiPoint']['readingArray'] = test_reading_array
-        self.side_effects_helper['ReadMultiPoint']['actualNumberOfPoints'] = test_actual_number_of_points
-        with nifake.Session('dev1') as session:
-            measurements, points = session.read_multi_point(test_maximum_time, len(test_reading_array))
-            assert len(measurements) == test_actual_number_of_points
-            assert points == test_actual_number_of_points
-            assert measurements == test_reading_array
-            from mock import call
-            calls = [call(SESSION_NUM_FOR_TEST, test_maximum_time, len(test_reading_array), ANY, ANY)]
-            self.patched_library.niFake_ReadMultiPoint.assert_has_calls(calls)
-            assert self.patched_library.niFake_ReadMultiPoint.call_count == 1
-
-    def test_array_input_function(self):
-        test_array = [1, 2, 3, 4]
-        test_array_size = len(test_array)
-        self.patched_library.niFake_ArrayInputFunction.side_effect = self.side_effects_helper.niFake_ArrayInputFunction
-        with nifake.Session('dev1') as session:
-            session.array_input_function(test_array)
-            self.patched_library.niFake_ArrayInputFunction.assert_called_once_with(SESSION_NUM_FOR_TEST, test_array_size, test_array)
-
-    def test_get_a_string_with_specified_maximum_size(self):
-        single_character_string = 'a'
-        self.patched_library.niFake_GetAStringWithSpecifiedMaximumSize.side_effect = self.side_effects_helper.niFake_GetAStringWithSpecifiedMaximumSize
-        self.side_effects_helper['GetAStringWithSpecifiedMaximumSize']['aString'] = single_character_string
-        with nifake.Session('dev1') as session:
-            buffer_size = 19
-            string_with_specified_buffer = session.get_a_string_with_specified_maximum_size(buffer_size)
-            assert(string_with_specified_buffer == single_character_string)
-            self.patched_library.niFake_GetAStringWithSpecifiedMaximumSize.assert_called_once_with(SESSION_NUM_FOR_TEST, ANY, ANY)
-
-    def test_get_a_string_of_fixed_maximum_size(self):
-        fixed_buffer_string = "this method will return fixed buffer string"
-        self.patched_library.niFake_GetAStringOfFixedMaximumSize.side_effect = self.side_effects_helper.niFake_GetAStringOfFixedMaximumSize
-        self.side_effects_helper['GetAStringOfFixedMaximumSize']['aString'] = fixed_buffer_string
-        with nifake.Session('dev1') as session:
-            returned_string = session.get_a_string_of_fixed_maximum_size()
-            assert (returned_string == fixed_buffer_string)
-            self.patched_library.niFake_GetAStringOfFixedMaximumSize.assert_called_once_with(SESSION_NUM_FOR_TEST, ANY)
-
-    def test_return_a_number_and_a_string(self):
-        test_string = "this string"
-        test_number = 13
-        self.patched_library.niFake_ReturnANumberAndAString.side_effect = self.side_effects_helper.niFake_ReturnANumberAndAString
-        self.side_effects_helper['ReturnANumberAndAString']['aString'] = test_string
-        self.side_effects_helper['ReturnANumberAndAString']['aNumber'] = test_number
-        with nifake.Session('dev1') as session:
-            returned_number, returned_string = session.return_a_number_and_a_string()
-            assert (returned_string == test_string)
-            assert (returned_number == test_number)
-            self.patched_library.niFake_ReturnANumberAndAString.assert_called_once_with(SESSION_NUM_FOR_TEST, ANY, ANY)
 
     def test_get_error_description_error_message(self):
         test_error_code = -42
@@ -573,24 +594,3 @@ class TestSession(object):
         from mock import call
         calls = [call(SESSION_NUM_FOR_TEST, test_error_code, ANY)]
         self.patched_library.niFake_error_message.assert_has_calls(calls)
-
-    '''
-    # TODO(bhaswath): Enable test once issue 320 is fixed
-    def test_read_with_warning(self):
-        test_maximum_time = 10
-        test_reading = float('nan')
-        test_error_code = 42
-        test_error_desc = "The answer to the ultimate question, only positive"
-        self.patched_library.niFake_Read.side_effect = self.side_effects_helper.niFake_Read
-        self.side_effects_helper['Read']['return'] = test_error_code
-        self.side_effects_helper['Read']['reading'] = test_reading
-        self.patched_library.niFake_GetError.side_effect = self.side_effects_helper.niFake_GetError
-        self.side_effects_helper['GetError']['errorCode'] = test_error_code
-        self.side_effects_helper['GetError']['description'] = test_error_desc
-        with nifake.Session('dev1') as session:
-            with warnings.catch_warnings(record=True) as w:
-                assert test_reading == session.read(test_maximum_time)
-                assert len(w) == 1
-                assert issubclass(w[0].category, nifake.NifakeWarning)
-                assert test_error_desc in str(w[0].message)
-    '''

--- a/generated/nifake/tests/test_session.py
+++ b/generated/nifake/tests/test_session.py
@@ -240,21 +240,6 @@ class TestSession(object):
                 assert e.code == test_error_code
                 assert e.description == test_error_desc
 
-    def test_method_with_warning(self):
-        test_error_code = 42
-        test_error_desc = "The answer to the ultimate question, only positive"
-        self.patched_library.niFake_SimpleFunction.side_effect = self.side_effects_helper.niFake_SimpleFunction
-        self.side_effects_helper['SimpleFunction']['return'] = test_error_code
-        self.patched_library.niFake_GetError.side_effect = self.side_effects_helper.niFake_GetError
-        self.side_effects_helper['GetError']['errorCode'] = test_error_code
-        self.side_effects_helper['GetError']['description'] = test_error_desc
-        with nifake.Session('dev1') as session:
-            with warnings.catch_warnings(record=True) as w:
-                session.simple_function()
-                assert len(w) == 1
-                assert issubclass(w[0].category, nifake.NifakeWarning)
-                assert test_error_desc in str(w[0].message)
-
     def test_invalid_method_call_not_enough_parameters_error(self):
         self.patched_library.niFake_GetAStringWithSpecifiedMaximumSize.side_effect = self.side_effects_helper.niFake_GetAStringWithSpecifiedMaximumSize
         with nifake.Session('dev1') as session:
@@ -272,6 +257,21 @@ class TestSession(object):
                 assert False
             except TypeError as e:
                 pass
+
+    def test_method_with_warning(self):
+        test_error_code = 42
+        test_error_desc = "The answer to the ultimate question, only positive"
+        self.patched_library.niFake_SimpleFunction.side_effect = self.side_effects_helper.niFake_SimpleFunction
+        self.side_effects_helper['SimpleFunction']['return'] = test_error_code
+        self.patched_library.niFake_GetError.side_effect = self.side_effects_helper.niFake_GetError
+        self.side_effects_helper['GetError']['errorCode'] = test_error_code
+        self.side_effects_helper['GetError']['description'] = test_error_desc
+        with nifake.Session('dev1') as session:
+            with warnings.catch_warnings(record=True) as w:
+                session.simple_function()
+                assert len(w) == 1
+                assert issubclass(w[0].category, nifake.NifakeWarning)
+                assert test_error_desc in str(w[0].message)
 
     '''
     # TODO(bhaswath): Enable test once issue 320 is fixed
@@ -423,7 +423,7 @@ class TestSession(object):
             self.patched_library.niFake_GetAttributeViString.assert_has_calls(calls)
             assert self.patched_library.niFake_GetAttributeViString.call_count == 2
 
-    def test_set_vi_string_attribute(self):
+    def test_set_attribute_string(self):
         self.patched_library.niFake_SetAttributeViString.side_effect = self.side_effects_helper.niFake_SetAttributeViString
         attribute_id = 1000002
         attrib_string = 'This is test string'
@@ -438,7 +438,7 @@ class TestSession(object):
             assert session.read_write_bool
             self.patched_library.niFake_GetAttributeViBoolean.assert_called_once_with(SESSION_NUM_FOR_TEST, b"", 1000000, ANY)
 
-    def test_set_bool_attribute(self):
+    def test_set_attribute_boolean(self):
         self.patched_library.niFake_SetAttributeViBoolean.side_effect = self.side_effects_helper.niFake_SetAttributeViBoolean
         attribute_id = 1000000
         attrib_bool = True
@@ -500,23 +500,6 @@ class TestSession(object):
     # def test_get_attribute_int64(self):
     # def test_set_attribute_int64(self):
 
-    def test_set_attribute_error(self):
-        test_error_code = -1
-        test_error_desc = 'Test'
-        self.patched_library.niFake_SetAttributeViReal64.side_effect = self.side_effects_helper.niFake_SetAttributeViReal64
-        self.side_effects_helper['SetAttributeViReal64']['return'] = test_error_code
-        self.patched_library.niFake_GetError.side_effect = self.side_effects_helper.niFake_GetError
-        self.side_effects_helper['GetError']['errorCode'] = test_error_code
-        self.side_effects_helper['GetError']['description'] = test_error_desc
-        with nifake.Session('dev1') as session:
-            try:
-                session.read_write_double = -42
-                assert False
-            except nifake.Error as e:
-                assert e.code == test_error_code
-                assert e.description == test_error_desc
-                self.patched_library.niFake_SetAttributeViReal64.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', 1000001, -42)
-
     def test_get_attribute_error(self):
         test_error_code = -123
         test_error_desc = "ascending order"
@@ -533,6 +516,23 @@ class TestSession(object):
             except nifake.Error as e:
                 assert e.code == test_error_code
                 assert e.description == test_error_desc
+
+    def test_set_attribute_error(self):
+        test_error_code = -1
+        test_error_desc = 'Test'
+        self.patched_library.niFake_SetAttributeViReal64.side_effect = self.side_effects_helper.niFake_SetAttributeViReal64
+        self.side_effects_helper['SetAttributeViReal64']['return'] = test_error_code
+        self.patched_library.niFake_GetError.side_effect = self.side_effects_helper.niFake_GetError
+        self.side_effects_helper['GetError']['errorCode'] = test_error_code
+        self.side_effects_helper['GetError']['description'] = test_error_desc
+        with nifake.Session('dev1') as session:
+            try:
+                session.read_write_double = -42
+                assert False
+            except nifake.Error as e:
+                assert e.code == test_error_code
+                assert e.description == test_error_desc
+                self.patched_library.niFake_SetAttributeViReal64.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', 1000001, -42)
 
     def test_add_properties_to_session_error(self):
         with nifake.Session('dev1') as session:

--- a/src/nifake/tests/test_session.py
+++ b/src/nifake/tests/test_session.py
@@ -72,14 +72,14 @@ class TestSession(object):
         session.close()
         self.patched_library.niFake_close.assert_called_once_with(SESSION_NUM_FOR_TEST)
 
-    # TODO(marcoskirsch): This should test that when close errors it raises.
-    # def test_close_errors(self):
-
     def test_session_context_manager(self):
         with nifake.Session('dev1') as session:
             assert type(session) == nifake.Session
             self.patched_library.niFake_InitWithOptions.assert_called_once_with(b'dev1', 0, False, b'', ANY)
         self.patched_library.niFake_close.assert_called_once_with(SESSION_NUM_FOR_TEST)
+
+    # TODO(marcoskirsch): This should test that when close errors it raises.
+    # def test_close_errors(self):
 
     # TODO(marcoskirsch): This should test that when init errors it raises.
     # def test_session_context_manager_error_on_init
@@ -135,9 +135,6 @@ class TestSession(object):
             assert isinstance(test_result, int)
             assert test_result == test_number
             self.patched_library.niFake_GetANumber.assert_called_once_with(SESSION_NUM_FOR_TEST, ANY)
-
-    # TODO(marcoskirsch):
-    # def test_multiple_outputs of different types
 
     def test_invalid_method_call_not_enough_parameters(self):
         self.patched_library.niFake_GetAStringWithSpecifiedMaximumSize.side_effect = self.side_effects_helper.niFake_GetAStringWithSpecifiedMaximumSize
@@ -216,41 +213,6 @@ class TestSession(object):
             self.patched_library.niFake_Abort.assert_called_once_with(SESSION_NUM_FOR_TEST)
         self.patched_library.niFake_close.assert_called_once_with(SESSION_NUM_FOR_TEST)
 
-    def test_cannot_add_properties_to_session(self):
-        with nifake.Session('dev1') as session:
-            try:
-                session.nonexistent_property = 5
-                assert False
-            except TypeError as e:
-                pass
-            try:
-                value = session.nonexistent_property  # noqa: F841
-                assert False
-            except AttributeError as e:
-                pass
-
-    # Retrieving buffers and strings
-
-    # TODO(marcoskirsch):
-    # def test_get_string_ivi_dance(self)
-
-    def test_get_string_ivi_dance_error(self):
-        test_error_code = -1234
-        test_error_desc = "ascending order"
-        self.patched_library.niFake_GetAttributeViString.side_effect = self.side_effects_helper.niFake_GetAttributeViString
-        self.side_effects_helper['GetAttributeViString']['attributeValue'] = 'Testing is fun?'
-        self.side_effects_helper['GetAttributeViString']['return'] = test_error_code
-        self.patched_library.niFake_GetError.side_effect = self.side_effects_helper.niFake_GetError
-        self.side_effects_helper['GetError']['errorCode'] = test_error_code
-        self.side_effects_helper['GetError']['description'] = test_error_desc
-        with nifake.Session('dev1') as session:
-            try:
-                session.read_write_string
-                assert False
-            except nifake.Error as e:
-                assert e.code == test_error_code
-                assert e.description == test_error_desc
-
     def test_single_point_read(self):
         test_maximum_time = 10
         test_reading = 5
@@ -271,7 +233,119 @@ class TestSession(object):
         with nifake.Session('dev1') as session:
             assert math.isnan(session.read(test_maximum_time))
 
-    # TODO(marcoskirsch): Other variations: multi-point/waveform with ViReal64 and ViInt16 * 3 mechanisms
+    def test_enum_input_function_with_defaults(self):
+        test_turtle = nifake.Turtle.DONATELLO
+        self.patched_library.niFake_EnumInputFunctionWithDefaults.side_effect = self.side_effects_helper.niFake_EnumInputFunctionWithDefaults
+        with nifake.Session('dev1') as session:
+            session.enum_input_function_with_defaults()
+            session.enum_input_function_with_defaults(test_turtle)
+            from mock import call
+            calls = [call(SESSION_NUM_FOR_TEST, 0), call(SESSION_NUM_FOR_TEST, 1)]  # 0 is the value of the default of nifake.Turtle.LEONARDO, 1 is the value of nifake.Turtle.DONATELLO
+            self.patched_library.niFake_EnumInputFunctionWithDefaults.assert_has_calls(calls)
+
+    def test_multipoint_read(self):
+        test_maximum_time = 1000
+        test_reading_array = [1.0, 0.1, 42, .42]
+        test_actual_number_of_points = len(test_reading_array)
+        self.patched_library.niFake_ReadMultiPoint.side_effect = self.side_effects_helper.niFake_ReadMultiPoint
+        self.side_effects_helper['ReadMultiPoint']['readingArray'] = test_reading_array
+        self.side_effects_helper['ReadMultiPoint']['actualNumberOfPoints'] = test_actual_number_of_points
+        with nifake.Session('dev1') as session:
+            measurements, points = session.read_multi_point(test_maximum_time, len(test_reading_array))
+            assert len(measurements) == test_actual_number_of_points
+            assert points == test_actual_number_of_points
+            assert measurements == test_reading_array
+            from mock import call
+            calls = [call(SESSION_NUM_FOR_TEST, test_maximum_time, len(test_reading_array), ANY, ANY)]
+            self.patched_library.niFake_ReadMultiPoint.assert_has_calls(calls)
+            assert self.patched_library.niFake_ReadMultiPoint.call_count == 1
+
+    def test_array_input_function(self):
+        test_array = [1, 2, 3, 4]
+        test_array_size = len(test_array)
+        self.patched_library.niFake_ArrayInputFunction.side_effect = self.side_effects_helper.niFake_ArrayInputFunction
+        with nifake.Session('dev1') as session:
+            session.array_input_function(test_array)
+            self.patched_library.niFake_ArrayInputFunction.assert_called_once_with(SESSION_NUM_FOR_TEST, test_array_size, test_array)
+
+    '''
+    # TODO(bhaswath): Enable test once issue 320 is fixed
+    def test_read_with_warning(self):
+        test_maximum_time = 10
+        test_reading = float('nan')
+        test_error_code = 42
+        test_error_desc = "The answer to the ultimate question, only positive"
+        self.patched_library.niFake_Read.side_effect = self.side_effects_helper.niFake_Read
+        self.side_effects_helper['Read']['return'] = test_error_code
+        self.side_effects_helper['Read']['reading'] = test_reading
+        self.patched_library.niFake_GetError.side_effect = self.side_effects_helper.niFake_GetError
+        self.side_effects_helper['GetError']['errorCode'] = test_error_code
+        self.side_effects_helper['GetError']['description'] = test_error_desc
+        with nifake.Session('dev1') as session:
+            with warnings.catch_warnings(record=True) as w:
+                assert test_reading == session.read(test_maximum_time)
+                assert len(w) == 1
+                assert issubclass(w[0].category, nifake.NifakeWarning)
+                assert test_error_desc in str(w[0].message)
+    '''
+
+    # TODO(marcoskirsch): Other read variations: waveform with ViReal64 and ViInt16 * 3 mechanisms
+
+    # TODO(marcoskirsch):
+    # def test_multiple_outputs of different types
+
+    # Retrieving buffers and strings
+
+    def test_get_string_ivi_dance_error(self):
+        test_error_code = -1234
+        test_error_desc = "ascending order"
+        self.patched_library.niFake_GetAttributeViString.side_effect = self.side_effects_helper.niFake_GetAttributeViString
+        self.side_effects_helper['GetAttributeViString']['attributeValue'] = 'Testing is fun?'
+        self.side_effects_helper['GetAttributeViString']['return'] = test_error_code
+        self.patched_library.niFake_GetError.side_effect = self.side_effects_helper.niFake_GetError
+        self.side_effects_helper['GetError']['errorCode'] = test_error_code
+        self.side_effects_helper['GetError']['description'] = test_error_desc
+        with nifake.Session('dev1') as session:
+            try:
+                session.read_write_string
+                assert False
+            except nifake.Error as e:
+                assert e.code == test_error_code
+                assert e.description == test_error_desc
+
+    def test_get_a_string_with_specified_maximum_size(self):
+        single_character_string = 'a'
+        self.patched_library.niFake_GetAStringWithSpecifiedMaximumSize.side_effect = self.side_effects_helper.niFake_GetAStringWithSpecifiedMaximumSize
+        self.side_effects_helper['GetAStringWithSpecifiedMaximumSize']['aString'] = single_character_string
+        with nifake.Session('dev1') as session:
+            buffer_size = 19
+            string_with_specified_buffer = session.get_a_string_with_specified_maximum_size(buffer_size)
+            assert(string_with_specified_buffer == single_character_string)
+            self.patched_library.niFake_GetAStringWithSpecifiedMaximumSize.assert_called_once_with(SESSION_NUM_FOR_TEST, ANY, ANY)
+
+    def test_get_a_string_of_fixed_maximum_size(self):
+        fixed_buffer_string = "this method will return fixed buffer string"
+        self.patched_library.niFake_GetAStringOfFixedMaximumSize.side_effect = self.side_effects_helper.niFake_GetAStringOfFixedMaximumSize
+        self.side_effects_helper['GetAStringOfFixedMaximumSize']['aString'] = fixed_buffer_string
+        with nifake.Session('dev1') as session:
+            returned_string = session.get_a_string_of_fixed_maximum_size()
+            assert (returned_string == fixed_buffer_string)
+            self.patched_library.niFake_GetAStringOfFixedMaximumSize.assert_called_once_with(SESSION_NUM_FOR_TEST, ANY)
+
+    def test_return_a_number_and_a_string(self):
+        test_string = "this string"
+        test_number = 13
+        self.patched_library.niFake_ReturnANumberAndAString.side_effect = self.side_effects_helper.niFake_ReturnANumberAndAString
+        self.side_effects_helper['ReturnANumberAndAString']['aString'] = test_string
+        self.side_effects_helper['ReturnANumberAndAString']['aNumber'] = test_number
+        with nifake.Session('dev1') as session:
+            returned_number, returned_string = session.return_a_number_and_a_string()
+            assert (returned_string == test_string)
+            assert (returned_number == test_number)
+            self.patched_library.niFake_ReturnANumberAndAString.assert_called_once_with(SESSION_NUM_FOR_TEST, ANY, ANY)
+
+    # TODO(marcoskirsch):
+    # def test_get_string_ivi_dance(self)
 
     # Repeated Capabilities
 
@@ -322,10 +396,6 @@ class TestSession(object):
             session.read_write_integer = test_number
             self.patched_library.niFake_SetAttributeViInt32.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', attribute_id, test_number)
 
-    # TODO(marcoskirsch)
-    # def test_get_attribute_int64(self):
-    # def test_set_attribute_int64(self):
-
     def test_get_attribute_real64(self):
         self.patched_library.niFake_GetAttributeViReal64.side_effect = self.side_effects_helper.niFake_GetAttributeViReal64
         test_number = 1.5
@@ -353,12 +423,28 @@ class TestSession(object):
             self.patched_library.niFake_GetAttributeViString.assert_has_calls(calls)
             assert self.patched_library.niFake_GetAttributeViString.call_count == 2
 
+    def test_set_vi_string_attribute(self):
+        self.patched_library.niFake_SetAttributeViString.side_effect = self.side_effects_helper.niFake_SetAttributeViString
+        attribute_id = 1000002
+        attrib_string = 'This is test string'
+        with nifake.Session('dev1') as session:
+            session.read_write_string = attrib_string
+            self.patched_library.niFake_SetAttributeViString.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', attribute_id, b'This is test string')
+
     def test_get_attribute_boolean(self):
         self.patched_library.niFake_GetAttributeViBoolean.side_effect = self.side_effects_helper.niFake_GetAttributeViBoolean
         self.side_effects_helper['GetAttributeViBoolean']['attributeValue'] = 1
         with nifake.Session('dev1') as session:
             assert session.read_write_bool
             self.patched_library.niFake_GetAttributeViBoolean.assert_called_once_with(SESSION_NUM_FOR_TEST, b"", 1000000, ANY)
+
+    def test_set_bool_attribute(self):
+        self.patched_library.niFake_SetAttributeViBoolean.side_effect = self.side_effects_helper.niFake_SetAttributeViBoolean
+        attribute_id = 1000000
+        attrib_bool = True
+        with nifake.Session('dev1') as session:
+            session.read_write_bool = attrib_bool
+            self.patched_library.niFake_SetAttributeViBoolean.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', attribute_id, 1)
 
     def test_get_attribute_enum_int32(self):
         self.patched_library.niFake_GetAttributeViInt32.side_effect = self.side_effects_helper.niFake_GetAttributeViInt32
@@ -375,13 +461,6 @@ class TestSession(object):
             session.read_write_color = enum_value
             attribute_id = 1000003
             self.patched_library.niFake_SetAttributeViInt32.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', attribute_id, enum_value.value)
-
-    def test_set_enum_attribute_int32_bad_type(self):
-        with nifake.Session('dev1') as session:
-            try:
-                session.read_write_color = 5
-            except TypeError as e:
-                assert str(e) == 'must be nifake.Color not int'
 
     def test_get_attribute_enum_real64(self):
         self.patched_library.niFake_GetAttributeViReal64.side_effect = self.side_effects_helper.niFake_GetAttributeViReal64
@@ -400,7 +479,7 @@ class TestSession(object):
             attribute_id = 1000005
             self.patched_library.niFake_SetAttributeViReal64.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', attribute_id, enum_value.value)
 
-    def test_get_attribute_channel_int32(self):
+    def test_get_attribute_channel(self):
         self.patched_library.niFake_GetAttributeViInt32.side_effect = self.side_effects_helper.niFake_GetAttributeViInt32
         test_number = 100
         self.side_effects_helper['GetAttributeViInt32']['attributeValue'] = test_number
@@ -409,13 +488,17 @@ class TestSession(object):
             assert(attr_int == test_number)
             self.patched_library.niFake_GetAttributeViInt32.assert_called_once_with(SESSION_NUM_FOR_TEST, b'0,1', 1000004, ANY)
 
-    def test_set_attribute_channel_real64(self):
+    def test_set_attribute_channel(self):
         self.patched_library.niFake_SetAttributeViReal64.side_effect = self.side_effects_helper.niFake_SetAttributeViReal64
         attribute_id = 1000001
         test_number = 0.001
         with nifake.Session('dev1') as session:
             session['0-24'].read_write_double = test_number
             self.patched_library.niFake_SetAttributeViReal64.assert_called_once_with(SESSION_NUM_FOR_TEST, b'0-24', attribute_id, test_number)
+
+    # TODO(marcoskirsch)
+    # def test_get_attribute_int64(self):
+    # def test_set_attribute_int64(self):
 
     def test_set_attribute_error(self):
         test_error_code = -1
@@ -451,6 +534,26 @@ class TestSession(object):
                 assert e.code == test_error_code
                 assert e.description == test_error_desc
 
+    def test_add_properties_to_session_error(self):
+        with nifake.Session('dev1') as session:
+            try:
+                session.nonexistent_property = 5
+                assert False
+            except TypeError as e:
+                pass
+            try:
+                value = session.nonexistent_property  # noqa: F841
+                assert False
+            except AttributeError as e:
+                pass
+
+    def test_set_enum_attribute_int32_error(self):
+        with nifake.Session('dev1') as session:
+            try:
+                session.read_write_color = 5
+            except TypeError as e:
+                assert str(e) == 'must be nifake.Color not int'
+
     # Error descriptions
 
     def test_get_error_and_error_message_returns_error(self):
@@ -470,88 +573,6 @@ class TestSession(object):
             except nifake.Error as e:
                 assert e.code == test_error_code
                 assert e.description == 'Failed to retrieve error description.'
-
-    def test_enum_input_function_with_defaults(self):
-        test_turtle = nifake.Turtle.DONATELLO
-        self.patched_library.niFake_EnumInputFunctionWithDefaults.side_effect = self.side_effects_helper.niFake_EnumInputFunctionWithDefaults
-        with nifake.Session('dev1') as session:
-            session.enum_input_function_with_defaults()
-            session.enum_input_function_with_defaults(test_turtle)
-            from mock import call
-            calls = [call(SESSION_NUM_FOR_TEST, 0), call(SESSION_NUM_FOR_TEST, 1)]  # 0 is the value of the default of nifake.Turtle.LEONARDO, 1 is the value of nifake.Turtle.DONATELLO
-            self.patched_library.niFake_EnumInputFunctionWithDefaults.assert_has_calls(calls)
-
-    def test_set_bool_attribute(self):
-        self.patched_library.niFake_SetAttributeViBoolean.side_effect = self.side_effects_helper.niFake_SetAttributeViBoolean
-        attribute_id = 1000000
-        attrib_bool = True
-        with nifake.Session('dev1') as session:
-            session.read_write_bool = attrib_bool
-            self.patched_library.niFake_SetAttributeViBoolean.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', attribute_id, 1)
-
-    def test_set_vi_string_attribute(self):
-        self.patched_library.niFake_SetAttributeViString.side_effect = self.side_effects_helper.niFake_SetAttributeViString
-        attribute_id = 1000002
-        attrib_string = 'This is test string'
-        with nifake.Session('dev1') as session:
-            session.read_write_string = attrib_string
-            self.patched_library.niFake_SetAttributeViString.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', attribute_id, b'This is test string')
-
-    def test_multipoint_read(self):
-        test_maximum_time = 1000
-        test_reading_array = [1.0, 0.1, 42, .42]
-        test_actual_number_of_points = len(test_reading_array)
-        self.patched_library.niFake_ReadMultiPoint.side_effect = self.side_effects_helper.niFake_ReadMultiPoint
-        self.side_effects_helper['ReadMultiPoint']['readingArray'] = test_reading_array
-        self.side_effects_helper['ReadMultiPoint']['actualNumberOfPoints'] = test_actual_number_of_points
-        with nifake.Session('dev1') as session:
-            measurements, points = session.read_multi_point(test_maximum_time, len(test_reading_array))
-            assert len(measurements) == test_actual_number_of_points
-            assert points == test_actual_number_of_points
-            assert measurements == test_reading_array
-            from mock import call
-            calls = [call(SESSION_NUM_FOR_TEST, test_maximum_time, len(test_reading_array), ANY, ANY)]
-            self.patched_library.niFake_ReadMultiPoint.assert_has_calls(calls)
-            assert self.patched_library.niFake_ReadMultiPoint.call_count == 1
-
-    def test_array_input_function(self):
-        test_array = [1, 2, 3, 4]
-        test_array_size = len(test_array)
-        self.patched_library.niFake_ArrayInputFunction.side_effect = self.side_effects_helper.niFake_ArrayInputFunction
-        with nifake.Session('dev1') as session:
-            session.array_input_function(test_array)
-            self.patched_library.niFake_ArrayInputFunction.assert_called_once_with(SESSION_NUM_FOR_TEST, test_array_size, test_array)
-
-    def test_get_a_string_with_specified_maximum_size(self):
-        single_character_string = 'a'
-        self.patched_library.niFake_GetAStringWithSpecifiedMaximumSize.side_effect = self.side_effects_helper.niFake_GetAStringWithSpecifiedMaximumSize
-        self.side_effects_helper['GetAStringWithSpecifiedMaximumSize']['aString'] = single_character_string
-        with nifake.Session('dev1') as session:
-            buffer_size = 19
-            string_with_specified_buffer = session.get_a_string_with_specified_maximum_size(buffer_size)
-            assert(string_with_specified_buffer == single_character_string)
-            self.patched_library.niFake_GetAStringWithSpecifiedMaximumSize.assert_called_once_with(SESSION_NUM_FOR_TEST, ANY, ANY)
-
-    def test_get_a_string_of_fixed_maximum_size(self):
-        fixed_buffer_string = "this method will return fixed buffer string"
-        self.patched_library.niFake_GetAStringOfFixedMaximumSize.side_effect = self.side_effects_helper.niFake_GetAStringOfFixedMaximumSize
-        self.side_effects_helper['GetAStringOfFixedMaximumSize']['aString'] = fixed_buffer_string
-        with nifake.Session('dev1') as session:
-            returned_string = session.get_a_string_of_fixed_maximum_size()
-            assert (returned_string == fixed_buffer_string)
-            self.patched_library.niFake_GetAStringOfFixedMaximumSize.assert_called_once_with(SESSION_NUM_FOR_TEST, ANY)
-
-    def test_return_a_number_and_a_string(self):
-        test_string = "this string"
-        test_number = 13
-        self.patched_library.niFake_ReturnANumberAndAString.side_effect = self.side_effects_helper.niFake_ReturnANumberAndAString
-        self.side_effects_helper['ReturnANumberAndAString']['aString'] = test_string
-        self.side_effects_helper['ReturnANumberAndAString']['aNumber'] = test_number
-        with nifake.Session('dev1') as session:
-            returned_number, returned_string = session.return_a_number_and_a_string()
-            assert (returned_string == test_string)
-            assert (returned_number == test_number)
-            self.patched_library.niFake_ReturnANumberAndAString.assert_called_once_with(SESSION_NUM_FOR_TEST, ANY, ANY)
 
     def test_get_error_description_error_message(self):
         test_error_code = -42
@@ -573,24 +594,3 @@ class TestSession(object):
         from mock import call
         calls = [call(SESSION_NUM_FOR_TEST, test_error_code, ANY)]
         self.patched_library.niFake_error_message.assert_has_calls(calls)
-
-    '''
-    # TODO(bhaswath): Enable test once issue 320 is fixed
-    def test_read_with_warning(self):
-        test_maximum_time = 10
-        test_reading = float('nan')
-        test_error_code = 42
-        test_error_desc = "The answer to the ultimate question, only positive"
-        self.patched_library.niFake_Read.side_effect = self.side_effects_helper.niFake_Read
-        self.side_effects_helper['Read']['return'] = test_error_code
-        self.side_effects_helper['Read']['reading'] = test_reading
-        self.patched_library.niFake_GetError.side_effect = self.side_effects_helper.niFake_GetError
-        self.side_effects_helper['GetError']['errorCode'] = test_error_code
-        self.side_effects_helper['GetError']['description'] = test_error_desc
-        with nifake.Session('dev1') as session:
-            with warnings.catch_warnings(record=True) as w:
-                assert test_reading == session.read(test_maximum_time)
-                assert len(w) == 1
-                assert issubclass(w[0].category, nifake.NifakeWarning)
-                assert test_error_desc in str(w[0].message)
-    '''

--- a/src/nifake/tests/test_session.py
+++ b/src/nifake/tests/test_session.py
@@ -240,21 +240,6 @@ class TestSession(object):
                 assert e.code == test_error_code
                 assert e.description == test_error_desc
 
-    def test_method_with_warning(self):
-        test_error_code = 42
-        test_error_desc = "The answer to the ultimate question, only positive"
-        self.patched_library.niFake_SimpleFunction.side_effect = self.side_effects_helper.niFake_SimpleFunction
-        self.side_effects_helper['SimpleFunction']['return'] = test_error_code
-        self.patched_library.niFake_GetError.side_effect = self.side_effects_helper.niFake_GetError
-        self.side_effects_helper['GetError']['errorCode'] = test_error_code
-        self.side_effects_helper['GetError']['description'] = test_error_desc
-        with nifake.Session('dev1') as session:
-            with warnings.catch_warnings(record=True) as w:
-                session.simple_function()
-                assert len(w) == 1
-                assert issubclass(w[0].category, nifake.NifakeWarning)
-                assert test_error_desc in str(w[0].message)
-
     def test_invalid_method_call_not_enough_parameters_error(self):
         self.patched_library.niFake_GetAStringWithSpecifiedMaximumSize.side_effect = self.side_effects_helper.niFake_GetAStringWithSpecifiedMaximumSize
         with nifake.Session('dev1') as session:
@@ -272,6 +257,21 @@ class TestSession(object):
                 assert False
             except TypeError as e:
                 pass
+
+    def test_method_with_warning(self):
+        test_error_code = 42
+        test_error_desc = "The answer to the ultimate question, only positive"
+        self.patched_library.niFake_SimpleFunction.side_effect = self.side_effects_helper.niFake_SimpleFunction
+        self.side_effects_helper['SimpleFunction']['return'] = test_error_code
+        self.patched_library.niFake_GetError.side_effect = self.side_effects_helper.niFake_GetError
+        self.side_effects_helper['GetError']['errorCode'] = test_error_code
+        self.side_effects_helper['GetError']['description'] = test_error_desc
+        with nifake.Session('dev1') as session:
+            with warnings.catch_warnings(record=True) as w:
+                session.simple_function()
+                assert len(w) == 1
+                assert issubclass(w[0].category, nifake.NifakeWarning)
+                assert test_error_desc in str(w[0].message)
 
     '''
     # TODO(bhaswath): Enable test once issue 320 is fixed
@@ -423,7 +423,7 @@ class TestSession(object):
             self.patched_library.niFake_GetAttributeViString.assert_has_calls(calls)
             assert self.patched_library.niFake_GetAttributeViString.call_count == 2
 
-    def test_set_vi_string_attribute(self):
+    def test_set_attribute_string(self):
         self.patched_library.niFake_SetAttributeViString.side_effect = self.side_effects_helper.niFake_SetAttributeViString
         attribute_id = 1000002
         attrib_string = 'This is test string'
@@ -438,7 +438,7 @@ class TestSession(object):
             assert session.read_write_bool
             self.patched_library.niFake_GetAttributeViBoolean.assert_called_once_with(SESSION_NUM_FOR_TEST, b"", 1000000, ANY)
 
-    def test_set_bool_attribute(self):
+    def test_set_attribute_boolean(self):
         self.patched_library.niFake_SetAttributeViBoolean.side_effect = self.side_effects_helper.niFake_SetAttributeViBoolean
         attribute_id = 1000000
         attrib_bool = True
@@ -500,23 +500,6 @@ class TestSession(object):
     # def test_get_attribute_int64(self):
     # def test_set_attribute_int64(self):
 
-    def test_set_attribute_error(self):
-        test_error_code = -1
-        test_error_desc = 'Test'
-        self.patched_library.niFake_SetAttributeViReal64.side_effect = self.side_effects_helper.niFake_SetAttributeViReal64
-        self.side_effects_helper['SetAttributeViReal64']['return'] = test_error_code
-        self.patched_library.niFake_GetError.side_effect = self.side_effects_helper.niFake_GetError
-        self.side_effects_helper['GetError']['errorCode'] = test_error_code
-        self.side_effects_helper['GetError']['description'] = test_error_desc
-        with nifake.Session('dev1') as session:
-            try:
-                session.read_write_double = -42
-                assert False
-            except nifake.Error as e:
-                assert e.code == test_error_code
-                assert e.description == test_error_desc
-                self.patched_library.niFake_SetAttributeViReal64.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', 1000001, -42)
-
     def test_get_attribute_error(self):
         test_error_code = -123
         test_error_desc = "ascending order"
@@ -533,6 +516,23 @@ class TestSession(object):
             except nifake.Error as e:
                 assert e.code == test_error_code
                 assert e.description == test_error_desc
+
+    def test_set_attribute_error(self):
+        test_error_code = -1
+        test_error_desc = 'Test'
+        self.patched_library.niFake_SetAttributeViReal64.side_effect = self.side_effects_helper.niFake_SetAttributeViReal64
+        self.side_effects_helper['SetAttributeViReal64']['return'] = test_error_code
+        self.patched_library.niFake_GetError.side_effect = self.side_effects_helper.niFake_GetError
+        self.side_effects_helper['GetError']['errorCode'] = test_error_code
+        self.side_effects_helper['GetError']['description'] = test_error_desc
+        with nifake.Session('dev1') as session:
+            try:
+                session.read_write_double = -42
+                assert False
+            except nifake.Error as e:
+                assert e.code == test_error_code
+                assert e.description == test_error_desc
+                self.patched_library.niFake_SetAttributeViReal64.assert_called_once_with(SESSION_NUM_FOR_TEST, b'', 1000001, -42)
 
     def test_add_properties_to_session_error(self):
         with nifake.Session('dev1') as session:


### PR DESCRIPTION
[ x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This organizes unit tests better

- Puts all tests of certain type in category (attribute tests in attributes section, etc)

- Moves attributes tests to follow get / set pattern

- Errors for each section go at bottom of each section

- Groups todos and commented code in correct locations within categories

- Updated names for consistency

### List issues fixed by this Pull Request below, if any.

NA

### What testing has been done?

Ran unit tests and flake 8

Before - 
bin/nifake/nifake/tests/test_session.py::TestSession::test_init_with_options_and_close PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_init_with_options_nondefault_and_close PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_error_on_init PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_close PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_session_context_manager PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_simple_function PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_method_with_error PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_method_with_warning PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_a_number PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_invalid_method_call_not_enough_parameters PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_invalid_method_call_wrong_type PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_one_input_function PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_vi_int_64_function PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_two_input_function PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_enum_value PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_a_boolean PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_acquisition_context_manager PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_cannot_add_properties_to_session PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_string_ivi_dance_error PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_single_point_read PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_single_point_read_nan PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_repeated_capability_method_on_session PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_repeated_capability_method_on_specific_channel PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_device_method_not_exist_on_repeated_capability PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_attribute_int32 PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_set_attribute_int32 PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_attribute_real64 PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_attribute_string PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_attribute_boolean PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_attribute_enum_int32 PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_set_attribute_enum_int32 PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_set_enum_attribute_int32_bad_type PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_attribute_enum_real64 PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_set_attribute_enum_real64 PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_attribute_channel_int32 PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_set_attribute_channel_real64 PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_set_attribute_error PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_attribute_error PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_error_and_error_message_returns_error PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_enum_input_function_with_defaults PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_set_bool_attribute PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_set_vi_string_attribute PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_multipoint_read PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_array_input_function PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_a_string_with_specified_maximum_size PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_a_string_of_fixed_maximum_size PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_return_a_number_and_a_string PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_error_description_error_message PASSED

After
bin/nifake/nifake/tests/test_session.py::TestSession::test_init_with_options_and_close PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_init_with_options_nondefault_and_close PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_close PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_session_context_manager PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_init_with_error PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_simple_function PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_a_number PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_one_input_function PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_vi_int_64_function PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_two_input_function PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_enum_value PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_a_boolean PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_acquisition_context_manager PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_single_point_read PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_single_point_read_nan PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_enum_input_function_with_defaults PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_multipoint_read PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_array_input_function PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_method_with_error PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_invalid_method_call_not_enough_parameters_error PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_invalid_method_call_wrong_type_error PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_method_with_warning PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_a_string_with_specified_maximum_size PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_a_string_of_fixed_maximum_size PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_return_a_number_and_a_string PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_string_ivi_dance_error PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_repeated_capability_method_on_session PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_repeated_capability_method_on_specific_channel PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_device_method_not_exist_on_repeated_capability_error PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_attribute_int32 PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_set_attribute_int32 PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_attribute_real64 PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_attribute_string PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_set_attribute_string PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_attribute_boolean PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_set_attribute_boolean PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_attribute_enum_int32 PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_set_attribute_enum_int32 PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_attribute_enum_real64 PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_set_attribute_enum_real64 PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_attribute_channel PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_set_attribute_channel PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_attribute_error PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_set_attribute_error PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_add_properties_to_session_error PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_set_enum_attribute_int32_error PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_error_and_error_message_returns_error PASSED
bin/nifake/nifake/tests/test_session.py::TestSession::test_get_error_description_error_message_error PASSED
