### PR TITLE
Move error handling methods to _SessionBase

### DIFF
--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -153,7 +153,7 @@ init_call_params = helper.get_params_snippet(init_function, helper.ParameterUsag
 
     ''' These are code-generated '''
 
-% for func_name in sorted({k: v for k, v in functions.items() if v['has_repeated_capability']}):
+% for func_name in sorted({k: v for k, v in functions.items() if v['has_repeated_capability'] or v['is_error_handling']}):
 ${render_method(functions[func_name])}
 % endfor
 
@@ -198,7 +198,7 @@ class Session(_SessionBase):
 
     ''' These are code-generated '''
 
-% for func_name in sorted({k: v for k, v in functions.items() if not v['has_repeated_capability']}):
+% for func_name in sorted({k: v for k, v in functions.items() if not v['has_repeated_capability'] and not v['is_error_handling']}):
 ${render_method(functions[func_name])}
 % endfor
 

--- a/generated/nidcpower/session.py
+++ b/generated/nidcpower/session.py
@@ -2890,6 +2890,50 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return channel_name_ctype.value.decode(self._encoding)
 
+    def _get_error(self):
+        '''_get_error
+
+        | Retrieves and then clears the IVI error information for the session or
+          the current execution thread unless **bufferSize** is 0, in which case
+          the function does not clear the error information. By passing 0 for
+          the buffer size, you can ascertain the buffer size required to get the
+          entire error description string and then call the function again with
+          a sufficiently large buffer size.
+        | If the user specifies a valid IVI session for **vi**, this function
+          retrieves and then clears the error information for the session. If
+          the user passes VI_NULL for **vi**, this function retrieves and then
+          clears the error information for the current execution thread. If
+          **vi** is an invalid session, the function does nothing and returns an
+          error. Normally, the error information describes the first error that
+          occurred since the user last called _get_error or
+          clear_error.
+
+        Args:
+            buffer_size (int): Specifies the number of bytes in the ViChar array you specify for
+                **description**.
+                If the error description, including the terminating NUL byte, contains
+                more bytes than you indicate in this attribute, the function copies
+                (buffer size - 1) bytes into the buffer, places an ASCII NUL byte at the
+                end of the buffer, and returns the buffer size you must pass to get the
+                entire value. For example, if the value is 123456 and the buffer size is
+                4, the function places 123 into the buffer and returns 7.
+                If you pass 0 for this attribute, you can pass VI_NULL for
+                **description**.
+
+        Returns:
+            code (int): Returns the error code for the session or execution thread.
+        '''
+        code_ctype = visatype.ViStatus(0)
+        buffer_size = 0
+        description_ctype = None
+        error_code = self._library.niDCPower_GetError(self._vi, ctypes.pointer(code_ctype), buffer_size, description_ctype)
+        errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=True)
+        buffer_size = error_code
+        description_ctype = (visatype.ViChar * buffer_size)()
+        error_code = self._library.niDCPower_GetError(self._vi, ctypes.pointer(code_ctype), buffer_size, description_ctype)
+        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
+        return int(code_ctype.value), description_ctype.value.decode(self._encoding)
+
     def measure(self, measurement_type):
         '''measure
 
@@ -3422,6 +3466,26 @@ class _SessionBase(object):
         error_code = self._library.niDCPower_SetSequence(self._vi, self._repeated_capability.encode(self._encoding), values, source_delays, size)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
+
+    def _error_message(self, error_code):
+        '''_error_message
+
+        Converts a status code returned by an instrument driver function into a
+        user-readable string.
+
+        Args:
+            error_code (int): Specifies the **status** parameter that is returned from any of the
+                NI-DCPower functions.
+
+        Returns:
+            error_message (string): Returns the user-readable message string that corresponds to the status
+                code you specify.
+                You must pass a ViChar array with at least 256 bytes.
+        '''
+        error_message_ctype = (visatype.ViChar * 256)()
+        error_code = self._library.niDCPower_error_message(self._vi, error_code, error_message_ctype)
+        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
+        return error_message_ctype.value.decode(self._encoding)
 
 
 class _RepeatedCapability(_SessionBase):
@@ -4019,50 +4083,6 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def _get_error(self):
-        '''_get_error
-
-        | Retrieves and then clears the IVI error information for the session or
-          the current execution thread unless **bufferSize** is 0, in which case
-          the function does not clear the error information. By passing 0 for
-          the buffer size, you can ascertain the buffer size required to get the
-          entire error description string and then call the function again with
-          a sufficiently large buffer size.
-        | If the user specifies a valid IVI session for **vi**, this function
-          retrieves and then clears the error information for the session. If
-          the user passes VI_NULL for **vi**, this function retrieves and then
-          clears the error information for the current execution thread. If
-          **vi** is an invalid session, the function does nothing and returns an
-          error. Normally, the error information describes the first error that
-          occurred since the user last called _get_error or
-          clear_error.
-
-        Args:
-            buffer_size (int): Specifies the number of bytes in the ViChar array you specify for
-                **description**.
-                If the error description, including the terminating NUL byte, contains
-                more bytes than you indicate in this attribute, the function copies
-                (buffer size - 1) bytes into the buffer, places an ASCII NUL byte at the
-                end of the buffer, and returns the buffer size you must pass to get the
-                entire value. For example, if the value is 123456 and the buffer size is
-                4, the function places 123 into the buffer and returns 7.
-                If you pass 0 for this attribute, you can pass VI_NULL for
-                **description**.
-
-        Returns:
-            code (int): Returns the error code for the session or execution thread.
-        '''
-        code_ctype = visatype.ViStatus(0)
-        buffer_size = 0
-        description_ctype = None
-        error_code = self._library.niDCPower_GetError(self._vi, ctypes.pointer(code_ctype), buffer_size, description_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=True)
-        buffer_size = error_code
-        description_ctype = (visatype.ViChar * buffer_size)()
-        error_code = self._library.niDCPower_GetError(self._vi, ctypes.pointer(code_ctype), buffer_size, description_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
-        return int(code_ctype.value), description_ctype.value.decode(self._encoding)
-
     def get_self_cal_last_date_and_time(self):
         '''get_self_cal_last_date_and_time
 
