### PR TITLE
Fix poor English created when substituting property for attribute

### DIFF
--- a/build/helper/documentation_helper.py
+++ b/build/helper/documentation_helper.py
@@ -410,6 +410,9 @@ def _fix_references(node, doc, cfg, make_link=False):
     # Several other standard replacements
     doc = re.sub(r'\bVI_FALSE\b', 'False', doc)
     doc = re.sub(r'\bVI_TRUE\b', 'True', doc)
+    doc = re.sub(r'\ban attribute\b', 'a property', doc)
+    doc = re.sub(r'\bAn attribute\b', 'A property', doc)
+    doc = re.sub(r'\bAn Attribute\b', 'A Property', doc)
     doc = re.sub(r'\battribute\b', 'property', doc)
     doc = re.sub(r'\battributes\b', 'properties', doc)
     doc = re.sub(r'\bAttribute\b', 'Property', doc)

--- a/docs/nidcpower/attributes.rst
+++ b/docs/nidcpower/attributes.rst
@@ -1487,7 +1487,7 @@ nidcpower.Session properties
     Specifies whether to perform interchangeability checking and log interchangeability warnings when you  call NI-DCPower methods. True specifies that interchangeability checking is enabled.
     Interchangeability warnings indicate that using your application with a different power supply might  cause different behavior. Call the :py:meth:`nidcpower.Session.GetNextInterchangeWarning` method to retrieve  interchange warnings.
     Call the :py:meth:`nidcpower.Session.GetNextInterchangeWarning` method to clear the list of interchangeability warnings  without reading them.
-    Interchangeability checking examines the properties in a capability group only if you specify a value  for at least one property within that group. Interchangeability warnings can occur when an property  affects the behavior of the device and you have not set that property or when the property has been  invalidated since you set it.
+    Interchangeability checking examines the properties in a capability group only if you specify a value  for at least one property within that group. Interchangeability warnings can occur when a property  affects the behavior of the device and you have not set that property or when the property has been  invalidated since you set it.
     Default Value: False
 
 

--- a/docs/nidmm/attributes.rst
+++ b/docs/nidmm/attributes.rst
@@ -609,7 +609,7 @@ nidmm.Session properties
     Specifies whether to perform interchangeability checking and log  interchangeability warnings when you call niDMM methods.
     The default value is False.
     Interchangeability warnings indicate that using your application with a  different instrument might cause different behavior.  Call :py:meth:`nidmm.Session.GetNextInterchangeWarning`  to extract interchange warnings.  Call :py:meth:`nidmm.Session.ClearInterchangeWarnings`  to clear the list of interchangeability warnings  without reading them.
-    Interchangeability checking examines the properties in a capability group  only if you specify a value for at least one property within that group.   Interchangeability warnings can occur when an property affects the behavior  of the instrument and you have not set that property, or the property has  been invalidated since you set it.
+    Interchangeability checking examines the properties in a capability group  only if you specify a value for at least one property within that group.   Interchangeability warnings can occur when a property affects the behavior  of the instrument and you have not set that property, or the property has  been invalidated since you set it.
 
 
 

--- a/docs/nifgen/attributes.rst
+++ b/docs/nifgen/attributes.rst
@@ -2118,7 +2118,7 @@ nifgen.Session properties
 
     Specifies whether to perform interchangeability checking and retrieve  interchangeability warnings when you call  :py:meth:`nifgen.Session._initiate_generation`.
     Interchangeability warnings indicate that using your application with a  different device might cause different behavior.   Call :py:meth:`nifgen.Session.GetNextInterchangeWarning` to extract interchange warnings.   Call :py:meth:`nifgen.Session.ClearInterchangeWarnings` to clear the list  of interchangeability warnings without reading them.
-    Interchangeability checking examines the properties in a  capability group only if you specify a value for at least one  property within that group. Interchangeability warnings can  occur when an property affects the behavior of the device and you  have not set that property, or the property has been invalidated since you set it.
+    Interchangeability checking examines the properties in a  capability group only if you specify a value for at least one  property within that group. Interchangeability warnings can  occur when a property affects the behavior of the device and you  have not set that property, or the property has been invalidated since you set it.
 
 
 

--- a/docs/niswitch/attributes.rst
+++ b/docs/niswitch/attributes.rst
@@ -424,7 +424,7 @@ niswitch.Session properties
     Specifies whether to perform interchangeability checking and retrieve  interchangeability warnings when you call  :py:meth:`niswitch.Session.connect`, :py:meth:`niswitch.Session.set_path` and :py:meth:`niswitch.Session._initiate_scan` methods.
     The default value is False.
     Interchangeability warnings indicate that using your application with a  different instrument might cause different behavior.   You call :py:meth:`niswitch.Session.GetNextInterchangeWarning` to extract interchange warnings.   Call the :py:meth:`niswitch.Session.ClearInterchangeWarnings` method to clear the list  of interchangeability warnings without reading them.
-    Interchangeability checking examines the properties in a  capability group only if you specify a value for at least one  property within that group.  Interchangeability warnings can  occur when an property affects the behavior of the instrument and you  have not set that property, or the property has been invalidated since you set it.
+    Interchangeability checking examines the properties in a  capability group only if you specify a value for at least one  property within that group.  Interchangeability warnings can  occur when a property affects the behavior of the instrument and you  have not set that property, or the property has been invalidated since you set it.
 
 
 

