### PR TITLE
Removing unused attribute methods and adding more systemtests for niscope

### DIFF
--- a/generated/niscope/library.py
+++ b/generated/niscope/library.py
@@ -49,7 +49,6 @@ class Library(object):
         self.niScope_FetchMeasurementStats_cfunc = None
         self.niScope_GetAttributeViBoolean_cfunc = None
         self.niScope_GetAttributeViInt32_cfunc = None
-        self.niScope_GetAttributeViInt64_cfunc = None
         self.niScope_GetAttributeViReal64_cfunc = None
         self.niScope_GetAttributeViString_cfunc = None
         self.niScope_GetEqualizationFilterCoefficients_cfunc = None
@@ -65,7 +64,6 @@ class Library(object):
         self.niScope_SendSoftwareTriggerEdge_cfunc = None
         self.niScope_SetAttributeViBoolean_cfunc = None
         self.niScope_SetAttributeViInt32_cfunc = None
-        self.niScope_SetAttributeViInt64_cfunc = None
         self.niScope_SetAttributeViReal64_cfunc = None
         self.niScope_SetAttributeViString_cfunc = None
         self.niScope_close_cfunc = None
@@ -312,14 +310,6 @@ class Library(object):
                 self.niScope_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_GetAttributeViInt32_cfunc(vi, channel_list, attribute_id, value)
 
-    def niScope_GetAttributeViInt64(self, vi, channel_list, attribute_id, value):  # noqa: N802
-        with self._func_lock:
-            if self.niScope_GetAttributeViInt64_cfunc is None:
-                self.niScope_GetAttributeViInt64_cfunc = self._library.niScope_GetAttributeViInt64
-                self.niScope_GetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt64)]  # noqa: F405
-                self.niScope_GetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
-        return self.niScope_GetAttributeViInt64_cfunc(vi, channel_list, attribute_id, value)
-
     def niScope_GetAttributeViReal64(self, vi, channel_list, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niScope_GetAttributeViReal64_cfunc is None:
@@ -439,14 +429,6 @@ class Library(object):
                 self.niScope_SetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32]  # noqa: F405
                 self.niScope_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_SetAttributeViInt32_cfunc(vi, channel_list, attribute_id, value)
-
-    def niScope_SetAttributeViInt64(self, vi, channel_list, attribute_id, value):  # noqa: N802
-        with self._func_lock:
-            if self.niScope_SetAttributeViInt64_cfunc is None:
-                self.niScope_SetAttributeViInt64_cfunc = self._library.niScope_SetAttributeViInt64
-                self.niScope_SetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt64]  # noqa: F405
-                self.niScope_SetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
-        return self.niScope_SetAttributeViInt64_cfunc(vi, channel_list, attribute_id, value)
 
     def niScope_SetAttributeViReal64(self, vi, channel_list, attribute_id, value):  # noqa: N802
         with self._func_lock:

--- a/generated/niscope/session.py
+++ b/generated/niscope/session.py
@@ -1977,40 +1977,6 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(value_ctype.value)
 
