### PR TITLE
Remove quotes around default values in documentation

### DIFF
--- a/build/helper/metadata_add_all.py
+++ b/build/helper/metadata_add_all.py
@@ -216,7 +216,7 @@ def _add_default_value_name_for_docs(parameter, module_name):
         if 'enum' in parameter and parameter['enum'] is not None and parameter['default_value'] is not None:
             name = parameter['python_name'] + "=" + module_name + '.' + parameter['default_value']
         else:
-            name = parameter['python_name'] + "=" + repr(parameter['default_value'])
+            name = parameter['python_name'] + "=" + str(parameter['default_value'])
 
     else:
         name = parameter['python_name']

--- a/docs/nidcpower/functions.rst
+++ b/docs/nidcpower/functions.rst
@@ -616,7 +616,7 @@ nidcpower.Session methods
 
 
 
-.. py:method:: export_signal(signal, output_terminal, signal_identifier='""')
+.. py:method:: export_signal(signal, output_terminal, signal_identifier="")
 
     Routes signals (triggers and events) to the output terminal you specify.
     The route is created when the session is :py:meth:`nidcpower.Session.commit`.
@@ -704,7 +704,7 @@ nidcpower.Session methods
 
     :type signal_identifier: str
 
-.. py:method:: fetch_multiple(count, timeout='datetime.timedelta(seconds=1.0)')
+.. py:method:: fetch_multiple(count, timeout=datetime.timedelta(seconds=1.0))
 
     Returns an array of voltage measurements, an array of current
     measurements, and an array of compliance measurements that were
@@ -734,7 +734,7 @@ nidcpower.Session methods
 
         .. code:: python
 
-            session.channels['0,1'].fetch_multiple(count, timeout='datetime.timedelta(seconds=1.0)')
+            session.channels['0,1'].fetch_multiple(count, timeout=datetime.timedelta(seconds=1.0))
 
 
     :param count:
@@ -1465,7 +1465,7 @@ nidcpower.Session methods
 
     :type values: list of float
 
-.. py:method:: wait_for_event(event_id, timeout='datetime.timedelta(seconds=10.0)')
+.. py:method:: wait_for_event(event_id, timeout=datetime.timedelta(seconds=10.0))
 
     Waits until the device has generated the specified event.
 

--- a/docs/nidmm/functions.rst
+++ b/docs/nidmm/functions.rst
@@ -201,7 +201,7 @@ nidmm.Session methods
 
     :type resolution_digits: float
 
-.. py:method:: configure_multi_point(trigger_count, sample_count, sample_trigger=nidmm.SampleTrigger.IMMEDIATE, sample_interval='datetime.timedelta(seconds=-1)')
+.. py:method:: configure_multi_point(trigger_count, sample_count, sample_trigger=nidmm.SampleTrigger.IMMEDIATE, sample_interval=datetime.timedelta(seconds=-1))
 
     Configures the properties for multipoint measurements. These properties
     include :py:data:`nidmm.Session.trigger_count`, :py:data:`nidmm.Session.sample_count`,
@@ -544,7 +544,7 @@ nidmm.Session methods
 
     :type reference_junction_type: :py:data:`nidmm.ThermocoupleReferenceJunctionType`
 