--- a/generated/nidcpower/session.py
+++ b/generated/nidcpower/session.py
@@ -683,7 +683,7 @@ class _SessionBase(object):
     Specifies whether to perform interchangeability checking and log interchangeability warnings when you  call NI-DCPower methods. True specifies that interchangeability checking is enabled.
     Interchangeability warnings indicate that using your application with a different power supply might  cause different behavior. Call the GetNextInterchangeWarning method to retrieve  interchange warnings.
     Call the GetNextInterchangeWarning method to clear the list of interchangeability warnings  without reading them.
-    Interchangeability checking examines the properties in a capability group only if you specify a value  for at least one property within that group. Interchangeability warnings can occur when an property  affects the behavior of the device and you have not set that property or when the property has been  invalidated since you set it.
+    Interchangeability checking examines the properties in a capability group only if you specify a value  for at least one property within that group. Interchangeability warnings can occur when a property  affects the behavior of the device and you have not set that property or when the property has been  invalidated since you set it.
     Default Value: False
 
     Note:
@@ -2553,19 +2553,19 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_boolean(attribute_id)
 
         Args:
-            attribute_id (int): Specifies the ID of an property. From the method panel window, you
+            attribute_id (int): Specifies the ID of a property. From the method panel window, you
                 can use this control as follows.
 
                 -  In the method panel window, click on the control or press **Enter**
                    or the spacebar to display a dialog box containing hierarchical list
                    of the available properties. Help text is shown for each property.
-                   Select an property by double-clicking on it or by selecting it and
+                   Select a property by double-clicking on it or by selecting it and
                    then pressing **Enter**.
                 -  A ring control at the top of the dialog box allows you to see all IVI
                    properties or only the properties of type ViBoolean. If you choose to
                    see all IVI properties, the data types appear to the right of the
                    property names in the list box. Properties with data types other
-                   than ViBoolean are dim. If you select an property data type that is
+                   than ViBoolean are dim. If you select a property data type that is
                    dim, LabWindows/CVI transfers you to the method panel for the
                    corresponding method that is consistent with the data type.
                 -  If you want to enter a variable name, press **Ctrl**\ +\ **T** to
@@ -2607,19 +2607,19 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_int32(attribute_id)
 
         Args:
-            attribute_id (int): Specifies the ID of an property. From the method panel window, you
+            attribute_id (int): Specifies the ID of a property. From the method panel window, you
                 can use this control as follows.
 
                 -  In the method panel window, click on the control or press **Enter**
                    or the spacebar to display a dialog box containing hierarchical list
                    of the available properties. Help text is shown for each property.
-                   Select an property by double-clicking on it or by selecting it and
+                   Select a property by double-clicking on it or by selecting it and
                    then pressing **Enter**.
                 -  A ring control at the top of the dialog box allows you to see all IVI
                    properties or only the properties of type ViInt32. If you choose to
                    see all IVI properties, the data types appear to the right of the
                    property names in the list box. Properties with data types other
-                   than ViInt32 are dim. If you select an property data type that is
+                   than ViInt32 are dim. If you select a property data type that is
                    dim, LabWindows/CVI transfers you to the method panel for the
                    corresponding method that is consistent with the data type.
                 -  If you want to enter a variable name, press **Ctrl**\ +\ **T** to
@@ -2661,19 +2661,19 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_int64(attribute_id)
 
         Args:
-            attribute_id (int): Specifies the ID of an property. From the method panel window, you
+            attribute_id (int): Specifies the ID of a property. From the method panel window, you
                 can use this control as follows.
 
                 -  In the method panel window, click on the control or press **Enter**
                    or the spacebar to display a dialog box containing hierarchical list
                    of the available properties. Help text is shown for each property.
-                   Select an property by double-clicking on it or by selecting it and
+                   Select a property by double-clicking on it or by selecting it and
                    then pressing **Enter**.
                 -  A ring control at the top of the dialog box allows you to see all IVI
                    properties or only the properties of type ViReal64. If you choose to
                    see all IVI properties, the data types appear to the right of the
                    property names in the list box. Properties with data types other
-                   than ViReal64 are dim. If you select an property data type that is
+                   than ViReal64 are dim. If you select a property data type that is
                    dim, LabWindows/CVI transfers you to the method panel for the
                    corresponding method that is consistent with the data type.
                 -  If you want to enter a variable name, press **Ctrl**\ +\ **T** to
@@ -2715,19 +2715,19 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_real64(attribute_id)
 
         Args:
-            attribute_id (int): Specifies the ID of an property. From the method panel window, you
+            attribute_id (int): Specifies the ID of a property. From the method panel window, you
                 can use this control as follows.
 
                 -  In the method panel window, click on the control or press **Enter**
                    or the spacebar to display a dialog box containing hierarchical list
                    of the available properties. Help text is shown for each property.
-                   Select an property by double-clicking on it or by selecting it and
+                   Select a property by double-clicking on it or by selecting it and
                    then pressing **Enter**.
                 -  A ring control at the top of the dialog box allows you to see all IVI
                    properties or only the properties of type ViReal64. If you choose to
                    see all IVI properties, the data types appear to the right of the
                    property names in the list box. Properties with data types other
-                   than ViReal64 are dim. If you select an property data type that is
+                   than ViReal64 are dim. If you select a property data type that is
                    dim, LabWindows/CVI transfers you to the method panel for the
                    corresponding method that is consistent with the data type.
                 -  If you want to enter a variable name, press **Ctrl**\ +\ **T** to
