### PR TITLE
Fixing system test running tools

### DIFF
--- a/tools/run_python_system_tests.py
+++ b/tools/run_python_system_tests.py
@@ -1,7 +1,6 @@
 import argparse
 import json
 import os
-import pip
 import subprocess
 import sys
 import tempfile

--- a/tools/run_python_system_tests.py
+++ b/tools/run_python_system_tests.py
@@ -16,6 +16,7 @@ args = parser.parse_args()
 
 
 print('****Installing tox to Python.****')
+subprocess.check_call(["python", '-m', 'pip', 'install', '--upgrade', 'pip'])
 subprocess.check_call(["python", '-m', 'pip', 'install', '--upgrade', 'tox'])
 
 

--- a/tools/run_python_system_tests.py
+++ b/tools/run_python_system_tests.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import os
 import pip
+import subprocess
 import sys
 import tempfile
 import time
@@ -16,7 +17,7 @@ args = parser.parse_args()
 
 
 print('****Installing tox to Python.****')
-pip.main(['install', 'tox'])
+subprocess.check_call(["python", '-m', 'pip', 'install', 'tox'])
 
 
 print('****Creating temporary directory.****')

--- a/tools/run_python_system_tests.py
+++ b/tools/run_python_system_tests.py
@@ -16,7 +16,7 @@ args = parser.parse_args()
 
 
 print('****Installing tox to Python.****')
-subprocess.check_call(["python", '-m', 'pip', 'install', 'tox'])
+subprocess.check_call(["python", '-m', 'pip', 'install', '--upgrade', 'tox'])
 
 
 print('****Creating temporary directory.****')


### PR DESCRIPTION
- [x ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~

~~- [ ] I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

The system tests were failing on machines that had upgraded pip. This was because pip removed the .main function in pip 10.0. Using another method to install tox. This also upgrades pip as well.

### List issues fixed by this Pull Request below, if any.

* Fix #844 

### What testing has been done?

Ran Flake8
Ran system test before changes and verify it fails. 
Ran system test after changes and verify it worked.
