### PR TITLE
SelfTestError needs to inherit from Error, not Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 * ### ALL
     * #### Added
     * #### Changed
+        * `SelfTestError` now inherits from `<driver>.Error` rather than `Exception` - [#830](https://github.com/ni/nimi-python/issues/830)
     * #### Removed
 * ### NI-DMM
     * #### Added

--- a/build/templates/errors.py.mako
+++ b/build/templates/errors.py.mako
@@ -73,7 +73,7 @@ class InvalidRepeatedCapabilityError(Error):
         super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({0}) was found in repeated capability string ({1})'.format(invalid_character, invalid_string))
 
 
-class SelfTestError(Exception):
+class SelfTestError(Error):
     '''An error due to a failed self-test'''
 
     def __init__(self, code, msg):

--- a/generated/nidcpower/errors.py
+++ b/generated/nidcpower/errors.py
@@ -64,7 +64,7 @@ class InvalidRepeatedCapabilityError(Error):
         super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({0}) was found in repeated capability string ({1})'.format(invalid_character, invalid_string))
 
 
-class SelfTestError(Exception):
+class SelfTestError(Error):
     '''An error due to a failed self-test'''
 
     def __init__(self, code, msg):

--- a/generated/nidmm/errors.py
+++ b/generated/nidmm/errors.py
@@ -64,7 +64,7 @@ class InvalidRepeatedCapabilityError(Error):
         super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({0}) was found in repeated capability string ({1})'.format(invalid_character, invalid_string))
 
 
-class SelfTestError(Exception):
+class SelfTestError(Error):
     '''An error due to a failed self-test'''
 
     def __init__(self, code, msg):

--- a/generated/nifake/errors.py
+++ b/generated/nifake/errors.py
@@ -64,7 +64,7 @@ class InvalidRepeatedCapabilityError(Error):
         super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({0}) was found in repeated capability string ({1})'.format(invalid_character, invalid_string))
 
 
-class SelfTestError(Exception):
+class SelfTestError(Error):
     '''An error due to a failed self-test'''
 
     def __init__(self, code, msg):

--- a/generated/nifgen/errors.py
+++ b/generated/nifgen/errors.py
@@ -64,7 +64,7 @@ class InvalidRepeatedCapabilityError(Error):
         super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({0}) was found in repeated capability string ({1})'.format(invalid_character, invalid_string))
 
 
-class SelfTestError(Exception):
+class SelfTestError(Error):
     '''An error due to a failed self-test'''
 
     def __init__(self, code, msg):

--- a/generated/nimodinst/errors.py
+++ b/generated/nimodinst/errors.py
@@ -64,7 +64,7 @@ class InvalidRepeatedCapabilityError(Error):
         super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({0}) was found in repeated capability string ({1})'.format(invalid_character, invalid_string))
 
 
-class SelfTestError(Exception):
+class SelfTestError(Error):
     '''An error due to a failed self-test'''
 
     def __init__(self, code, msg):

--- a/generated/niscope/errors.py
+++ b/generated/niscope/errors.py
@@ -64,7 +64,7 @@ class InvalidRepeatedCapabilityError(Error):
         super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({0}) was found in repeated capability string ({1})'.format(invalid_character, invalid_string))
 
 
-class SelfTestError(Exception):
+class SelfTestError(Error):
     '''An error due to a failed self-test'''
 
     def __init__(self, code, msg):

--- a/generated/niswitch/errors.py
+++ b/generated/niswitch/errors.py
@@ -64,7 +64,7 @@ class InvalidRepeatedCapabilityError(Error):
         super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({0}) was found in repeated capability string ({1})'.format(invalid_character, invalid_string))
 
 
-class SelfTestError(Exception):
+class SelfTestError(Error):
     '''An error due to a failed self-test'''
 
     def __init__(self, code, msg):


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- [x] ~~I've added tests applicable for this pull request~~
### What does this Pull Request accomplish?
* `SelfTestError` now inherits from `<driver>.Error`

### List issues fixed by this Pull Request below, if any.
* Fix #830 

### What testing has been done?
* Unit
* System