### PR TITLE
Fix niscope.Session.active_channel.fetch_array_measurement()

### DIFF
--- a/build/helper/metadata_add_all.py
+++ b/build/helper/metadata_add_all.py
@@ -150,11 +150,21 @@ _repeated_capability_parameter_names = ['channelName', 'channelList', 'channel',
 
 
 def _add_has_repeated_capability(f):
-    '''Adds a boolean 'has_repeated_capability' to the function metadata by inferring it from its parameter names, if not previously populated..'''
+    '''Adds a boolean 'has_repeated_capability' to the function metadata by inferring it from its parameter names, if not previously populated.'''
     if 'has_repeated_capability' not in f:
         f['has_repeated_capability'] = False
         for p in f['parameters']:
             f['has_repeated_capability'] = f['has_repeated_capability'] or p['name'] in _repeated_capability_parameter_names
+
+
+def _add_render_in_session_base(f):
+    '''Adds a boolean 'render_in_session_base' to the function metadata if not previously populated.
+
+    This tells the code generator to render those methods in _SessionBase class and not Session.
+    By default, we want all functions that have repeated capability input and all error handling related functions in _SessionBase but there are exceptions to this rule.
+    '''
+    if 'render_in_session_base' not in f:
+        f['render_in_session_base'] = f['has_repeated_capability'] or f['is_error_handling']
 
 
 def _add_is_repeated_capability(parameter):
@@ -183,6 +193,7 @@ def add_all_function_metadata(functions, config):
         _add_python_method_name(functions[f], f)
         _add_is_error_handling(functions[f])
         _add_has_repeated_capability(functions[f])
+        _add_render_in_session_base(functions[f])
         for p in functions[f]['parameters']:
             _add_buffer_info(p)
             _fix_type(p)
@@ -473,6 +484,7 @@ def test_add_all_metadata_simple():
             },
             'has_repeated_capability': True,
             'is_error_handling': False,
+            'render_in_session_base': True,
             'parameters': [
                 {
                     'ctypes_type': 'ViSession',
@@ -581,6 +593,7 @@ def test_add_all_metadata_simple():
             'name': 'MakeAPrivateMethod',
             'python_name': '_make_a_private_method',
             'is_error_handling': False,
+            'render_in_session_base': False,
             'has_repeated_capability': False
         }
     }

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -153,7 +153,7 @@ init_call_params = helper.get_params_snippet(init_function, helper.ParameterUsag
 
     ''' These are code-generated '''
 
-% for func_name in sorted({k: v for k, v in functions.items() if v['has_repeated_capability'] or v['is_error_handling']}):
+% for func_name in sorted({k: v for k, v in functions.items() if v['render_in_session_base']}):
 ${render_method(functions[func_name])}
 % endfor
 
@@ -198,7 +198,7 @@ class Session(_SessionBase):
 
     ''' These are code-generated '''
 
-% for func_name in sorted({k: v for k, v in functions.items() if not v['has_repeated_capability'] and not v['is_error_handling']}):
+% for func_name in sorted({k: v for k, v in functions.items() if not v['render_in_session_base']}):
 ${render_method(functions[func_name])}
 % endfor
 

--- a/src/niscope/metadata/functions_addon.py
+++ b/src/niscope/metadata/functions_addon.py
@@ -117,8 +117,8 @@ functions_buffer_info = {
                                                                   5: { 'size': {'mechanism':'python-code', 'value':'self._actual_num_wfms()'}, }, }, },
     'Fetch':                                    { 'parameters': { 4: { 'size': {'mechanism':'python-code', 'value':'(num_samples * self._actual_num_wfms())'}, },
                                                                   5: { 'size': {'mechanism':'python-code', 'value':'self._actual_num_wfms()'}, }, }, },
