### PR TITLE
Consolidate filter functions

### DIFF
--- a/build/helper/__init__.py
+++ b/build/helper/__init__.py
@@ -1,4 +1,3 @@
-from build.helper.codegen_helper import filter_parameters  # noqa: F401
 from build.helper.codegen_helper import get_ctype_variable_declaration_snippet  # noqa: F401
 from build.helper.codegen_helper import get_dictionary_snippet  # noqa: F401
 from build.helper.codegen_helper import get_enum_type_check_snippet  # noqa: F401
@@ -22,9 +21,9 @@ from build.helper.helper import sorted_attrs  # noqa: F401
 from build.helper.metadata_add_all import add_all_function_metadata  # noqa: F401
 
 from build.helper.metadata_filters import filter_codegen_functions  # noqa: F401
-from build.helper.metadata_filters import filter_enum_parameters  # noqa: F401
 from build.helper.metadata_filters import filter_ivi_dance_parameter  # noqa: F401
 from build.helper.metadata_filters import filter_len_parameter  # noqa: F401
+from build.helper.metadata_filters import filter_parameters  # noqa: F401
 
 from build.helper.metadata_find import find_size_parameter  # noqa: F401
 

--- a/build/helper/__init__.py
+++ b/build/helper/__init__.py
@@ -22,10 +22,8 @@ from build.helper.metadata_add_all import add_all_function_metadata  # noqa: F40
 
 from build.helper.metadata_filters import filter_codegen_functions  # noqa: F401
 from build.helper.metadata_filters import filter_enum_parameters  # noqa: F401
-from build.helper.metadata_filters import filter_input_parameters  # noqa: F401
 from build.helper.metadata_filters import filter_ivi_dance_parameter  # noqa: F401
 from build.helper.metadata_filters import filter_len_parameter  # noqa: F401
-from build.helper.metadata_filters import filter_output_parameters  # noqa: F401
 
 from build.helper.metadata_find import find_size_parameter  # noqa: F401
 

--- a/build/helper/__init__.py
+++ b/build/helper/__init__.py
@@ -4,7 +4,8 @@ from build.helper.codegen_helper import get_dictionary_snippet  # noqa: F401
 from build.helper.codegen_helper import get_enum_type_check_snippet  # noqa: F401
 from build.helper.codegen_helper import get_method_return_snippet  # noqa: F401
 from build.helper.codegen_helper import get_params_snippet  # noqa: F401
-from build.helper.codegen_helper import ParameterUsageOptions  # noqa: F401
+
+from build.helper.parameter_usage_options import ParameterUsageOptions  # noqa: F401
 
 from build.helper.documentation_helper import as_rest_table  # noqa: F401
 from build.helper.documentation_helper import get_documentation_for_node_docstring  # noqa: F401

--- a/build/helper/codegen_helper.py
+++ b/build/helper/codegen_helper.py
@@ -25,6 +25,10 @@ class ParameterUsageOptions(Enum):
     '''For setting up the ctypes argument types'''
     LIBRARY_METHOD_DECLARATION = 7
     '''For declaring a method in Library'''
+    INPUT_PARAMETERS = 8
+    '''Get all input parameters, other than self, rep caps, and size'''
+    OUTPUT_PARAMETERS = 9
+    '''Get all output parameters, other than ivi-dance'''
 
 
 _parameterUsageOptions = {}