-.. py:method:: configure_trigger(trigger_source, trigger_delay='datetime.timedelta(seconds=-1)')
+.. py:method:: configure_trigger(trigger_source, trigger_delay=datetime.timedelta(seconds=-1))
 
     Configures the DMM **Trigger_Source** and **Trigger_Delay**. Refer to
     `Triggering <http://zone.ni.com/reference/en-XX/help/370384T-01/dmm/trigger/>`__ and `Using
@@ -675,7 +675,7 @@ nidmm.Session methods
 
 
 
-.. py:method:: fetch(maximum_time='datetime.timedelta(milliseconds=-1)')
+.. py:method:: fetch(maximum_time=datetime.timedelta(milliseconds=-1))
 
     Returns the value from a previously initiated measurement. You must call
     :py:meth:`nidmm.Session._initiate` before calling this method.
@@ -715,7 +715,7 @@ nidmm.Session methods
 
 
 
-.. py:method:: fetch_multi_point(array_size, maximum_time='datetime.timedelta(milliseconds=-1)')
+.. py:method:: fetch_multi_point(array_size, maximum_time=datetime.timedelta(milliseconds=-1))
 
     Returns an array of values from a previously initiated multipoint
     measurement. The number of measurements the DMM makes is determined by
@@ -787,7 +787,7 @@ nidmm.Session methods
 
 
 
-.. py:method:: fetch_waveform(array_size, maximum_time='datetime.timedelta(milliseconds=-1)')
+.. py:method:: fetch_waveform(array_size, maximum_time=datetime.timedelta(milliseconds=-1))
 
     For the NI 4080/4081/4082 and the NI 4070/4071/4072, returns an array of
     values from a previously initiated waveform acquisition. You must call
@@ -852,7 +852,7 @@ nidmm.Session methods
 
 
 
-.. py:method:: fetch_waveform_into(array_size, maximum_time='datetime.timedelta(milliseconds=-1)')
+.. py:method:: fetch_waveform_into(array_size, maximum_time=datetime.timedelta(milliseconds=-1))
 
     For the NI 4080/4081/4082 and the NI 4070/4071/4072, returns an array of
     values from a previously initiated waveform acquisition. You must call
@@ -1028,7 +1028,7 @@ nidmm.Session methods
 
 
 
-.. py:method:: get_dev_temp(options='""')
+.. py:method:: get_dev_temp(options="")
 
     Returns the current **Temperature** of the device.
 
@@ -1248,7 +1248,7 @@ nidmm.Session methods
 
 
 
-.. py:method:: read(maximum_time='datetime.timedelta(milliseconds=-1)')
+.. py:method:: read(maximum_time=datetime.timedelta(milliseconds=-1))
 
     Acquires a single measurement and returns the measured value.
 
@@ -1287,7 +1287,7 @@ nidmm.Session methods
 
 
 
-.. py:method:: read_multi_point(array_size, maximum_time='datetime.timedelta(milliseconds=-1)')
+.. py:method:: read_multi_point(array_size, maximum_time=datetime.timedelta(milliseconds=-1))
 
     Acquires multiple measurements and returns an array of measured values.
     The number of measurements the DMM makes is determined by the values you
@@ -1410,7 +1410,7 @@ nidmm.Session methods
 
 
 
-.. py:method:: read_waveform(array_size, maximum_time='datetime.timedelta(milliseconds=-1)')
+.. py:method:: read_waveform(array_size, maximum_time=datetime.timedelta(milliseconds=-1))
 
     For the NI 4080/4081/4082 and the NI 4070/4071/4072, acquires a waveform
     and returns data as an array of values or as a waveform data type. The

--- a/docs/niscope/functions.rst
+++ b/docs/niscope/functions.rst
@@ -435,7 +435,7 @@ niscope.Session methods
 
     :type high: float
 
-.. py:method:: configure_trigger_digital(trigger_source, slope=niscope.TriggerSlope.POSITIVE, holdoff='datetime.timedelta(seconds=0.0)', delay='datetime.timedelta(seconds=0.0)')
+.. py:method:: configure_trigger_digital(trigger_source, slope=niscope.TriggerSlope.POSITIVE, holdoff=datetime.timedelta(seconds=0.0), delay=datetime.timedelta(seconds=0.0))
 
     Configures the common properties of a digital trigger.
 
@@ -514,7 +514,7 @@ niscope.Session methods
 
     :type delay: datetime.timedelta
 
-.. py:method:: configure_trigger_edge(trigger_source, trigger_coupling, level=0.0, slope=niscope.TriggerSlope.POSITIVE, holdoff='datetime.timedelta(seconds=0.0)', delay='datetime.timedelta(seconds=0.0)')
+.. py:method:: configure_trigger_edge(trigger_source, trigger_coupling, level=0.0, slope=niscope.TriggerSlope.POSITIVE, holdoff=datetime.timedelta(seconds=0.0), delay=datetime.timedelta(seconds=0.0))
 
     Configures common properties for analog edge triggering.
 
@@ -603,7 +603,7 @@ niscope.Session methods
 
     :type delay: datetime.timedelta
 
-.. py:method:: configure_trigger_hysteresis(trigger_source, trigger_coupling, level=0.0, hysteresis=0.05, slope=niscope.TriggerSlope.POSITIVE, holdoff='datetime.timedelta(seconds=0.0)', delay='datetime.timedelta(seconds=0.0)')
+.. py:method:: configure_trigger_hysteresis(trigger_source, trigger_coupling, level=0.0, hysteresis=0.05, slope=niscope.TriggerSlope.POSITIVE, holdoff=datetime.timedelta(seconds=0.0), delay=datetime.timedelta(seconds=0.0))
 
     Configures common properties for analog hysteresis triggering. This kind
     of trigger specifies an additional value, specified in the
@@ -722,7 +722,7 @@ niscope.Session methods
 
 
 
-.. py:method:: configure_trigger_software(holdoff='datetime.timedelta(seconds=0.0)', delay='datetime.timedelta(seconds=0.0)')
+.. py:method:: configure_trigger_software(holdoff=datetime.timedelta(seconds=0.0), delay=datetime.timedelta(seconds=0.0))
 
     Configures common properties for software triggering.
 
@@ -772,7 +772,7 @@ niscope.Session methods
 
     :type delay: datetime.timedelta
 
-.. py:method:: configure_trigger_video(trigger_source, signal_format, event, polarity, trigger_coupling, enable_dc_restore=False, line_number=1, holdoff='datetime.timedelta(seconds=0.0)', delay='datetime.timedelta(seconds=0.0)')
+.. py:method:: configure_trigger_video(trigger_source, signal_format, event, polarity, trigger_coupling, enable_dc_restore=False, line_number=1, holdoff=datetime.timedelta(seconds=0.0), delay=datetime.timedelta(seconds=0.0))
 
     Configures the common properties for video triggering, including the
     signal format, TV event, line number, polarity, and enable DC restore. A
@@ -899,7 +899,7 @@ niscope.Session methods
 
     :type delay: datetime.timedelta
 
-.. py:method:: configure_trigger_window(trigger_source, low_level, high_level, window_mode, trigger_coupling, holdoff='datetime.timedelta(seconds=0.0)', delay='datetime.timedelta(seconds=0.0)')
+.. py:method:: configure_trigger_window(trigger_source, low_level, high_level, window_mode, trigger_coupling, holdoff=datetime.timedelta(seconds=0.0), delay=datetime.timedelta(seconds=0.0))
 
     Configures common properties for analog window triggering. A window
     trigger occurs when a signal enters or leaves a window you specify with
@@ -1080,7 +1080,7 @@ niscope.Session methods
 
 
 
-.. py:method:: export_signal(signal, output_terminal, signal_identifier='"None"')
+.. py:method:: export_signal(signal, output_terminal, signal_identifier="None")
 
     Configures the digitizer to generate a signal that other devices can
     detect when configured for digital triggering or sharing clocks. The
@@ -1191,7 +1191,7 @@ niscope.Session methods
 
     :type signal_identifier: str
 
-.. py:method:: fetch(num_samples=None, relative_to=niscope.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout='datetime.timedelta(seconds=5.0)')
+.. py:method:: fetch(num_samples=None, relative_to=niscope.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout=datetime.timedelta(seconds=5.0))
 
     Returns the waveform from a previously initiated acquisition that the
     digitizer acquires for the specified channel. This method returns
@@ -1212,7 +1212,7 @@ niscope.Session methods
 
         .. code:: python
 
-            session.channels['0,1'].fetch(num_samples=None, relative_to=niscope.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout='datetime.timedelta(seconds=5.0)')
+            session.channels['0,1'].fetch(num_samples=None, relative_to=niscope.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout=datetime.timedelta(seconds=5.0))
 
 
     :param num_samples:
@@ -1301,7 +1301,7 @@ niscope.Session methods
 
 
 
-.. py:method:: fetch_into(wfm, relative_to=niscope.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout='datetime.timedelta(seconds=5.0)')
+.. py:method:: fetch_into(wfm, relative_to=niscope.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout=datetime.timedelta(seconds=5.0))
 
     Returns the waveform from a previously initiated acquisition that the
     digitizer acquires for the specified channel. This method returns
@@ -1322,7 +1322,7 @@ niscope.Session methods
 
         .. code:: python
 
-            session.channels['0,1'].fetch(wfm, relative_to=niscope.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout='datetime.timedelta(seconds=5.0)')
+            session.channels['0,1'].fetch(wfm, relative_to=niscope.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout=datetime.timedelta(seconds=5.0))
 
 
     :param wfm:
@@ -1423,7 +1423,7 @@ niscope.Session methods
 
 
 
-.. py:method:: fetch_measurement(scalar_meas_function, timeout='datetime.timedelta(seconds=5.0)')
+.. py:method:: fetch_measurement(scalar_meas_function, timeout=datetime.timedelta(seconds=5.0))
 
     Fetches a waveform from the digitizer and performs the specified
     waveform measurement. Refer to `Using Fetch