-    'FetchArrayMeasurement':                    { 'parameters': { 4: { 'size': {'mechanism':'python-code', 'value':'self._actual_meas_wfm_size()'}, },
-                                                                  5: { 'size': {'mechanism':'python-code', 'value':'(self._actual_meas_wfm_size() * self._actual_num_wfms())'}, },
+    'FetchArrayMeasurement':                    { 'parameters': { 4: { 'size': {'mechanism':'python-code', 'value':'self._actual_meas_wfm_size(array_meas_function)'}, },
+                                                                  5: { 'size': {'mechanism':'python-code', 'value':'(self._actual_meas_wfm_size(array_meas_function) * self._actual_num_wfms())'}, },
                                                                   6: { 'size': {'mechanism':'python-code', 'value':'self._actual_num_wfms()'}, }, }, },
 }
 
@@ -128,8 +128,6 @@ functions_bad_source_metadata = {
     'GetFrequencyResponse':                     { 'parameters': { 3: { 'direction': 'out'},
                                                                   4: { 'direction': 'out'},
                                                                   5: { 'direction': 'out'}, }, },
-
-
 }
 
 # These are functions we mark as "error_handling":True. The generator uses this information to
@@ -138,6 +136,10 @@ functions_bad_source_metadata = {
 functions_is_error_handling = {
     'error_message':                { 'is_error_handling': True },
     'GetError':                     { 'is_error_handling': True },
+}
+
+functions_render_in_session_base = {
+    'ActualMeasWfmSize':               { 'render_in_session_base': True, },  # Internally called by function with a repeated capability.
 }
 
 # Default values for method parameters

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -105,7 +105,7 @@ def test_probe_compensation_signal(session):
     session.probe_compensation_signal_stop()
 
 
-def test_configure_channel_characteristics(session):
+def test_configure_horizontal_timing(session):
     session.configure_vertical(5.0, niscope.VerticalCoupling.DC)
     session.auto_setup()
     session.configure_horizontal_timing(10000000, 1000, 50.0, 1, True)
@@ -125,6 +125,24 @@ def test_waveform_processing(session):
     session.clear_waveform_processing()
     session.horz_record_length == 4096
     session.horz_sample_rate == 10000000
+
+
+def test_fetch_read_measurement(session):
+    active_channel = session['0']
+    read_measurement = active_channel.read_measurement(niscope.ScalarMeasurement.FREQUENCY)[0]  # fetching first measurement from returned array
+    expected_measurement = 10000
+    in_range = abs(read_measurement - expected_measurement) <= max(1e-02 * max(abs(read_measurement), abs(expected_measurement)), 0.0)  # https://stackoverflow.com/questions/5595425/what-is-the-best-way-to-compare-floats-for-almost-equality-in-python
+    assert in_range is True
+    fetch_measurement = active_channel.fetch_measurement(niscope.ScalarMeasurement.FREQUENCY)[0]
+    in_range = abs(fetch_measurement - expected_measurement) <= max(1e-02 * max(abs(fetch_measurement), abs(expected_measurement)), 0.0)  # https://stackoverflow.com/questions/5595425/what-is-the-best-way-to-compare-floats-for-almost-equality-in-python
+    assert in_range is True
+    measurement_stats = active_channel.fetch_measurement_stats(niscope.ScalarMeasurement.FREQUENCY)[0][0]  # extracting single measurement from fetch_measurement_stats
+    in_range = abs(measurement_stats - expected_measurement) <= max(1e-02 * max(abs(measurement_stats), abs(expected_measurement)), 0.0)  # https://stackoverflow.com/questions/5595425/what-is-the-best-way-to-compare-floats-for-almost-equality-in-python
+    assert in_range is True
+    waveform, waveform_info = active_channel.fetch_array_measurement(-1, niscope.ArrayMeasurement.ARRAY_GAIN)
+    actual_number_of_samples = waveform_info[0].actual_samples
+    assert 1000 == len(waveform)  # Driver returns 1000 for simulated 5164
+    assert 1000 == actual_number_of_samples  # Driver returns 1000 for simulated 5164
 
 
 def test_configure_ref_levels(session):


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~

[X] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

*Allows customization of where a method is generated (class _SessionBase or Session).
    * This used to be deduced from function metadata values for 'has_repeated_capability' and 'is_error_handling'
    * Done through a new metadata value 'render_in_session_base'
        * By default it's deduced from  'has_repeated_capability' and 'is_error_handling'
        * But can be overridden in metadata
* Fix niscope functions_addon.py to pass parameter to _actual_meas_wfm_size()
* Move _actual_meas_wfm_size() to _SessionBase
    * It needs to be called by fetch_array_measurement which is in _RepeatedCapability class, not in Session. 

### List issues fixed by this Pull Request below, if any.

* Fix #629 

### What testing has been done?

A preliminary system test was provided by @injaleea and modified to work now that the method is fixed.