### PR TITLE
Small metadata fix to NI-FAKE

### DIFF
--- a/generated/nifake/library.py
+++ b/generated/nifake/library.py
@@ -388,7 +388,7 @@ class Library(object):
         with self._func_lock:
             if self.niFake_TwoInputFunction_cfunc is None:
                 self.niFake_TwoInputFunction_cfunc = self._library.niFake_TwoInputFunction
-                self.niFake_TwoInputFunction_cfunc.argtypes = [ViSession, ViReal64, ViChar]  # noqa: F405
+                self.niFake_TwoInputFunction_cfunc.argtypes = [ViSession, ViReal64, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_TwoInputFunction_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_TwoInputFunction_cfunc(vi, a_number, a_string)
 

--- a/generated/nifake/session.py
+++ b/generated/nifake/session.py
@@ -1015,7 +1015,7 @@ class Session(_SessionBase):
 
         Args:
             a_number (float): Contains a number
-            a_string (int): Contains a string
+            a_string (string): Contains a string
         '''
         vi_ctype = visatype.ViSession(self._vi)  # case 1
         a_number_ctype = visatype.ViReal64(a_number)  # case 9

--- a/src/nifake/metadata/functions.py
+++ b/src/nifake/metadata/functions.py
@@ -916,6 +916,7 @@ functions = {
             {
                 'direction': 'in',
                 'enum': None,
+                'is_buffer': True,
                 'name': 'aString',
                 'type': 'ViChar',
                 'documentation': {

--- a/src/nifake/metadata/functions.py
+++ b/src/nifake/metadata/functions.py
@@ -916,9 +916,8 @@ functions = {
             {
                 'direction': 'in',
                 'enum': None,
-                'is_buffer': True,
                 'name': 'aString',
-                'type': 'ViChar',
+                'type': 'ViChar[]',
                 'documentation': {
                     'description': 'Contains a string',
                 },


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~

~~[ ] I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

Fixes a small metadata inconsistency in NI-FAKE. A string was not marked as a buffer. The generator didn't catch it due to how the logic is laid out.

I caught it in an attempt to refactor parts of the code generator. This will come in a future PR.

### List issues fixed by this Pull Request below, if any.

N/A

### What testing has been done?

Generated Python doesn't change so all is the same. The documentation got fixed though.