### PR TITLE
Restrict add all function metadata

### DIFF
--- a/build/helper/metadata_add_all.py
+++ b/build/helper/metadata_add_all.py
@@ -2,6 +2,7 @@
 
 from .helper import camelcase_to_snakecase
 from .helper import get_python_type_for_visa_type
+from .metadata_filters import filter_codegen_functions
 
 import copy
 import pprint
@@ -173,7 +174,7 @@ def _add_is_session_handle(parameter):
 
 def add_all_function_metadata(functions, config):
     '''Adds all codegen-specific metada to the function metadata list'''
-    for f in functions:
+    for f in filter_codegen_functions(functions):
         _add_name(functions[f], f)
         _add_python_method_name(functions[f], f)
         _add_is_error_handling(functions[f])

--- a/docs/nidcpower/functions.rst
+++ b/docs/nidcpower/functions.rst
@@ -1035,15 +1035,15 @@ nidcpower.Session methods
     The compliance limit is the current limit when the output function is
     set to NIDCPOWER\_VAL\_DC\_VOLTAGE. If the output is operating at the
     compliance limit, the output reaches the current limit before the
-    desired voltage level. Refer to the :py:func:`nidcpower.configure_output_function`
-    function and the :py:func:`nidcpower.configure_current_limit` function for more
+    desired voltage level. Refer to the :py:func:`nidcpower.ConfigureOutputFunction`
+    function and the :py:func:`nidcpower.ConfigureCurrentLimit` function for more
     information about output function and current limit, respectively.
 
     The compliance limit is the voltage limit when the output function is
     set to NIDCPOWER\_VAL\_DC\_CURRENT. If the output is operating at the
     compliance limit, the output reaches the voltage limit before the
-    desired current level. Refer to the :py:func:`nidcpower.configure_output_function`
-    function and the :py:func:`nidcpower.configure_voltage_limit` function for more
+    desired current level. Refer to the :py:func:`nidcpower.ConfigureOutputFunction`
+    function and the :py:func:`nidcpower.ConfigureVoltageLimit` function for more
     information about output function and voltage limit, respectively.
 
     **Related Topics:**

--- a/docs/nidmm/functions.rst
+++ b/docs/nidmm/functions.rst
@@ -440,7 +440,7 @@ nidmm.Session methods
 
 
         Specifies the Steinhart-Hart A coefficient for thermistor scaling when
-        Thermistor Type is set to Custom in the :py:func:`nidmm.configure_thermistor_type`
+        Thermistor Type is set to Custom in the :py:func:`nidmm.ConfigureThermistorType`
         function. The default is 1.0295e-3 (44006).
 
         
@@ -451,7 +451,7 @@ nidmm.Session methods
 
 
         Specifies the Steinhart-Hart B coefficient for thermistor scaling when
-        Thermistor Type is set to Custom in the :py:func:`nidmm.configure_thermistor_type`
+        Thermistor Type is set to Custom in the :py:func:`nidmm.ConfigureThermistorType`
         function. The default is 2.391e-4 (44006).
 
         
@@ -462,7 +462,7 @@ nidmm.Session methods
 
 
         Specifies the Steinhart-Hart C coefficient for thermistor scaling when
-        Thermistor Type is set to Custom in the :py:func:`nidmm.configure_thermistor_type`
+        Thermistor Type is set to Custom in the :py:func:`nidmm.ConfigureThermistorType`
         function. The default is 1.568e-7 (44006).
 
         

--- a/docs/niswitch/functions.rst
+++ b/docs/niswitch/functions.rst
@@ -830,7 +830,7 @@ niswitch.Session methods
 
 
             A particular NI-SWITCH session established with
-            :py:func:`niswitch.init_with_topology`, :py:func:`niswitch.init_with_options`, or :py:func:`niswitch.init`
+            :py:func:`niswitch.init_with_topology`, :py:func:`niswitch.InitWithOptions`, or :py:func:`niswitch.init`
             and used for all subsequent NI-SWITCH calls.
 
             

--- a/generated/nidcpower/session.py
+++ b/generated/nidcpower/session.py
@@ -3347,7 +3347,7 @@ class _SessionBase(object):
           **vi** is an invalid session, the function does nothing and returns an
           error. Normally, the error information describes the first error that
           occurred since the user last called _get_error or
-          clear_error.
+          ClearError.
 
         Args:
             buffer_size (int): Specifies the number of bytes in the ViChar array you specify for
@@ -3455,15 +3455,15 @@ class _SessionBase(object):
         The compliance limit is the current limit when the output function is
         set to NIDCPOWER_VAL_DC_VOLTAGE. If the output is operating at the
         compliance limit, the output reaches the current limit before the
