### PR TITLE
Add buffer_info for niDCPower_FetchMultiple() parameters

### DIFF
--- a/generated/nidcpower/session.py
+++ b/generated/nidcpower/session.py
@@ -2590,13 +2590,13 @@ class _SessionBase(object):
             actual_count (int): Indicates the number of measured values actually retrieved from the
                 device.
         '''
-        voltage_measurements_ctype = (visatype.ViReal64 * 1)()
-        current_measurements_ctype = (visatype.ViReal64 * 1)()
-        in_compliance_ctype = (visatype.ViBoolean * 1)()
+        voltage_measurements_ctype = (visatype.ViReal64 * count)()
+        current_measurements_ctype = (visatype.ViReal64 * count)()
+        in_compliance_ctype = (visatype.ViBoolean * count)()
         actual_count_ctype = visatype.ViInt32(0)
         error_code = self._library.niDCPower_FetchMultiple(self._vi, self._repeated_capability.encode(self._encoding), timeout, count, voltage_measurements_ctype, current_measurements_ctype, in_compliance_ctype, ctypes.pointer(actual_count_ctype))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return [voltage_measurements_ctype[i] for i in range(1)], [current_measurements_ctype[i] for i in range(1)], [in_compliance_ctype[i] for i in range(1)], int(actual_count_ctype.value)
+        return [voltage_measurements_ctype[i] for i in range(count)], [current_measurements_ctype[i] for i in range(count)], [in_compliance_ctype[i] for i in range(count)], int(actual_count_ctype.value)
 
     def _get_attribute_vi_boolean(self, attribute_id):
         '''_get_attribute_vi_boolean

--- a/src/nidcpower/metadata/functions_addon.py
+++ b/src/nidcpower/metadata/functions_addon.py
@@ -85,6 +85,9 @@ functions_buffer_info = {
     'InitializeWithChannels':       { 'parameters': { 0: { 'is_buffer': True, },
                                                       1: { 'is_buffer': True, },
                                                       3: { 'is_buffer': True, }, }, },
+    'FetchMultiple':                { 'parameters': { 4: { 'size': {'mechanism':'passed-in', 'value':'Count'}, },
+                                                      5: { 'size': {'mechanism':'passed-in', 'value':'Count'}, },
+                                                      6: { 'size': {'mechanism':'passed-in', 'value':'Count'}, }, }, }
 }
 
 # These are functions we mark as "error_handling":True. The generator uses this information to


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~

### What does this Pull Request accomplish?

Makes nidcpower.Session.fetch_multiple() work with count > 1. Without this memory gets corrupted.

### List issues fixed by this Pull Request below, if any.

N/A

### What testing has been done?

Tested with examples on my end. Examples will be posted in a separate PR.