### PR TITLE
[4]Only use regular expressions for functions

### DIFF
--- a/build/helper/metadata_add_all.py
+++ b/build/helper/metadata_add_all.py
@@ -239,7 +239,7 @@ def _add_use_in_python_api(p, parameters):
 
 def add_all_function_metadata(functions, config):
     '''Merges and Adds all codegen-specific metada to the function metadata list'''
-    functions = merge_helper(functions, 'functions', config)
+    functions = merge_helper(functions, 'functions', config, use_re=True)
 
     for f in filter_codegen_functions(functions):
         _add_name(functions[f], f)
@@ -281,7 +281,7 @@ def _add_python_name(a, attributes):
 
 def add_all_attribute_metadata(attributes, config):
     '''Merges and Adds all codegen-specific metada to the function metadata list'''
-    attributes = merge_helper(attributes, 'attributes', config)
+    attributes = merge_helper(attributes, 'attributes', config, use_re=False)
 
     for a in attributes:
         _add_attr_codegen_method(a, attributes)
@@ -382,7 +382,7 @@ def _add_enum_value_python_name(enum_info, config):
 
 def add_all_enum_metadata(enums, config):
     '''Merges and Adds all codegen-specific metada to the function metadata list'''
-    enums = merge_helper(enums, 'enums', config)
+    enums = merge_helper(enums, 'enums', config, use_re=False)
 
     # Workaround for NI Internal CAR #675174
     try:


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [X] I've added tests applicable for this pull request
### What does this Pull Request accomplish?
* Make regular expression an option when merging dictionaries
* Only use regular expressions when merging function metadata

### List issues fixed by this Pull Request below, if any.
* Fix #624 

### What testing has been done?
* Unit
* System