### PR TITLE
Create object and return iter instead of implementing iter on nimodinst session

### DIFF
--- a/generated/nimodinst/session.py
+++ b/generated/nimodinst/session.py
@@ -140,22 +140,10 @@ class Session(object):
         return self._item_count
 
     def __iter__(self):
-        self._current_item = 0
-        return self
-
-    def get_next(self):
-        if self._current_item + 1 > self._item_count:
-            raise StopIteration
-        else:
-            result = Device(self, self._current_item)
-            self._current_item += 1
-            return result
-
-    def next(self):
-        return self.get_next()
-
-    def __next__(self):
-        return self.get_next()
+        devices = []
+        for i in range(self._item_count):
+            devices.append(Device(self, i))
+        return iter(devices)
 
     def close(self):
         # TODO(marcoskirsch): Should we raise an exception on double close? Look at what File does.

--- a/generated/nimodinst/session.py
+++ b/generated/nimodinst/session.py
@@ -33,7 +33,7 @@ class AttributeViString(object):
         return self._owner._get_installed_device_attribute_vi_string(self._index, self._attribute_id)
 
 
-class Device(object):
+class _Device(object):
 
     # This is needed during __init__. Without it, __setattr__ raises an exception
     _is_frozen = False
@@ -107,6 +107,36 @@ class Device(object):
         object.__setattr__(self, name, value)
 
 
+class _DeviceIterable(object):
+    def __init__(self, owner, count):
+        self._current_index = 0
+        self._owner = owner
+        self._count = count
+        self._param_list = 'owner=' + pp.pformat(owner) + ', count=' + pp.pformat(count)
+        self._is_frozen = True
+
+    def get_next(self):
+        if self._current_index + 1 > self._count:
+            raise StopIteration
+        else:
+            self._current_index += 1
+            return _Device(self._owner, self._current_index)
+
+    def next(self):
+        return self.get_next()
+
+    def __next__(self):
+        return self.get_next()
+
+    def __repr__(self):
+        return '{0}.{1}({2})'.format('nimodinst', self.__class__.__name__, self._param_list)
+
+    def __str__(self):
+        ret_str = self.__repr__() + ':\n'
+        ret_str += '    current index = {0}'.format(self._current_index)
+        return ret_str
+
+
 class Session(object):
     '''A NI-ModInst session to get device information'''
 
@@ -130,7 +160,7 @@ class Session(object):
     def __str__(self):
         ret_str = self.__repr__() + ':\n'
         for i in range(self._item_count):
-            ret_str += str(Device(self, i)) + '\n'
+            ret_str += str(_Device(self, i)) + '\n'
         return ret_str
 
     def __setattr__(self, key, value):
@@ -139,7 +169,7 @@ class Session(object):
         object.__setattr__(self, key, value)
 
     def __getitem__(self, index):
-        return Device(self, index)
+        return _Device(self, index)
 
     def __enter__(self):
         return self
@@ -172,10 +202,7 @@ class Session(object):
         return self._item_count
 
     def __iter__(self):
-        devices = []
-        for i in range(self._item_count):
-            devices.append(Device(self, i))
-        return iter(devices)
+        return _DeviceIterable(self, self._item_count)
 
     def close(self):
         # TODO(marcoskirsch): Should we raise an exception on double close? Look at what File does.

--- a/generated/nimodinst/unit_tests/test_modinst.py
+++ b/generated/nimodinst/unit_tests/test_modinst.py
@@ -77,14 +77,6 @@ class TestSession(object):
             for d in session:
                 pass
 
-    def test_iterating_next(self):
-        self.side_effects_helper['OpenInstalledDevicesSession']['deviceCount'] = 2
-        with nimodinst.Session('') as session:
-            assert len(session) == 2
-            d1 = session.next()
-            d2 = session.next()
-            assert d1 != d2
-
     def test_get_extended_error_info(self):
         error_string = 'Error'
         self.patched_library.niModInst_GetExtendedErrorInfo.side_effect = self.side_effects_helper.niModInst_GetExtendedErrorInfo

--- a/generated/nimodinst/unit_tests/test_modinst.py
+++ b/generated/nimodinst/unit_tests/test_modinst.py
@@ -74,8 +74,19 @@ class TestSession(object):
         self.side_effects_helper['OpenInstalledDevicesSession']['deviceCount'] = 2
         with nimodinst.Session('') as session:
             assert len(session) == 2
+            count = 0
             for d in session:
-                pass
+                count += 1
+            assert count == len(session)
+
+    def test_iterating_for_empty(self):
+        self.side_effects_helper['OpenInstalledDevicesSession']['deviceCount'] = 0
+        with nimodinst.Session('') as session:
+            assert len(session) == 0
+            count = 0
+            for d in session:
+                count += 1
+            assert count == len(session)
 
     def test_get_extended_error_info(self):
         error_string = 'Error'
@@ -185,7 +196,7 @@ class TestSession(object):
                 session[0].non_existent_property
                 assert False
             except AttributeError as e:
-                assert str(e) == "'Device' object has no attribute 'non_existent_property'"
+                assert str(e) == "'_Device' object has no attribute 'non_existent_property'"
 
     def test_vi_int32_attribute_read_only(self):
         self.side_effects_helper['OpenInstalledDevicesSession']['deviceCount'] = 1

--- a/src/nimodinst/templates/session.py.mako
+++ b/src/nimodinst/templates/session.py.mako
@@ -124,22 +124,10 @@ class Session(object):
         return self._item_count
 
     def __iter__(self):
-        self._current_item = 0
-        return self
-
-    def get_next(self):
-        if self._current_item + 1 > self._item_count:
-            raise StopIteration
-        else:
-            result = Device(self, self._current_item)
-            self._current_item += 1
-            return result
-
-    def next(self):
-        return self.get_next()
-
-    def __next__(self):
-        return self.get_next()
+        devices = []
+        for i in range(self._item_count):
+            devices.append(Device(self, i))
+        return iter(devices)
 
     def close(self):
         # TODO(marcoskirsch): Should we raise an exception on double close? Look at what File does.

--- a/src/nimodinst/unit_tests/test_modinst.py
+++ b/src/nimodinst/unit_tests/test_modinst.py
@@ -77,14 +77,6 @@ class TestSession(object):
             for d in session:
                 pass
 
-    def test_iterating_next(self):
-        self.side_effects_helper['OpenInstalledDevicesSession']['deviceCount'] = 2
-        with nimodinst.Session('') as session:
-            assert len(session) == 2
-            d1 = session.next()
-            d2 = session.next()
-            assert d1 != d2
-
     def test_get_extended_error_info(self):
         error_string = 'Error'
         self.patched_library.niModInst_GetExtendedErrorInfo.side_effect = self.side_effects_helper.niModInst_GetExtendedErrorInfo

--- a/src/nimodinst/unit_tests/test_modinst.py
+++ b/src/nimodinst/unit_tests/test_modinst.py
@@ -74,8 +74,19 @@ class TestSession(object):
         self.side_effects_helper['OpenInstalledDevicesSession']['deviceCount'] = 2
         with nimodinst.Session('') as session:
             assert len(session) == 2
+            count = 0
             for d in session:
-                pass
+                count += 1
+            assert count == len(session)
+
+    def test_iterating_for_empty(self):
+        self.side_effects_helper['OpenInstalledDevicesSession']['deviceCount'] = 0
+        with nimodinst.Session('') as session:
+            assert len(session) == 0
+            count = 0
+            for d in session:
+                count += 1
+            assert count == len(session)
 
     def test_get_extended_error_info(self):
         error_string = 'Error'
@@ -185,7 +196,7 @@ class TestSession(object):
                 session[0].non_existent_property
                 assert False
             except AttributeError as e:
-                assert str(e) == "'Device' object has no attribute 'non_existent_property'"
+                assert str(e) == "'_Device' object has no attribute 'non_existent_property'"
 
     def test_vi_int32_attribute_read_only(self):
         self.side_effects_helper['OpenInstalledDevicesSession']['deviceCount'] = 1

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ commands =
     test: python --version
     test: python -c "import platform; print(platform.architecture())"
     test: coverage run --rcfile=tools/coverage_unit_tests.rc --append --source nifake -m py.test bin/nifake/nifake {posargs} -s
-    test: coverage run --rcfile=tools/coverage_unit_tests.rc --append --source nimodinst -m py.test bin/nimodinst/nimodinst {posargs}
+    test: coverage run --rcfile=tools/coverage_unit_tests.rc --append --source nimodinst -m py.test bin/nimodinst/nimodinst {posargs} -s
     test: coverage report --rcfile=tools/coverage_unit_tests.rc
     test: coverage html --rcfile=tools/coverage_unit_tests.rc  --directory=bin/htmlcov/unit_tests
     clean: python --version


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
~~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
[X] I've ~~added~~removed tests applicable for this pull request
### What does this Pull Request accomplish?
* Create a iterator of list of Devices when iterating on session
* This allows multiple simultaneous iterators.

### List issues fixed by this Pull Request below, if any.
* Fix #669 

### What testing has been done?
* Unit
* System