@@ -1447,7 +1447,7 @@ niscope.Session methods
 
         .. code:: python
 
-            session.channels['0,1'].fetch_measurement(scalar_meas_function, timeout='datetime.timedelta(seconds=5.0)')
+            session.channels['0,1'].fetch_measurement(scalar_meas_function, timeout=datetime.timedelta(seconds=5.0))
 
 
     :param scalar_meas_function:
@@ -1484,7 +1484,7 @@ niscope.Session methods
 
 
 
-.. py:method:: fetch_measurement_stats(scalar_meas_function, timeout='datetime.timedelta(seconds=5.0)')
+.. py:method:: fetch_measurement_stats(scalar_meas_function, timeout=datetime.timedelta(seconds=5.0))
 
     Obtains a waveform measurement and returns the measurement value. This
     method may return multiple statistical results depending on the number
@@ -1521,7 +1521,7 @@ niscope.Session methods
 
         .. code:: python
 
-            session.channels['0,1'].fetch_measurement_stats(scalar_meas_function, timeout='datetime.timedelta(seconds=5.0)')
+            session.channels['0,1'].fetch_measurement_stats(scalar_meas_function, timeout=datetime.timedelta(seconds=5.0))
 
 
     :param scalar_meas_function:
@@ -1666,7 +1666,7 @@ niscope.Session methods
 
 
 