@@ -2769,19 +2769,19 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_string(attribute_id)
 
         Args:
-            attribute_id (int): Specifies the ID of an property. From the method panel window, you
+            attribute_id (int): Specifies the ID of a property. From the method panel window, you
                 can use this control as follows.
 
                 -  In the method panel window, click on the control or press or the
                    spacebar to display a dialog box containing hierarchical list of the
                    available properties. Help text is shown for each property. Select
-                   an property by double-clicking on it or by selecting it and then
+                   a property by double-clicking on it or by selecting it and then
                    pressing .
                 -  A ring control at the top of the dialog box allows you to see all IVI
                    properties or only the properties of type ViString. If you choose to
                    see all IVI properties, the data types appear to the right of the
                    property names in the list box. Properties with data types other
-                   than ViString are dimmed. If you select an property data type that
+                   than ViString are dimmed. If you select a property data type that
                    is dimmed, LabWindows/CVI transfers you to the method panel for the
                    corresponding method that is consistent with the data type.
                 -  If you want to enter a variable name, press to change this ring
@@ -3180,13 +3180,13 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_boolean(attribute_id, attribute_value)
 
         Args:
-            attribute_id (int): Specifies the ID of an property. From the method panel window, you
+            attribute_id (int): Specifies the ID of a property. From the method panel window, you
                 can use this control as follows.
 
                 -  In the method panel window, click on the control or press **Enter**
                    or the spacebar to display a dialog box containing hierarchical list
                    of the available properties. Properties whose value cannot be set are
-                   dim. Help text is shown for each property. Select an property by
+                   dim. Help text is shown for each property. Select a property by
                    double-clicking on it or by selecting it and then pressing **Enter**.
                 -  Read-only properties appear dim in the list box. If you select a
                    read-only property, an error message appears. A ring control at the
@@ -3194,7 +3194,7 @@ class _SessionBase(object):
                    the properties of type ViBoolean. If you choose to see all IVI
                    properties, the data types appear to the right of the property names
                    in the list box. Properties with data types other than ViBoolean are
-                   dim. If you select an property data type that is dim, LabWindows/CVI
+                   dim. If you select a property data type that is dim, LabWindows/CVI
                    transfers you to the method panel for the corresponding method
                    that is consistent with the data type.
                 -  If you want to enter a variable name, press **Ctrl**\ +\ **T** to
@@ -3237,13 +3237,13 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_int32(attribute_id, attribute_value)
 
         Args:
-            attribute_id (int): Specifies the ID of an property. From the method panel window, you
+            attribute_id (int): Specifies the ID of a property. From the method panel window, you
                 can use this control as follows.
 
                 -  In the method panel window, click on the control or press **Enter**
                    or the spacebar to display a dialog box containing hierarchical list
                    of the available properties. Properties whose value cannot be set are
-                   dim. Help text is shown for each property. Select an property by
+                   dim. Help text is shown for each property. Select a property by
                    double-clicking on it or by selecting it and then pressing **Enter**.
                 -  Read-only properties appear dim in the list box. If you select a
                    read-only property, an error message appears. A ring control at the
@@ -3251,7 +3251,7 @@ class _SessionBase(object):
                    the properties of type ViInt32. If you choose to see all IVI
                    properties, the data types appear to the right of the property names
                    in the list box. Properties with data types other than ViInt32 are
-                   dim. If you select an property data type that is dim, LabWindows/CVI
+                   dim. If you select a property data type that is dim, LabWindows/CVI
                    transfers you to the method panel for the corresponding method
                    that is consistent with the data type.
                 -  If you want to enter a variable name, press **Ctrl**\ +\ **T** to
@@ -3294,13 +3294,13 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_int64(attribute_id, attribute_value)
 
         Args:
-            attribute_id (int): Specifies the ID of an property. From the method panel window, you
+            attribute_id (int): Specifies the ID of a property. From the method panel window, you
                 can use this control as follows.
 
                 -  In the method panel window, click on the control or press **Enter**
                    or the spacebar to display a dialog box containing hierarchical list
                    of the available properties. Properties whose value cannot be set are
-                   dim. Help text is shown for each property. Select an property by
+                   dim. Help text is shown for each property. Select a property by
                    double-clicking on it or by selecting it and then pressing **Enter**.
                 -  Read-only properties appear dim in the list box. If you select a
                    read-only property, an error message appears. A ring control at the
@@ -3308,7 +3308,7 @@ class _SessionBase(object):
                    the properties of type ViReal64. If you choose to see all IVI
                    properties, the data types appear to the right of the property names
                    in the list box. Properties with data types other than ViReal64 are
-                   dim. If you select an property data type that is dim, LabWindows/CVI
+                   dim. If you select a property data type that is dim, LabWindows/CVI
                    transfers you to the method panel for the corresponding method
                    that is consistent with the data type.
                 -  If you want to enter a variable name, press **Ctrl**\ +\ **T** to
@@ -3351,13 +3351,13 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_real64(attribute_id, attribute_value)
 
         Args:
-            attribute_id (int): Specifies the ID of an property. From the method panel window, you
+            attribute_id (int): Specifies the ID of a property. From the method panel window, you
                 can use this control as follows.
 
                 -  In the method panel window, click on the control or press **Enter**
                    or the spacebar to display a dialog box containing hierarchical list
                    of the available properties. Properties whose value cannot be set are
