### PR TITLE
Removing function not used for nifgen

### DIFF
--- a/generated/nifgen/library.py
+++ b/generated/nifgen/library.py
@@ -48,7 +48,6 @@ class Library(object):
         self.niFgen_ExportSignal_cfunc = None
         self.niFgen_GetAttributeViBoolean_cfunc = None
         self.niFgen_GetAttributeViInt32_cfunc = None
-        self.niFgen_GetAttributeViInt64_cfunc = None
         self.niFgen_GetAttributeViReal64_cfunc = None
         self.niFgen_GetAttributeViString_cfunc = None
         self.niFgen_GetError_cfunc = None
@@ -73,7 +72,6 @@ class Library(object):
         self.niFgen_SendSoftwareEdgeTrigger_cfunc = None
         self.niFgen_SetAttributeViBoolean_cfunc = None
         self.niFgen_SetAttributeViInt32_cfunc = None
-        self.niFgen_SetAttributeViInt64_cfunc = None
         self.niFgen_SetAttributeViReal64_cfunc = None
         self.niFgen_SetAttributeViString_cfunc = None
         self.niFgen_SetNamedWaveformNextWritePosition_cfunc = None
@@ -337,14 +335,6 @@ class Library(object):
                 self.niFgen_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
 
-    def niFgen_GetAttributeViInt64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
-        with self._func_lock:
-            if self.niFgen_GetAttributeViInt64_cfunc is None:
-                self.niFgen_GetAttributeViInt64_cfunc = self._library.niFgen_GetAttributeViInt64
-                self.niFgen_GetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt64)]  # noqa: F405
-                self.niFgen_GetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFgen_GetAttributeViInt64_cfunc(vi, channel_name, attribute_id, attribute_value)
-
     def niFgen_GetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetAttributeViReal64_cfunc is None:
@@ -536,14 +526,6 @@ class Library(object):
                 self.niFgen_SetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32]  # noqa: F405
                 self.niFgen_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
-
-    def niFgen_SetAttributeViInt64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
-        with self._func_lock:
-            if self.niFgen_SetAttributeViInt64_cfunc is None:
-                self.niFgen_SetAttributeViInt64_cfunc = self._library.niFgen_SetAttributeViInt64
-                self.niFgen_SetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt64]  # noqa: F405
-                self.niFgen_SetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFgen_SetAttributeViInt64_cfunc(vi, channel_name, attribute_id, attribute_value)
 
     def niFgen_SetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:

--- a/generated/nifgen/session.py
+++ b/generated/nifgen/session.py
@@ -1789,41 +1789,6 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(attribute_value_ctype.value)
 