-.. py:method:: read(num_samples, timeout='datetime.timedelta(seconds=5.0)')
+.. py:method:: read(num_samples, timeout=datetime.timedelta(seconds=5.0))
 
     Initiates an acquisition, waits for it to complete, and retrieves the
     data. The process is similar to calling :py:meth:`niscope.Session._initiate_acquisition`,
@@ -1693,7 +1693,7 @@ niscope.Session methods
 
         .. code:: python
 
-            session.channels['0,1'].read(num_samples, timeout='datetime.timedelta(seconds=5.0)')
+            session.channels['0,1'].read(num_samples, timeout=datetime.timedelta(seconds=5.0))
 
 
     :param num_samples:
@@ -1783,7 +1783,7 @@ niscope.Session methods
 
 
 
-.. py:method:: read_measurement(scalar_meas_function, timeout='datetime.timedelta(seconds=5.0)')
+.. py:method:: read_measurement(scalar_meas_function, timeout=datetime.timedelta(seconds=5.0))
 
     Initiates an acquisition, waits for it to complete, and performs the
     specified waveform measurement for a single channel and record or for
@@ -1810,7 +1810,7 @@ niscope.Session methods
 
         .. code:: python
 
-            session.channels['0,1'].read_measurement(scalar_meas_function, timeout='datetime.timedelta(seconds=5.0)')
+            session.channels['0,1'].read_measurement(scalar_meas_function, timeout=datetime.timedelta(seconds=5.0))
 
 
     :param scalar_meas_function:

--- a/docs/niswitch/functions.rst
+++ b/docs/niswitch/functions.rst
@@ -133,7 +133,7 @@ niswitch.Session methods
 
     :type scan_mode: :py:data:`niswitch.ScanMode`
 
-.. py:method:: configure_scan_trigger(trigger_input, scan_advanced_output, scan_delay='datetime.timedelta(seconds=0.0)')
+.. py:method:: configure_scan_trigger(trigger_input, scan_advanced_output, scan_delay=datetime.timedelta(seconds=0.0))
 
     Configures the scan triggers for the scan list established with
     :py:meth:`niswitch.Session.configure_scan_list`. Refer to Devices Overview to determine if
@@ -771,7 +771,7 @@ niswitch.Session methods
 
     :type path_list: str
 
-.. py:method:: wait_for_debounce(maximum_time_ms='datetime.timedelta(milliseconds=5000)')
+.. py:method:: wait_for_debounce(maximum_time_ms=datetime.timedelta(milliseconds=5000))
 
     Pauses until all created paths have settled. If the time you specify
     with the Maximum Time (ms) parameter elapsed before the switch paths