-                   dim. Help text is shown for each property. Select an property by
+                   dim. Help text is shown for each property. Select a property by
                    double-clicking on it or by selecting it and then pressing **Enter**.
                 -  Read-only properties appear dim in the list box. If you select a
                    read-only property, an error message appears. A ring control at the
@@ -3365,7 +3365,7 @@ class _SessionBase(object):
                    the properties of type ViReal64. If you choose to see all IVI
                    properties, the data types appear to the right of the property names
                    in the list box. Properties with data types other than ViReal64 are
-                   dim. If you select an property data type that is dim, LabWindows/CVI
+                   dim. If you select a property data type that is dim, LabWindows/CVI
                    transfers you to the method panel for the corresponding method
                    that is consistent with the data type.
                 -  If you want to enter a variable name, press **Ctrl**\ +\ **T** to
@@ -3408,13 +3408,13 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_string(attribute_id, attribute_value)
 
         Args:
-            attribute_id (int): Specifies the ID of an property. From the method panel window, you
+            attribute_id (int): Specifies the ID of a property. From the method panel window, you
                 can use this control as follows.
 
                 -  In the method panel window, click on the control or press **Enter**
                    or the spacebar to display a dialog box containing hierarchical list
                    of the available properties. Properties whose value cannot be set are
-                   dim. Help text is shown for each property. Select an property by
+                   dim. Help text is shown for each property. Select a property by
                    double-clicking on it or by selecting it and then pressing **Enter**.
                 -  Read-only properties appear dim in the list box. If you select a
                    read-only property, an error message appears. A ring control at the
@@ -3422,7 +3422,7 @@ class _SessionBase(object):
                    the properties of type ViString. If you choose to see all IVI
                    properties, the data types appear to the right of the property names
                    in the list box. Properties with data types other than ViString are
-                   dim. If you select an property data type that is dim, LabWindows/CVI
+                   dim. If you select a property data type that is dim, LabWindows/CVI
                    transfers you to the method panel for the corresponding method
                    that is consistent with the data type.
                 -  If you want to enter a variable name, press **Ctrl**\ +\ **T** to
@@ -3592,7 +3592,7 @@ class Session(_SessionBase):
                 { 'simulate': False }
 
                 You do not have to specify a value for all the properties. If you do not
-                specify a value for an property, the default value is used.
+                specify a value for a property, the default value is used.
 
                 Advanced Example:
                 { 'simulate': True, 'driver_setup': { 'Model': '<model number>',  'BoardType': '<type>' } }
@@ -4484,7 +4484,7 @@ class Session(_SessionBase):
                 "Simulate=0"
 
                 You do not have to specify a value for all the properties. If you do not
-                specify a value for an property, the default value is used.
+                specify a value for a property, the default value is used.
 
                 For more information about simulating a device, refer to `Simulating a
                 Power Supply or SMU <REPLACE_DRIVER_SPECIFIC_URL_1(simulate)>`__.

--- a/generated/nidmm/session.py
+++ b/generated/nidmm/session.py
@@ -242,7 +242,7 @@ class _SessionBase(object):
     Specifies whether to perform interchangeability checking and log  interchangeability warnings when you call niDMM methods.
     The default value is False.
     Interchangeability warnings indicate that using your application with a  different instrument might cause different behavior.  Call GetNextInterchangeWarning  to extract interchange warnings.  Call ClearInterchangeWarnings  to clear the list of interchangeability warnings  without reading them.
-    Interchangeability checking examines the properties in a capability group  only if you specify a value for at least one property within that group.   Interchangeability warnings can occur when an property affects the behavior  of the instrument and you have not set that property, or the property has  been invalidated since you set it.
+    Interchangeability checking examines the properties in a capability group  only if you specify a value for at least one property within that group.   Interchangeability warnings can occur when a property affects the behavior  of the instrument and you have not set that property, or the property has  been invalidated since you set it.
 
     Note:
     One or more of the referenced methods are not in the Python API for this driver.
@@ -662,7 +662,7 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_boolean(attribute_id)
 
         Args:
-            attribute_id (int): Pass the ID of an property.
+            attribute_id (int): Pass the ID of a property.
 
 
         Returns:
@@ -701,7 +701,7 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_int32(attribute_id)
 
         Args:
-            attribute_id (int): Pass the ID of an property.
+            attribute_id (int): Pass the ID of a property.
 
 
         Returns:
@@ -740,7 +740,7 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_real64(attribute_id)
 
         Args:
-            attribute_id (int): Pass the ID of an property.
+            attribute_id (int): Pass the ID of a property.
 
 
         Returns:
@@ -782,7 +782,7 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_string(attribute_id)
 
         Args:
-            attribute_id (int): Pass the ID of an property.
+            attribute_id (int): Pass the ID of a property.
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -863,7 +863,7 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_boolean(attribute_id, attribute_value)
 
         Args:
-            attribute_id (int): Pass the ID of an property.
+            attribute_id (int): Pass the ID of a property.
 
             attribute_value (bool): Pass the value that you want to set the property to.
 
@@ -914,7 +914,7 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_int32(attribute_id, attribute_value)
 
         Args:
-            attribute_id (int): Pass the ID of an property.
+            attribute_id (int): Pass the ID of a property.
 
             attribute_value (int): Pass the value that you want to set the property to.
 
@@ -965,7 +965,7 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_real64(attribute_id, attribute_value)
 
         Args:
-            attribute_id (int): Pass the ID of an property.
+            attribute_id (int): Pass the ID of a property.
 
             attribute_value (float): Pass the value that you want to set the property to.
 