-        desired voltage level. Refer to the configure_output_function
-        function and the configure_current_limit function for more
+        desired voltage level. Refer to the ConfigureOutputFunction
+        function and the ConfigureCurrentLimit function for more
         information about output function and current limit, respectively.
 
         The compliance limit is the voltage limit when the output function is
         set to NIDCPOWER_VAL_DC_CURRENT. If the output is operating at the
         compliance limit, the output reaches the voltage limit before the
-        desired current level. Refer to the configure_output_function
-        function and the configure_voltage_limit function for more
+        desired current level. Refer to the ConfigureOutputFunction
+        function and the ConfigureVoltageLimit function for more
         information about output function and voltage limit, respectively.
 
         **Related Topics:**
@@ -3984,7 +3984,7 @@ class Session(_SessionBase):
         when you call the _abort function, the output channels remain
         in their current state and continue providing power.
 
-        Use the configure_output_enabled function to disable power
+        Use the ConfigureOutputEnabled function to disable power
         output on a per channel basis. Use the reset function to
         disable output on all channels.
 
@@ -4823,7 +4823,7 @@ class Session(_SessionBase):
         Closes the session specified in **vi** and deallocates the resources
         that NI-DCPower reserves. If power output is enabled when you call this
         function, the output channels remain in their existing state and
-        continue providing power. Use the configure_output_enabled
+        continue providing power. Use the ConfigureOutputEnabled
         function to disable power output on a per channel basis. Use the
         reset function to disable power output on all channel(s).
 

--- a/generated/nidmm/session.py
+++ b/generated/nidmm/session.py
@@ -1542,13 +1542,13 @@ class Session(_SessionBase):
 
         Args:
             thermistor_a (float): Specifies the Steinhart-Hart A coefficient for thermistor scaling when
-                Thermistor Type is set to Custom in the configure_thermistor_type
+                Thermistor Type is set to Custom in the ConfigureThermistorType
                 function. The default is 1.0295e-3 (44006).
             thermistor_b (float): Specifies the Steinhart-Hart B coefficient for thermistor scaling when
-                Thermistor Type is set to Custom in the configure_thermistor_type
+                Thermistor Type is set to Custom in the ConfigureThermistorType
                 function. The default is 2.391e-4 (44006).
             thermistor_c (float): Specifies the Steinhart-Hart C coefficient for thermistor scaling when
-                Thermistor Type is set to Custom in the configure_thermistor_type
+                Thermistor Type is set to Custom in the ConfigureThermistorType
                 function. The default is 1.568e-7 (44006).
         '''
         error_code = self._library.niDMM_ConfigureThermistorCustom(self._vi, thermistor_a, thermistor_b, thermistor_c)

--- a/generated/niswitch/session.py
+++ b/generated/niswitch/session.py
@@ -1251,7 +1251,7 @@ class _SessionBase(object):
         current execution thread. If the InstrumentHandle parameter is an
         invalid session, the function does nothing and returns an error.
         Normally, the error information describes the first error that occurred
-        since the user last called _get_error or clear_error.
+        since the user last called _get_error or ClearError.
 
         Args:
             buffer_size (int): Pass the number of bytes in the ViChar array you specify for the
@@ -2246,7 +2246,7 @@ class Session(_SessionBase):
 
         Returns:
             vi (int): A particular NI-SWITCH session established with
-                init_with_topology, init_with_options, or init
+                init_with_topology, InitWithOptions, or init
                 and used for all subsequent NI-SWITCH calls.
         '''
         vi_ctype = visatype.ViSession(0)
@@ -2484,7 +2484,7 @@ class Session(_SessionBase):
         deallocates any memory resources the driver uses. Notes: (1) You must
         unlock the session before calling _close. (2) After calling
         _close, you cannot use the instrument driver again until you
-        call init or init_with_options.
+        call init or InitWithOptions.
         '''
         error_code = self._library.niSwitch_close(self._vi)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~

~~[] I've added any unit tests that are applicable for this pull request~~

### What does this Pull Request accomplish?

There is a step in code generation after we read API metadata in which we add a lot of calculated metadata that makes later code generation simpler. We've been adding this metadata to all functions. This change makes it so that we only calculate additional metadata for functions that we actually include in the Python APIs.

This exposes small internal bugs. For example, when generating documentation, we would generate broken links to functions that don't actually exist in the Python API. After this change, the generated documentation is "funky" but at least we get a code-generation warning about it and we can go and address these cases.

### List issues fixed by this Pull Request below, if any.

N/A

### What testing has been done?

Diffed codegen output.