-    def _get_attribute_vi_int64(self, attribute_id):
-        '''_get_attribute_vi_int64
-
-        Queries the value of a ViInt64 attribute. You can use this function to
-        get the values of instrument-specific attributes and inherent IVI
-        attributes. If the attribute represents an instrument state, this
-        function performs instrument I/O in the following cases:
-
-        -  State caching is disabled for the entire session or for the
-           particular attribute.
-        -  State caching is enabled and the currently cached value is invalid.
-
-        Tip:
-        This method requires repeated capabilities (usually channels). If called directly on the
-        niscope.Session object, then the method will use all repeated capabilities in the session.
-        You can specify a subset of repeated capabilities using the Python index notation on an
-        niscope.Session instance, and calling this method on the result.:
-
-            session['0,1']._get_attribute_vi_int64(attribute_id)
-
-        Args:
-            attribute_id (int): The ID of an attribute.
-
-        Returns:
-            value (int): Returns the current value of the attribute.
-        '''
-        vi_ctype = visatype.ViSession(self._vi)  # case 1
-        channel_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case 2
-        attribute_id_ctype = visatype.ViAttr(attribute_id)  # case 9
-        value_ctype = visatype.ViInt64()  # case 14
-        error_code = self._library.niScope_GetAttributeViInt64(vi_ctype, channel_list_ctype, attribute_id_ctype, ctypes.pointer(value_ctype))
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return int(value_ctype.value)
-
     def _get_attribute_vi_real64(self, attribute_id):
         '''_get_attribute_vi_real64
 
@@ -2397,53 +2363,6 @@ class _SessionBase(object):
         attribute_id_ctype = visatype.ViAttr(attribute_id)  # case 9
         value_ctype = visatype.ViInt32(value)  # case 9
         error_code = self._library.niScope_SetAttributeViInt32(vi_ctype, channel_list_ctype, attribute_id_ctype, value_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return
-
-    def _set_attribute_vi_int64(self, attribute_id, value):
-        '''_set_attribute_vi_int64
-
-        Sets the value of a ViInt64 attribute. This is a low-level function that
-        you can use to set the values of instrument-specific attributes and
-        inherent IVI attributes. If the attribute represents an instrument
-        state, this function performs instrument I/O in the following cases:
-
-        -  State caching is disabled for the entire session or for the
-           particular attribute.
-        -  State caching is enabled and the currently cached value is invalid or
-           is different than the value you specify.
-
-        Note:
-        NI-SCOPE contains high-level functions that set most of the instrument
-        attributes. Use the high-level functions as much as possible because
-        they handle order dependencies and multithread locking for you. In
-        addition, high-level functions perform status checking only after
-        setting all of the attributes. In contrast, when you set multiple
-        attributes using the Set Attribute functions, the functions check the
-        instrument status after each call. Also, when state caching is enabled,
-        the high-level functions that configure multiple attributes perform
-        instrument I/O only for the attributes whose value you change. Thus, you
-        can safely call the high-level functions without the penalty of
-        redundant instrument I/O.
-
-        Tip:
-        This method requires repeated capabilities (usually channels). If called directly on the
-        niscope.Session object, then the method will use all repeated capabilities in the session.
-        You can specify a subset of repeated capabilities using the Python index notation on an
-        niscope.Session instance, and calling this method on the result.:
-
-            session['0,1']._set_attribute_vi_int64(attribute_id, value)
-
-        Args:
-            attribute_id (int): The ID of an attribute.
-            value (int): The value that you want to set the attribute. Some values might not be
-                valid depending on the current settings of the instrument session.
-        '''
-        vi_ctype = visatype.ViSession(self._vi)  # case 1
-        channel_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case 2
-        attribute_id_ctype = visatype.ViAttr(attribute_id)  # case 9
-        value_ctype = visatype.ViInt64(value)  # case 9
-        error_code = self._library.niScope_SetAttributeViInt64(vi_ctype, channel_list_ctype, attribute_id_ctype, value_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 

--- a/generated/niscope/unit_tests/mock_helper.py
+++ b/generated/niscope/unit_tests/mock_helper.py
@@ -90,9 +90,6 @@ class SideEffectsHelper(object):
         self._defaults['GetAttributeViInt32'] = {}
         self._defaults['GetAttributeViInt32']['return'] = 0
         self._defaults['GetAttributeViInt32']['Value'] = None
-        self._defaults['GetAttributeViInt64'] = {}
-        self._defaults['GetAttributeViInt64']['return'] = 0
-        self._defaults['GetAttributeViInt64']['Value'] = None
         self._defaults['GetAttributeViReal64'] = {}
         self._defaults['GetAttributeViReal64']['return'] = 0
         self._defaults['GetAttributeViReal64']['Value'] = None
@@ -132,8 +129,6 @@ class SideEffectsHelper(object):
         self._defaults['SetAttributeViBoolean']['return'] = 0
         self._defaults['SetAttributeViInt32'] = {}
         self._defaults['SetAttributeViInt32']['return'] = 0
-        self._defaults['SetAttributeViInt64'] = {}
-        self._defaults['SetAttributeViInt64']['return'] = 0
         self._defaults['SetAttributeViReal64'] = {}
         self._defaults['SetAttributeViReal64']['return'] = 0
         self._defaults['SetAttributeViString'] = {}
@@ -406,14 +401,6 @@ class SideEffectsHelper(object):
         value.contents.value = self._defaults['GetAttributeViInt32']['Value']
         return self._defaults['GetAttributeViInt32']['return']
 
-    def niScope_GetAttributeViInt64(self, vi, channel_list, attribute_id, value):  # noqa: N802
-        if self._defaults['GetAttributeViInt64']['return'] != 0:
-            return self._defaults['GetAttributeViInt64']['return']
-        if self._defaults['GetAttributeViInt64']['Value'] is None:
-            raise MockFunctionCallError("niScope_GetAttributeViInt64", param='Value')
-        value.contents.value = self._defaults['GetAttributeViInt64']['Value']
-        return self._defaults['GetAttributeViInt64']['return']
-
     def niScope_GetAttributeViReal64(self, vi, channel_list, attribute_id, value):  # noqa: N802
         if self._defaults['GetAttributeViReal64']['return'] != 0:
             return self._defaults['GetAttributeViReal64']['return']
@@ -540,11 +527,6 @@ class SideEffectsHelper(object):
             return self._defaults['SetAttributeViInt32']['return']
         return self._defaults['SetAttributeViInt32']['return']
 
-    def niScope_SetAttributeViInt64(self, vi, channel_list, attribute_id, value):  # noqa: N802
-        if self._defaults['SetAttributeViInt64']['return'] != 0:
-            return self._defaults['SetAttributeViInt64']['return']
-        return self._defaults['SetAttributeViInt64']['return']
-
     def niScope_SetAttributeViReal64(self, vi, channel_list, attribute_id, value):  # noqa: N802
         if self._defaults['SetAttributeViReal64']['return'] != 0:
             return self._defaults['SetAttributeViReal64']['return']
@@ -643,8 +625,6 @@ class SideEffectsHelper(object):
         mock_library.niScope_GetAttributeViBoolean.return_value = 0
         mock_library.niScope_GetAttributeViInt32.side_effect = MockFunctionCallError("niScope_GetAttributeViInt32")
         mock_library.niScope_GetAttributeViInt32.return_value = 0
-        mock_library.niScope_GetAttributeViInt64.side_effect = MockFunctionCallError("niScope_GetAttributeViInt64")
-        mock_library.niScope_GetAttributeViInt64.return_value = 0
         mock_library.niScope_GetAttributeViReal64.side_effect = MockFunctionCallError("niScope_GetAttributeViReal64")
         mock_library.niScope_GetAttributeViReal64.return_value = 0
         mock_library.niScope_GetAttributeViString.side_effect = MockFunctionCallError("niScope_GetAttributeViString")
@@ -675,8 +655,6 @@ class SideEffectsHelper(object):
         mock_library.niScope_SetAttributeViBoolean.return_value = 0
         mock_library.niScope_SetAttributeViInt32.side_effect = MockFunctionCallError("niScope_SetAttributeViInt32")
         mock_library.niScope_SetAttributeViInt32.return_value = 0
-        mock_library.niScope_SetAttributeViInt64.side_effect = MockFunctionCallError("niScope_SetAttributeViInt64")
-        mock_library.niScope_SetAttributeViInt64.return_value = 0
         mock_library.niScope_SetAttributeViReal64.side_effect = MockFunctionCallError("niScope_SetAttributeViReal64")
         mock_library.niScope_SetAttributeViReal64.return_value = 0
         mock_library.niScope_SetAttributeViString.side_effect = MockFunctionCallError("niScope_SetAttributeViString")

--- a/src/niscope/metadata/functions_addon.py
+++ b/src/niscope/metadata/functions_addon.py
@@ -62,7 +62,7 @@ functions_codegen_method = {
     'FetchBinary32':                    { 'codegen_method': 'no',       },  # TODO(marcoskirsch):No support for fetching binary. Issue #511
     'ActualMeasWfmSize':                { 'codegen_method': 'private',  },  # We use it internally so the customer doesn't have to.
     'ActualNumWfms':                    { 'codegen_method': 'private',  },  # We use it internally so the customer doesn't have to.
-    '.etAttributeViInt64':              { 'codegen_method': 'no',       },  # NI-Scope has no ViInt64 attributes.	
+    '.etAttributeViInt64':              { 'codegen_method': 'no',       },  # NI-SCOPE has no ViInt64 attributes.	
 }
 
 # Attach the given parameter to the given enum from enums.py

--- a/src/niscope/metadata/functions_addon.py
+++ b/src/niscope/metadata/functions_addon.py
@@ -62,6 +62,7 @@ functions_codegen_method = {
     'FetchBinary32':                    { 'codegen_method': 'no',       },  # TODO(marcoskirsch):No support for fetching binary. Issue #511
     'ActualMeasWfmSize':                { 'codegen_method': 'private',  },  # We use it internally so the customer doesn't have to.
     'ActualNumWfms':                    { 'codegen_method': 'private',  },  # We use it internally so the customer doesn't have to.
+    '.etAttributeViInt64':              { 'codegen_method': 'no',       },  # NI-Scope has no ViInt64 attributes.	
 }
 
 # Attach the given parameter to the given enum from enums.py

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -148,12 +148,12 @@ def test_configure_chan_characteristics(session):
 
 
 # TODO(injaleea): check after issue #639 fixed, will have to modify after according to fix for issue#614
-def test_filters():
+def test_filter_coefficients():
     with niscope.Session('FakeDevice', False, True, 'Simulate=1, DriverSetup=Model:5142; BoardType:PXIe') as session:  # filter coefficients methods are available on devices with OSP
         assert [1.0, 0.0, 0.0] == session.get_equalization_filter_coefficients(3)
         try:
-            fir_conf = [1.0, 0.0, 0.0]
-            session.configure_equalization_filter_coefficients(fir_conf)
+            filter_coefficients = [1.0, 0.0, 0.0]
+            session.configure_equalization_filter_coefficients(filter_coefficients)
         except niscope.Error as e:
             assert e.code == -1074135024  # coefficients list should have 35 items
 

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -139,6 +139,11 @@ def test_fetch_read_measuremet(session):
     measurement_stats = active_channel.fetch_measurement_stats(niscope.ScalarMeasurement.FREQUENCY)[0][0]  # extracting single measurement from fetch_measurement_stats
     in_range = abs(measurement_stats - expected_measurement) <= max(1e-02 * max(abs(measurement_stats), abs(expected_measurement)), 0.0)  # https://stackoverflow.com/questions/5595425/what-is-the-best-way-to-compare-floats-for-almost-equality-in-python
     assert in_range is True
+    '''
+    (TODO)injaleea: fix after issue#629 fixed
+    fetch_measurement = session.fetch_array_measurement(-1, niscope.ArrayMeasurement.ARRAY_GAIN)[1][3]  # extracting actual number of samples from measurement
+    assert 1500 == fetch_measurement  # actual number of sample should be 1500 for a simulated 5164
+    '''
 
 
 def test_configure_chan_characteristics(session):


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~

~~[ ] I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

**- Adding more systemtests for niscope**

1. test_fetch_read_measuremet
2. test_configure_chan_characteristics
3. test_filter_coefficients
4. test_send_software_trigger_edge
5. test_disable

**Removing SetAttributeViInt64 and GetAttributeViInt64 method since there is no attribute of ViInt64**

### List issues fixed by this Pull Request below, if any.

TODO: List of issues.

Partial towards #520 

### What testing has been done?
Systemtests, tox
