### PR TITLE
Remove incorrect leading underscore from enum values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ All notable changes to this project will be documented in this file.
 * ### NI-DMM
   * #### Added
   * #### Changed
+    * Removed incorrect leading underscore from some enum values:
+        * Function.AC_VOLTS_DC_COUPLED
+        * Function.WAVEFORM_CURRENT
+        * MeasurementCompleteDest.LBR_TRIG_0
+        * OperationMode.IVIDMM_MODE
+        * SampleTrigger.EXTERNAL
+        * SampleTrigger.TTL_3
+        * TriggerSource.TTL_0
+        * TriggerSource.TTL_3
+        * TriggerSource.TTL_7
+        * TriggerSource.PXI_STAR
   * #### Removed
 * ### NI-ModInst
   * #### Added

--- a/docs/nidmm/enums.rst
+++ b/docs/nidmm/enums.rst
@@ -471,7 +471,7 @@ Enums used in NI-DMM
 
 
 
-    .. py:attribute:: nidmm.Function._AC_VOLTS_DC_COUPLED
+    .. py:attribute:: nidmm.Function.AC_VOLTS_DC_COUPLED
 
 
 
@@ -501,7 +501,7 @@ Enums used in NI-DMM
 
 
 
-    .. py:attribute:: nidmm.Function._WAVEFORM_CURRENT
+    .. py:attribute:: nidmm.Function.WAVEFORM_CURRENT
 
 
 
@@ -702,7 +702,7 @@ Enums used in NI-DMM
 
 
 
-    .. py:attribute:: nidmm.MeasurementCompleteDest._LBR_TRIG_0
+    .. py:attribute:: nidmm.MeasurementCompleteDest.LBR_TRIG_0
 
 
 
@@ -761,7 +761,7 @@ Enums used in NI-DMM
 
 .. py:data:: OperationMode
 
-    .. py:attribute:: nidmm.OperationMode._IVIDMM_MODE
+    .. py:attribute:: nidmm.OperationMode.IVIDMM_MODE
 
 
 
@@ -918,7 +918,7 @@ Enums used in NI-DMM
 
 
 
-    .. py:attribute:: nidmm.SampleTrigger._EXTERNAL
+    .. py:attribute:: nidmm.SampleTrigger.EXTERNAL
 
 
 
@@ -979,7 +979,7 @@ Enums used in NI-DMM
 
 
 
-    .. py:attribute:: nidmm.SampleTrigger._TTL_3
+    .. py:attribute:: nidmm.SampleTrigger.TTL_3
 
 
 
@@ -1300,7 +1300,7 @@ Enums used in NI-DMM
 
 
 
-    .. py:attribute:: nidmm.TriggerSource._TTL_0
+    .. py:attribute:: nidmm.TriggerSource.TTL_0
 
 
 
@@ -1330,7 +1330,7 @@ Enums used in NI-DMM
 
 
 
-    .. py:attribute:: nidmm.TriggerSource._TTL_3
+    .. py:attribute:: nidmm.TriggerSource.TTL_3
 
 
 
@@ -1370,7 +1370,7 @@ Enums used in NI-DMM
 
 
 
-    .. py:attribute:: nidmm.TriggerSource._TTL_7
+    .. py:attribute:: nidmm.TriggerSource.TTL_7
 
 
 
@@ -1380,7 +1380,7 @@ Enums used in NI-DMM
 
 
 
-    .. py:attribute:: nidmm.TriggerSource._PXI_STAR
+    .. py:attribute:: nidmm.TriggerSource.PXI_STAR
 
 
 

--- a/generated/nidmm/enums.py
+++ b/generated/nidmm/enums.py
@@ -214,7 +214,7 @@ class Function(Enum):
     '''
     NI 4065, and NI 4070/4071/4072 supported.
     '''
-    _AC_VOLTS_DC_COUPLED = 1001
+    AC_VOLTS_DC_COUPLED = 1001
     '''
     NI 4070/4071/4072 supported.
     '''
@@ -226,7 +226,7 @@ class Function(Enum):
     '''
     NI 4070/4071/4072 supported.
     '''
-    _WAVEFORM_CURRENT = 1004
+    WAVEFORM_CURRENT = 1004
     '''
     NI 4070/4071/4072 supported.
     '''
@@ -313,7 +313,7 @@ class MeasurementCompleteDest(Enum):
     '''
     PXI Trigger Line 7
     '''
-    _LBR_TRIG_0 = 1003
+    LBR_TRIG_0 = 1003
     '''
     Local Bus Right Trigger Line 0 of PXI/SCXI combination chassis
     '''
@@ -342,7 +342,7 @@ class OffsetCompensatedOhms(Enum):
 
 
 class OperationMode(Enum):