@@ -1016,7 +1016,7 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_string(attribute_id, attribute_value)
 
         Args:
-            attribute_id (int): Pass the ID of an property.
+            attribute_id (int): Pass the ID of a property.
 
             attribute_value (str): Pass the value that you want to set the property to.
 
@@ -1129,7 +1129,7 @@ class Session(_SessionBase):
                 { 'simulate': False }
 
                 You do not have to specify a value for all the properties. If you do not
-                specify a value for an property, the default value is used.
+                specify a value for a property, the default value is used.
 
                 Advanced Example:
                 { 'simulate': True, 'driver_setup': { 'Model': '<model number>',  'BoardType': '<type>' } }

--- a/generated/nifake/session.py
+++ b/generated/nifake/session.py
@@ -97,22 +97,22 @@ class _SessionBase(object):
     float_enum = _attributes.AttributeEnum(_attributes.AttributeViReal64, enums.FloatEnum, 1000005)
     '''Type: enums.FloatEnum
 
-    An property with an enum that is also a float
+    A property with an enum that is also a float
     '''
     read_write_bool = _attributes.AttributeViBoolean(1000000)
     '''Type: bool
 
-    An property of type bool with read/write access.
+    A property of type bool with read/write access.
     '''
     read_write_color = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.Color, 1000003)
     '''Type: enums.Color
 
-    An property of type Color with read/write access.
+    A property of type Color with read/write access.
     '''
     read_write_double = _attributes.AttributeViReal64(1000001)
     '''Type: float
 
-    An property of type float with read/write access.
+    A property of type float with read/write access.
     '''
     read_write_double_with_converter = _attributes.AttributeViReal64TimeDeltaSeconds(1000007)
     '''Type: float in seconds or datetime.timedelta
@@ -122,12 +122,12 @@ class _SessionBase(object):
     read_write_int64 = _attributes.AttributeViInt64(1000006)
     '''Type: int
 
-    An property of type 64-bit integer with read/write access.
+    A property of type 64-bit integer with read/write access.
     '''
     read_write_integer = _attributes.AttributeViInt32(1000004)
     '''Type: int
 
-    An property of type integer with read/write access.
+    A property of type integer with read/write access.
     '''
     read_write_integer_with_converter = _attributes.AttributeViInt32TimeDeltaMilliseconds(1000008)
     '''Type: float in seconds or datetime.timedelta
@@ -137,7 +137,7 @@ class _SessionBase(object):
     read_write_string = _attributes.AttributeViString(1000002)
     '''Type: str
 
-    An property of type string with read/write access.
+    A property of type string with read/write access.
     '''
 
     def __init__(self, repeated_capability_list, vi, library, encoding, freeze_it=False):
@@ -203,7 +203,7 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_boolean(attribute_id)
 
         Args:
-            attribute_id (int): Pass the ID of an property.
+            attribute_id (int): Pass the ID of a property.
 
 
         Returns:
@@ -232,7 +232,7 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_int32(attribute_id)
 
         Args:
-            attribute_id (int): Pass the ID of an property.
+            attribute_id (int): Pass the ID of a property.
 
 
         Returns:
@@ -261,7 +261,7 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_int64(attribute_id)
 
         Args:
-            attribute_id (int): Pass the ID of an property.
+            attribute_id (int): Pass the ID of a property.
 
 
         Returns:
@@ -290,7 +290,7 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_real64(attribute_id)
 
         Args:
-            attribute_id (int): Pass the ID of an property.
+            attribute_id (int): Pass the ID of a property.
 
 
         Returns:
@@ -319,7 +319,7 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_string(attribute_id)
 
         Args:
-            attribute_id (int): Pass the ID of an property.
+            attribute_id (int): Pass the ID of a property.
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -399,7 +399,7 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_boolean(attribute_id, attribute_value)
 
         Args:
-            attribute_id (int): Pass the ID of an property.
+            attribute_id (int): Pass the ID of a property.
 
             attribute_value (bool): Pass the value that you want to set the property to.
 
@@ -426,7 +426,7 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_int32(attribute_id, attribute_value)
 
         Args:
-            attribute_id (int): Pass the ID of an property.
+            attribute_id (int): Pass the ID of a property.
 
             attribute_value (int): Pass the value that you want to set the property to.
 
@@ -453,7 +453,7 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_int64(attribute_id, attribute_value)
 
         Args:
-            attribute_id (int): Pass the ID of an property.
+            attribute_id (int): Pass the ID of a property.
 
             attribute_value (int): Pass the value that you want to set the property to.
 
@@ -480,7 +480,7 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_real64(attribute_id, attribute_value)
 
         Args:
-            attribute_id (int): Pass the ID of an property.
+            attribute_id (int): Pass the ID of a property.
 
             attribute_value (float): Pass the value that you want to set the property to.
 
@@ -507,7 +507,7 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_string(attribute_id, attribute_value)
 
         Args:
-            attribute_id (int): Pass the ID of an property.
+            attribute_id (int): Pass the ID of a property.
 
             attribute_value (str): Pass the value that you want to set the property to.
 
@@ -561,7 +561,7 @@ class Session(_SessionBase):
                 { 'simulate': False }
 
                 You do not have to specify a value for all the properties. If you do not
-                specify a value for an property, the default value is used.
+                specify a value for a property, the default value is used.
 
                 Advanced Example:
                 { 'simulate': True, 'driver_setup': { 'Model': '<model number>',  'BoardType': '<type>' } }