-    def _get_attribute_vi_int64(self, attribute_id):
-        '''_get_attribute_vi_int64
-
-        Queries the value of a ViInt64 attribute. You can use this function to
-        get the values of instrument-specific attributes and inherent IVI
-        attributes. If the attribute represents an instrument state, this
-        function performs instrument I/O in the following cases:
-
-        -  State caching is disabled for the entire session or for the
-           particular attribute.
-        -  State caching is enabled and the currently cached value is invalid.
-
-        Tip:
-        This method requires repeated capabilities (usually channels). If called directly on the
-        nifgen.Session object, then the method will use all repeated capabilities in the session.
-        You can specify a subset of repeated capabilities using the Python index notation on an
-        nifgen.Session instance, and calling this method on the result.:
-
-            session['0,1']._get_attribute_vi_int64(attribute_id)
-
-        Args:
-            attribute_id (int): Specifies the ID of an attribute.
-
-        Returns:
-            attribute_value (int): Returns the current value of the attribute. Pass the address of a
-                ViInt64 variable.
-        '''
-        vi_ctype = visatype.ViSession(self._vi)  # case 1
-        channel_name_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case 2
-        attribute_id_ctype = visatype.ViAttr(attribute_id)  # case 9
-        attribute_value_ctype = visatype.ViInt64()  # case 14
-        error_code = self._library.niFgen_GetAttributeViInt64(vi_ctype, channel_name_ctype, attribute_id_ctype, ctypes.pointer(attribute_value_ctype))
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return int(attribute_value_ctype.value)
-
     def _get_attribute_vi_real64(self, attribute_id):
         '''_get_attribute_vi_real64
 
@@ -2246,59 +2211,6 @@ class _SessionBase(object):
         attribute_id_ctype = visatype.ViAttr(attribute_id)  # case 9
         attribute_value_ctype = visatype.ViInt32(attribute_value)  # case 9
         error_code = self._library.niFgen_SetAttributeViInt32(vi_ctype, channel_name_ctype, attribute_id_ctype, attribute_value_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return
-
-    def _set_attribute_vi_int64(self, attribute_id, attribute_value):
-        '''_set_attribute_vi_int64
-
-        Sets the value of a ViInt64 attribute.
-
-        This is a low-level function that you can use to set the values of
-        instrument-specific attributes and inherent IVI attributes. If the
-        attribute represents an instrument state, this function performs
-        instrument I/O in the following cases:
-
-        -  State caching is disabled for the entire session or for the
-           particular attribute.
-        -  State caching is enabled and the currently cached value is invalid or
-           is different than the value you specify.
-
-        NI-FGEN contains high-level functions that set most of the instrument
-        attributes. NI recommends that you use the high-level driver functions
-        as much as possible. They handle order dependencies and multithread
-        locking for you. In addition, they perform status checking only after
-        setting all of the attributes. In contrast, when you set multiple
-        attributes using the Set Attribute functions, the functions check the
-        instrument status after each call.
-
-        Also, when state caching is enabled, the high-level functions that
-        configure multiple attributes perform instrument I/O only for the
-        attributes whose value you change. Thus, you can safely call the
-        high-level functions without the penalty of redundant instrument I/O.
-
-        Tip:
-        This method requires repeated capabilities (usually channels). If called directly on the
-        nifgen.Session object, then the method will use all repeated capabilities in the session.
-        You can specify a subset of repeated capabilities using the Python index notation on an
-        nifgen.Session instance, and calling this method on the result.:
-
-            session['0,1']._set_attribute_vi_int64(attribute_id, attribute_value)
-
-        Args:
-            attribute_id (int): Specifies the ID of an attribute.
-            attribute_value (int): Specifies the value to which you want to set the attribute. **Default
-                Value**: None
-
-                Note:
-                Some of the values might not be valid depending on the current
-                settings of the instrument session.
-        '''
-        vi_ctype = visatype.ViSession(self._vi)  # case 1
-        channel_name_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case 2
-        attribute_id_ctype = visatype.ViAttr(attribute_id)  # case 9
-        attribute_value_ctype = visatype.ViInt64(attribute_value)  # case 9
-        error_code = self._library.niFgen_SetAttributeViInt64(vi_ctype, channel_name_ctype, attribute_id_ctype, attribute_value_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 

--- a/generated/nifgen/unit_tests/mock_helper.py
+++ b/generated/nifgen/unit_tests/mock_helper.py
@@ -87,9 +87,6 @@ class SideEffectsHelper(object):
         self._defaults['GetAttributeViInt32'] = {}
         self._defaults['GetAttributeViInt32']['return'] = 0
         self._defaults['GetAttributeViInt32']['attributeValue'] = None
-        self._defaults['GetAttributeViInt64'] = {}
-        self._defaults['GetAttributeViInt64']['return'] = 0
-        self._defaults['GetAttributeViInt64']['attributeValue'] = None
         self._defaults['GetAttributeViReal64'] = {}
         self._defaults['GetAttributeViReal64']['return'] = 0
         self._defaults['GetAttributeViReal64']['attributeValue'] = None
@@ -176,8 +173,6 @@ class SideEffectsHelper(object):
         self._defaults['SetAttributeViBoolean']['return'] = 0
         self._defaults['SetAttributeViInt32'] = {}
         self._defaults['SetAttributeViInt32']['return'] = 0
-        self._defaults['SetAttributeViInt64'] = {}
-        self._defaults['SetAttributeViInt64']['return'] = 0
         self._defaults['SetAttributeViReal64'] = {}
         self._defaults['SetAttributeViReal64']['return'] = 0
         self._defaults['SetAttributeViString'] = {}
@@ -408,14 +403,6 @@ class SideEffectsHelper(object):
             raise MockFunctionCallError("niFgen_GetAttributeViInt32", param='attributeValue')
         attribute_value.contents.value = self._defaults['GetAttributeViInt32']['attributeValue']
         return self._defaults['GetAttributeViInt32']['return']
-
-    def niFgen_GetAttributeViInt64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
-        if self._defaults['GetAttributeViInt64']['return'] != 0:
-            return self._defaults['GetAttributeViInt64']['return']
-        if self._defaults['GetAttributeViInt64']['attributeValue'] is None:
-            raise MockFunctionCallError("niFgen_GetAttributeViInt64", param='attributeValue')
-        attribute_value.contents.value = self._defaults['GetAttributeViInt64']['attributeValue']
-        return self._defaults['GetAttributeViInt64']['return']
 
     def niFgen_GetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         if self._defaults['GetAttributeViReal64']['return'] != 0:
@@ -658,11 +645,6 @@ class SideEffectsHelper(object):
             return self._defaults['SetAttributeViInt32']['return']
         return self._defaults['SetAttributeViInt32']['return']
 
-    def niFgen_SetAttributeViInt64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
-        if self._defaults['SetAttributeViInt64']['return'] != 0:
-            return self._defaults['SetAttributeViInt64']['return']
-        return self._defaults['SetAttributeViInt64']['return']
-
     def niFgen_SetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         if self._defaults['SetAttributeViReal64']['return'] != 0:
             return self._defaults['SetAttributeViReal64']['return']
@@ -816,8 +798,6 @@ class SideEffectsHelper(object):
         mock_library.niFgen_GetAttributeViBoolean.return_value = 0
         mock_library.niFgen_GetAttributeViInt32.side_effect = MockFunctionCallError("niFgen_GetAttributeViInt32")
         mock_library.niFgen_GetAttributeViInt32.return_value = 0
-        mock_library.niFgen_GetAttributeViInt64.side_effect = MockFunctionCallError("niFgen_GetAttributeViInt64")
-        mock_library.niFgen_GetAttributeViInt64.return_value = 0
         mock_library.niFgen_GetAttributeViReal64.side_effect = MockFunctionCallError("niFgen_GetAttributeViReal64")
         mock_library.niFgen_GetAttributeViReal64.return_value = 0
         mock_library.niFgen_GetAttributeViString.side_effect = MockFunctionCallError("niFgen_GetAttributeViString")
@@ -866,8 +846,6 @@ class SideEffectsHelper(object):
         mock_library.niFgen_SetAttributeViBoolean.return_value = 0
         mock_library.niFgen_SetAttributeViInt32.side_effect = MockFunctionCallError("niFgen_SetAttributeViInt32")
         mock_library.niFgen_SetAttributeViInt32.return_value = 0
-        mock_library.niFgen_SetAttributeViInt64.side_effect = MockFunctionCallError("niFgen_SetAttributeViInt64")
-        mock_library.niFgen_SetAttributeViInt64.return_value = 0
         mock_library.niFgen_SetAttributeViReal64.side_effect = MockFunctionCallError("niFgen_SetAttributeViReal64")
         mock_library.niFgen_SetAttributeViReal64.return_value = 0
         mock_library.niFgen_SetAttributeViString.side_effect = MockFunctionCallError("niFgen_SetAttributeViString")

--- a/src/nifgen/metadata/functions_addon.py
+++ b/src/nifgen/metadata/functions_addon.py
@@ -57,6 +57,7 @@ functions_codegen_method = {
     '.+Complex.+':                          { 'codegen_method': 'no',       },
     'GetStreamEndpointHandle':              { 'codegen_method': 'no',       },
     'AdjustSampleClockRelativeDelay':       { 'codegen_method': 'no',       },  # This is used internally by NI-TClk, but not by end users.
+	'.etAttributeViInt64':                  { 'codegen_method': 'no',       },  # Not used by python APIs
 }
 
 # Attach the given parameter to the given enum from enums.py

--- a/src/nifgen/metadata/functions_addon.py
+++ b/src/nifgen/metadata/functions_addon.py
@@ -57,7 +57,7 @@ functions_codegen_method = {
     '.+Complex.+':                          { 'codegen_method': 'no',       },
     'GetStreamEndpointHandle':              { 'codegen_method': 'no',       },
     'AdjustSampleClockRelativeDelay':       { 'codegen_method': 'no',       },  # This is used internally by NI-TClk, but not by end users.
-	'.etAttributeViInt64':                  { 'codegen_method': 'no',       },  # Not used by python APIs
+    '.etAttributeViInt64':                  { 'codegen_method': 'no',       },  # Not used by python APIs
 }
 
 # Attach the given parameter to the given enum from enums.py


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~

~~[ ] I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?
Removing GetAttributeViInt64, SetAttributeViInt64 from nifgen since there is no ViInt64 attributes.

Submission of this PR will be based on the decision for issue #608 

### What testing has been done?

systemtests, tox