@@ -4370,26 +4390,6 @@ class Session(_SessionBase):
         error_code = self._library.niDCPower_close(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
-
-    def _error_message(self, error_code):
-        '''_error_message
-
-        Converts a status code returned by an instrument driver function into a
-        user-readable string.
-
-        Args:
-            error_code (int): Specifies the **status** parameter that is returned from any of the
-                NI-DCPower functions.
-
-        Returns:
-            error_message (string): Returns the user-readable message string that corresponds to the status
-                code you specify.
-                You must pass a ViChar array with at least 256 bytes.
-        '''
-        error_message_ctype = (visatype.ViChar * 256)()
-        error_code = self._library.niDCPower_error_message(self._vi, error_code, error_message_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
-        return error_message_ctype.value.decode(self._encoding)
 
     def reset(self):
         '''reset

--- a/generated/nifake/tests/test_session.py
+++ b/generated/nifake/tests/test_session.py
@@ -126,6 +126,22 @@ class TestSession(object):
                 assert issubclass(w[0].category, nifake.NifakeWarning)
                 assert test_error_desc in str(w[0].message)
 
+    def test_error_with_rep_cap(self):
+        test_error_code = -42
+        test_error_desc = "The answer to the ultimate question"
+        self.patched_library.niFake_SetAttributeViReal64.side_effect = self.side_effects_helper.niFake_SetAttributeViReal64
+        self.side_effects_helper['SetAttributeViReal64']['return'] = test_error_code
+        self.patched_library.niFake_GetError.side_effect = self.side_effects_helper.niFake_GetError
+        self.side_effects_helper['GetError']['errorCode'] = test_error_code
+        self.side_effects_helper['GetError']['description'] = test_error_desc
+        with nifake.Session('dev1') as session:
+            try:
+                session['100'].read_write_double = 5.0
+                assert False
+            except nifake.Error as e:
+                assert e.code == test_error_code
+                assert e.description == test_error_desc
+
     def test_get_a_number(self):
         test_number = 16
         self.patched_library.niFake_GetANumber.side_effect = self.side_effects_helper.niFake_GetANumber

--- a/generated/niswitch/session.py
+++ b/generated/niswitch/session.py
@@ -1082,6 +1082,52 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return attribute_value_ctype.value.decode(self._encoding)
 
+    def _get_error(self):
+        '''_get_error
+
+        This function retrieves and then clears the IVI error information for
+        the session or the current execution thread. One exception exists: If
+        the buffer_size parameter is 0, the function does not clear the error
+        information. By passing 0 for the buffer size, the caller can ascertain
+        the buffer size required to get the entire error description string and
+        then call the function again with a sufficiently large buffer. If the
+        user specifies a valid IVI session for the InstrumentHandle parameter,
+        Get Error retrieves and then clears the error information for the
+        session. If the user passes VI_NULL for the InstrumentHandle parameter,
+        this function retrieves and then clears the error information for the
+        current execution thread. If the InstrumentHandle parameter is an
+        invalid session, the function does nothing and returns an error.
+        Normally, the error information describes the first error that occurred
+        since the user last called _get_error or clear_error.
+
+        Args:
+            buffer_size (int): Pass the number of bytes in the ViChar array you specify for the
+                Description parameter. If the error description, including the
+                terminating NUL byte, contains more bytes than you indicate in this
+                parameter, the function copies buffer_size - 1 bytes into the buffer,
+                places an ASCII NUL byte at the end of the buffer, and returns the
+                buffer size you must pass to get the entire value. For example, if the
+                value is "123456" and the Buffer Size is 4, the function places "123"
+                into the buffer and returns 7. If you pass a negative number, the
+                function copies the value to the buffer regardless of the number of
+                bytes in the value. If you pass 0, you can pass VI_NULL for the
+                Description buffer parameter. Default Value: None
+
+        Returns:
+            code (int): Returns the error code for the session or execution thread. If you pass
+                0 for the Buffer Size, you can pass VI_NULL for this parameter.
+        '''
+        code_ctype = visatype.ViStatus(0)
+        buffer_size = 0
+        description_ctype = None
+        error_code = self._library.niSwitch_GetError(self._vi, ctypes.pointer(code_ctype), buffer_size, description_ctype)
+        errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=True)
+        buffer_size = error_code
+        description_ctype = (visatype.ViChar * buffer_size)()
+        error_code = self._library.niSwitch_GetError(self._vi, ctypes.pointer(code_ctype), buffer_size, description_ctype)
+        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
+        return int(code_ctype.value), description_ctype.value.decode(self._encoding)
+
     def _set_attribute_vi_boolean(self, attribute_id, attribute_value):
         '''_set_attribute_vi_boolean
 
@@ -1325,6 +1371,27 @@ class _SessionBase(object):
         error_code = self._library.niSwitch_SetAttributeViString(self._vi, self._repeated_capability.encode(self._encoding), attribute_id, attribute_value.encode(self._encoding))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
+
+    def _error_message(self, error_code):
+        '''_error_message
+
+        Converts an error code returned by NI-SWITCH into a user-readable
+        string. Generally this information is supplied in error out of any
+        NI-SWITCH VI. Use _error_message for a static lookup of an
+        error code description.
+
+        Args:
+            error_code (int): Status code returned by any NI-SWITCH function. Default Value: 0
+                (VI_SUCCESS)
+
+        Returns:
+            error_message (string): The error information formatted into a string. You must pass a ViChar
+                array with at least 256 bytes.
+        '''
+        error_message_ctype = (visatype.ViChar * 256)()
+        error_code = self._library.niSwitch_error_message(self._vi, error_code, error_message_ctype)
+        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
+        return error_message_ctype.value.decode(self._encoding)
 
 
 class _RepeatedCapability(_SessionBase):
@@ -1675,52 +1742,6 @@ class Session(_SessionBase):
         error_code = self._library.niSwitch_GetChannelName(self._vi, index, buffer_size, channel_name_buffer_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return channel_name_buffer_ctype.value.decode(self._encoding)
-
-    def _get_error(self):
-        '''_get_error
-
-        This function retrieves and then clears the IVI error information for
-        the session or the current execution thread. One exception exists: If
-        the buffer_size parameter is 0, the function does not clear the error
-        information. By passing 0 for the buffer size, the caller can ascertain
-        the buffer size required to get the entire error description string and
-        then call the function again with a sufficiently large buffer. If the
-        user specifies a valid IVI session for the InstrumentHandle parameter,
-        Get Error retrieves and then clears the error information for the
-        session. If the user passes VI_NULL for the InstrumentHandle parameter,
-        this function retrieves and then clears the error information for the
-        current execution thread. If the InstrumentHandle parameter is an
-        invalid session, the function does nothing and returns an error.
-        Normally, the error information describes the first error that occurred
-        since the user last called _get_error or clear_error.
-
-        Args:
-            buffer_size (int): Pass the number of bytes in the ViChar array you specify for the
-                Description parameter. If the error description, including the
-                terminating NUL byte, contains more bytes than you indicate in this
-                parameter, the function copies buffer_size - 1 bytes into the buffer,
-                places an ASCII NUL byte at the end of the buffer, and returns the
-                buffer size you must pass to get the entire value. For example, if the
-                value is "123456" and the Buffer Size is 4, the function places "123"
-                into the buffer and returns 7. If you pass a negative number, the
-                function copies the value to the buffer regardless of the number of
-                bytes in the value. If you pass 0, you can pass VI_NULL for the
-                Description buffer parameter. Default Value: None
-
-        Returns:
-            code (int): Returns the error code for the session or execution thread. If you pass
-                0 for the Buffer Size, you can pass VI_NULL for this parameter.
-        '''
-        code_ctype = visatype.ViStatus(0)
-        buffer_size = 0
-        description_ctype = None
-        error_code = self._library.niSwitch_GetError(self._vi, ctypes.pointer(code_ctype), buffer_size, description_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=True)
-        buffer_size = error_code
-        description_ctype = (visatype.ViChar * buffer_size)()
-        error_code = self._library.niSwitch_GetError(self._vi, ctypes.pointer(code_ctype), buffer_size, description_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
-        return int(code_ctype.value), description_ctype.value.decode(self._encoding)
 
     def get_path(self, channel1, channel2):
         '''get_path
@@ -2315,27 +2336,6 @@ class Session(_SessionBase):
         error_code = self._library.niSwitch_close(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
-
-    def _error_message(self, error_code):
-        '''_error_message
-
-        Converts an error code returned by NI-SWITCH into a user-readable
-        string. Generally this information is supplied in error out of any
-        NI-SWITCH VI. Use _error_message for a static lookup of an
-        error code description.
-
-        Args:
-            error_code (int): Status code returned by any NI-SWITCH function. Default Value: 0
-                (VI_SUCCESS)
-
-        Returns:
-            error_message (string): The error information formatted into a string. You must pass a ViChar
-                array with at least 256 bytes.
-        '''
-        error_message_ctype = (visatype.ViChar * 256)()
-        error_code = self._library.niSwitch_error_message(self._vi, error_code, error_message_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
-        return error_message_ctype.value.decode(self._encoding)
 
     def reset(self):
         '''reset

--- a/src/nifake/tests/test_session.py
+++ b/src/nifake/tests/test_session.py
@@ -126,6 +126,22 @@ class TestSession(object):
                 assert issubclass(w[0].category, nifake.NifakeWarning)
                 assert test_error_desc in str(w[0].message)
 
+    def test_error_with_rep_cap(self):
+        test_error_code = -42
+        test_error_desc = "The answer to the ultimate question"
+        self.patched_library.niFake_SetAttributeViReal64.side_effect = self.side_effects_helper.niFake_SetAttributeViReal64
+        self.side_effects_helper['SetAttributeViReal64']['return'] = test_error_code
+        self.patched_library.niFake_GetError.side_effect = self.side_effects_helper.niFake_GetError
+        self.side_effects_helper['GetError']['errorCode'] = test_error_code
+        self.side_effects_helper['GetError']['description'] = test_error_desc
+        with nifake.Session('dev1') as session:
+            try:
+                session['100'].read_write_double = 5.0
+                assert False
+            except nifake.Error as e:
+                assert e.code == test_error_code
+                assert e.description == test_error_desc
+
     def test_get_a_number(self):
         test_number = 16
         self.patched_library.niFake_GetANumber.side_effect = self.side_effects_helper.niFake_GetANumber


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
~~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
### What does this Pull Request accomplish?
* Move the error handling methods to _SessionBase
  * This way the repeated capabilities object can properly handle errors

### List issues fixed by this Pull Request below, if any.
* Fix #456 

### What testing has been done?
* Travis
* System test
* Hand testing