--- a/generated/nifgen/session.py
+++ b/generated/nifgen/session.py
@@ -593,7 +593,7 @@ class _SessionBase(object):
 
     Specifies whether to perform interchangeability checking and retrieve  interchangeability warnings when you call  _initiate_generation.
     Interchangeability warnings indicate that using your application with a  different device might cause different behavior.   Call GetNextInterchangeWarning to extract interchange warnings.   Call ClearInterchangeWarnings to clear the list  of interchangeability warnings without reading them.
-    Interchangeability checking examines the properties in a  capability group only if you specify a value for at least one  property within that group. Interchangeability warnings can  occur when an property affects the behavior of the device and you  have not set that property, or the property has been invalidated since you set it.
+    Interchangeability checking examines the properties in a  capability group only if you specify a value for at least one  property within that group. Interchangeability warnings can  occur when a property affects the behavior of the device and you  have not set that property, or the property has been invalidated since you set it.
 
     Note:
     One or more of the referenced methods are not in the Python API for this driver.
@@ -2199,7 +2199,7 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_boolean(attribute_id)
 
         Args:
-            attribute_id (int): Specifies the ID of an property.
+            attribute_id (int): Specifies the ID of a property.
 
 
         Returns:
@@ -2236,7 +2236,7 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_int32(attribute_id)
 
         Args:
-            attribute_id (int): Specifies the ID of an property.
+            attribute_id (int): Specifies the ID of a property.
 
 
         Returns:
@@ -2275,7 +2275,7 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_real64(attribute_id)
 
         Args:
-            attribute_id (int): Specifies the ID of an property.
+            attribute_id (int): Specifies the ID of a property.
 
 
         Returns:
@@ -2332,7 +2332,7 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_string(attribute_id)
 
         Args:
-            attribute_id (int): Specifies the ID of an property.
+            attribute_id (int): Specifies the ID of a property.
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -2618,7 +2618,7 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_boolean(attribute_id, attribute_value)
 
         Args:
-            attribute_id (int): Specifies the ID of an property.
+            attribute_id (int): Specifies the ID of a property.
 
             attribute_value (bool): Specifies the value to which you want to set the property. **Default
                 Value**: None
@@ -2673,7 +2673,7 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_int32(attribute_id, attribute_value)
 
         Args:
-            attribute_id (int): Specifies the ID of an property.
+            attribute_id (int): Specifies the ID of a property.
 
             attribute_value (int): Specifies the value to which you want to set the property. **Default
                 Value**: None
@@ -2728,7 +2728,7 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_real64(attribute_id, attribute_value)
 
         Args:
-            attribute_id (int): Specifies the ID of an property.
+            attribute_id (int): Specifies the ID of a property.
 
             attribute_value (float): Specifies the value to which you want to set the property. **Default
                 Value**: None
@@ -2783,7 +2783,7 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_string(attribute_id, attribute_value)
 
         Args:
-            attribute_id (int): Specifies the ID of an property.
+            attribute_id (int): Specifies the ID of a property.
 
             attribute_value (str): Specifies the value to which you want to set the property. **Default
                 Value**: None
@@ -3406,7 +3406,7 @@ class Session(_SessionBase):
                 { 'simulate': False }
 
                 You do not have to specify a value for all the properties. If you do not
-                specify a value for an property, the default value is used.
+                specify a value for a property, the default value is used.
 
                 Advanced Example:
                 { 'simulate': True, 'driver_setup': { 'Model': '<model number>',  'BoardType': '<type>' } }

--- a/generated/niscope/session.py
+++ b/generated/niscope/session.py
@@ -3023,7 +3023,7 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_boolean(attribute_id)
 
         Args:
-            attribute_id (int): The ID of an property.
+            attribute_id (int): The ID of a property.
 
 
         Returns:
@@ -3060,7 +3060,7 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_int32(attribute_id)
 
         Args:
-            attribute_id (int): The ID of an property.
+            attribute_id (int): The ID of a property.
 
 
         Returns:
@@ -3096,7 +3096,7 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_real64(attribute_id)
 
         Args:
-            attribute_id (int): The ID of an property.
+            attribute_id (int): The ID of a property.
 
 
         Returns:
@@ -3144,7 +3144,7 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_string(attribute_id)
 
         Args:
-            attribute_id (int): The ID of an property.
+            attribute_id (int): The ID of a property.
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -3469,7 +3469,7 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_boolean(attribute_id, value)
 
         Args:
-            attribute_id (int): The ID of an property.
+            attribute_id (int): The ID of a property.
 
             value (bool): The value that you want to set the property to. Some values might not
                 be valid depending on the current settings of the instrument session.
@@ -3518,7 +3518,7 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_int32(attribute_id, value)
 
         Args:
-            attribute_id (int): The ID of an property.
+            attribute_id (int): The ID of a property.
 
             value (int): The value that you want to set the property. Some values might not be
                 valid depending on the current settings of the instrument session.
@@ -3567,7 +3567,7 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_real64(attribute_id, value)
 
         Args:
-            attribute_id (int): The ID of an property.
+            attribute_id (int): The ID of a property.
 
             value (float): The value that you want to set the property to. Some values might not
                 be valid depending on the current settings of the instrument session.
@@ -3618,7 +3618,7 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_string(attribute_id, value)
 
         Args:
-            attribute_id (int): The ID of an property.
+            attribute_id (int): The ID of a property.
 
             value (str): The value that you want to set the property to. Some values might not
                 be valid depending on the current settings of the instrument session.
