### PR TITLE
Allow specifying multiple templates for a single function

### DIFF
--- a/build/helper/metadata_add_all.py
+++ b/build/helper/metadata_add_all.py
@@ -156,7 +156,7 @@ def _add_method_template_filenames(f):
     # Prefix the templates with a / so mako can find them. Not sure mako it works this way.
     prefixed_filenames = []
     for filename in f['method_template_filenames']:
-        prefixed_filenames.append('/' + filename if filename != '/' else filename)
+        prefixed_filenames.append('/' + filename if filename[0] != '/' else filename)
     f['method_template_filenames'] = prefixed_filenames
 
 
@@ -435,6 +435,7 @@ def test_add_all_metadata_simple():
         'MakeAFoo': {
             'codegen_method': 'public',
             'returns': 'ViStatus',
+            'method_template_filenames': ['/cool_template.py.mako'],
             'parameters': [
                 {
                     'direction': 'in',
@@ -497,7 +498,7 @@ def test_add_all_metadata_simple():
             'has_repeated_capability': True,
             'is_error_handling': False,
             'render_in_session_base': True,
-            'method_template_filenames': ['/session_default_method.py.mako'],
+            'method_template_filenames': ['/cool_template.py.mako'],
             'parameters': [
                 {
                     'ctypes_type': 'ViSession',

--- a/build/helper/metadata_add_all.py
+++ b/build/helper/metadata_add_all.py
@@ -149,12 +149,15 @@ def _add_default_value_name_for_docs(parameter, module_name):
 _repeated_capability_parameter_names = ['channelName', 'channelList', 'channel', 'channelNameList']
 
 
-def _add_method_template_filename(f):
-    '''Adds 'method_template_filename' value to function metadata if not found. This is the mako template that will be used to render the method.'''
-    if 'method_template_filename' not in f:
-        f['method_template_filename'] = 'session_default_method.py.mako'
-    if f['method_template_filename'][0] != '/':
-        f['method_template_filename'] = '/' + f['method_template_filename']
+def _add_method_template_filenames(f):
+    '''Adds a list of 'method_template_filenames' value to function metadata if not found. This are the mako templates that will be used to render the method.'''
+    if 'method_template_filenames' not in f:
+        f['method_template_filenames'] = ['session_default_method.py.mako']
+    # Prefix the templates with a / so mako can find them. Not sure mako it works this way.
+    prefixed_filenames = []
+    for filename in f['method_template_filenames']:
+        prefixed_filenames.append('/' + filename if filename != '/' else filename)
+    f['method_template_filenames'] = prefixed_filenames
 
 
 def _add_has_repeated_capability(f):
@@ -202,7 +205,7 @@ def add_all_function_metadata(functions, config):
         _add_is_error_handling(functions[f])
         _add_has_repeated_capability(functions[f])
         _add_render_in_session_base(functions[f])
-        _add_method_template_filename(functions[f])
+        _add_method_template_filenames(functions[f])
         for p in functions[f]['parameters']:
             _add_buffer_info(p)
             _fix_type(p)
@@ -494,7 +497,7 @@ def test_add_all_metadata_simple():
             'has_repeated_capability': True,
             'is_error_handling': False,
             'render_in_session_base': True,
-            'method_template_filename': '/session_default_method.py.mako',
+            'method_template_filenames': ['/session_default_method.py.mako'],
             'parameters': [
                 {
                     'ctypes_type': 'ViSession',
@@ -549,7 +552,7 @@ def test_add_all_metadata_simple():
         'MakeAPrivateMethod': {
             'codegen_method': 'private',
             'returns': 'ViStatus',
-            'method_template_filename': '/session_default_method.py.mako',
+            'method_template_filenames': ['/session_default_method.py.mako'],
             'parameters': [{
                 'direction': 'in',
                 'enum': None,

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -120,7 +120,9 @@ init_call_params = helper.get_params_snippet(init_function, helper.ParameterUsag
     ''' These are code-generated '''
 
 % for func_name in sorted({k: v for k, v in functions.items() if v['render_in_session_base']}):
-<%include file="${functions[func_name]['method_template_filename']}" args="f=functions[func_name], config=config" />\
+% for method_template_filename in functions[func_name]['method_template_filenames']:
+<%include file="${method_template_filename}" args="f=functions[func_name], config=config" />\
+% endfor
 % endfor
 
 class _RepeatedCapability(_SessionBase):
@@ -165,7 +167,9 @@ class Session(_SessionBase):
     ''' These are code-generated '''
 
 % for func_name in sorted({k: v for k, v in functions.items() if not v['render_in_session_base']}):
-<%include file="${functions[func_name]['method_template_filename']}" args="f=functions[func_name], config=config" />\
+% for method_template_filename in functions[func_name]['method_template_filenames']:
+<%include file="${method_template_filename}" args="f=functions[func_name], config=config" />\
+% endfor
 % endfor
 
 

--- a/src/nimodinst/templates/session.py.mako
+++ b/src/nimodinst/templates/session.py.mako
@@ -149,6 +149,8 @@ class Session(object):
 
     ''' These are code-generated '''
 % for func_name in sorted(functions):
-<%include file="${functions[func_name]['method_template_filename']}" args="f=functions[func_name], config=config" />\
+% for method_template_filename in functions[func_name]['method_template_filenames']:
+<%include file="${method_template_filename}" args="f=functions[func_name], config=config" />\
+% endfor
 % endfor
 


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~

[X] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

Allows to specify via metadata multiple, rather than just one, templates to apply to a single function.
This way we can generate twice for one function. This is necessary for numpy support: for example, we want both nidmm.Session.fetch_waveform() and nidmm.Session.fetch_waveform_into().

### List issues fixed by this Pull Request below, if any.

* Work towards #511 

### What testing has been done?

Verified that by default generated code is the same. Feature will be leveraged in future PRs.
