### PR TITLE
Remove id_query parameter from Session() where appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 * ### NI-DMM
   * #### Added
   * #### Changed
+    * `nidmm.Session()` no longer takes id_query parameter
   * #### Removed
 * ### NI-ModInst
   * #### Added
@@ -38,6 +39,7 @@ All notable changes to this project will be documented in this file.
 * ### NI-SCOPE
   * #### Added
   * #### Changed
+  * `niscope.Session()` no longer takes id_query parameter
   * #### Removed
 
 ## 0.6.0 - 2017-12-20

--- a/build/helper/codegen_helper.py
+++ b/build/helper/codegen_helper.py
@@ -13,6 +13,10 @@ _parameterUsageOptionsSnippet[ParameterUsageOptions.SESSION_METHOD_DECLARATION] 
     'skip_self': False,
     'name_to_use': 'python_name_with_default',
 }
+_parameterUsageOptionsSnippet[ParameterUsageOptions.SESSION_INIT_DECLARATION] = {
+    'skip_self': False,
+    'name_to_use': 'python_name_with_default',
+}
 _parameterUsageOptionsSnippet[ParameterUsageOptions.SESSION_NUMPY_INTO_METHOD_DECLARATION] = {
     'skip_self': False,
     'name_to_use': 'python_name_with_default',
@@ -20,6 +24,10 @@ _parameterUsageOptionsSnippet[ParameterUsageOptions.SESSION_NUMPY_INTO_METHOD_DE
 _parameterUsageOptionsSnippet[ParameterUsageOptions.SESSION_METHOD_CALL] = {
     'skip_self': True,
     'name_to_use': 'python_name',
+}
+_parameterUsageOptionsSnippet[ParameterUsageOptions.SESSION_INIT_CALL] = {
+    'skip_self': True,
+    'name_to_use': 'python_name_or_default_for_init',
 }
 _parameterUsageOptionsSnippet[ParameterUsageOptions.DOCUMENTATION_SESSION_METHOD] = {
     'skip_self': True,

--- a/build/helper/metadata_add_all.py
+++ b/build/helper/metadata_add_all.py
@@ -38,7 +38,8 @@ def _add_python_method_name(function, name):
 
 def _add_python_parameter_name(parameter):
     '''Adds a python_name key/value pair to the parameter metadata'''
-    parameter['python_name'] = camelcase_to_snakecase(parameter['name'])
+    if 'python_name' not in parameter:
+        parameter['python_name'] = camelcase_to_snakecase(parameter['name'])
     return parameter
 
 
@@ -144,14 +145,21 @@ def _add_default_value_name(parameter):
     '''Declaration with default value, if set'''
     if 'default_value' in parameter:
         if 'enum' in parameter and parameter['enum'] is not None:
-            name = parameter['python_name'] + "=enums." + parameter['default_value']
+            name_with_default = parameter['python_name'] + "=enums." + parameter['default_value']
         else:
-            name = parameter['python_name'] + "=" + repr(parameter['default_value'])
+            name_with_default = parameter['python_name'] + "=" + repr(parameter['default_value'])
+
+        if parameter['use_in_python_api']:
+            name_for_init = parameter['python_name']
+        else:
+            name_for_init = parameter['default_value']
 
     else:
-        name = parameter['python_name']
+        name_with_default = parameter['python_name']
+        name_for_init = parameter['python_name']
 
-    parameter['python_name_with_default'] = name
+    parameter['python_name_with_default'] = name_with_default
+    parameter['python_name_or_default_for_init'] = str(name_for_init)
 
 
 def _add_default_value_name_for_docs(parameter, module_name):
@@ -561,6 +569,7 @@ def test_add_all_metadata_simple():
                     'type': 'ViSession',
                     'library_method_call_snippet': 'vi_ctype',
                     'use_in_python_api': True,
+                    'python_name_or_default_for_init': 'vi',
                 },
                 {
                     'ctypes_type': 'ViChar',
@@ -585,6 +594,7 @@ def test_add_all_metadata_simple():
                     'original_type': 'ViString',
                     'library_method_call_snippet': 'channel_name_ctype',
                     'use_in_python_api': True,
+                    'python_name_or_default_for_init': 'channel_name',
                 },
             ],
             'python_name': 'make_a_foo',
@@ -619,6 +629,7 @@ def test_add_all_metadata_simple():
                 'is_session_handle': True,
                 'library_method_call_snippet': 'vi_ctype',
                 'use_in_python_api': True,
+                'python_name_or_default_for_init': 'vi',
             }, {
                 'direction': 'out',
                 'enum': None,
@@ -645,6 +656,7 @@ def test_add_all_metadata_simple():
                 'is_session_handle': False,
                 'library_method_call_snippet': 'status_ctype',
                 'use_in_python_api': True,
+                'python_name_or_default_for_init': 'status',
             }],
             'documentation': {
                 'description': 'Perform actions as method defined'

--- a/build/helper/metadata_filters.py
+++ b/build/helper/metadata_filters.py
@@ -20,6 +20,10 @@ _parameterUsageOptionsFiltering[ParameterUsageOptions.SESSION_METHOD_DECLARATION
     'mechanism': 'fixed, passed-in, len',
     'python_api_list': True,
 }
+# Only difference is we want to skip parameters not in api
+_parameterUsageOptionsFiltering[ParameterUsageOptions.SESSION_INIT_DECLARATION] = _parameterUsageOptionsFiltering[ParameterUsageOptions.SESSION_METHOD_DECLARATION].copy()
+_parameterUsageOptionsFiltering[ParameterUsageOptions.SESSION_INIT_DECLARATION]['python_api_list'] = False
+
 _parameterUsageOptionsFiltering[ParameterUsageOptions.SESSION_NUMPY_INTO_METHOD_DECLARATION] = {
     'skip_session_handle': True,
     'skip_input_parameters': False,
@@ -46,6 +50,9 @@ _parameterUsageOptionsFiltering[ParameterUsageOptions.SESSION_METHOD_CALL] = {
     'mechanism': 'fixed, passed-in',
     'python_api_list': True,
 }
+# Only difference is we want to skip parameters not in api
+_parameterUsageOptionsFiltering[ParameterUsageOptions.SESSION_INIT_CALL] = _parameterUsageOptionsFiltering[ParameterUsageOptions.SESSION_METHOD_CALL].copy()
+
 _parameterUsageOptionsFiltering[ParameterUsageOptions.DOCUMENTATION_SESSION_METHOD] = {
     'skip_session_handle': True,
     'skip_input_parameters': False,

--- a/build/helper/parameter_usage_options.py
+++ b/build/helper/parameter_usage_options.py
@@ -5,32 +5,36 @@ class ParameterUsageOptions(Enum):
     '''Different usage options for parameter lists.'''
 
     SESSION_METHOD_DECLARATION = 1
-    '''For declaring a method in Session'''
-    SESSION_NUMPY_INTO_METHOD_DECLARATION = 2
+    '''For declaring a regular method in Session'''
+    SESSION_INIT_DECLARATION = 2
+    '''For declaring an init method in Session'''
+    SESSION_NUMPY_INTO_METHOD_DECLARATION = 3
     '''For calling into a Session method that uses numpy arrays.'''
-    SESSION_METHOD_CALL = 3
-    '''For calling into a Session method.'''
-    DOCUMENTATION_SESSION_METHOD = 4
+    SESSION_METHOD_CALL = 4
+    '''For calling into a regular Session method.'''
+    SESSION_INIT_CALL = 5
+    '''For calling into an init Session method.'''
+    DOCUMENTATION_SESSION_METHOD = 6
     '''For documentation (rst) of Session methods'''
-    CTYPES_CALL = 5
+    CTYPES_CALL = 7
     '''For Library implementation calling into the DLL via ctypes'''
-    LIBRARY_METHOD_CALL = 6
+    LIBRARY_METHOD_CALL = 8
     '''For calling into a method in Library.'''
-    CTYPES_ARGTYPES = 7
+    CTYPES_ARGTYPES = 9
     '''For setting up the ctypes argument types'''
-    LIBRARY_METHOD_DECLARATION = 8
+    LIBRARY_METHOD_DECLARATION = 10
     '''For declaring a method in Library'''
-    INPUT_PARAMETERS = 9
+    INPUT_PARAMETERS = 11
     '''Get all input parameters, other than self, rep caps, and size'''
-    OUTPUT_PARAMETERS = 10
+    OUTPUT_PARAMETERS = 12
     '''Get all output parameters, other than ivi-dance'''
-    IVI_DANCE_PARAMETER = 11
+    IVI_DANCE_PARAMETER = 13
     '''Get the ivi-dance parameter'''
-    NUMPY_PARAMETERS = 12
+    NUMPY_PARAMETERS = 14
     '''Get all buffer parameters that support numpy.array in the Python API'''
-    LEN_PARAMETER = 13
+    LEN_PARAMETER = 15
     '''Get the len parameter'''
-    INPUT_ENUM_PARAMETERS = 14
+    INPUT_ENUM_PARAMETERS = 16
     '''Get any input parameters whose type is enum'''
 
 

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -81,8 +81,8 @@ if attributes[attribute]['channel_based'] == 'True':
 % endfor
 <%
 init_function = functions[config['init_function']]
-init_method_params = helper.get_params_snippet(init_function, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)
-init_call_params = helper.get_params_snippet(init_function, helper.ParameterUsageOptions.SESSION_METHOD_CALL)
+init_method_params = helper.get_params_snippet(init_function, helper.ParameterUsageOptions.SESSION_INIT_DECLARATION)
+init_call_params = helper.get_params_snippet(init_function, helper.ParameterUsageOptions.SESSION_INIT_CALL)
 %>\
 
     def __init__(self, repeated_capability):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI Modular Instruments Python API'
-copyright = '2017-2017, National Instruments'
+copyright = '2017-2018, National Instruments'
 author = 'National Instruments'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -63,7 +63,7 @@ author = 'National Instruments'
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = '0.6.1.dev0'
+release = '0.6.0'
 # The short X.Y version.
 version = release[:3]
 

--- a/generated/nidmm/session.py
+++ b/generated/nidmm/session.py
@@ -852,10 +852,10 @@ class _RepeatedCapability(_SessionBase):
 class Session(_SessionBase):
     '''An NI-DMM session to a National Instruments Digital Multimeter'''
 
-    def __init__(self, resource_name, id_query=False, reset_device=False, option_string=''):
+    def __init__(self, resource_name, reset_device=False, option_string=''):
         super(Session, self).__init__(repeated_capability='')
         self._vi = 0  # This must be set before calling _init_with_options().
-        self._vi = self._init_with_options(resource_name, id_query, reset_device, option_string)
+        self._vi = self._init_with_options(resource_name, False, reset_device, option_string)
         self._is_frozen = True
 
     def __enter__(self):

--- a/generated/nifake/session.py
+++ b/generated/nifake/session.py
@@ -432,10 +432,10 @@ class _RepeatedCapability(_SessionBase):
 class Session(_SessionBase):
     '''An NI-FAKE session to a fake MI driver whose sole purpose is to test nimi-python code generation'''
 
-    def __init__(self, resource_name, id_query=False, reset_device=False, option_string=''):
+    def __init__(self, resource_name, reset_device=False, option_string=''):
         super(Session, self).__init__(repeated_capability='')
         self._vi = 0  # This must be set before calling _init_with_options().
-        self._vi = self._init_with_options(resource_name, id_query, reset_device, option_string)
+        self._vi = self._init_with_options(resource_name, False, reset_device, option_string)
         self._is_frozen = True
 
     def __enter__(self):

--- a/generated/nifake/unit_tests/test_session.py
+++ b/generated/nifake/unit_tests/test_session.py
@@ -55,8 +55,8 @@ class TestSession(object):
         errors_patcher.stop()
 
     def test_init_with_options_nondefault_and_close(self):
-        session = nifake.Session('FakeDevice', True, True, 'Some string')
-        self.patched_library.niFake_InitWithOptions.assert_called_once_with(matchers.ViStringMatcher('FakeDevice'), matchers.ViBooleanMatcher(True), matchers.ViBooleanMatcher(True), matchers.ViStringMatcher('Some string'), matchers.ViSessionPointerMatcher())
+        session = nifake.Session('FakeDevice', True, 'Some string')
+        self.patched_library.niFake_InitWithOptions.assert_called_once_with(matchers.ViStringMatcher('FakeDevice'), matchers.ViBooleanMatcher(False), matchers.ViBooleanMatcher(True), matchers.ViStringMatcher('Some string'), matchers.ViSessionPointerMatcher())
         session.close()
         self.patched_library.niFake_close.assert_called_once_with(matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST))
 

--- a/generated/niscope/session.py
+++ b/generated/niscope/session.py
@@ -2988,10 +2988,10 @@ class _RepeatedCapability(_SessionBase):
 class Session(_SessionBase):
     '''An NI-SCOPE session to a National Instruments Digitizer.'''
 
-    def __init__(self, resource_name, id_query=False, reset_device=False, option_string=''):
+    def __init__(self, resource_name, reset_device=False, option_string=''):
         super(Session, self).__init__(repeated_capability='')
         self._vi = 0  # This must be set before calling _init_with_options().
-        self._vi = self._init_with_options(resource_name, id_query, reset_device, option_string)
+        self._vi = self._init_with_options(resource_name, False, reset_device, option_string)
         self._is_frozen = True
 
     def __enter__(self):

--- a/src/nidmm/metadata/functions_addon.py
+++ b/src/nidmm/metadata/functions_addon.py
@@ -126,3 +126,8 @@ functions_numpy = {
     'FetchWaveform':                        { 'parameters': { 3: { 'numpy': True, }, }, },
 }
 
+# Don't need ID_Query in the python API since they don't do anything
+functions_remove_parameters_from_python = {
+    'InitWithOptions':                      { 'parameters': { 1: { 'use_in_python_api': False, }, }, },
+}
+

--- a/src/nidmm/system_tests/test_system_nidmm.py
+++ b/src/nidmm/system_tests/test_system_nidmm.py
@@ -7,7 +7,7 @@ import time
 
 @pytest.fixture(scope='function')
 def session():
-    with nidmm.Session('FakeDevice', False, True, 'Simulate=1, DriverSetup=Model:4082; BoardType:PXIe') as simulated_session:
+    with nidmm.Session('FakeDevice', True, 'Simulate=1, DriverSetup=Model:4082; BoardType:PXIe') as simulated_session:
         yield simulated_session
 
 
@@ -273,7 +273,7 @@ def test_fetch_waveform_error(session):
 
 
 def test_get_measurement_period():
-        with nidmm.Session('FakeDevice', False, True, 'Simulate=1, DriverSetup=Model:4072; BoardType:PXI') as session:
+        with nidmm.Session('FakeDevice', True, 'Simulate=1, DriverSetup=Model:4072; BoardType:PXI') as session:
             session.configure_measurement_digits(nidmm.Function.DC_VOLTS, 10, 5.5)
             measurement_period = session.get_measurement_period()
             expected_period = 0.0071333333333333335  # 0.0071333333333333335 is the time required for 4072 to take a DC_VOLT measurement with range 10V on Digits_resolution 5.5

--- a/src/nifake/metadata/functions_addon.py
+++ b/src/nifake/metadata/functions_addon.py
@@ -99,3 +99,8 @@ functions_numpy = {
     'WriteWaveform':                        { 'parameters': { 2: { 'numpy': True, }, }, },
 }
 
+# Don't need ID_Query in the python API since they don't do anything
+functions_remove_parameters_from_python = {
+    'InitWithOptions':                      { 'parameters': { 1: { 'use_in_python_api': False, }, }, },
+}
+

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -55,8 +55,8 @@ class TestSession(object):
         errors_patcher.stop()
 
     def test_init_with_options_nondefault_and_close(self):
-        session = nifake.Session('FakeDevice', True, True, 'Some string')
-        self.patched_library.niFake_InitWithOptions.assert_called_once_with(matchers.ViStringMatcher('FakeDevice'), matchers.ViBooleanMatcher(True), matchers.ViBooleanMatcher(True), matchers.ViStringMatcher('Some string'), matchers.ViSessionPointerMatcher())
+        session = nifake.Session('FakeDevice', True, 'Some string')
+        self.patched_library.niFake_InitWithOptions.assert_called_once_with(matchers.ViStringMatcher('FakeDevice'), matchers.ViBooleanMatcher(False), matchers.ViBooleanMatcher(True), matchers.ViStringMatcher('Some string'), matchers.ViSessionPointerMatcher())
         session.close()
         self.patched_library.niFake_close.assert_called_once_with(matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST))
 

--- a/src/niscope/metadata/functions_addon.py
+++ b/src/niscope/metadata/functions_addon.py
@@ -488,4 +488,8 @@ functions_numpy = {
     'FetchDispatcher':                               { 'parameters': { 4: { 'numpy': True, }, }, },
 }
 
+# Don't need ID_Query in the python API since they don't do anything
+functions_remove_parameters_from_python = {
+    'InitWithOptions':                      { 'parameters': { 1: { 'use_in_python_api': False, }, }, },
+}
 

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -6,7 +6,7 @@ import pytest
 
 @pytest.fixture(scope='function')
 def session():
-    with niscope.Session('FakeDevice', False, True, 'Simulate=1, DriverSetup=Model:5164; BoardType:PXIe') as simulated_session:
+    with niscope.Session('FakeDevice', True, 'Simulate=1, DriverSetup=Model:5164; BoardType:PXIe') as simulated_session:
         yield simulated_session
 
 
@@ -208,7 +208,7 @@ def test_configure_chan_characteristics(session):
 '''
 # TODO(frank): re-add after issue #650 is fixed.
 def test_filter_coefficients():
-    with niscope.Session('FakeDevice', False, True, 'Simulate=1, DriverSetup=Model:5142; BoardType:PXI') as session:  # filter coefficients methods are available on devices with OSP
+    with niscope.Session('FakeDevice', True, 'Simulate=1, DriverSetup=Model:5142; BoardType:PXI') as session:  # filter coefficients methods are available on devices with OSP
         assert [1.0, 0.0, 0.0] == session.get_equalization_filter_coefficients(3)
         try:
             filter_coefficients = [1.0, 0.0, 0.0]
@@ -261,7 +261,7 @@ def test_configure_trigger_software(session):
 '''
 # TODO(frank): re-add after issue #650 is fixed.
 def test_configure_trigger_video():
-    with niscope.Session('FakeDevice', False, True, 'Simulate=1, DriverSetup=Model:5124; BoardType:PXI') as session:  # Unable to invoke configure_trigger_video method on 5164
+    with niscope.Session('FakeDevice', True, 'Simulate=1, DriverSetup=Model:5124; BoardType:PXI') as session:  # Unable to invoke configure_trigger_video method on 5164
         session.configure_trigger_video('0', niscope.VideoSignalFormat.PAL, niscope.VideoTriggerEvent.FIELD1, niscope.VideoPolarity.POSITIVE, niscope.TriggerCoupling.DC)
         assert niscope.VideoSignalFormat.PAL == session.tv_trigger_signal_format
         assert niscope.VideoTriggerEvent.FIELD1 == session.tv_trigger_event

--- a/tox.ini
+++ b/tox.ini
@@ -227,4 +227,3 @@ python =
   3.6: py36-test, flake8, docs
 
 
-


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
[X] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
[X] I've ~~added~~updated tests applicable for this pull request
### What does this Pull Request accomplish?
* `id_query` does not do anything on NI devices
* Remove from any session constructor parameter lists that had it
  * nidmm
  * niscope
  * nifake (for unit testing)
* When removed, pass on the default value to the underlying init function, usually `InitWithOptions()`

### List issues fixed by this Pull Request below, if any.
* Fix #670 

### What testing has been done?
* Unit
* System