@@ -3740,7 +3740,7 @@ class Session(_SessionBase):
                 { 'simulate': False }
 
                 You do not have to specify a value for all the properties. If you do not
-                specify a value for an property, the default value is used.
+                specify a value for a property, the default value is used.
 
                 Advanced Example:
                 { 'simulate': True, 'driver_setup': { 'Model': '<model number>',  'BoardType': '<type>' } }

--- a/generated/niswitch/session.py
+++ b/generated/niswitch/session.py
@@ -211,7 +211,7 @@ class _SessionBase(object):
     Specifies whether to perform interchangeability checking and retrieve  interchangeability warnings when you call  connect, set_path and _initiate_scan methods.
     The default value is False.
     Interchangeability warnings indicate that using your application with a  different instrument might cause different behavior.   You call GetNextInterchangeWarning to extract interchange warnings.   Call the ClearInterchangeWarnings method to clear the list  of interchangeability warnings without reading them.
-    Interchangeability checking examines the properties in a  capability group only if you specify a value for at least one  property within that group.  Interchangeability warnings can  occur when an property affects the behavior of the instrument and you  have not set that property, or the property has been invalidated since you set it.
+    Interchangeability checking examines the properties in a  capability group only if you specify a value for at least one  property within that group.  Interchangeability warnings can  occur when a property affects the behavior of the instrument and you  have not set that property, or the property has been invalidated since you set it.
 
     Note:
     One or more of the referenced methods are not in the Python API for this driver.
@@ -688,17 +688,17 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_boolean(attribute_id)
 
         Args:
-            attribute_id (int): Pass the ID of an property. From the method panel window, you can use
+            attribute_id (int): Pass the ID of a property. From the method panel window, you can use
                 this control as follows. - Click on the control or press , , or , to
                 display a dialog box containing a hierarchical list of the available
                 properties. Properties whose value cannot be set are dim. Help text is
-                shown for each property. Select an property by double-clicking on it
+                shown for each property. Select a property by double-clicking on it
                 or by selecting it and then pressing . A ring control at the top of the
                 dialog box allows you to see all IVI properties or only the properties
                 of the ViInt32 type. If you choose to see all IVI properties, the data
                 types appear to the right of the property names in the list box. The
                 data types that are not consistent with this method are dim. If you
-                select an property data type that is dim, LabWindows/CVI transfers you
+                select a property data type that is dim, LabWindows/CVI transfers you
                 to the method panel for the corresponding method that is consistent
                 with the data type. - If you want to enter a variable name, press to
                 change this ring control to a manual input box. - If the property in
@@ -743,17 +743,17 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_int32(attribute_id)
 
         Args:
-            attribute_id (int): Pass the ID of an property. From the method panel window, you can use
+            attribute_id (int): Pass the ID of a property. From the method panel window, you can use
                 this control as follows. - Click on the control or press , , or , to
                 display a dialog box containing a hierarchical list of the available
                 properties. Properties whose value cannot be set are dim. Help text is
-                shown for each property. Select an property by double-clicking on it
+                shown for each property. Select a property by double-clicking on it
                 or by selecting it and then pressing . A ring control at the top of the
                 dialog box allows you to see all IVI properties or only the properties
                 of the ViInt32 type. If you choose to see all IVI properties, the data
                 types appear to the right of the property names in the list box. The
                 data types that are not consistent with this method are dim. If you
-                select an property data type that is dim, LabWindows/CVI transfers you
+                select a property data type that is dim, LabWindows/CVI transfers you
                 to the method panel for the corresponding method that is consistent
                 with the data type. - If you want to enter a variable name, press to
                 change this ring control to a manual input box. - If the property in
@@ -798,17 +798,17 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_real64(attribute_id)
 
         Args:
-            attribute_id (int): Pass the ID of an property. From the method panel window, you can use
+            attribute_id (int): Pass the ID of a property. From the method panel window, you can use
                 this control as follows. - Click on the control or press , , or , to
                 display a dialog box containing a hierarchical list of the available
                 properties. Properties whose value cannot be set are dim. Help text is
-                shown for each property. Select an property by double-clicking on it
+                shown for each property. Select a property by double-clicking on it
                 or by selecting it and then pressing . A ring control at the top of the
                 dialog box allows you to see all IVI properties or only the properties
                 of the ViInt32 type. If you choose to see all IVI properties, the data
                 types appear to the right of the property names in the list box. The
                 data types that are not consistent with this method are dim. If you
-                select an property data type that is dim, LabWindows/CVI transfers you
+                select a property data type that is dim, LabWindows/CVI transfers you
                 to the method panel for the corresponding method that is consistent
                 with the data type. - If you want to enter a variable name, press to
                 change this ring control to a manual input box. - If the property in
@@ -865,17 +865,17 @@ class _SessionBase(object):
             session.channels['0,1']._get_attribute_vi_string(attribute_id)
 
         Args:
-            attribute_id (int): Pass the ID of an property. From the method panel window, you can use
+            attribute_id (int): Pass the ID of a property. From the method panel window, you can use
                 this control as follows. - Click on the control or press , , or , to
                 display a dialog box containing a hierarchical list of the available
                 properties. Properties whose value cannot be set are dim. Help text is
