### PR TITLE
Adding more nifgen systemtests

### DIFF
--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -191,7 +191,8 @@ def test_arb_seq(session):
     assert in_range is True
     session.arb_sample_rate = 10000000
     session.create_arb_sequence(2, [0, 1], [1, 1])
-    in_range = abs(actual_sample_rate - 20000000) <= max(1e-09 * max(abs(actual_sample_rate), abs(20000000)), 0.0)   # https://stackoverflow.com/questions/5595425/what-is-the-best-way-to-compare-floats-for-almost-equality-in-python
+    actual_sample_rate = session.arb_sample_rate
+    in_range = abs(actual_sample_rate - 10000000) <= max(1e-09 * max(abs(actual_sample_rate), abs(10000000)), 0.0)   # https://stackoverflow.com/questions/5595425/what-is-the-best-way-to-compare-floats-for-almost-equality-in-python
     assert in_range is True
     arb_gain = session.arb_gain
     assert arb_gain == 1

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -151,7 +151,11 @@ def test_read_current_temperature(session):
 
 
 def test_allocate_waveform(session):
-    session.allocate_waveform(1024)
+    try:
+        waveforme_data = [ 1, 1, 1, 1, 1, -1 , -1, -1, -1, -1, 1]
+        session.write_waveform(session.allocate_waveform(10), waveforme_data)
+    except nifgen.Error as e:
+        assert e.code == -1074126841  # Writing more data than allocated
 
 
 def test_clear_waveform_memory(session):
@@ -163,7 +167,7 @@ def test_clear_waveform_memory(session):
 
 def test_query_arb_seq_capabilities(session):
     maximum_number_of_sequences, minimum_sequence_length, maximum_sequence_length, maximum_loop_count = session.query_arb_seq_capabilities()
-    assert maximum_number_of_sequences == 65535  # maximum_number_of_sequences, minimum_sequence_length, maximum_sequence_length, maximum_loop_count are 65535, 1, 65535, 16777215 respectively for simulated 5433
+    assert maximum_number_of_sequences == 65535
     assert minimum_sequence_length == 1
     assert maximum_sequence_length == 65535
     assert maximum_loop_count == 16777215

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -148,3 +148,22 @@ def test_query_freq_list_capabilities(session):
 
 def test_read_current_temperature(session):
     assert session.read_current_temperature() > 25.0
+
+
+def test_allocate_waveform(session):
+    session.allocate_waveform(1024)
+
+
+def test_clear_waveform_memory(session):
+    session.clear_arb_memory()  
+    session.clear_user_standard_waveform()
+    session.clear_arb_sequence(-1)
+    session.clear_arb_waveform(-1)
+
+
+def test_query_arb_seq_capabilities(session):
+    maximum_number_of_sequences, minimum_sequence_length, maximum_sequence_length, maximum_loop_count = session.query_arb_seq_capabilities()
+    assert maximum_number_of_sequences == 65535  # maximum_number_of_sequences, minimum_sequence_length, maximum_sequence_length, maximum_loop_count are 65535, 1, 65535, 16777215 respectively for simulated 5433
+    assert minimum_sequence_length == 1
+    assert maximum_sequence_length == 65535
+    assert maximum_loop_count == 16777215

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -155,7 +155,7 @@ def test_allocate_waveform(session):
 
 
 def test_clear_waveform_memory(session):
-    session.clear_arb_memory()  
+    session.clear_arb_memory()
     session.clear_user_standard_waveform()
     session.clear_arb_sequence(-1)
     session.clear_arb_waveform(-1)

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -152,7 +152,7 @@ def test_read_current_temperature(session):
 
 def test_allocate_waveform(session):
     try:
-        waveforme_data = [ 1, 1, 1, 1, 1, -1 , -1, -1, -1, -1, 1]
+        waveforme_data = [1, 1, 1, 1, 1, -1, -1, -1, -1, -1, 1]
         session.write_waveform(session.allocate_waveform(10), waveforme_data)
     except nifgen.Error as e:
         assert e.code == -1074126841  # Writing more data than allocated

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -189,6 +189,10 @@ def test_arb_seq(session):
     actual_sample_rate = session.arb_sample_rate
     in_range = abs(actual_sample_rate - 20000000) <= max(1e-09 * max(abs(actual_sample_rate), abs(20000000)), 0.0)   # https://stackoverflow.com/questions/5595425/what-is-the-best-way-to-compare-floats-for-almost-equality-in-python
     assert in_range is True
+    session.arb_sample_rate = 10000000
+    session.create_arb_sequence(2, [0, 1], [1, 1])
+    in_range = abs(actual_sample_rate - 20000000) <= max(1e-09 * max(abs(actual_sample_rate), abs(20000000)), 0.0)   # https://stackoverflow.com/questions/5595425/what-is-the-best-way-to-compare-floats-for-almost-equality-in-python
+    assert in_range is True
     arb_gain = session.arb_gain
     assert arb_gain == 1
 

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -225,3 +225,23 @@ def test_reset(session):
     assert session.output_mode == nifgen.OutputMode.SEQ
     session.reset()
     assert session.output_mode == nifgen.OutputMode.ARB
+
+
+def test_reset_device(session):
+    default_trigger_mode = session.trigger_mode
+    assert default_trigger_mode == nifgen.TriggerMode.CONTINUOUS
+    session.trigger_mode = nifgen.TriggerMode.STEPPED
+    non_default_trigger_mode = nifgen.TriggerMode.STEPPED
+    assert non_default_trigger_mode == nifgen.TriggerMode.STEPPED
+    session.reset_device()
+    assert session.trigger_mode == nifgen.TriggerMode.CONTINUOUS
+
+
+def test_reset_with_default(session):
+    default_sample_rate = session.arb_sample_rate
+    assert default_sample_rate == 250000000.0
+    session.arb_sample_rate = 100000000.0
+    non_default_arb_sample_rate = session.arb_sample_rate
+    assert non_default_arb_sample_rate == 100000000.0
+    session.reset_with_defaults()
+    assert session.arb_sample_rate == 250000000.0


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).


~~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~


[X] I've added tests applicable for this pull request


### What does this Pull Request accomplish?

Adding 8 more system tests for nifgen

- test_allocate_waveform
- test_clear_waveform_memory
- test_query_arb_seq_capabilities
- test_arb_seq
- test_arb_script
- test_reset
- test_reset_device
- test_reset_with_default

### List issues fixed by this Pull Request below, if any.
* Partial work towards #484 


### What testing has been done?

systemtests, tox
