### PR TITLE
Change Warning class name to be PEP8 compliant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this project will be documented in this file.
     * #### Added
     * #### Changed
         * `SelfTestError` now inherits from `<driver>.Error` rather than `Exception` - [#830](https://github.com/ni/nimi-python/issues/830)
-        * Warning class name is now PEP8 compliant. This means the case has changed. I.e. `NidcpowerWarning` --> `NIDCPowerWarning`, or `NimodinstWarning` --> `NIModInstWarning` - [#658](https://github.com/ni/nimi-python/issues/658)
+        * Warning class name changed to `<driver>.DriverWarning` for all drivers - [#658](https://github.com/ni/nimi-python/issues/658)
     * #### Removed
         * IVI properties as applicable - some where already removed from some drivers [#824](https://github.com/ni/nimi-python/issues/824)
             * `engine_major_version`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
     * #### Added
     * #### Changed
         * `SelfTestError` now inherits from `<driver>.Error` rather than `Exception` - [#830](https://github.com/ni/nimi-python/issues/830)
+        * Warning class name is now PEP8 compliant. This means the case has changed. I.e. `NidcpowerWarning` --> `NIDCPowerWarning`, or `NimodinstWarning` --> `NIModInstWarning` - [#658](https://github.com/ni/nimi-python/issues/658)
     * #### Removed
         * IVI properties as applicable - some where already removed from some drivers [#824](https://github.com/ni/nimi-python/issues/824)
             * `engine_major_version`

--- a/build/templates/__init__.py.mako
+++ b/build/templates/__init__.py.mako
@@ -4,15 +4,12 @@
 enums = template_parameters['metadata'].enums
 config = template_parameters['metadata'].config
 module_name = config['module_name']
-driver_name = config['driver_name']
-driver_name_class = driver_name.replace('-', '')  # We want something like 'NIDCPower' or 'NIDMM' to be PEP8 compliant
-warning_name_class = driver_name_class + 'Warning'
 %>
 % if len(enums) > 0:
 from ${module_name}.enums import *          # noqa: F403,F401,H303
 % endif
+from ${module_name}.errors import DriverWarning   # noqa: F401
 from ${module_name}.errors import Error     # noqa: F401
-from ${module_name}.errors import ${warning_name_class}   # noqa: F401
 from ${module_name}.session import Session  # noqa: F401
 <%
  # Blank lines are to make each import separate so that they do not need to be sorted

--- a/build/templates/__init__.py.mako
+++ b/build/templates/__init__.py.mako
@@ -4,13 +4,15 @@
 enums = template_parameters['metadata'].enums
 config = template_parameters['metadata'].config
 module_name = config['module_name']
-module_name_class = module_name.title()
+driver_name = config['driver_name']
+driver_name_class = driver_name.replace('-', '')  # We want something like 'NIDCPower' or 'NIDMM' to be PEP8 compliant
+warning_name_class = driver_name_class + 'Warning'
 %>
 % if len(enums) > 0:
 from ${module_name}.enums import *          # noqa: F403,F401,H303
 % endif
 from ${module_name}.errors import Error     # noqa: F401
-from ${module_name}.errors import ${module_name_class}Warning   # noqa: F401
+from ${module_name}.errors import ${warning_name_class}   # noqa: F401
 from ${module_name}.session import Session  # noqa: F401
 <%
  # Blank lines are to make each import separate so that they do not need to be sorted

--- a/build/templates/errors.py.mako
+++ b/build/templates/errors.py.mako
@@ -6,9 +6,10 @@ attributes    = config['attributes']
 functions     = config['functions']
 
 module_name = config['module_name']
-module_name_class = module_name.title()
 c_function_prefix = config['c_function_prefix']
 driver_name = config['driver_name']
+driver_name_class = driver_name.replace('-', '')  # We want something like 'NIDCPower' or 'NIDMM' to be PEP8 compliant
+warning_name_class = driver_name_class + 'Warning'
 %>
 
 import platform
@@ -44,12 +45,12 @@ class DriverError(Error):
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
 
 
-class ${module_name_class}Warning(Warning):
+class ${warning_name_class}(Warning):
     '''A warning originating from the ${driver_name} driver'''
 
     def __init__(self, code, description):
         assert (_is_warning(code)), "Should not create Warning if code is not positive."
-        super(${module_name_class}Warning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(${warning_name_class}, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 
 class UnsupportedConfigurationError(Error):
@@ -104,7 +105,7 @@ def handle_error(session, code, ignore_warnings, is_error_handling):
         raise DriverError(code, description)
 
     assert _is_warning(code)
-    warnings.warn(${module_name_class}Warning(code, description))
+    warnings.warn(${warning_name_class}(code, description))
 
 
-warnings.filterwarnings("always", category=${module_name_class}Warning)
+warnings.filterwarnings("always", category=${warning_name_class})

--- a/build/templates/errors.py.mako
+++ b/build/templates/errors.py.mako
@@ -8,8 +8,6 @@ functions     = config['functions']
 module_name = config['module_name']
 c_function_prefix = config['c_function_prefix']
 driver_name = config['driver_name']
-driver_name_class = driver_name.replace('-', '')  # We want something like 'NIDCPower' or 'NIDMM' to be PEP8 compliant
-warning_name_class = driver_name_class + 'Warning'
 %>
 
 import platform
@@ -45,12 +43,12 @@ class DriverError(Error):
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
 
 
-class ${warning_name_class}(Warning):
+class DriverWarning(Warning):
     '''A warning originating from the ${driver_name} driver'''
 
     def __init__(self, code, description):
         assert (_is_warning(code)), "Should not create Warning if code is not positive."
-        super(${warning_name_class}, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 
 class UnsupportedConfigurationError(Error):
@@ -105,7 +103,7 @@ def handle_error(session, code, ignore_warnings, is_error_handling):
         raise DriverError(code, description)
 
     assert _is_warning(code)
-    warnings.warn(${warning_name_class}(code, description))
+    warnings.warn(DriverWarning(code, description))
 
 
-warnings.filterwarnings("always", category=${warning_name_class})
+warnings.filterwarnings("always", category=DriverWarning)

--- a/generated/nidcpower/__init__.py
+++ b/generated/nidcpower/__init__.py
@@ -3,6 +3,6 @@
 
 from nidcpower.enums import *          # noqa: F403,F401,H303
 from nidcpower.errors import Error     # noqa: F401
-from nidcpower.errors import NidcpowerWarning   # noqa: F401
+from nidcpower.errors import NIDCPowerWarning   # noqa: F401
 from nidcpower.session import Session  # noqa: F401
 

--- a/generated/nidcpower/__init__.py
+++ b/generated/nidcpower/__init__.py
@@ -2,7 +2,7 @@
 # This file was generated
 
 from nidcpower.enums import *          # noqa: F403,F401,H303
+from nidcpower.errors import DriverWarning   # noqa: F401
 from nidcpower.errors import Error     # noqa: F401
-from nidcpower.errors import NIDCPowerWarning   # noqa: F401
 from nidcpower.session import Session  # noqa: F401
 

--- a/generated/nidcpower/errors.py
+++ b/generated/nidcpower/errors.py
@@ -35,12 +35,12 @@ class DriverError(Error):
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
 
 
-class NidcpowerWarning(Warning):
+class NIDCPowerWarning(Warning):
     '''A warning originating from the NI-DCPower driver'''
 
     def __init__(self, code, description):
         assert (_is_warning(code)), "Should not create Warning if code is not positive."
-        super(NidcpowerWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(NIDCPowerWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 
 class UnsupportedConfigurationError(Error):
@@ -95,7 +95,7 @@ def handle_error(session, code, ignore_warnings, is_error_handling):
         raise DriverError(code, description)
 
     assert _is_warning(code)
-    warnings.warn(NidcpowerWarning(code, description))
+    warnings.warn(NIDCPowerWarning(code, description))
 
 
-warnings.filterwarnings("always", category=NidcpowerWarning)
+warnings.filterwarnings("always", category=NIDCPowerWarning)

--- a/generated/nidcpower/errors.py
+++ b/generated/nidcpower/errors.py
@@ -35,12 +35,12 @@ class DriverError(Error):
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
 
 
-class NIDCPowerWarning(Warning):
+class DriverWarning(Warning):
     '''A warning originating from the NI-DCPower driver'''
 
     def __init__(self, code, description):
         assert (_is_warning(code)), "Should not create Warning if code is not positive."
-        super(NIDCPowerWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 
 class UnsupportedConfigurationError(Error):
@@ -95,7 +95,7 @@ def handle_error(session, code, ignore_warnings, is_error_handling):
         raise DriverError(code, description)
 
     assert _is_warning(code)
-    warnings.warn(NIDCPowerWarning(code, description))
+    warnings.warn(DriverWarning(code, description))
 
 
-warnings.filterwarnings("always", category=NIDCPowerWarning)
+warnings.filterwarnings("always", category=DriverWarning)

--- a/generated/nidmm/__init__.py
+++ b/generated/nidmm/__init__.py
@@ -3,6 +3,6 @@
 
 from nidmm.enums import *          # noqa: F403,F401,H303
 from nidmm.errors import Error     # noqa: F401
-from nidmm.errors import NidmmWarning   # noqa: F401
+from nidmm.errors import NIDMMWarning   # noqa: F401
 from nidmm.session import Session  # noqa: F401
 

--- a/generated/nidmm/__init__.py
+++ b/generated/nidmm/__init__.py
@@ -2,7 +2,7 @@
 # This file was generated
 
 from nidmm.enums import *          # noqa: F403,F401,H303
+from nidmm.errors import DriverWarning   # noqa: F401
 from nidmm.errors import Error     # noqa: F401
-from nidmm.errors import NIDMMWarning   # noqa: F401
 from nidmm.session import Session  # noqa: F401
 

--- a/generated/nidmm/errors.py
+++ b/generated/nidmm/errors.py
@@ -35,12 +35,12 @@ class DriverError(Error):
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
 
 
-class NidmmWarning(Warning):
+class NIDMMWarning(Warning):
     '''A warning originating from the NI-DMM driver'''
 
     def __init__(self, code, description):
         assert (_is_warning(code)), "Should not create Warning if code is not positive."
-        super(NidmmWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(NIDMMWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 
 class UnsupportedConfigurationError(Error):
@@ -95,7 +95,7 @@ def handle_error(session, code, ignore_warnings, is_error_handling):
         raise DriverError(code, description)
 
     assert _is_warning(code)
-    warnings.warn(NidmmWarning(code, description))
+    warnings.warn(NIDMMWarning(code, description))
 
 
-warnings.filterwarnings("always", category=NidmmWarning)
+warnings.filterwarnings("always", category=NIDMMWarning)

--- a/generated/nidmm/errors.py
+++ b/generated/nidmm/errors.py
@@ -35,12 +35,12 @@ class DriverError(Error):
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
 
 
-class NIDMMWarning(Warning):
+class DriverWarning(Warning):
     '''A warning originating from the NI-DMM driver'''
 
     def __init__(self, code, description):
         assert (_is_warning(code)), "Should not create Warning if code is not positive."
-        super(NIDMMWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 
 class UnsupportedConfigurationError(Error):
@@ -95,7 +95,7 @@ def handle_error(session, code, ignore_warnings, is_error_handling):
         raise DriverError(code, description)
 
     assert _is_warning(code)
-    warnings.warn(NIDMMWarning(code, description))
+    warnings.warn(DriverWarning(code, description))
 
 
-warnings.filterwarnings("always", category=NIDMMWarning)
+warnings.filterwarnings("always", category=DriverWarning)

--- a/generated/nifake/__init__.py
+++ b/generated/nifake/__init__.py
@@ -2,8 +2,8 @@
 # This file was generated
 
 from nifake.enums import *          # noqa: F403,F401,H303
+from nifake.errors import DriverWarning   # noqa: F401
 from nifake.errors import Error     # noqa: F401
-from nifake.errors import NIFAKEWarning   # noqa: F401
 from nifake.session import Session  # noqa: F401
 
 from nifake.custom_struct import CustomStruct  # noqa: F401

--- a/generated/nifake/__init__.py
+++ b/generated/nifake/__init__.py
@@ -3,7 +3,7 @@
 
 from nifake.enums import *          # noqa: F403,F401,H303
 from nifake.errors import Error     # noqa: F401
-from nifake.errors import NifakeWarning   # noqa: F401
+from nifake.errors import NIFAKEWarning   # noqa: F401
 from nifake.session import Session  # noqa: F401
 
 from nifake.custom_struct import CustomStruct  # noqa: F401

--- a/generated/nifake/errors.py
+++ b/generated/nifake/errors.py
@@ -35,12 +35,12 @@ class DriverError(Error):
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
 
 
-class NifakeWarning(Warning):
+class NIFAKEWarning(Warning):
     '''A warning originating from the NI-FAKE driver'''
 
     def __init__(self, code, description):
         assert (_is_warning(code)), "Should not create Warning if code is not positive."
-        super(NifakeWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(NIFAKEWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 
 class UnsupportedConfigurationError(Error):
@@ -95,7 +95,7 @@ def handle_error(session, code, ignore_warnings, is_error_handling):
         raise DriverError(code, description)
 
     assert _is_warning(code)
-    warnings.warn(NifakeWarning(code, description))
+    warnings.warn(NIFAKEWarning(code, description))
 
 
-warnings.filterwarnings("always", category=NifakeWarning)
+warnings.filterwarnings("always", category=NIFAKEWarning)

--- a/generated/nifake/errors.py
+++ b/generated/nifake/errors.py
@@ -35,12 +35,12 @@ class DriverError(Error):
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
 
 
-class NIFAKEWarning(Warning):
+class DriverWarning(Warning):
     '''A warning originating from the NI-FAKE driver'''
 
     def __init__(self, code, description):
         assert (_is_warning(code)), "Should not create Warning if code is not positive."
-        super(NIFAKEWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 
 class UnsupportedConfigurationError(Error):
@@ -95,7 +95,7 @@ def handle_error(session, code, ignore_warnings, is_error_handling):
         raise DriverError(code, description)
 
     assert _is_warning(code)
-    warnings.warn(NIFAKEWarning(code, description))
+    warnings.warn(DriverWarning(code, description))
 
 
-warnings.filterwarnings("always", category=NIFAKEWarning)
+warnings.filterwarnings("always", category=DriverWarning)

--- a/generated/nifake/unit_tests/test_session.py
+++ b/generated/nifake/unit_tests/test_session.py
@@ -589,7 +589,7 @@ class TestSession(object):
             with warnings.catch_warnings(record=True) as w:
                 session.simple_function()
                 assert len(w) == 1
-                assert issubclass(w[0].category, nifake.NifakeWarning)
+                assert issubclass(w[0].category, nifake.NIFAKEWarning)
                 assert test_error_desc in str(w[0].message)
 
     def test_read_with_warning(self):
@@ -608,7 +608,7 @@ class TestSession(object):
             with warnings.catch_warnings(record=True) as w:
                 assert math.isnan(session.read(test_maximum_time))
                 assert len(w) == 1
-                assert issubclass(w[0].category, nifake.NifakeWarning)
+                assert issubclass(w[0].category, nifake.NIFAKEWarning)
                 assert test_error_desc in str(w[0].message)
 
     # Retrieving buffers and strings

--- a/generated/nifake/unit_tests/test_session.py
+++ b/generated/nifake/unit_tests/test_session.py
@@ -589,7 +589,7 @@ class TestSession(object):
             with warnings.catch_warnings(record=True) as w:
                 session.simple_function()
                 assert len(w) == 1
-                assert issubclass(w[0].category, nifake.NIFAKEWarning)
+                assert issubclass(w[0].category, nifake.DriverWarning)
                 assert test_error_desc in str(w[0].message)
 
     def test_read_with_warning(self):
@@ -608,7 +608,7 @@ class TestSession(object):
             with warnings.catch_warnings(record=True) as w:
                 assert math.isnan(session.read(test_maximum_time))
                 assert len(w) == 1
-                assert issubclass(w[0].category, nifake.NIFAKEWarning)
+                assert issubclass(w[0].category, nifake.DriverWarning)
                 assert test_error_desc in str(w[0].message)
 
     # Retrieving buffers and strings

--- a/generated/nifgen/__init__.py
+++ b/generated/nifgen/__init__.py
@@ -3,6 +3,6 @@
 
 from nifgen.enums import *          # noqa: F403,F401,H303
 from nifgen.errors import Error     # noqa: F401
-from nifgen.errors import NifgenWarning   # noqa: F401
+from nifgen.errors import NIFGENWarning   # noqa: F401
 from nifgen.session import Session  # noqa: F401
 

--- a/generated/nifgen/__init__.py
+++ b/generated/nifgen/__init__.py
@@ -2,7 +2,7 @@
 # This file was generated
 
 from nifgen.enums import *          # noqa: F403,F401,H303
+from nifgen.errors import DriverWarning   # noqa: F401
 from nifgen.errors import Error     # noqa: F401
-from nifgen.errors import NIFGENWarning   # noqa: F401
 from nifgen.session import Session  # noqa: F401
 

--- a/generated/nifgen/errors.py
+++ b/generated/nifgen/errors.py
@@ -35,12 +35,12 @@ class DriverError(Error):
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
 
 
-class NifgenWarning(Warning):
+class NIFGENWarning(Warning):
     '''A warning originating from the NI-FGEN driver'''
 
     def __init__(self, code, description):
         assert (_is_warning(code)), "Should not create Warning if code is not positive."
-        super(NifgenWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(NIFGENWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 
 class UnsupportedConfigurationError(Error):
@@ -95,7 +95,7 @@ def handle_error(session, code, ignore_warnings, is_error_handling):
         raise DriverError(code, description)
 
     assert _is_warning(code)
-    warnings.warn(NifgenWarning(code, description))
+    warnings.warn(NIFGENWarning(code, description))
 
 
-warnings.filterwarnings("always", category=NifgenWarning)
+warnings.filterwarnings("always", category=NIFGENWarning)

--- a/generated/nifgen/errors.py
+++ b/generated/nifgen/errors.py
@@ -35,12 +35,12 @@ class DriverError(Error):
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
 
 
-class NIFGENWarning(Warning):
+class DriverWarning(Warning):
     '''A warning originating from the NI-FGEN driver'''
 
     def __init__(self, code, description):
         assert (_is_warning(code)), "Should not create Warning if code is not positive."
-        super(NIFGENWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 
 class UnsupportedConfigurationError(Error):
@@ -95,7 +95,7 @@ def handle_error(session, code, ignore_warnings, is_error_handling):
         raise DriverError(code, description)
 
     assert _is_warning(code)
-    warnings.warn(NIFGENWarning(code, description))
+    warnings.warn(DriverWarning(code, description))
 
 
-warnings.filterwarnings("always", category=NIFGENWarning)
+warnings.filterwarnings("always", category=DriverWarning)

--- a/generated/nimodinst/__init__.py
+++ b/generated/nimodinst/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # This file was generated
 
+from nimodinst.errors import DriverWarning   # noqa: F401
 from nimodinst.errors import Error     # noqa: F401
-from nimodinst.errors import NIModInstWarning   # noqa: F401
 from nimodinst.session import Session  # noqa: F401
 

--- a/generated/nimodinst/__init__.py
+++ b/generated/nimodinst/__init__.py
@@ -2,6 +2,6 @@
 # This file was generated
 
 from nimodinst.errors import Error     # noqa: F401
-from nimodinst.errors import NimodinstWarning   # noqa: F401
+from nimodinst.errors import NIModInstWarning   # noqa: F401
 from nimodinst.session import Session  # noqa: F401
 

--- a/generated/nimodinst/errors.py
+++ b/generated/nimodinst/errors.py
@@ -35,12 +35,12 @@ class DriverError(Error):
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
 
 
-class NIModInstWarning(Warning):
+class DriverWarning(Warning):
     '''A warning originating from the NI-ModInst driver'''
 
     def __init__(self, code, description):
         assert (_is_warning(code)), "Should not create Warning if code is not positive."
-        super(NIModInstWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 
 class UnsupportedConfigurationError(Error):
@@ -95,7 +95,7 @@ def handle_error(session, code, ignore_warnings, is_error_handling):
         raise DriverError(code, description)
 
     assert _is_warning(code)
-    warnings.warn(NIModInstWarning(code, description))
+    warnings.warn(DriverWarning(code, description))
 
 
-warnings.filterwarnings("always", category=NIModInstWarning)
+warnings.filterwarnings("always", category=DriverWarning)

--- a/generated/nimodinst/errors.py
+++ b/generated/nimodinst/errors.py
@@ -35,12 +35,12 @@ class DriverError(Error):
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
 
 
-class NimodinstWarning(Warning):
+class NIModInstWarning(Warning):
     '''A warning originating from the NI-ModInst driver'''
 
     def __init__(self, code, description):
         assert (_is_warning(code)), "Should not create Warning if code is not positive."
-        super(NimodinstWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(NIModInstWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 
 class UnsupportedConfigurationError(Error):
@@ -95,7 +95,7 @@ def handle_error(session, code, ignore_warnings, is_error_handling):
         raise DriverError(code, description)
 
     assert _is_warning(code)
-    warnings.warn(NimodinstWarning(code, description))
+    warnings.warn(NIModInstWarning(code, description))
 
 
-warnings.filterwarnings("always", category=NimodinstWarning)
+warnings.filterwarnings("always", category=NIModInstWarning)

--- a/generated/nimodinst/unit_tests/test_modinst.py
+++ b/generated/nimodinst/unit_tests/test_modinst.py
@@ -245,7 +245,7 @@ class TestSession(object):
             with warnings.catch_warnings(record=True) as w:
                 session[0].chassis_number
                 assert len(w) == 1
-                assert issubclass(w[0].category, nimodinst.NimodinstWarning)
+                assert issubclass(w[0].category, nimodinst.NIModInstWarning)
                 assert error_string in str(w[0].message)
 
     def test_repr_and_str(self):

--- a/generated/nimodinst/unit_tests/test_modinst.py
+++ b/generated/nimodinst/unit_tests/test_modinst.py
@@ -245,7 +245,7 @@ class TestSession(object):
             with warnings.catch_warnings(record=True) as w:
                 session[0].chassis_number
                 assert len(w) == 1
-                assert issubclass(w[0].category, nimodinst.NIModInstWarning)
+                assert issubclass(w[0].category, nimodinst.DriverWarning)
                 assert error_string in str(w[0].message)
 
     def test_repr_and_str(self):

--- a/generated/niscope/__init__.py
+++ b/generated/niscope/__init__.py
@@ -3,7 +3,7 @@
 
 from niscope.enums import *          # noqa: F403,F401,H303
 from niscope.errors import Error     # noqa: F401
-from niscope.errors import NiscopeWarning   # noqa: F401
+from niscope.errors import NISCOPEWarning   # noqa: F401
 from niscope.session import Session  # noqa: F401
 
 from niscope.waveform_info import WaveformInfo  # noqa: F401

--- a/generated/niscope/__init__.py
+++ b/generated/niscope/__init__.py
@@ -2,8 +2,8 @@
 # This file was generated
 
 from niscope.enums import *          # noqa: F403,F401,H303
+from niscope.errors import DriverWarning   # noqa: F401
 from niscope.errors import Error     # noqa: F401
-from niscope.errors import NISCOPEWarning   # noqa: F401
 from niscope.session import Session  # noqa: F401
 
 from niscope.waveform_info import WaveformInfo  # noqa: F401

--- a/generated/niscope/errors.py
+++ b/generated/niscope/errors.py
@@ -35,12 +35,12 @@ class DriverError(Error):
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
 
 
-class NiscopeWarning(Warning):
+class NISCOPEWarning(Warning):
     '''A warning originating from the NI-SCOPE driver'''
 
     def __init__(self, code, description):
         assert (_is_warning(code)), "Should not create Warning if code is not positive."
-        super(NiscopeWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(NISCOPEWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 
 class UnsupportedConfigurationError(Error):
@@ -95,7 +95,7 @@ def handle_error(session, code, ignore_warnings, is_error_handling):
         raise DriverError(code, description)
 
     assert _is_warning(code)
-    warnings.warn(NiscopeWarning(code, description))
+    warnings.warn(NISCOPEWarning(code, description))
 
 
-warnings.filterwarnings("always", category=NiscopeWarning)
+warnings.filterwarnings("always", category=NISCOPEWarning)

--- a/generated/niscope/errors.py
+++ b/generated/niscope/errors.py
@@ -35,12 +35,12 @@ class DriverError(Error):
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
 
 
-class NISCOPEWarning(Warning):
+class DriverWarning(Warning):
     '''A warning originating from the NI-SCOPE driver'''
 
     def __init__(self, code, description):
         assert (_is_warning(code)), "Should not create Warning if code is not positive."
-        super(NISCOPEWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 
 class UnsupportedConfigurationError(Error):
@@ -95,7 +95,7 @@ def handle_error(session, code, ignore_warnings, is_error_handling):
         raise DriverError(code, description)
 
     assert _is_warning(code)
-    warnings.warn(NISCOPEWarning(code, description))
+    warnings.warn(DriverWarning(code, description))
 
 
-warnings.filterwarnings("always", category=NISCOPEWarning)
+warnings.filterwarnings("always", category=DriverWarning)

--- a/generated/niswitch/__init__.py
+++ b/generated/niswitch/__init__.py
@@ -3,6 +3,6 @@
 
 from niswitch.enums import *          # noqa: F403,F401,H303
 from niswitch.errors import Error     # noqa: F401
-from niswitch.errors import NiswitchWarning   # noqa: F401
+from niswitch.errors import NISWITCHWarning   # noqa: F401
 from niswitch.session import Session  # noqa: F401
 

--- a/generated/niswitch/__init__.py
+++ b/generated/niswitch/__init__.py
@@ -2,7 +2,7 @@
 # This file was generated
 
 from niswitch.enums import *          # noqa: F403,F401,H303
+from niswitch.errors import DriverWarning   # noqa: F401
 from niswitch.errors import Error     # noqa: F401
-from niswitch.errors import NISWITCHWarning   # noqa: F401
 from niswitch.session import Session  # noqa: F401
 

--- a/generated/niswitch/errors.py
+++ b/generated/niswitch/errors.py
@@ -35,12 +35,12 @@ class DriverError(Error):
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
 
 
-class NISWITCHWarning(Warning):
+class DriverWarning(Warning):
     '''A warning originating from the NI-SWITCH driver'''
 
     def __init__(self, code, description):
         assert (_is_warning(code)), "Should not create Warning if code is not positive."
-        super(NISWITCHWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 
 class UnsupportedConfigurationError(Error):
@@ -95,7 +95,7 @@ def handle_error(session, code, ignore_warnings, is_error_handling):
         raise DriverError(code, description)
 
     assert _is_warning(code)
-    warnings.warn(NISWITCHWarning(code, description))
+    warnings.warn(DriverWarning(code, description))
 
 
-warnings.filterwarnings("always", category=NISWITCHWarning)
+warnings.filterwarnings("always", category=DriverWarning)

--- a/generated/niswitch/errors.py
+++ b/generated/niswitch/errors.py
@@ -35,12 +35,12 @@ class DriverError(Error):
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
 
 
-class NiswitchWarning(Warning):
+class NISWITCHWarning(Warning):
     '''A warning originating from the NI-SWITCH driver'''
 
     def __init__(self, code, description):
         assert (_is_warning(code)), "Should not create Warning if code is not positive."
-        super(NiswitchWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(NISWITCHWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 
 class UnsupportedConfigurationError(Error):
@@ -95,7 +95,7 @@ def handle_error(session, code, ignore_warnings, is_error_handling):
         raise DriverError(code, description)
 
     assert _is_warning(code)
-    warnings.warn(NiswitchWarning(code, description))
+    warnings.warn(NISWITCHWarning(code, description))
 
 
-warnings.filterwarnings("always", category=NiswitchWarning)
+warnings.filterwarnings("always", category=NISWITCHWarning)

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -589,7 +589,7 @@ class TestSession(object):
             with warnings.catch_warnings(record=True) as w:
                 session.simple_function()
                 assert len(w) == 1
-                assert issubclass(w[0].category, nifake.NifakeWarning)
+                assert issubclass(w[0].category, nifake.NIFAKEWarning)
                 assert test_error_desc in str(w[0].message)
 
     def test_read_with_warning(self):
@@ -608,7 +608,7 @@ class TestSession(object):
             with warnings.catch_warnings(record=True) as w:
                 assert math.isnan(session.read(test_maximum_time))
                 assert len(w) == 1
-                assert issubclass(w[0].category, nifake.NifakeWarning)
+                assert issubclass(w[0].category, nifake.NIFAKEWarning)
                 assert test_error_desc in str(w[0].message)
 
     # Retrieving buffers and strings

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -589,7 +589,7 @@ class TestSession(object):
             with warnings.catch_warnings(record=True) as w:
                 session.simple_function()
                 assert len(w) == 1
-                assert issubclass(w[0].category, nifake.NIFAKEWarning)
+                assert issubclass(w[0].category, nifake.DriverWarning)
                 assert test_error_desc in str(w[0].message)
 
     def test_read_with_warning(self):
@@ -608,7 +608,7 @@ class TestSession(object):
             with warnings.catch_warnings(record=True) as w:
                 assert math.isnan(session.read(test_maximum_time))
                 assert len(w) == 1
-                assert issubclass(w[0].category, nifake.NIFAKEWarning)
+                assert issubclass(w[0].category, nifake.DriverWarning)
                 assert test_error_desc in str(w[0].message)
 
     # Retrieving buffers and strings

--- a/src/nimodinst/unit_tests/test_modinst.py
+++ b/src/nimodinst/unit_tests/test_modinst.py
@@ -245,7 +245,7 @@ class TestSession(object):
             with warnings.catch_warnings(record=True) as w:
                 session[0].chassis_number
                 assert len(w) == 1
-                assert issubclass(w[0].category, nimodinst.NimodinstWarning)
+                assert issubclass(w[0].category, nimodinst.NIModInstWarning)
                 assert error_string in str(w[0].message)
 
     def test_repr_and_str(self):

--- a/src/nimodinst/unit_tests/test_modinst.py
+++ b/src/nimodinst/unit_tests/test_modinst.py
@@ -245,7 +245,7 @@ class TestSession(object):
             with warnings.catch_warnings(record=True) as w:
                 session[0].chassis_number
                 assert len(w) == 1
-                assert issubclass(w[0].category, nimodinst.NIModInstWarning)
+                assert issubclass(w[0].category, nimodinst.DriverWarning)
                 assert error_string in str(w[0].message)
 
     def test_repr_and_str(self):


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- [X] I've added tests applicable for this pull request

### What does this Pull Request accomplish?
* Renamed warning class name to `<driver>.DriverWarning` for all drivers

### List issues fixed by this Pull Request below, if any.
* Fix #658 

### What testing has been done?
* Unit
* System
* Visual inspection of generated files