@@ -38,6 +42,7 @@ _parameterUsageOptions[ParameterUsageOptions.SESSION_METHOD_DECLARATION] = {
     'reordered_for_default_values': True,
     'name_to_use': 'python_name_with_default',
     'skip_repeated_capability_parameter': True,
+    'mechanism': 'any',
 }
 _parameterUsageOptions[ParameterUsageOptions.SESSION_METHOD_CALL] = {
     'skip_self': True,
@@ -48,6 +53,7 @@ _parameterUsageOptions[ParameterUsageOptions.SESSION_METHOD_CALL] = {
     'reordered_for_default_values': True,
     'name_to_use': 'python_name',
     'skip_repeated_capability_parameter': True,
+    'mechanism': 'any',
 }
 _parameterUsageOptions[ParameterUsageOptions.DOCUMENTATION_SESSION_METHOD] = {
     'skip_self': True,
@@ -58,6 +64,7 @@ _parameterUsageOptions[ParameterUsageOptions.DOCUMENTATION_SESSION_METHOD] = {
     'reordered_for_default_values': True,
     'name_to_use': 'python_name_with_doc_default',
     'skip_repeated_capability_parameter': True,
+    'mechanism': 'any',
 }
 _parameterUsageOptions[ParameterUsageOptions.CTYPES_CALL] = {
     'skip_self': True,
@@ -68,6 +75,7 @@ _parameterUsageOptions[ParameterUsageOptions.CTYPES_CALL] = {
     'reordered_for_default_values': False,
     'name_to_use': 'python_name',
     'skip_repeated_capability_parameter': False,
+    'mechanism': 'any',
 }
 _parameterUsageOptions[ParameterUsageOptions.LIBRARY_METHOD_CALL] = {
     'skip_self': True,
@@ -78,6 +86,7 @@ _parameterUsageOptions[ParameterUsageOptions.LIBRARY_METHOD_CALL] = {
     'reordered_for_default_values': False,
     'name_to_use': 'library_method_call_snippet',
     'skip_repeated_capability_parameter': False,
+    'mechanism': 'any',
 }
 _parameterUsageOptions[ParameterUsageOptions.CTYPES_ARGTYPES] = {
     'skip_self': True,
@@ -88,6 +97,7 @@ _parameterUsageOptions[ParameterUsageOptions.CTYPES_ARGTYPES] = {
     'reordered_for_default_values': False,
     'name_to_use': 'ctypes_type_library_call',
     'skip_repeated_capability_parameter': False,
+    'mechanism': 'any',
 }
 _parameterUsageOptions[ParameterUsageOptions.LIBRARY_METHOD_DECLARATION] = {
     'skip_self': False,
@@ -98,6 +108,29 @@ _parameterUsageOptions[ParameterUsageOptions.LIBRARY_METHOD_DECLARATION] = {
     'reordered_for_default_values': False,
     'name_to_use': 'python_name',
     'skip_repeated_capability_parameter': False,
+    'mechanism': 'any',
+}
+_parameterUsageOptions[ParameterUsageOptions.INPUT_PARAMETERS] = {
+    'skip_self': True,
+    'skip_session_handle': True,
+    'skip_input_parameters': False,
+    'skip_output_parameters': True,
+    'skip_size_parameter': False,
+    'reordered_for_default_values': False,
+    'name_to_use': 'python_name',
+    'skip_repeated_capability_parameter': True,
+    'mechanism': 'any',
+}
+_parameterUsageOptions[ParameterUsageOptions.OUTPUT_PARAMETERS] = {
+    'skip_self': True,
+    'skip_session_handle': True,
+    'skip_input_parameters': True,
+    'skip_output_parameters': False,
+    'skip_size_parameter': False,
+    'reordered_for_default_values': False,
+    'name_to_use': 'python_name',
+    'skip_repeated_capability_parameter': False,
+    'mechanism': 'fixed, passed-in, len', # any but ivi-dance
 }
 
 
@@ -129,6 +162,8 @@ def filter_parameters(function, parameter_usage_options):
         if x['is_session_handle'] is True and options_to_use['skip_session_handle']:
             skip = True
         if x['is_repeated_capability'] is True and options_to_use['skip_repeated_capability_parameter']:
+            skip = True
+        if options_to_use['mechanism'] != 'any' and x['size']['mechanism'] not in options_to_use['mechanism']:
             skip = True
         if not skip:
             parameters_to_use.append(x)

--- a/build/helper/codegen_helper.py
+++ b/build/helper/codegen_helper.py
@@ -7,108 +7,40 @@ import pprint
 pp = pprint.PrettyPrinter(indent=4)
 
 
-
-_parameterUsageOptions = {}
-
-_parameterUsageOptions[ParameterUsageOptions.SESSION_METHOD_DECLARATION] = {
+_parameterUsageOptionsSnippet[ParameterUsageOptions.SESSION_METHOD_DECLARATION] = {
     'skip_self': False,
-    'skip_session_handle': True,
-    'skip_input_parameters': False,
-    'skip_output_parameters': True,
-    'skip_size_parameter': True,
-    'reordered_for_default_values': True,
     'name_to_use': 'python_name_with_default',
-    'skip_repeated_capability_parameter': True,
-    'mechanism': 'any',
 }
-_parameterUsageOptions[ParameterUsageOptions.SESSION_METHOD_CALL] = {
+_parameterUsageOptionsSnippet[ParameterUsageOptions.SESSION_METHOD_CALL] = {
     'skip_self': True,
-    'skip_session_handle': True,
-    'skip_input_parameters': False,
-    'skip_output_parameters': True,
-    'skip_size_parameter': True,
-    'reordered_for_default_values': True,
     'name_to_use': 'python_name',
-    'skip_repeated_capability_parameter': True,
-    'mechanism': 'any',
 }
-_parameterUsageOptions[ParameterUsageOptions.DOCUMENTATION_SESSION_METHOD] = {
+_parameterUsageOptionsSnippet[ParameterUsageOptions.DOCUMENTATION_SESSION_METHOD] = {
     'skip_self': True,
-    'skip_session_handle': True,
-    'skip_input_parameters': False,
-    'skip_output_parameters': True,
-    'skip_size_parameter': True,
-    'reordered_for_default_values': True,
     'name_to_use': 'python_name_with_doc_default',
-    'skip_repeated_capability_parameter': True,
-    'mechanism': 'any',
 }
-_parameterUsageOptions[ParameterUsageOptions.CTYPES_CALL] = {
+_parameterUsageOptionsSnippet[ParameterUsageOptions.CTYPES_CALL] = {
     'skip_self': True,
-    'skip_session_handle': False,
-    'skip_input_parameters': False,
-    'skip_output_parameters': False,
-    'skip_size_parameter': False,
-    'reordered_for_default_values': False,
     'name_to_use': 'python_name',
-    'skip_repeated_capability_parameter': False,
-    'mechanism': 'any',
 }
-_parameterUsageOptions[ParameterUsageOptions.LIBRARY_METHOD_CALL] = {
+_parameterUsageOptionsSnippet[ParameterUsageOptions.LIBRARY_METHOD_CALL] = {
     'skip_self': True,
-    'skip_session_handle': False,
-    'skip_input_parameters': False,
-    'skip_output_parameters': False,
-    'skip_size_parameter': False,
-    'reordered_for_default_values': False,
     'name_to_use': 'library_method_call_snippet',
-    'skip_repeated_capability_parameter': False,
-    'mechanism': 'any',
 }
-_parameterUsageOptions[ParameterUsageOptions.CTYPES_ARGTYPES] = {
+_parameterUsageOptionsSnippet[ParameterUsageOptions.CTYPES_ARGTYPES] = {
     'skip_self': True,
-    'skip_session_handle': False,
-    'skip_input_parameters': False,
-    'skip_output_parameters': False,
-    'skip_size_parameter': False,
-    'reordered_for_default_values': False,
     'name_to_use': 'ctypes_type_library_call',
-    'skip_repeated_capability_parameter': False,
-    'mechanism': 'any',
 }
-_parameterUsageOptions[ParameterUsageOptions.LIBRARY_METHOD_DECLARATION] = {
+_parameterUsageOptionsSnippet[ParameterUsageOptions.LIBRARY_METHOD_DECLARATION] = {
     'skip_self': False,
-    'skip_session_handle': False,
-    'skip_input_parameters': False,
-    'skip_output_parameters': False,
-    'skip_size_parameter': False,
-    'reordered_for_default_values': False,
     'name_to_use': 'python_name',
-    'skip_repeated_capability_parameter': False,
-    'mechanism': 'any',
 }
-_parameterUsageOptions[ParameterUsageOptions.INPUT_PARAMETERS] = {
-    'skip_self': True,
-    'skip_session_handle': True,
-    'skip_input_parameters': False,
-    'skip_output_parameters': True,
-    'skip_size_parameter': False,
-    'reordered_for_default_values': False,
-    'name_to_use': 'python_name',
-    'skip_repeated_capability_parameter': True,
-    'mechanism': 'any',
-}
-_parameterUsageOptions[ParameterUsageOptions.OUTPUT_PARAMETERS] = {
-    'skip_self': True,
-    'skip_session_handle': True,
-    'skip_input_parameters': True,
-    'skip_output_parameters': False,
-    'skip_size_parameter': False,
-    'reordered_for_default_values': False,
-    'name_to_use': 'python_name',
-    'skip_repeated_capability_parameter': False,
-    'mechanism': 'fixed, passed-in, len',  # any but ivi-dance
-}
+# Only used for filtering
+#   ParameterUsageOptions.INPUT_PARAMETERS
+#   ParameterUsageOptions.OUTPUT_PARAMETERS
+#   ParameterUsageOptions.IVI_DANCE_PARAMETER
+#   ParameterUsageOptions.LEN_PARAMETER
+#   ParameterUsageOptions.INPUT_ENUM_PARAMETERS
 
 
 def filter_parameters(function, parameter_usage_options):

--- a/build/helper/codegen_helper.py
+++ b/build/helper/codegen_helper.py
@@ -130,7 +130,7 @@ _parameterUsageOptions[ParameterUsageOptions.OUTPUT_PARAMETERS] = {
     'reordered_for_default_values': False,
     'name_to_use': 'python_name',
     'skip_repeated_capability_parameter': False,
-    'mechanism': 'fixed, passed-in, len', # any but ivi-dance
+    'mechanism': 'fixed, passed-in, len',  # any but ivi-dance
 }
 
 

--- a/build/helper/codegen_helper.py
+++ b/build/helper/codegen_helper.py
@@ -7,29 +7,6 @@ import pprint
 pp = pprint.PrettyPrinter(indent=4)
 
 
-# Functions that return snippets that can be placed directly in the templates.
-class ParameterUsageOptions(Enum):
-    '''Different usage options for parameter lists.'''
-
-    SESSION_METHOD_DECLARATION = 1
-    '''For declaring a method in Session'''
-    SESSION_METHOD_CALL = 2
-    '''For calling into a Session method.'''
-    DOCUMENTATION_SESSION_METHOD = 3
-    '''For documentation (rst) of Session methods'''
-    CTYPES_CALL = 4
-    '''For Library implementation calling into the DLL via ctypes'''
-    LIBRARY_METHOD_CALL = 5
-    '''For calling into a method in Library.'''
-    CTYPES_ARGTYPES = 6
-    '''For setting up the ctypes argument types'''
-    LIBRARY_METHOD_DECLARATION = 7
-    '''For declaring a method in Library'''
-    INPUT_PARAMETERS = 8
-    '''Get all input parameters, other than self, rep caps, and size'''
-    OUTPUT_PARAMETERS = 9
-    '''Get all output parameters, other than ivi-dance'''
-
 
 _parameterUsageOptions = {}
 

--- a/build/helper/documentation_helper.py
+++ b/build/helper/documentation_helper.py
@@ -342,7 +342,7 @@ def get_function_rst(fname, config, indent=0):
     indent += 4
     rst += get_documentation_for_node_rst(function, config, indent)
 
-    input_params = filter_parameters(function['parameters'], ParameterUsageOptions.INPUT_PARAMETERS)
+    input_params = filter_parameters(function, ParameterUsageOptions.INPUT_PARAMETERS)
     if len(input_params) > 0:
         rst += '\n'
     for p in input_params:
@@ -352,7 +352,7 @@ def get_function_rst(fname, config, indent=0):
         p_type = _format_type_for_rst_documentation(p, config)
         rst += '\n' + (' ' * indent) + ':type {0}: '.format(p['python_name']) + p_type
 
-    output_params = filter_parameters(function['parameters'], ParameterUsageOptions.OUTPUT_PARAMETERS)
+    output_params = filter_parameters(function, ParameterUsageOptions.OUTPUT_PARAMETERS)
     if len(output_params) > 1:
         rst += '\n\n' + (' ' * indent) + ':rtype: tuple (' + ', '.join([p['python_name'] for p in output_params]) + ')\n\n'
         rst += (' ' * (indent + 4)) + 'WHERE\n'
@@ -403,14 +403,14 @@ def get_function_docstring(fname, config, indent=0):
 
     docstring += get_documentation_for_node_docstring(function, config, indent)
 
-    input_params = filter_parameters(function['parameters'], ParameterUsageOptions.INPUT_PARAMETERS)
+    input_params = filter_parameters(function, ParameterUsageOptions.INPUT_PARAMETERS)
     if len(input_params) > 0:
         docstring += '\n\n' + (' ' * indent) + 'Args:'
     for p in input_params:
         docstring += '\n' + (' ' * (indent + 4)) + '{0} ({1}): '.format(p['python_name'], _format_type_for_docstring(p, config))
         docstring += get_documentation_for_node_docstring(p, config, indent + 8)
 
-    output_params = filter_parameters(function['parameters'], ParameterUsageOptions.OUTPUT_PARAMETERS)
+    output_params = filter_parameters(function, ParameterUsageOptions.OUTPUT_PARAMETERS)
     if len(output_params) > 0:
         docstring += '\n\n' + (' ' * indent) + 'Returns:'
         for p in output_params:

--- a/build/helper/documentation_helper.py
+++ b/build/helper/documentation_helper.py
@@ -1,7 +1,7 @@
 
 from .codegen_helper import filter_parameters
 from .codegen_helper import get_params_snippet
-from .codegen_helper import ParameterUsageOptions
+from .parameter_usage_options import ParameterUsageOptions
 
 import re
 import string

--- a/build/helper/documentation_helper.py
+++ b/build/helper/documentation_helper.py
@@ -1,7 +1,5 @@
 
-from .metadata_filters import filter_input_parameters
-from .metadata_filters import filter_output_parameters
-
+from .codegen_helper import filter_parameters
 from .codegen_helper import get_params_snippet
 from .codegen_helper import ParameterUsageOptions
 
@@ -344,7 +342,7 @@ def get_function_rst(fname, config, indent=0):
     indent += 4
     rst += get_documentation_for_node_rst(function, config, indent)
 
-    input_params = filter_input_parameters(function['parameters'])
+    input_params = filter_parameters(function['parameters'], ParameterUsageOptions.INPUT_PARAMETERS)
     if len(input_params) > 0:
         rst += '\n'
     for p in input_params:
@@ -354,7 +352,7 @@ def get_function_rst(fname, config, indent=0):
         p_type = _format_type_for_rst_documentation(p, config)
         rst += '\n' + (' ' * indent) + ':type {0}: '.format(p['python_name']) + p_type
 
-    output_params = filter_output_parameters(function['parameters'])
+    output_params = filter_parameters(function['parameters'], ParameterUsageOptions.OUTPUT_PARAMETERS)
     if len(output_params) > 1:
         rst += '\n\n' + (' ' * indent) + ':rtype: tuple (' + ', '.join([p['python_name'] for p in output_params]) + ')\n\n'
         rst += (' ' * (indent + 4)) + 'WHERE\n'
@@ -405,14 +403,14 @@ def get_function_docstring(fname, config, indent=0):
 
     docstring += get_documentation_for_node_docstring(function, config, indent)
 
-    input_params = filter_input_parameters(function['parameters'])
+    input_params = filter_parameters(function['parameters'], ParameterUsageOptions.INPUT_PARAMETERS)
     if len(input_params) > 0:
         docstring += '\n\n' + (' ' * indent) + 'Args:'
     for p in input_params:
         docstring += '\n' + (' ' * (indent + 4)) + '{0} ({1}): '.format(p['python_name'], _format_type_for_docstring(p, config))
         docstring += get_documentation_for_node_docstring(p, config, indent + 8)
 
-    output_params = filter_output_parameters(function['parameters'])
+    output_params = filter_parameters(function['parameters'], ParameterUsageOptions.OUTPUT_PARAMETERS)
     if len(output_params) > 0:
         docstring += '\n\n' + (' ' * indent) + 'Returns:'
         for p in output_params:

--- a/build/helper/metadata_filters.py
+++ b/build/helper/metadata_filters.py
@@ -6,16 +6,6 @@ def filter_codegen_functions(functions):
     return {k: v for k, v in functions.items() if v['codegen_method'] != 'no'}
 
 
-def filter_input_parameters(parameters):
-    '''Returns list of parameters that includes only input parameters, except the session parameter or repeated capability parameter if they exists'''
-    return [x for x in parameters if x['direction'] == 'in' and not x['is_session_handle'] and not x['is_repeated_capability']]
-
-
-def filter_output_parameters(parameters):
-    '''Returns list of parameters that includes only output parameters, except the ivi-dance parameter if it exists'''
-    return [x for x in parameters if x['direction'] == 'out' and x['size']['mechanism'] != 'ivi-dance']
-
-
 def filter_enum_parameters(parameters):
     '''Returns a list of parameters whose type is an enum'''
     return [x for x in parameters if x['enum'] is not None]

--- a/build/helper/metadata_filters.py
+++ b/build/helper/metadata_filters.py
@@ -1,10 +1,132 @@
 from .parameter_usage_options import ParameterUsageOptions
 # Filters
 
+_parameterUsageOptionsFiltering = {}
 
 def filter_codegen_functions(functions):
     '''Returns function metadata only for those functions to be included in codegen'''
     return {k: v for k, v in functions.items() if v['codegen_method'] != 'no'}
+_parameterUsageOptionsFiltering[ParameterUsageOptions.SESSION_METHOD_DECLARATION] = {
+    'skip_session_handle': True,
+    'skip_input_parameters': False,
+    'skip_output_parameters': True,
+    'skip_size_parameter': True,
+    'reordered_for_default_values': True,
+    'skip_repeated_capability_parameter': True,
+    'skip_non_enum_parameter': False,
+    'mechanism': 'any',
+}
+_parameterUsageOptionsFiltering[ParameterUsageOptions.SESSION_METHOD_CALL] = {
+    'skip_session_handle': True,
+    'skip_input_parameters': False,
+    'skip_output_parameters': True,
+    'skip_size_parameter': True,
+    'reordered_for_default_values': True,
+    'skip_repeated_capability_parameter': True,
+    'skip_non_enum_parameter': False,
+    'mechanism': 'any',
+}
+_parameterUsageOptionsFiltering[ParameterUsageOptions.DOCUMENTATION_SESSION_METHOD] = {
+    'skip_session_handle': True,
+    'skip_input_parameters': False,
+    'skip_output_parameters': True,
+    'skip_size_parameter': True,
+    'reordered_for_default_values': True,
+    'skip_repeated_capability_parameter': True,
+    'skip_non_enum_parameter': False,
+    'mechanism': 'any',
+}
+_parameterUsageOptionsFiltering[ParameterUsageOptions.CTYPES_CALL] = {
+    'skip_session_handle': False,
+    'skip_input_parameters': False,
+    'skip_output_parameters': False,
+    'skip_size_parameter': False,
+    'reordered_for_default_values': False,
+    'skip_repeated_capability_parameter': False,
+    'skip_non_enum_parameter': False,
+    'mechanism': 'any',
+}
+_parameterUsageOptionsFiltering[ParameterUsageOptions.LIBRARY_METHOD_CALL] = {
+    'skip_session_handle': False,
+    'skip_input_parameters': False,
+    'skip_output_parameters': False,
+    'skip_size_parameter': False,
+    'reordered_for_default_values': False,
+    'skip_repeated_capability_parameter': False,
+    'skip_non_enum_parameter': False,
+    'mechanism': 'any',
+}
+_parameterUsageOptionsFiltering[ParameterUsageOptions.CTYPES_ARGTYPES] = {
+    'skip_session_handle': False,
+    'skip_input_parameters': False,
+    'skip_output_parameters': False,
+    'skip_size_parameter': False,
+    'reordered_for_default_values': False,
+    'skip_repeated_capability_parameter': False,
+    'skip_non_enum_parameter': False,
+    'mechanism': 'any',
+}
+_parameterUsageOptionsFiltering[ParameterUsageOptions.LIBRARY_METHOD_DECLARATION] = {
+    'skip_session_handle': False,
+    'skip_input_parameters': False,
+    'skip_output_parameters': False,
+    'skip_size_parameter': False,
+    'reordered_for_default_values': False,
+    'skip_repeated_capability_parameter': False,
+    'skip_non_enum_parameter': False,
+    'mechanism': 'any',
+}
+_parameterUsageOptionsFiltering[ParameterUsageOptions.INPUT_PARAMETERS] = {
+    'skip_session_handle': True,
+    'skip_input_parameters': False,
+    'skip_output_parameters': True,
+    'skip_size_parameter': False,
+    'reordered_for_default_values': False,
+    'skip_repeated_capability_parameter': True,
+    'skip_non_enum_parameter': False,
+    'mechanism': 'any',
+}
+_parameterUsageOptionsFiltering[ParameterUsageOptions.OUTPUT_PARAMETERS] = {
+    'skip_session_handle': True,
+    'skip_input_parameters': True,
+    'skip_output_parameters': False,
+    'skip_size_parameter': False,
+    'reordered_for_default_values': False,
+    'skip_repeated_capability_parameter': False,
+    'skip_non_enum_parameter': False,
+    'mechanism': 'fixed, passed-in, len',  # any but ivi-dance
+}
+_parameterUsageOptionsFiltering[ParameterUsageOptions.IVI_DANCE_PARAMETER] = {
+    'skip_session_handle': True,
+    'skip_input_parameters': True,
+    'skip_output_parameters': False,
+    'skip_size_parameter': False,
+    'reordered_for_default_values': False,
+    'skip_repeated_capability_parameter': False,
+    'skip_non_enum_parameter': False,
+    'mechanism': 'ivi-dance',
+}
+_parameterUsageOptionsFiltering[ParameterUsageOptions.LEN_PARAMETER] = {
+    'skip_session_handle': True,
+    'skip_input_parameters': False,
+    'skip_output_parameters': True,
+    'skip_size_parameter': False,
+    'reordered_for_default_values': False,
+    'skip_repeated_capability_parameter': False,
+    'skip_non_enum_parameter': False,
+    'mechanism': 'len',
+}
+_parameterUsageOptionsFiltering[ParameterUsageOptions.INPUT_ENUM_PARAMETERS] = {
+    'skip_session_handle': True,
+    'skip_input_parameters': False,
+    'skip_output_parameters': True,
+    'skip_size_parameter': False,
+    'reordered_for_default_values': False,
+    'skip_repeated_capability_parameter': True,
+    'skip_non_enum_parameter': True,
+    'mechanism': 'any',
+}
+
 
 
 def filter_enum_parameters(parameters):

--- a/build/helper/metadata_filters.py
+++ b/build/helper/metadata_filters.py
@@ -1,3 +1,4 @@
+from .parameter_usage_options import ParameterUsageOptions
 # Filters
 
 

--- a/build/helper/parameter_usage_options.py
+++ b/build/helper/parameter_usage_options.py
@@ -1,0 +1,33 @@
+from enum import Enum
+
+
+class ParameterUsageOptions(Enum):
+    '''Different usage options for parameter lists.'''
+
+    SESSION_METHOD_DECLARATION = 1
+    '''For declaring a method in Session'''
+    SESSION_METHOD_CALL = 2
+    '''For calling into a Session method.'''
+    DOCUMENTATION_SESSION_METHOD = 3
+    '''For documentation (rst) of Session methods'''
+    CTYPES_CALL = 4
+    '''For Library implementation calling into the DLL via ctypes'''
+    LIBRARY_METHOD_CALL = 5
+    '''For calling into a method in Library.'''
+    CTYPES_ARGTYPES = 6
+    '''For setting up the ctypes argument types'''
+    LIBRARY_METHOD_DECLARATION = 7
+    '''For declaring a method in Library'''
+    INPUT_PARAMETERS = 8
+    '''Get all input parameters, other than self, rep caps, and size'''
+    OUTPUT_PARAMETERS = 9
+    '''Get all output parameters, other than ivi-dance'''
+    IVI_DANCE_PARAMETER = 10
+    '''Get the ivi-dance parameter'''
+    LEN_PARAMETER = 11
+    '''Get the len parameter'''
+    INPUT_ENUM_PARAMETERS = 12
+    '''Get any input parameters whose type is enum'''
+
+
+

--- a/build/templates/mock_helper.py.mako
+++ b/build/templates/mock_helper.py.mako
@@ -34,7 +34,7 @@ f = functions[func_name]
 %>\
         self._defaults['${func_name}'] = {}
         self._defaults['${func_name}']['return'] = 0
-% for p in helper.filter_output_parameters(f['parameters']):
+% for p in helper.filter_parameters(f['parameters'], ParameterUsageOptions.OUTPUT_PARAMETERS):
         self._defaults['${func_name}']['${p['name']}'] = None
 % endfor
 <%
@@ -55,7 +55,7 @@ ivi_dance_param = helper.filter_ivi_dance_parameter(f['parameters'])
 <%
 f = functions[func_name]
 params = f['parameters']
-output_params = helper.filter_output_parameters(params)
+output_params = helper.filter_parameters(params, ParameterUsageOptions.OUTPUT_PARAMETERS)
 ivi_dance_param = helper.filter_ivi_dance_parameter(params)
 ivi_dance_size_param = helper.find_size_parameter(ivi_dance_param, params)
 %>\

--- a/build/templates/mock_helper.py.mako
+++ b/build/templates/mock_helper.py.mako
@@ -34,7 +34,7 @@ f = functions[func_name]
 %>\
         self._defaults['${func_name}'] = {}
         self._defaults['${func_name}']['return'] = 0
-% for p in helper.filter_parameters(f['parameters'], ParameterUsageOptions.OUTPUT_PARAMETERS):
+% for p in helper.filter_parameters(f, helper.ParameterUsageOptions.OUTPUT_PARAMETERS):
         self._defaults['${func_name}']['${p['name']}'] = None
 % endfor
 <%
@@ -55,7 +55,7 @@ ivi_dance_param = helper.filter_ivi_dance_parameter(f['parameters'])
 <%
 f = functions[func_name]
 params = f['parameters']
-output_params = helper.filter_parameters(params, ParameterUsageOptions.OUTPUT_PARAMETERS)
+output_params = helper.filter_parameters(f, helper.ParameterUsageOptions.OUTPUT_PARAMETERS)
 ivi_dance_param = helper.filter_ivi_dance_parameter(params)
 ivi_dance_size_param = helper.find_size_parameter(ivi_dance_param, params)
 %>\

--- a/build/templates/mock_helper.py.mako
+++ b/build/templates/mock_helper.py.mako
@@ -38,7 +38,7 @@ f = functions[func_name]
         self._defaults['${func_name}']['${p['name']}'] = None
 % endfor
 <%
-ivi_dance_param = helper.filter_ivi_dance_parameter(f['parameters'])
+ivi_dance_param = helper.filter_ivi_dance_parameter(f)
 %>\
 % if ivi_dance_param is not None:
         self._defaults['${func_name}']['${ivi_dance_param['name']}'] = None
@@ -56,7 +56,7 @@ ivi_dance_param = helper.filter_ivi_dance_parameter(f['parameters'])
 f = functions[func_name]
 params = f['parameters']
 output_params = helper.filter_parameters(f, helper.ParameterUsageOptions.OUTPUT_PARAMETERS)
-ivi_dance_param = helper.filter_ivi_dance_parameter(params)
+ivi_dance_param = helper.filter_ivi_dance_parameter(f)
 ivi_dance_size_param = helper.find_size_parameter(ivi_dance_param, params)
 %>\
     def ${c_function_prefix}${func_name}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.LIBRARY_METHOD_DECLARATION)}):  # noqa: N802

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -27,7 +27,7 @@ ${encoding_tag}
 
     parameters = f['parameters']
     output_parameters = helper.filter_output_parameters(parameters)
-    enum_input_parameters = helper.filter_enum_parameters(helper.filter_input_parameters(parameters))
+    enum_input_parameters = helper.filter_enum_parameters(helper.filter_parameters(parameters, ParameterUsageOptions.INPUT_PARAMETERS))
     ivi_dance_parameter = helper.filter_ivi_dance_parameter(parameters)
     ivi_dance_size_parameter = helper.find_size_parameter(ivi_dance_parameter, parameters)
     len_parameter = helper.filter_len_parameter(parameters)

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -27,10 +27,10 @@ ${encoding_tag}
 
     parameters = f['parameters']
     output_parameters = helper.filter_parameters(f, helper.ParameterUsageOptions.OUTPUT_PARAMETERS)
-    enum_input_parameters = helper.filter_enum_parameters(helper.filter_parameters(f, helper.ParameterUsageOptions.INPUT_PARAMETERS))
-    ivi_dance_parameter = helper.filter_ivi_dance_parameter(parameters)
+    enum_input_parameters = helper.filter_parameters(f, helper.ParameterUsageOptions.INPUT_ENUM_PARAMETERS)
+    ivi_dance_parameter = helper.filter_ivi_dance_parameter(f)
     ivi_dance_size_parameter = helper.find_size_parameter(ivi_dance_parameter, parameters)
-    len_parameter = helper.filter_len_parameter(parameters)
+    len_parameter = helper.filter_len_parameter(f)
     len_size_parameter = helper.find_size_parameter(len_parameter, parameters)
     assert ivi_dance_size_parameter is None or len_size_parameter is None
 %>\

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -26,8 +26,8 @@ ${encoding_tag}
     '''Renders a Session method corresponding to the passed-in function metadata.'''
 
     parameters = f['parameters']
-    output_parameters = helper.filter_output_parameters(parameters)
-    enum_input_parameters = helper.filter_enum_parameters(helper.filter_parameters(parameters, ParameterUsageOptions.INPUT_PARAMETERS))
+    output_parameters = helper.filter_parameters(f, helper.ParameterUsageOptions.OUTPUT_PARAMETERS)
+    enum_input_parameters = helper.filter_enum_parameters(helper.filter_parameters(f, helper.ParameterUsageOptions.INPUT_PARAMETERS))
     ivi_dance_parameter = helper.filter_ivi_dance_parameter(parameters)
     ivi_dance_size_parameter = helper.find_size_parameter(ivi_dance_parameter, parameters)
     len_parameter = helper.filter_len_parameter(parameters)

--- a/src/nimodinst/templates/session.py.mako
+++ b/src/nimodinst/templates/session.py.mako
@@ -152,8 +152,8 @@ class Session(object):
 <%
     f = functions[func_name]
     parameters = f['parameters']
-    input_parameters = helper.filter_parameters(parameters, ParameterUsageOptions.INPUT_PARAMETERS)
-    output_parameters = helper.filter_parameters(parameters, ParameterUsageOptions.OUTPUT_PARAMETERS)
+    input_parameters = helper.filter_parameters(f, helper.ParameterUsageOptions.INPUT_PARAMETERS)
+    output_parameters = helper.filter_parameters(f, helper.ParameterUsageOptions.OUTPUT_PARAMETERS)
     enum_input_parameters = helper.filter_enum_parameters(input_parameters)
     ivi_dance_parameter = helper.filter_ivi_dance_parameter(parameters)
     ivi_dance_size_parameter = helper.find_size_parameter(ivi_dance_parameter, parameters)

--- a/src/nimodinst/templates/session.py.mako
+++ b/src/nimodinst/templates/session.py.mako
@@ -152,8 +152,8 @@ class Session(object):
 <%
     f = functions[func_name]
     parameters = f['parameters']
-    input_parameters = helper.filter_input_parameters(parameters)
-    output_parameters = helper.filter_output_parameters(parameters)
+    input_parameters = helper.filter_parameters(parameters, ParameterUsageOptions.INPUT_PARAMETERS)
+    output_parameters = helper.filter_parameters(parameters, ParameterUsageOptions.OUTPUT_PARAMETERS)
     enum_input_parameters = helper.filter_enum_parameters(input_parameters)
     ivi_dance_parameter = helper.filter_ivi_dance_parameter(parameters)
     ivi_dance_size_parameter = helper.find_size_parameter(ivi_dance_parameter, parameters)

--- a/src/nimodinst/templates/session.py.mako
+++ b/src/nimodinst/templates/session.py.mako
@@ -154,8 +154,8 @@ class Session(object):
     parameters = f['parameters']
     input_parameters = helper.filter_parameters(f, helper.ParameterUsageOptions.INPUT_PARAMETERS)
     output_parameters = helper.filter_parameters(f, helper.ParameterUsageOptions.OUTPUT_PARAMETERS)
-    enum_input_parameters = helper.filter_enum_parameters(input_parameters)
-    ivi_dance_parameter = helper.filter_ivi_dance_parameter(parameters)
+    enum_input_parameters = helper.filter_parameters(f, helper.ParameterUsageOptions.INPUT_ENUM_PARAMETERS)
+    ivi_dance_parameter = helper.filter_ivi_dance_parameter(f)
     ivi_dance_size_parameter = helper.find_size_parameter(ivi_dance_parameter, parameters)
 %>
     def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
~~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
### What does this Pull Request accomplish?
* Consolidate filter functions to use filter_parameters with new options
  * Break _parameterUsageOptions into two parts
    1. filtering
    1. snippets
  * Maintain wrapper functions for finding len parameter and ivi-damce parameter
    * Returns None if not found
    * Ensure no more than one found
    * Returns parameter dictionary and not list of parameter dictionaries

### ~~List issues fixed by this Pull Request below, if any.~~

### What testing has been done?
* Travis
* System test