@@ -795,7 +795,7 @@ niswitch.Session methods
 
     :type maximum_time_ms: int
 
-.. py:method:: wait_for_scan_complete(maximum_time_ms='datetime.timedelta(milliseconds=5000)')
+.. py:method:: wait_for_scan_complete(maximum_time_ms=datetime.timedelta(milliseconds=5000))
 
     Pauses until the switch module stops scanning or the maximum time has
     elapsed and returns a timeout error. If the time you specify with the

--- a/generated/nidcpower/session.py
+++ b/generated/nidcpower/session.py
@@ -2390,7 +2390,7 @@ class _SessionBase(object):
         You can specify a subset of repeated capabilities using the Python index notation on an
         nidcpower.Session instance, and calling this method on the result.:
 
-            session.channels['0,1'].fetch_multiple(count, timeout='datetime.timedelta(seconds=1.0)')
+            session.channels['0,1'].fetch_multiple(count, timeout=datetime.timedelta(seconds=1.0))
 
         Args:
             count (int): Specifies the number of measurements to fetch.

--- a/generated/nifgen/session.py
+++ b/generated/nifgen/session.py
@@ -2452,7 +2452,7 @@ class _SessionBase(object):
         You can specify a subset of repeated capabilities using the Python index notation on an
         nifgen.Session instance, and calling this method on the result.:
 
-            session.channels['0,1']._initialize_with_channels(resource_name, reset_device=False, option_string='""')
+            session.channels['0,1']._initialize_with_channels(resource_name, reset_device=False, option_string="")
 
         Args:
             resource_name (str): Caution:
@@ -3333,7 +3333,7 @@ class Session(_SessionBase):
         You can specify a subset of repeated capabilities using the Python index notation on an
         nifgen.Session instance, and calling this method on the result.:
 
-            session.channels['0,1']._initialize_with_channels(resource_name, reset_device=False, option_string='""')
+            session.channels['0,1']._initialize_with_channels(resource_name, reset_device=False, option_string="")
 
         Args:
             resource_name (str): Caution:

--- a/generated/niscope/session.py
+++ b/generated/niscope/session.py
@@ -1932,7 +1932,7 @@ class _SessionBase(object):
         You can specify a subset of repeated capabilities using the Python index notation on an
         niscope.Session instance, and calling this method on the result.:
 
-            session.channels['0,1'].fetch(num_samples=None, relative_to=niscope.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout='datetime.timedelta(seconds=5.0)')
+            session.channels['0,1'].fetch(num_samples=None, relative_to=niscope.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout=datetime.timedelta(seconds=5.0))
 
         Args:
             num_samples (datetime.timedelta): The maximum number of samples to fetch for each waveform. If the acquisition finishes with fewer points than requested, some devices return partial data if the acquisition finished, was aborted, or a timeout of 0 was used. If it fails to complete within the timeout period, the method throws an exception.
@@ -2029,7 +2029,7 @@ class _SessionBase(object):
         You can specify a subset of repeated capabilities using the Python index notation on an
         niscope.Session instance, and calling this method on the result.:
 
-            session.channels['0,1']._fetch(num_samples, timeout='datetime.timedelta(seconds=5.0)')
+            session.channels['0,1']._fetch(num_samples, timeout=datetime.timedelta(seconds=5.0))
 
         Args:
             num_samples (int): The maximum number of samples to fetch for each waveform. If the
@@ -2130,7 +2130,7 @@ class _SessionBase(object):
         You can specify a subset of repeated capabilities using the Python index notation on an
         niscope.Session instance, and calling this method on the result.:
 
-            session.channels['0,1']._fetch(num_samples, timeout='datetime.timedelta(seconds=5.0)')
+            session.channels['0,1']._fetch(num_samples, timeout=datetime.timedelta(seconds=5.0))
 
         Args:
             num_samples (int): The maximum number of samples to fetch for each waveform. If the
@@ -2256,7 +2256,7 @@ class _SessionBase(object):
         You can specify a subset of repeated capabilities using the Python index notation on an
         niscope.Session instance, and calling this method on the result.:
 
-            session.channels['0,1']._fetch_binary16(num_samples, timeout='datetime.timedelta(seconds=5.0)')
+            session.channels['0,1']._fetch_binary16(num_samples, timeout=datetime.timedelta(seconds=5.0))
 
         Args:
             num_samples (int): The maximum number of samples to fetch for each waveform. If the
