### PR TITLE
Fix initiate usage without context manager

### DIFF
--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -76,9 +76,9 @@ def get_ctypes_and_array(value, array_type):
 class ${session_context_manager}(object):
     def __init__(self, session):
         self._session = session
+        self._session.${session_context_manager_initiate}()
 
     def __enter__(self):
-        self._session.${session_context_manager_initiate}()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/generated/nidcpower/session.py
+++ b/generated/nidcpower/session.py
@@ -50,9 +50,9 @@ def get_ctypes_and_array(value, array_type):
 class _Acquisition(object):
     def __init__(self, session):
         self._session = session
+        self._session._initiate()
 
     def __enter__(self):
-        self._session._initiate()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/generated/nidmm/session.py
+++ b/generated/nidmm/session.py
@@ -50,9 +50,9 @@ def get_ctypes_and_array(value, array_type):
 class _Acquisition(object):
     def __init__(self, session):
         self._session = session
+        self._session._initiate()
 
     def __enter__(self):
-        self._session._initiate()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/generated/nifake/session.py
+++ b/generated/nifake/session.py
@@ -52,9 +52,9 @@ def get_ctypes_and_array(value, array_type):
 class _Acquisition(object):
     def __init__(self, session):
         self._session = session
+        self._session._initiate()
 
     def __enter__(self):
-        self._session._initiate()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
@@ -100,7 +100,7 @@ class _SessionBase(object):
     An attribute of type float with read/write access.
     '''
     read_write_double_with_converter = attributes.AttributeViReal64TimeDeltaSeconds(1000007)
-    '''Type: float
+    '''Type: datetime.timedelta
 
     Attribute in seconds
     '''
@@ -115,7 +115,7 @@ class _SessionBase(object):
     An attribute of type integer with read/write access.
     '''
     read_write_integer_with_converter = attributes.AttributeViInt32TimeDeltaMilliseconds(1000008)
-    '''Type: int
+    '''Type: datetime.timedelta
 
     Attribute in milliseconds
     '''
@@ -349,7 +349,7 @@ class _SessionBase(object):
             session.channels['0,1'].read_from_channel(maximum_time)
 
         Args:
-            maximum_time (int): Specifies the **maximum_time** allowed in microseconds.
+            maximum_time (datetime.timedelta): Specifies the **maximum_time** allowed in microseconds.
 
 
         Returns:
@@ -1171,7 +1171,7 @@ class Session(_SessionBase):
         Acquires a single measurement and returns the measured value.
 
         Args:
-            maximum_time (float): Specifies the **maximum_time** allowed in seconds.
+            maximum_time (datetime.timedelta): Specifies the **maximum_time** allowed in seconds.
 
 
         Returns:

--- a/generated/nifake/unit_tests/test_session.py
+++ b/generated/nifake/unit_tests/test_session.py
@@ -247,6 +247,16 @@ class TestSession(object):
             self.patched_library.niFake_Abort.assert_called_once_with(matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST))
         self.patched_library.niFake_close.assert_called_once_with(matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST))
 
+    def test_acquisition_no_context_manager(self):
+        self.patched_library.niFake_Initiate.side_effect = self.side_effects_helper.niFake_Initiate
+        self.patched_library.niFake_Abort.side_effect = self.side_effects_helper.niFake_Abort
+        with nifake.Session('dev1') as session:
+            session.initiate()
+            self.patched_library.niFake_Initiate.assert_called_once_with(matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST))
+            session.abort()
+            self.patched_library.niFake_Abort.assert_called_once_with(matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST))
+        self.patched_library.niFake_close.assert_called_once_with(matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST))
+
     def test_single_point_read_timedelta(self):
         test_maximum_time_ms = 100  # milliseconds
         test_maximum_time_s = .1    # seconds

--- a/generated/nifgen/session.py
+++ b/generated/nifgen/session.py
@@ -50,9 +50,9 @@ def get_ctypes_and_array(value, array_type):
 class _Generation(object):
     def __init__(self, session):
         self._session = session
+        self._session._initiate_generation()
 
     def __enter__(self):
-        self._session._initiate_generation()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/generated/niscope/session.py
+++ b/generated/niscope/session.py
@@ -52,9 +52,9 @@ def get_ctypes_and_array(value, array_type):
 class _Acquisition(object):
     def __init__(self, session):
         self._session = session
+        self._session._initiate_acquisition()
 
     def __enter__(self):
-        self._session._initiate_acquisition()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/generated/niswitch/session.py
+++ b/generated/niswitch/session.py
@@ -50,9 +50,9 @@ def get_ctypes_and_array(value, array_type):
 class _Scan(object):
     def __init__(self, session):
         self._session = session
+        self._session._initiate_scan()
 
     def __enter__(self):
-        self._session._initiate_scan()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -247,6 +247,16 @@ class TestSession(object):
             self.patched_library.niFake_Abort.assert_called_once_with(matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST))
         self.patched_library.niFake_close.assert_called_once_with(matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST))
 
+    def test_acquisition_no_context_manager(self):
+        self.patched_library.niFake_Initiate.side_effect = self.side_effects_helper.niFake_Initiate
+        self.patched_library.niFake_Abort.side_effect = self.side_effects_helper.niFake_Abort
+        with nifake.Session('dev1') as session:
+            session.initiate()
+            self.patched_library.niFake_Initiate.assert_called_once_with(matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST))
+            session.abort()
+            self.patched_library.niFake_Abort.assert_called_once_with(matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST))
+        self.patched_library.niFake_close.assert_called_once_with(matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST))
+
     def test_single_point_read_timedelta(self):
         test_maximum_time_ms = 100  # milliseconds
         test_maximum_time_s = .1    # seconds


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [X] I've added tests applicable for this pull request
### What does this Pull Request accomplish?
* Calling `session.initiate()` outside of a context manager did not work as expected
* Move actual call to driver `_initiate()` into constructor so it is always called, regardless of whether it is used within a context manager or not.
* If called outside of a context manager, user is responsible for calling session.abort()
* Added test that demonstrated issue prior to fix and not afterwards

### List issues fixed by this Pull Request below, if any.
* Fix #745 

### What testing has been done?
* Unit
* System