### PR TITLE
Fix tests so they check for the right text type regardless of Python version

### DIFF
--- a/generated/nifake/tests/test_session.py
+++ b/generated/nifake/tests/test_session.py
@@ -2,6 +2,7 @@ import matchers
 import math
 import mock_helper
 import nifake
+import six
 import warnings
 
 from mock import patch
@@ -324,10 +325,7 @@ class TestSession(object):
             assert isinstance(result_array, list)
             assert isinstance(result_array[0], float)
             assert result_string == string_val
-            try:
-                assert isinstance(result_string, basestring)
-            except NameError:
-                assert isinstance(result_string, str)
+            assert isinstance(result_string, six.text_type)
             assert self.patched_library.niFake_ReturnMultipleTypes.call_count == 2
 
     def test_multiple_array_types(self):

--- a/src/nifake/tests/test_session.py
+++ b/src/nifake/tests/test_session.py
@@ -2,6 +2,7 @@ import matchers
 import math
 import mock_helper
 import nifake
+import six
 import warnings
 
 from mock import patch
@@ -324,10 +325,7 @@ class TestSession(object):
             assert isinstance(result_array, list)
             assert isinstance(result_array[0], float)
             assert result_string == string_val
-            try:
-                assert isinstance(result_string, basestring)
-            except NameError:
-                assert isinstance(result_string, str)
+            assert isinstance(result_string, six.text_type)
             assert self.patched_library.niFake_ReturnMultipleTypes.call_count == 2
 
     def test_multiple_array_types(self):

--- a/src/nimodinst/system_tests/test_system_nimodinst.py
+++ b/src/nimodinst/system_tests/test_system_nimodinst.py
@@ -2,6 +2,7 @@
 
 import nimodinst
 import re
+import six
 
 
 def test_bad_device_family():
@@ -49,7 +50,7 @@ def test_string_attribute_error_on_non_existant_device():
 def test_device_name_attribute():
     with nimodinst.Session('') as session:
         assert len(session) > 0, 'Must have hardware for ModInst tests to be valid.'
-        assert isinstance(session[0].device_name, str)
+        assert isinstance(session[0].device_name, six.text_type)
         assert len(session[0].device_name) > 0  # device name must be at least 1 character
 
 
@@ -57,7 +58,7 @@ def test_device_model_attribute():
     with nimodinst.Session('') as session:
         assert len(session) > 0, 'Must have hardware for ModInst tests to be valid.'
         assert len(session[0].device_model) > 0
-        assert isinstance(session[0].device_model, str)
+        assert isinstance(session[0].device_model, six.text_type)
         pattern = r'(NI )?[A-Z]+e?-\d\d\d\d'
         assert re.search(pattern, session[0].device_model) is not None  # NI Model numbers are generally "NI PXIe-2532", but might also be "USB-2532"
 
@@ -66,7 +67,7 @@ def test_serial_number_attribute():
     with nimodinst.Session('') as session:
         assert len(session) > 0, 'Must have hardware for ModInst tests to be valid.'
         pattern = r'^[0-9A-F]+$'
-        assert isinstance(session[0].serial_number, str)
+        assert isinstance(session[0].serial_number, six.text_type)
         assert (len(session[0].serial_number) == 0) | (re.search(pattern, session[0].serial_number) is not None)  # NI Serial numbers hex unless it is simulated than it is 0
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -123,6 +123,7 @@ deps =
     system_tests: enum34;python_version<"3.4"
     system_tests: pytest
     system_tests: coverage
+    system_tests: six
     nidcpower_system_tests: enum34;python_version<"3.4"
     nidcpower_system_tests: pytest
     nidcpower_system_tests: nidcpower

--- a/tox.ini
+++ b/tox.ini
@@ -102,6 +102,7 @@ deps =
     test: coverage
     test: mock
     test: mako
+    test: six
     build_test: pytest
     build_test: coverage
     build_test: mako
@@ -146,6 +147,7 @@ deps =
     nimodinst_system_tests: pytest
     nimodinst_system_tests: nimodinst
     nimodinst_system_tests: pytest-json
+    nimodinst_system_tests: six
 
 
 whitelist_externals =


### PR DESCRIPTION
[x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~~[] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~

[x] I've added any unit tests that are applicable for this pull request

### What does this Pull Request accomplish?

Use six module to check text type in our tests.

### List issues fixed by this Pull Request below, if any.

* Fix #565 

### What testing has been done?

Ran all tests