### PR TITLE
updating helper file for system_tests on internal testsuite

### DIFF
--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -312,3 +312,9 @@ def test_send_software_edge_trigger(session):
     with session.initiate():
         session.send_software_edge_trigger(nifgen.Trigger.SCRIPT, 'ScriptTrigger0')
 
+
+def test_write_waveform_from_file_f64(session):
+    try:
+        session.create_waveform_from_file_f64(os.path.join(os.getcwd(), 'src\\nifgen\\system_tests', 'SineI16BigEndian_1000.bin'), nifgen.ByteOrder.BIG)
+    except nifgen.Error as e:
+        assert e.code == -1074135024  # Expecting error since loading an I16 file when f64 is expected.

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -154,7 +154,7 @@ def test_configure_chan_characteristics(session):
 '''
 # TODO(frank): re-add after issue #650 is fixed.
 def test_filter_coefficients():
-    with niscope.Session('FakeDevice', False, True, 'Simulate=1, DriverSetup=Model:5142; BoardType:PXIe') as session:  # filter coefficients methods are available on devices with OSP
+    with niscope.Session('FakeDevice', False, True, 'Simulate=1, DriverSetup=Model:5142; BoardType:PXI') as session:  # filter coefficients methods are available on devices with OSP
         assert [1.0, 0.0, 0.0] == session.get_equalization_filter_coefficients(3)
         try:
             filter_coefficients = [1.0, 0.0, 0.0]

--- a/tools/run_python_system_tests.py
+++ b/tools/run_python_system_tests.py
@@ -10,8 +10,8 @@ import zipfile
 
 parser = argparse.ArgumentParser(description='Downloads the latest release nimi-python and runs system tests on the specified driver.', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument('-d', '--driver', required=True, type=str, help='Driver Name.')
-parser.add_argument('-pv', '--python_version', required=False, type=str, help='Python version to be run.', default ='py27')  # pass py36 if wanted to run on python-3.6
-parser.add_argument('-pb', '--python_bitness', required=False, type=str, help='Python bitness to be run.', default =' ')  # pass --32 if you want to run on a 32bit python if available
+parser.add_argument('-pv', '--python_version', required=False, type=str, help='Python version to be run.', default='py27')  # pass py36 if wanted to run on python-3.6
+parser.add_argument('-pb', '--python_bitness', required=False, type=str, help='Python bitness to be run.', default=' ')  # pass '--32' if you want to run on a 32bit python if both available
 args = parser.parse_args()
 
 
@@ -56,5 +56,5 @@ print(zip_folder)
 print('****Running system tests in tox.****')
 tox_dir = os.path.join(zip_folder, os.listdir(zip_folder)[0])
 os.chdir(tox_dir)
-result = os.system('tox ' + args.python_bitness + ' -e ' + args.python_version + '-'+ args.driver +'_system_tests')
+result = os.system('tox ' + args.python_bitness + ' -e ' + args.python_version + '-' + args.driver + '_system_tests')
 sys.exit(result)

--- a/tools/run_python_system_tests.py
+++ b/tools/run_python_system_tests.py
@@ -10,6 +10,8 @@ import zipfile
 
 parser = argparse.ArgumentParser(description='Downloads the latest release nimi-python and runs system tests on the specified driver.', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument('-d', '--driver', required=True, type=str, help='Driver Name.')
+parser.add_argument('-pv', '--python_version', required=False, type=str, help='Python version to be run.', default ='py27')  # pass py36 if wanted to run on python-3.6
+parser.add_argument('-pb', '--python_bitness', required=False, type=str, help='Python bitness to be run.', default =' ')  # pass --32 if you want to run on a 32bit python if available
 args = parser.parse_args()
 
 
@@ -54,5 +56,5 @@ print(zip_folder)
 print('****Running system tests in tox.****')
 tox_dir = os.path.join(zip_folder, os.listdir(zip_folder)[0])
 os.chdir(tox_dir)
-result = os.system('python -m tox -e ' + args.driver + '_system_tests')
+result = os.system('tox ' + args.python_bitness + ' -e ' + args.python_version + '-'+ args.driver +'_system_tests')
 sys.exit(result)


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~

~~[ ] I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?
Added 2 optional parameter for running systemtests on internal testsuite.
'-pv', '--python_version',  accepts py27 and py36.
'-pb', '--python_bitness', accepts ' ' and '--32'

Adding new system test for nifgen

- test_write_waveform_from_file_f64

### List issues fixed by this Pull Request below, if any.

* Fix #644 
* Fix #484 


### What testing has been done?

systemtests, tox
