### PR TITLE
Workaround NI-SCOPE simulation bug

### DIFF
--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -4,7 +4,7 @@ import pytest
 
 @pytest.fixture(scope='function')
 def session():
-    with niscope.Session('FakeDevice', False, True, 'Simulate=1, DriverSetup=Model:5122; BoardType:PXIe') as simulated_session:
+    with niscope.Session('FakeDevice', False, True, 'Simulate=1, DriverSetup=Model:5164; BoardType:PXIe') as simulated_session:
         yield simulated_session
 
 


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~

[X] I've added any unit tests that are applicable for this pull request

### What does this Pull Request accomplish?

Simulate a 5164 digitizer device. This is not only faster, but also works around an NI-SCOPE bug with DAQmx-based digitizers.

### List issues fixed by this Pull Request below, if any.

* Fix #576 

### What testing has been done?

Ran `tox -e system_tests` locally and it works.