### PR TITLE
Fixes Issue #532 of test_get_attribute_int64 failing

### DIFF
--- a/src/nifake/tests/test_session.py
+++ b/src/nifake/tests/test_session.py
@@ -694,7 +694,7 @@ class TestSession(object):
         with nifake.Session('dev1') as session:
             attr_int = session.read_write_int64
             assert(attr_int == test_number)
-            self.patched_library.niFake_GetAttributeViInt64.assert_called_once_with(matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), matchers.ViStringMatcher(''), matchers.ViInt32Matcher(attribute_id), matchers.ViInt32PointerMatcher())
+            self.patched_library.niFake_GetAttributeViInt64.assert_called_once_with(matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), matchers.ViStringMatcher(''), matchers.ViInt32Matcher(attribute_id), matchers.ViInt64PointerMatcher())
 
     def test_set_attribute_int64(self):
         self.patched_library.niFake_SetAttributeViInt64.side_effect = self.side_effects_helper.niFake_SetAttributeViInt64


### PR DESCRIPTION
Changing the test to assert called with Int64 instead of Int32

[X ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

(https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

[X ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

(https://github.com/ni/nimi-python/blob/master/CHANGELOG.md).

[X ] I've added any unit tests that are applicable for this pull request


### What does this Pull Request accomplish?
Fixes Issue #532 of test_get_attribute_int64 failing

### List issues fixed by this Pull Request below, if any.
Fix #532 


### What testing has been done?
Unit test passed