@@ -2382,7 +2382,7 @@ class _SessionBase(object):
         You can specify a subset of repeated capabilities using the Python index notation on an
         niscope.Session instance, and calling this method on the result.:
 
-            session.channels['0,1']._fetch_binary32(num_samples, timeout='datetime.timedelta(seconds=5.0)')
+            session.channels['0,1']._fetch_binary32(num_samples, timeout=datetime.timedelta(seconds=5.0))
 
         Args:
             num_samples (int): The maximum number of samples to fetch for each waveform. If the
@@ -2508,7 +2508,7 @@ class _SessionBase(object):
         You can specify a subset of repeated capabilities using the Python index notation on an
         niscope.Session instance, and calling this method on the result.:
 
-            session.channels['0,1']._fetch_binary8(num_samples, timeout='datetime.timedelta(seconds=5.0)')
+            session.channels['0,1']._fetch_binary8(num_samples, timeout=datetime.timedelta(seconds=5.0))
 
         Args:
             num_samples (int): The maximum number of samples to fetch for each waveform. If the
@@ -2628,7 +2628,7 @@ class _SessionBase(object):
         You can specify a subset of repeated capabilities using the Python index notation on an
         niscope.Session instance, and calling this method on the result.:
 
-            session.channels['0,1'].fetch(wfm, relative_to=niscope.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout='datetime.timedelta(seconds=5.0)')
+            session.channels['0,1'].fetch(wfm, relative_to=niscope.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout=datetime.timedelta(seconds=5.0))
 
         Args:
             wfm (array.array("d")): numpy array of the appropriate type and size the should be acquired as a 1D array. Size should be **num_samples** times number of waveforms. Call _actual_num_wfms to determine the number of waveforms.
@@ -2725,7 +2725,7 @@ class _SessionBase(object):
         You can specify a subset of repeated capabilities using the Python index notation on an
         niscope.Session instance, and calling this method on the result.:
 
-            session.channels['0,1'].fetch_measurement(scalar_meas_function, timeout='datetime.timedelta(seconds=5.0)')
+            session.channels['0,1'].fetch_measurement(scalar_meas_function, timeout=datetime.timedelta(seconds=5.0))
 
         Args:
             scalar_meas_function (enums.ScalarMeasurement): The `scalar
@@ -2788,7 +2788,7 @@ class _SessionBase(object):
         You can specify a subset of repeated capabilities using the Python index notation on an
         niscope.Session instance, and calling this method on the result.:
 
-            session.channels['0,1'].fetch_measurement_stats(scalar_meas_function, timeout='datetime.timedelta(seconds=5.0)')
+            session.channels['0,1'].fetch_measurement_stats(scalar_meas_function, timeout=datetime.timedelta(seconds=5.0))
 
         Args:
             scalar_meas_function (enums.ScalarMeasurement): The `scalar
@@ -3102,7 +3102,7 @@ class _SessionBase(object):
         You can specify a subset of repeated capabilities using the Python index notation on an
         niscope.Session instance, and calling this method on the result.:
 
-            session.channels['0,1'].read(num_samples, timeout='datetime.timedelta(seconds=5.0)')
+            session.channels['0,1'].read(num_samples, timeout=datetime.timedelta(seconds=5.0))
 
         Args:
             num_samples (int): The maximum number of samples to fetch for each waveform. If the
@@ -3201,7 +3201,7 @@ class _SessionBase(object):
         You can specify a subset of repeated capabilities using the Python index notation on an
         niscope.Session instance, and calling this method on the result.:
 
-            session.channels['0,1'].read_measurement(scalar_meas_function, timeout='datetime.timedelta(seconds=5.0)')
+            session.channels['0,1'].read_measurement(scalar_meas_function, timeout=datetime.timedelta(seconds=5.0))
 
         Args:
             scalar_meas_function (enums.ScalarMeasurement): The `scalar


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [X] ~~I've added tests applicable for this pull request~~
### What does this Pull Request accomplish?
* Remove quotes around default values in documentation
  `timeout='datetime.timedelta(seconds=1.0)'` --> `timeout=datetime.timedelta(seconds=1.0)`
### ~~List issues fixed by this Pull Request below, if any.~~

### What testing has been done?
* Visual inspection of generated files