-                shown for each property. Select an property by double-clicking on it
+                shown for each property. Select a property by double-clicking on it
                 or by selecting it and then pressing . A ring control at the top of the
                 dialog box allows you to see all IVI properties or only the properties
                 of the ViInt32 type. If you choose to see all IVI properties, the data
                 types appear to the right of the property names in the list box. The
                 data types that are not consistent with this method are dim. If you
-                select an property data type that is dim, LabWindows/CVI transfers you
+                select a property data type that is dim, LabWindows/CVI transfers you
                 to the method panel for the corresponding method that is consistent
                 with the data type. - If you want to enter a variable name, press to
                 change this ring control to a manual input box. - If the property in
@@ -965,18 +965,18 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_boolean(attribute_id, attribute_value)
 
         Args:
-            attribute_id (int): Pass the ID of an property. From the method panel window, you can use
+            attribute_id (int): Pass the ID of a property. From the method panel window, you can use
                 this control as follows. - Click on the control or press , , or , to
                 display a dialog box containing a hierarchical list of the available
                 properties. Properties whose value cannot be set are dim. Help text is
-                shown for each property. Select an property by double-clicking on it
+                shown for each property. Select a property by double-clicking on it
                 or by selecting it and then pressing . Read-only properties appear dim
                 in the list box. If you select a read-only property, an error message
                 appears. A ring control at the top of the dialog box allows you to see
                 all IVI properties or only the properties of the ViInt32 type. If you
                 choose to see all IVI properties, the data types appear to the right of
                 the property names in the list box. The data types that are not
-                consistent with this method are dim. If you select an property data
+                consistent with this method are dim. If you select a property data
                 type that is dim, LabWindows/CVI transfers you to the method panel for
                 the corresponding method that is consistent with the data type. - If
                 you want to enter a variable name, press to change this ring control to
@@ -1032,18 +1032,18 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_int32(attribute_id, attribute_value)
 
         Args:
-            attribute_id (int): Pass the ID of an property. From the method panel window, you can use
+            attribute_id (int): Pass the ID of a property. From the method panel window, you can use
                 this control as follows. - Click on the control or press , , or , to
                 display a dialog box containing a hierarchical list of the available
                 properties. Properties whose value cannot be set are dim. Help text is
-                shown for each property. Select an property by double-clicking on it
+                shown for each property. Select a property by double-clicking on it
                 or by selecting it and then pressing . Read-only properties appear dim
                 in the list box. If you select a read-only property, an error message
                 appears. A ring control at the top of the dialog box allows you to see
                 all IVI properties or only the properties of the ViInt32 type. If you
                 choose to see all IVI properties, the data types appear to the right of
                 the property names in the list box. The data types that are not
-                consistent with this method are dim. If you select an property data
+                consistent with this method are dim. If you select a property data
                 type that is dim, LabWindows/CVI transfers you to the method panel for
                 the corresponding method that is consistent with the data type. - If
                 you want to enter a variable name, press to change this ring control to
@@ -1099,18 +1099,18 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_real64(attribute_id, attribute_value)
 
         Args:
-            attribute_id (int): Pass the ID of an property. From the method panel window, you can use
+            attribute_id (int): Pass the ID of a property. From the method panel window, you can use
                 this control as follows. - Click on the control or press , , or , to
                 display a dialog box containing a hierarchical list of the available
                 properties. Properties whose value cannot be set are dim. Help text is
-                shown for each property. Select an property by double-clicking on it
+                shown for each property. Select a property by double-clicking on it
                 or by selecting it and then pressing . Read-only properties appear dim
                 in the list box. If you select a read-only property, an error message
                 appears. A ring control at the top of the dialog box allows you to see
                 all IVI properties or only the properties of the ViInt32 type. If you
                 choose to see all IVI properties, the data types appear to the right of
                 the property names in the list box. The data types that are not
-                consistent with this method are dim. If you select an property data
+                consistent with this method are dim. If you select a property data
                 type that is dim, LabWindows/CVI transfers you to the method panel for
                 the corresponding method that is consistent with the data type. - If
                 you want to enter a variable name, press to change this ring control to
@@ -1166,18 +1166,18 @@ class _SessionBase(object):
             session.channels['0,1']._set_attribute_vi_string(attribute_id, attribute_value)
 
         Args:
-            attribute_id (int): Pass the ID of an property. From the method panel window, you can use
+            attribute_id (int): Pass the ID of a property. From the method panel window, you can use
                 this control as follows. - Click on the control or press , , or , to
                 display a dialog box containing a hierarchical list of the available
                 properties. Properties whose value cannot be set are dim. Help text is
-                shown for each property. Select an property by double-clicking on it
+                shown for each property. Select a property by double-clicking on it
                 or by selecting it and then pressing . Read-only properties appear dim
                 in the list box. If you select a read-only property, an error message
                 appears. A ring control at the top of the dialog box allows you to see
                 all IVI properties or only the properties of the ViInt32 type. If you
                 choose to see all IVI properties, the data types appear to the right of
                 the property names in the list box. The data types that are not
-                consistent with this method are dim. If you select an property data
+                consistent with this method are dim. If you select a property data
                 type that is dim, LabWindows/CVI transfers you to the method panel for
                 the corresponding method that is consistent with the data type. - If
                 you want to enter a variable name, press to change this ring control to


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [X] ~~I've added tests applicable for this pull request~~
### What does this Pull Request accomplish?
* Look for 'an attribute' and replace with 'a property', plus variations of capitalization
### List issues fixed by this Pull Request below, if any.
* Fix #808 

### What testing has been done?
* Visual inspection of generated files