-    _IVIDMM_MODE = 0
+    IVIDMM_MODE = 0
     '''
     Single or multipoint measurements: When the Trigger Count and Sample
     Count properties are both set to 1, the NI 4065, NI 4070/4071/4072, and
@@ -415,7 +415,7 @@ class SampleTrigger(Enum):
     '''
     No trigger specified
     '''
-    _EXTERNAL = 2
+    EXTERNAL = 2
     '''
     Pin 9 on the AUX Connector
     '''
@@ -440,7 +440,7 @@ class SampleTrigger(Enum):
     '''
     PXI Trigger Line 2
     '''
-    _TTL_3 = 114
+    TTL_3 = 114
     '''
     PXI Trigger Line 3
     '''
@@ -581,7 +581,7 @@ class TriggerSource(Enum):
     Waits until `niDMM Send Software
     Trigger <dmmviref.chm::/niDMM_Send_Software_Trigger.html>`__ is called.
     '''
-    _TTL_0 = 111
+    TTL_0 = 111
     '''
     PXI Trigger Line 0
     '''
@@ -593,7 +593,7 @@ class TriggerSource(Enum):
     '''
     PXI Trigger Line 2
     '''
-    _TTL_3 = 114
+    TTL_3 = 114
     '''
     PXI Trigger Line 3
     '''
@@ -609,11 +609,11 @@ class TriggerSource(Enum):
     '''
     PXI Trigger Line 6
     '''
-    _TTL_7 = 118
+    TTL_7 = 118
     '''
     PXI Trigger Line 7
     '''
-    _PXI_STAR = 131
+    PXI_STAR = 131
     '''
     PXI Star Trigger Line
     '''

--- a/src/nidmm/metadata/enums.py
+++ b/src/nidmm/metadata/enums.py
@@ -370,7 +370,7 @@ a bell-curve weighing function.
 },
             },
             {
-                'name': '_AC_VOLTS_DC_COUPLED',
+                'name': 'AC_VOLTS_DC_COUPLED',
                 'value': 1001,
 'documentation': {
 'description': 'NI 4070/4071/4072 supported.',
@@ -391,7 +391,7 @@ a bell-curve weighing function.
 },
             },
             {
-                'name': '_WAVEFORM_CURRENT',
+                'name': 'WAVEFORM_CURRENT',
                 'value': 1004,
 'documentation': {
 'description': 'NI 4070/4071/4072 supported.',
@@ -542,7 +542,7 @@ inductance.
 },
             },
             {
-                'name': '_LBR_TRIG_0',
+                'name': 'LBR_TRIG_0',
                 'value': 1003,
 'documentation': {
 'description': 'Local Bus Right Trigger Line 0 of PXI/SCXI combination chassis',
@@ -589,7 +589,7 @@ inductance.
     'OperationMode': {
         'values': [
             {
-                'name': '_IVIDMM_MODE',
+                'name': 'IVIDMM_MODE',
                 'value': 0,
 'documentation': {
 'description': '''
@@ -714,7 +714,7 @@ and C coefficients.
 },
             },
             {
-                'name': '_EXTERNAL',
+                'name': 'EXTERNAL',
                 'value': 2,
 'documentation': {
 'description': 'Pin 9 on the AUX Connector',
@@ -759,7 +759,7 @@ Trigger <dmmviref.chm::/niDMM_Send_Software_Trigger.html>`__ is called.
 },
             },
             {
-                'name': '_TTL_3',
+                'name': 'TTL_3',
                 'value': 114,
 'documentation': {
 'description': 'PXI Trigger Line 3',
@@ -1002,7 +1002,7 @@ Trigger <dmmviref.chm::/niDMM_Send_Software_Trigger.html>`__ is called.
 },
             },
             {
-                'name': '_TTL_0',
+                'name': 'TTL_0',
                 'value': 111,
 'documentation': {
 'description': 'PXI Trigger Line 0',
@@ -1023,7 +1023,7 @@ Trigger <dmmviref.chm::/niDMM_Send_Software_Trigger.html>`__ is called.
 },
             },
             {
-                'name': '_TTL_3',
+                'name': 'TTL_3',
                 'value': 114,
 'documentation': {
 'description': 'PXI Trigger Line 3',
@@ -1051,14 +1051,14 @@ Trigger <dmmviref.chm::/niDMM_Send_Software_Trigger.html>`__ is called.
 },
             },
             {
-                'name': '_TTL_7',
+                'name': 'TTL_7',
                 'value': 118,
 'documentation': {
 'description': 'PXI Trigger Line 7',
 },
             },
             {
-                'name': '_PXI_STAR',
+                'name': 'PXI_STAR',
                 'value': 131,
 'documentation': {
 'description': 'PXI Star Trigger Line',


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
[X] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
~~[ ] I've added any unit tests that are applicable for this pull request~~
### What does this Pull Request accomplish?
* Remove incorrect leading underscore from enum values
  * Cause was leading space in source
  * Process changes all spaces into underscore in names
* Extractor now strips whitespace from names before replacing spaces
### List issues fixed by this Pull Request below, if any.
* Fix #324 

### What testing has been done?
* System
* Unit