### PR TITLE
nifgen combine named and non-named waveform methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ All notable changes to this project will be documented in this file.
         * Some functions missed setting repeated capabilities, leaving these as parameters instead of using the repeated capabilites object.
             * `session.configure_digital_edge_script_trigger('ScriptTrigger0', source, ...)` becomes `session.script_triggers[0].configure_digital_edge_script_trigger(source, ...)`
             * `session.configure_digital_level_script_trigger('ScriptTrigger0', source, ...)` becomes `session.script_triggers[0].configure_digital_level_script_trigger(source, ...)`
+        * Combined named and un-named waveform methods into one [#862](https://github.com/ni/nimi-python/issues/862)
+            * `set_waveform_next_write_position()` and `set_named_waveform_next_write_position()` becomes `set_next_write_position()`
+            * `clear_arb_waveform()` and `delete_named_waveform()` becomes `delete_waveform()`
     * #### Removed
         * `export_signal()` - [#828](https://github.com/ni/nimi-python/issues/828)
         * `osp_fir_filter_interpolation` - [#864](https://github.com/ni/nimi-python/issues/864)

--- a/docs/nifgen/class.rst
+++ b/docs/nifgen/class.rst
@@ -396,8 +396,6 @@ nifgen.Session
     +-----------------------------------------------------+
     | :py:func:`clear_arb_sequence`                       |
     +-----------------------------------------------------+
-    | :py:func:`clear_arb_waveform`                       |
-    +-----------------------------------------------------+
     | :py:func:`clear_freq_list`                          |
     +-----------------------------------------------------+
     | :py:func:`clear_user_standard_waveform`             |
@@ -434,9 +432,9 @@ nifgen.Session
     +-----------------------------------------------------+
     | :py:func:`define_user_standard_waveform`            |
     +-----------------------------------------------------+
-    | :py:func:`delete_named_waveform`                    |
-    +-----------------------------------------------------+
     | :py:func:`delete_script`                            |
+    +-----------------------------------------------------+
+    | :py:func:`delete_waveform`                          |
     +-----------------------------------------------------+
     | :py:func:`disable`                                  |
     +-----------------------------------------------------+
@@ -480,9 +478,7 @@ nifgen.Session
     +-----------------------------------------------------+
     | :py:func:`send_software_edge_trigger`               |
     +-----------------------------------------------------+
-    | :py:func:`set_named_waveform_next_write_position`   |
-    +-----------------------------------------------------+
-    | :py:func:`set_waveform_next_write_position`         |
+    | :py:func:`set_next_write_position`                  |
     +-----------------------------------------------------+
     | :py:func:`unlock`                                   |
     +-----------------------------------------------------+
@@ -4302,54 +4298,6 @@ clear_arb_sequence
 
             :type sequence_handle: int
 
-clear_arb_waveform
-~~~~~~~~~~~~~~~~~~
-
-    .. py:currentmodule:: nifgen.Session
-
-    .. py:method:: clear_arb_waveform(waveform_handle)
-
-            Removes a previously created arbitrary waveform from the signal
-            generator memory and invalidates the waveform handle.
-
-            
-
-            .. note:: The signal generator must not be in the Generating state when you
-                call this method.
-
-
-
-            :param waveform_handle:
-
-
-                Specifies the handle of the arbitrary waveform that you want the signal
-                generator to remove.
-
-                You can create multiple arbitrary waveforms using one of the following
-                niFgen Create Waveform methods:
-
-                -  :py:meth:`nifgen.Session.create_waveform`
-                -  :py:meth:`nifgen.Session.create_waveform`
-                -  :py:meth:`nifgen.Session.create_waveform_from_file_i16`
-                -  :py:meth:`nifgen.Session.create_waveform_from_file_f64`
-                -  :py:meth:`nifgen.Session.CreateWaveformFromFileHWS`
-
-                **Defined Value**:
-
-                :py:data:`~nifgen.NIFGEN_VAL_ALL_WAVEFORMS`—Remove all waveforms from the signal
-                generator.
-
-                **Default Value**: None
-
-                
-
-                .. note:: One or more of the referenced methods are not in the Python API for this driver.
-
-                .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
-
-
-            :type waveform_handle: int
-
 clear_freq_list
 ~~~~~~~~~~~~~~~
 
@@ -5765,42 +5713,6 @@ define_user_standard_waveform
 
             :type waveform_data_array: list of float
 
-delete_named_waveform
-~~~~~~~~~~~~~~~~~~~~~
-
-    .. py:currentmodule:: nifgen.Session
-
-    .. py:method:: delete_named_waveform(waveform_name)
-
-            Removes a previously created arbitrary waveform from the signal
-            generator memory and invalidates the waveform handle.
-
-            
-
-            .. note:: The signal generator must not be in the Generating state when you call
-                this method.
-
-
-            .. tip:: This method requires repeated capabilities (usually channels). If called directly on the
-                nifgen.Session object, then the method will use all repeated capabilities in the session.
-                You can specify a subset of repeated capabilities using the Python index notation on an
-                nifgen.Session instance, and calling this method on the result.:
-
-                .. code:: python
-
-                    session.channels['0,1'].delete_named_waveform(waveform_name)
-
-
-            :param waveform_name:
-
-
-                Specifies the name to associate with the allocated waveform.
-
-                
-
-
-            :type waveform_name: str
-
 delete_script
 ~~~~~~~~~~~~~
 
@@ -5833,6 +5745,40 @@ delete_script
 
 
             :type script_name: str
+
+delete_waveform
+~~~~~~~~~~~~~~~
+
+    .. py:currentmodule:: nifgen.Session
+
+    .. py:method:: delete_waveform(waveform_name_or_handle)
+
+            Removes a previously created arbitrary waveform from the signal generator memory and invalidates the waveform handle.
+
+            
+
+            .. note:: The signal generator must not be in the Generating state when you call this method.
+
+
+            .. tip:: This method requires repeated capabilities (usually channels). If called directly on the
+                nifgen.Session object, then the method will use all repeated capabilities in the session.
+                You can specify a subset of repeated capabilities using the Python index notation on an
+                nifgen.Session instance, and calling this method on the result.:
+
+                .. code:: python
+
+                    session.channels['0,1'].delete_waveform(waveform_name_or_handle)
+
+
+            :param waveform_name_or_handle:
+
+
+                The name (str) or handle (int) of an arbitrary waveform previously allocated with :py:meth:`nifgen.Session.allocate_named_waveform` or :py:meth:`nifgen.Session.allocate_waveform`.
+
+                
+
+
+            :type waveform_name_or_handle: str or int
 
 disable
 ~~~~~~~
@@ -6546,84 +6492,12 @@ send_software_edge_trigger
 
             :type trigger_id: str
 
-set_named_waveform_next_write_position
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+set_next_write_position
+~~~~~~~~~~~~~~~~~~~~~~~
 
     .. py:currentmodule:: nifgen.Session
 
-    .. py:method:: set_named_waveform_next_write_position(waveform_name, relative_to, offset)
-
-            Sets the position in the waveform to which data is written at the next
-            write. This method allows you to write to arbitrary locations within
-            the waveform. These settings apply only to the next write to the
-            waveform specified by the **waveformHandle** parameter. Subsequent
-            writes to that waveform begin where the last write left off, unless this
-            method is called again. The **waveformHandle** passed in must have
-            been created with a call to one of the following methods:
-
-            -  nifgen_AllocateWaveform
-            -  nifgen_CreateWaveformF64
-            -  nifgen_CreateWaveformI16
-            -  nifgen_CreateWaveformFromFileI16
-            -  nifgen_CreateWaveformFromFileF64
-            -  nifgen_CreateWaveformFromFileHWS
-
-            
-
-
-            .. tip:: This method requires repeated capabilities (usually channels). If called directly on the
-                nifgen.Session object, then the method will use all repeated capabilities in the session.
-                You can specify a subset of repeated capabilities using the Python index notation on an
-                nifgen.Session instance, and calling this method on the result.:
-
-                .. code:: python
-
-                    session.channels['0,1'].set_named_waveform_next_write_position(waveform_name, relative_to, offset)
-
-
-            :param waveform_name:
-
-
-                Specifies the name to associate with the allocated waveform.
-
-                
-
-
-            :type waveform_name: str
-            :param relative_to:
-
-
-                Specifies the reference position in the waveform. This position and
-                **offset** together determine where to start loading data into the
-                waveform.
-
-                ****Defined Values****
-
-                +-------------------------------------------+-------------------------------------------------------------------------+
-                | :py:data:`~nifgen.RelativeTo.START` (0)   | Use the start of the waveform as the reference position.                |
-                +-------------------------------------------+-------------------------------------------------------------------------+
-                | :py:data:`~nifgen.RelativeTo.CURRENT` (1) | Use the current position within the waveform as the reference position. |
-                +-------------------------------------------+-------------------------------------------------------------------------+
-
-
-            :type relative_to: :py:data:`nifgen.RelativeTo`
-            :param offset:
-
-
-                Specifies the offset from the **relativeTo** parameter at which to start
-                loading the data into the waveform.
-
-                
-
-
-            :type offset: int
-
-set_waveform_next_write_position
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-    .. py:currentmodule:: nifgen.Session
-
-    .. py:method:: set_waveform_next_write_position(waveform_handle, relative_to, offset)
+    .. py:method:: set_next_write_position(waveform_name_or_handle, relative_to, offset)
 
             Sets the position in the waveform at which the next waveform data is
             written. This method allows you to write to arbitrary locations within
@@ -6634,11 +6508,10 @@ set_waveform_next_write_position
             a call to the nifgen_AllocateWaveform method or one of the following
             niFgen CreateWaveform methods:
 
-            -  nifgen_CreateWaveformF64
-            -  nifgen_CreateWaveformI16
-            -  nifgen_CreateWaveformFromFileI16
-            -  nifgen_CreateWaveformFromFileF64
-            -  nifgen_CreateWaveformFromFileHWS
+            -  :py:meth:`nifgen.Session.create_waveform`
+            -  :py:meth:`nifgen.Session.create_waveform`
+            -  :py:meth:`nifgen.Session.create_waveform_from_file_i16`
+            -  :py:meth:`nifgen.Session.create_waveform_from_file_f64`
 
             
 
@@ -6650,19 +6523,18 @@ set_waveform_next_write_position
 
                 .. code:: python
 
-                    session.channels['0,1'].set_waveform_next_write_position(waveform_handle, relative_to, offset)
+                    session.channels['0,1'].set_next_write_position(waveform_name_or_handle, relative_to, offset)
 
 
-            :param waveform_handle:
+            :param waveform_name_or_handle:
 
 
-                Specifies the handle of the arbitrary waveform previously allocated with
-                the nifgen_AllocateWaveform method.
+                The name (str) or handle (int) of an arbitrary waveform previously allocated with :py:meth:`nifgen.Session.allocate_named_waveform` or :py:meth:`nifgen.Session.allocate_waveform`.
 
                 
 
 
-            :type waveform_handle: int
+            :type waveform_name_or_handle: str or int
             :param relative_to:
 
 
@@ -6799,7 +6671,7 @@ write_waveform
                 
 
 
-            :type waveform_name_or_handle: int
+            :type waveform_name_or_handle: str or int
             :param data:
 
 
@@ -7075,8 +6947,6 @@ Methods
 +--------------------------------------------------------------------+
 | :py:func:`nifgen.Session.clear_arb_sequence`                       |
 +--------------------------------------------------------------------+
-| :py:func:`nifgen.Session.clear_arb_waveform`                       |
-+--------------------------------------------------------------------+
 | :py:func:`nifgen.Session.clear_freq_list`                          |
 +--------------------------------------------------------------------+
 | :py:func:`nifgen.Session.clear_user_standard_waveform`             |
@@ -7113,9 +6983,9 @@ Methods
 +--------------------------------------------------------------------+
 | :py:func:`nifgen.Session.define_user_standard_waveform`            |
 +--------------------------------------------------------------------+
-| :py:func:`nifgen.Session.delete_named_waveform`                    |
-+--------------------------------------------------------------------+
 | :py:func:`nifgen.Session.delete_script`                            |
++--------------------------------------------------------------------+
+| :py:func:`nifgen.Session.delete_waveform`                          |
 +--------------------------------------------------------------------+
 | :py:func:`nifgen.Session.disable`                                  |
 +--------------------------------------------------------------------+
@@ -7159,9 +7029,7 @@ Methods
 +--------------------------------------------------------------------+
 | :py:func:`nifgen.Session.send_software_edge_trigger`               |
 +--------------------------------------------------------------------+
-| :py:func:`nifgen.Session.set_named_waveform_next_write_position`   |
-+--------------------------------------------------------------------+
-| :py:func:`nifgen.Session.set_waveform_next_write_position`         |
+| :py:func:`nifgen.Session.set_next_write_position`                  |
 +--------------------------------------------------------------------+
 | :py:func:`nifgen.Session.unlock`                                   |
 +--------------------------------------------------------------------+

--- a/docs/nifgen/class.rst
+++ b/docs/nifgen/class.rst
@@ -5753,7 +5753,7 @@ delete_waveform
 
     .. py:method:: delete_waveform(waveform_name_or_handle)
 
-            Removes a previously created arbitrary waveform from the signal generator memory and invalidates the waveform handle.
+            Removes a previously created arbitrary waveform from the signal generator memory.
 
             
 
@@ -5773,7 +5773,7 @@ delete_waveform
             :param waveform_name_or_handle:
 
 
-                The name (str) or handle (int) of an arbitrary waveform previously allocated with :py:meth:`nifgen.Session.allocate_named_waveform` or :py:meth:`nifgen.Session.allocate_waveform`.
+                The name (str) or handle (int) of an arbitrary waveform previously allocated with :py:meth:`nifgen.Session.allocate_named_waveform`, :py:meth:`nifgen.Session.allocate_waveform` or :py:meth:`nifgen.Session.create_waveform`.
 
                 
 
@@ -6506,12 +6506,7 @@ set_next_write_position
             that waveform begin where the last write left off, unless this method
             is called again. The waveformHandle passed in must have been created by
             a call to the nifgen_AllocateWaveform method or one of the following
-            niFgen CreateWaveform methods:
-
-            -  :py:meth:`nifgen.Session.create_waveform`
-            -  :py:meth:`nifgen.Session.create_waveform`
-            -  :py:meth:`nifgen.Session.create_waveform_from_file_i16`
-            -  :py:meth:`nifgen.Session.create_waveform_from_file_f64`
+            :py:meth:`nifgen.Session.create_waveform` method.
 
             
 
@@ -6529,7 +6524,7 @@ set_next_write_position
             :param waveform_name_or_handle:
 
 
-                The name (str) or handle (int) of an arbitrary waveform previously allocated with :py:meth:`nifgen.Session.allocate_named_waveform` or :py:meth:`nifgen.Session.allocate_waveform`.
+                The name (str) or handle (int) of an arbitrary waveform previously allocated with :py:meth:`nifgen.Session.allocate_named_waveform`, :py:meth:`nifgen.Session.allocate_waveform` or :py:meth:`nifgen.Session.create_waveform`.
 
                 
 
@@ -6666,7 +6661,7 @@ write_waveform
             :param waveform_name_or_handle:
 
 
-                The name (str) or handle (int) of an arbitrary waveform previously allocated with :py:meth:`nifgen.Session.allocate_named_waveform` or :py:meth:`nifgen.Session.allocate_waveform`.
+                The name (str) or handle (int) of an arbitrary waveform previously allocated with :py:meth:`nifgen.Session.allocate_named_waveform`, :py:meth:`nifgen.Session.allocate_waveform` or :py:meth:`nifgen.Session.create_waveform`.
 
                 
 

--- a/generated/nifgen/_library.py
+++ b/generated/nifgen/_library.py
@@ -44,6 +44,7 @@ class Library(object):
         self.niFgen_DefineUserStandardWaveform_cfunc = None
         self.niFgen_DeleteNamedWaveform_cfunc = None
         self.niFgen_DeleteScript_cfunc = None
+        self.niFgen_DeleteWaveformDispatch_cfunc = None
         self.niFgen_Disable_cfunc = None
         self.niFgen_GetAttributeViBoolean_cfunc = None
         self.niFgen_GetAttributeViInt32_cfunc = None
@@ -77,6 +78,7 @@ class Library(object):
         self.niFgen_SetAttributeViReal64_cfunc = None
         self.niFgen_SetAttributeViString_cfunc = None
         self.niFgen_SetNamedWaveformNextWritePosition_cfunc = None
+        self.niFgen_SetNextWritePositionDispatcher_cfunc = None
         self.niFgen_SetWaveformNextWritePosition_cfunc = None
         self.niFgen_UnlockSession_cfunc = None
         self.niFgen_WaitUntilDone_cfunc = None
@@ -306,6 +308,14 @@ class Library(object):
                 self.niFgen_DeleteScript_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_DeleteScript_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_DeleteScript_cfunc(vi, channel_name, script_name)
+
+    def niFgen_DeleteWaveformDispatch(self, vi, channel_name, waveform_name_or_handle):  # noqa: N802
+        with self._func_lock:
+            if self.niFgen_DeleteWaveformDispatch_cfunc is None:
+                self.niFgen_DeleteWaveformDispatch_cfunc = self._library.niFgen_DeleteWaveformDispatch
+                self.niFgen_DeleteWaveformDispatch_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
+                self.niFgen_DeleteWaveformDispatch_cfunc.restype = ViStatus  # noqa: F405
+        return self.niFgen_DeleteWaveformDispatch_cfunc(vi, channel_name, waveform_name_or_handle)
 
     def niFgen_Disable(self, vi):  # noqa: N802
         with self._func_lock:
@@ -570,6 +580,14 @@ class Library(object):
                 self.niFgen_SetNamedWaveformNextWritePosition_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViInt32]  # noqa: F405
                 self.niFgen_SetNamedWaveformNextWritePosition_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SetNamedWaveformNextWritePosition_cfunc(vi, channel_name, waveform_name, relative_to, offset)
+
+    def niFgen_SetNextWritePositionDispatcher(self, vi, channel_name, waveform_name_or_handle, relative_to, offset):  # noqa: N802
+        with self._func_lock:
+            if self.niFgen_SetNextWritePositionDispatcher_cfunc is None:
+                self.niFgen_SetNextWritePositionDispatcher_cfunc = self._library.niFgen_SetNextWritePositionDispatcher
+                self.niFgen_SetNextWritePositionDispatcher_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViInt32, ViInt32]  # noqa: F405
+                self.niFgen_SetNextWritePositionDispatcher_cfunc.restype = ViStatus  # noqa: F405
+        return self.niFgen_SetNextWritePositionDispatcher_cfunc(vi, channel_name, waveform_name_or_handle, relative_to, offset)
 
     def niFgen_SetWaveformNextWritePosition(self, vi, channel_name, waveform_handle, relative_to, offset):  # noqa: N802
         with self._func_lock:

--- a/generated/nifgen/_library.py
+++ b/generated/nifgen/_library.py
@@ -44,7 +44,6 @@ class Library(object):
         self.niFgen_DefineUserStandardWaveform_cfunc = None
         self.niFgen_DeleteNamedWaveform_cfunc = None
         self.niFgen_DeleteScript_cfunc = None
-        self.niFgen_DeleteWaveformDispatch_cfunc = None
         self.niFgen_Disable_cfunc = None
         self.niFgen_GetAttributeViBoolean_cfunc = None
         self.niFgen_GetAttributeViInt32_cfunc = None
@@ -78,7 +77,6 @@ class Library(object):
         self.niFgen_SetAttributeViReal64_cfunc = None
         self.niFgen_SetAttributeViString_cfunc = None
         self.niFgen_SetNamedWaveformNextWritePosition_cfunc = None
-        self.niFgen_SetNextWritePositionDispatcher_cfunc = None
         self.niFgen_SetWaveformNextWritePosition_cfunc = None
         self.niFgen_UnlockSession_cfunc = None
         self.niFgen_WaitUntilDone_cfunc = None
@@ -87,7 +85,6 @@ class Library(object):
         self.niFgen_WriteNamedWaveformI16_cfunc = None
         self.niFgen_WriteScript_cfunc = None
         self.niFgen_WriteWaveform_cfunc = None
-        self.niFgen_WriteWaveformDispatcher_cfunc = None
         self.niFgen_close_cfunc = None
         self.niFgen_error_message_cfunc = None
         self.niFgen_reset_cfunc = None
@@ -308,14 +305,6 @@ class Library(object):
                 self.niFgen_DeleteScript_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_DeleteScript_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_DeleteScript_cfunc(vi, channel_name, script_name)
-
-    def niFgen_DeleteWaveformDispatch(self, vi, channel_name, waveform_name_or_handle):  # noqa: N802
-        with self._func_lock:
-            if self.niFgen_DeleteWaveformDispatch_cfunc is None:
-                self.niFgen_DeleteWaveformDispatch_cfunc = self._library.niFgen_DeleteWaveformDispatch
-                self.niFgen_DeleteWaveformDispatch_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
-                self.niFgen_DeleteWaveformDispatch_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFgen_DeleteWaveformDispatch_cfunc(vi, channel_name, waveform_name_or_handle)
 
     def niFgen_Disable(self, vi):  # noqa: N802
         with self._func_lock:
@@ -581,14 +570,6 @@ class Library(object):
                 self.niFgen_SetNamedWaveformNextWritePosition_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SetNamedWaveformNextWritePosition_cfunc(vi, channel_name, waveform_name, relative_to, offset)
 
-    def niFgen_SetNextWritePositionDispatcher(self, vi, channel_name, waveform_name_or_handle, relative_to, offset):  # noqa: N802
-        with self._func_lock:
-            if self.niFgen_SetNextWritePositionDispatcher_cfunc is None:
-                self.niFgen_SetNextWritePositionDispatcher_cfunc = self._library.niFgen_SetNextWritePositionDispatcher
-                self.niFgen_SetNextWritePositionDispatcher_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViInt32, ViInt32]  # noqa: F405
-                self.niFgen_SetNextWritePositionDispatcher_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFgen_SetNextWritePositionDispatcher_cfunc(vi, channel_name, waveform_name_or_handle, relative_to, offset)
-
     def niFgen_SetWaveformNextWritePosition(self, vi, channel_name, waveform_handle, relative_to, offset):  # noqa: N802
         with self._func_lock:
             if self.niFgen_SetWaveformNextWritePosition_cfunc is None:
@@ -652,14 +633,6 @@ class Library(object):
                 self.niFgen_WriteWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_WriteWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_WriteWaveform_cfunc(vi, channel_name, waveform_handle, size, data)
-
-    def niFgen_WriteWaveformDispatcher(self, vi, channel_name, waveform_name_or_handle, size, data):  # noqa: N802
-        with self._func_lock:
-            if self.niFgen_WriteWaveformDispatcher_cfunc is None:
-                self.niFgen_WriteWaveformDispatcher_cfunc = self._library.niFgen_WriteWaveformDispatcher
-                self.niFgen_WriteWaveformDispatcher_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
-                self.niFgen_WriteWaveformDispatcher_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFgen_WriteWaveformDispatcher_cfunc(vi, channel_name, waveform_name_or_handle, size, data)
 
     def niFgen_close(self, vi):  # noqa: N802
         with self._func_lock:

--- a/generated/nifgen/session.py
+++ b/generated/nifgen/session.py
@@ -1973,7 +1973,7 @@ class _SessionBase(object):
     def delete_waveform(self, waveform_name_or_handle):
         '''delete_waveform
 
-        Removes a previously created arbitrary waveform from the signal generator memory and invalidates the waveform handle.
+        Removes a previously created arbitrary waveform from the signal generator memory.
 
         Note: The signal generator must not be in the Generating state when you call this method.
 
@@ -1986,7 +1986,7 @@ class _SessionBase(object):
             session.channels['0,1'].delete_waveform(waveform_name_or_handle)
 
         Args:
-            waveform_name_or_handle (str or int): The name (str) or handle (int) of an arbitrary waveform previously allocated with allocate_named_waveform or allocate_waveform.
+            waveform_name_or_handle (str or int): The name (str) or handle (int) of an arbitrary waveform previously allocated with allocate_named_waveform, allocate_waveform or create_waveform.
 
         '''
         if isinstance(waveform_name_or_handle, str):
@@ -2601,12 +2601,7 @@ class _SessionBase(object):
         that waveform begin where the last write left off, unless this method
         is called again. The waveformHandle passed in must have been created by
         a call to the nifgen_AllocateWaveform method or one of the following
-        niFgen CreateWaveform methods:
-
-        -  create_waveform
-        -  create_waveform
-        -  create_waveform_from_file_i16
-        -  create_waveform_from_file_f64
+        create_waveform method.
 
         Tip:
         This method requires repeated capabilities (usually channels). If called directly on the
@@ -2617,7 +2612,7 @@ class _SessionBase(object):
             session.channels['0,1'].set_next_write_position(waveform_name_or_handle, relative_to, offset)
 
         Args:
-            waveform_name_or_handle (str or int): The name (str) or handle (int) of an arbitrary waveform previously allocated with allocate_named_waveform or allocate_waveform.
+            waveform_name_or_handle (str or int): The name (str) or handle (int) of an arbitrary waveform previously allocated with allocate_named_waveform, allocate_waveform or create_waveform.
 
             relative_to (enums.RelativeTo): Specifies the reference position in the waveform. This position and
                 **offset** together determine where to start loading data into the
@@ -3069,7 +3064,7 @@ class _SessionBase(object):
             session.channels['0,1'].write_waveform(waveform_name_or_handle, data)
 
         Args:
-            waveform_name_or_handle (str or int): The name (str) or handle (int) of an arbitrary waveform previously allocated with allocate_named_waveform or allocate_waveform.
+            waveform_name_or_handle (str or int): The name (str) or handle (int) of an arbitrary waveform previously allocated with allocate_named_waveform, allocate_waveform or create_waveform.
 
             data (list of float): Array of data to load into the waveform. This may be an iterable of float, or for best performance a numpy.ndarray of dtype int16 or float64.
 

--- a/generated/nifgen/session.py
+++ b/generated/nifgen/session.py
@@ -1914,8 +1914,8 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def delete_named_waveform(self, waveform_name):
-        '''delete_named_waveform
+    def _delete_named_waveform(self, waveform_name):
+        '''_delete_named_waveform
 
         Removes a previously created arbitrary waveform from the signal
         generator memory and invalidates the waveform handle.
@@ -1930,7 +1930,7 @@ class _SessionBase(object):
         You can specify a subset of repeated capabilities using the Python index notation on an
         nifgen.Session instance, and calling this method on the result.:
 
-            session.channels['0,1'].delete_named_waveform(waveform_name)
+            session.channels['0,1']._delete_named_waveform(waveform_name)
 
         Args:
             waveform_name (str): Specifies the name to associate with the allocated waveform.
@@ -1968,6 +1968,31 @@ class _SessionBase(object):
         error_code = self._library.niFgen_DeleteScript(vi_ctype, channel_name_ctype, script_name_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
+
+    @ivi_synchronized
+    def delete_waveform(self, waveform_name_or_handle):
+        '''delete_waveform
+
+        Removes a previously created arbitrary waveform from the signal generator memory and invalidates the waveform handle.
+
+        Note: The signal generator must not be in the Generating state when you call this method.
+
+        Tip:
+        This method requires repeated capabilities (usually channels). If called directly on the
+        nifgen.Session object, then the method will use all repeated capabilities in the session.
+        You can specify a subset of repeated capabilities using the Python index notation on an
+        nifgen.Session instance, and calling this method on the result.:
+
+            session.channels['0,1'].delete_waveform(waveform_name_or_handle)
+
+        Args:
+            waveform_name_or_handle (str or int): The name (str) or handle (int) of an arbitrary waveform previously allocated with allocate_named_waveform or allocate_waveform.
+
+        '''
+        if isinstance(waveform_name_or_handle, str):
+            return self._delete_named_waveform(waveform_name_or_handle)
+        else:
+            return self._clear_arb_waveform(waveform_name_or_handle)
 
     @ivi_synchronized
     def _get_attribute_vi_boolean(self, attribute_id):
@@ -2509,8 +2534,8 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def set_named_waveform_next_write_position(self, waveform_name, relative_to, offset):
-        '''set_named_waveform_next_write_position
+    def _set_named_waveform_next_write_position(self, waveform_name, relative_to, offset):
+        '''_set_named_waveform_next_write_position
 
         Sets the position in the waveform to which data is written at the next
         write. This method allows you to write to arbitrary locations within
@@ -2533,7 +2558,7 @@ class _SessionBase(object):
         You can specify a subset of repeated capabilities using the Python index notation on an
         nifgen.Session instance, and calling this method on the result.:
 
-            session.channels['0,1'].set_named_waveform_next_write_position(waveform_name, relative_to, offset)
+            session.channels['0,1']._set_named_waveform_next_write_position(waveform_name, relative_to, offset)
 
         Args:
             waveform_name (str): Specifies the name to associate with the allocated waveform.
@@ -2566,8 +2591,58 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def set_waveform_next_write_position(self, waveform_handle, relative_to, offset):
-        '''set_waveform_next_write_position
+    def set_next_write_position(self, waveform_name_or_handle, relative_to, offset):
+        '''set_next_write_position
+
+        Sets the position in the waveform at which the next waveform data is
+        written. This method allows you to write to arbitrary locations within
+        the waveform. These settings apply only to the next write to the
+        waveform specified by the waveformHandle parameter. Subsequent writes to
+        that waveform begin where the last write left off, unless this method
+        is called again. The waveformHandle passed in must have been created by
+        a call to the nifgen_AllocateWaveform method or one of the following
+        niFgen CreateWaveform methods:
+
+        -  create_waveform
+        -  create_waveform
+        -  create_waveform_from_file_i16
+        -  create_waveform_from_file_f64
+
+        Tip:
+        This method requires repeated capabilities (usually channels). If called directly on the
+        nifgen.Session object, then the method will use all repeated capabilities in the session.
+        You can specify a subset of repeated capabilities using the Python index notation on an
+        nifgen.Session instance, and calling this method on the result.:
+
+            session.channels['0,1'].set_next_write_position(waveform_name_or_handle, relative_to, offset)
+
+        Args:
+            waveform_name_or_handle (str or int): The name (str) or handle (int) of an arbitrary waveform previously allocated with allocate_named_waveform or allocate_waveform.
+
+            relative_to (enums.RelativeTo): Specifies the reference position in the waveform. This position and
+                **offset** together determine where to start loading data into the
+                waveform.
+
+                ****Defined Values****
+
+                +------------------------+-------------------------------------------------------------------------+
+                | RelativeTo.START (0)   | Use the start of the waveform as the reference position.                |
+                +------------------------+-------------------------------------------------------------------------+
+                | RelativeTo.CURRENT (1) | Use the current position within the waveform as the reference position. |
+                +------------------------+-------------------------------------------------------------------------+
+
+            offset (int): Specifies the offset from **relativeTo** at which to start loading the
+                data into the waveform.
+
+        '''
+        if isinstance(waveform_name_or_handle, str):
+            return self._set_named_waveform_next_write_position(waveform_name_or_handle, relative_to, offset)
+        else:
+            return self._set_waveform_next_write_position(waveform_name_or_handle, relative_to, offset)
+
+    @ivi_synchronized
+    def _set_waveform_next_write_position(self, waveform_handle, relative_to, offset):
+        '''_set_waveform_next_write_position
 
         Sets the position in the waveform at which the next waveform data is
         written. This method allows you to write to arbitrary locations within
@@ -2590,7 +2665,7 @@ class _SessionBase(object):
         You can specify a subset of repeated capabilities using the Python index notation on an
         nifgen.Session instance, and calling this method on the result.:
 
-            session.channels['0,1'].set_waveform_next_write_position(waveform_handle, relative_to, offset)
+            session.channels['0,1']._set_waveform_next_write_position(waveform_handle, relative_to, offset)
 
         Args:
             waveform_handle (int): Specifies the handle of the arbitrary waveform previously allocated with
@@ -2994,7 +3069,7 @@ class _SessionBase(object):
             session.channels['0,1'].write_waveform(waveform_name_or_handle, data)
 
         Args:
-            waveform_name_or_handle (int): The name (str) or handle (int) of an arbitrary waveform previously allocated with allocate_named_waveform or allocate_waveform.
+            waveform_name_or_handle (str or int): The name (str) or handle (int) of an arbitrary waveform previously allocated with allocate_named_waveform or allocate_waveform.
 
             data (list of float): Array of data to load into the waveform. This may be an iterable of float, or for best performance a numpy.ndarray of dtype int16 or float64.
 
@@ -3266,8 +3341,8 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def clear_arb_waveform(self, waveform_handle):
-        '''clear_arb_waveform
+    def _clear_arb_waveform(self, waveform_handle):
+        '''_clear_arb_waveform
 
         Removes a previously created arbitrary waveform from the signal
         generator memory and invalidates the waveform handle.

--- a/generated/nifgen/unit_tests/_mock_helper.py
+++ b/generated/nifgen/unit_tests/_mock_helper.py
@@ -78,8 +78,6 @@ class SideEffectsHelper(object):
         self._defaults['DeleteNamedWaveform']['return'] = 0
         self._defaults['DeleteScript'] = {}
         self._defaults['DeleteScript']['return'] = 0
-        self._defaults['DeleteWaveformDispatch'] = {}
-        self._defaults['DeleteWaveformDispatch']['return'] = 0
         self._defaults['Disable'] = {}
         self._defaults['Disable']['return'] = 0
         self._defaults['GetAttributeViBoolean'] = {}
@@ -189,8 +187,6 @@ class SideEffectsHelper(object):
         self._defaults['SetAttributeViString']['return'] = 0
         self._defaults['SetNamedWaveformNextWritePosition'] = {}
         self._defaults['SetNamedWaveformNextWritePosition']['return'] = 0
-        self._defaults['SetNextWritePositionDispatcher'] = {}
-        self._defaults['SetNextWritePositionDispatcher']['return'] = 0
         self._defaults['SetWaveformNextWritePosition'] = {}
         self._defaults['SetWaveformNextWritePosition']['return'] = 0
         self._defaults['UnlockSession'] = {}
@@ -208,8 +204,6 @@ class SideEffectsHelper(object):
         self._defaults['WriteScript']['return'] = 0
         self._defaults['WriteWaveform'] = {}
         self._defaults['WriteWaveform']['return'] = 0
-        self._defaults['WriteWaveformDispatcher'] = {}
-        self._defaults['WriteWaveformDispatcher']['return'] = 0
         self._defaults['close'] = {}
         self._defaults['close']['return'] = 0
         self._defaults['error_message'] = {}
@@ -413,11 +407,6 @@ class SideEffectsHelper(object):
         if self._defaults['DeleteScript']['return'] != 0:
             return self._defaults['DeleteScript']['return']
         return self._defaults['DeleteScript']['return']
-
-    def niFgen_DeleteWaveformDispatch(self, vi, channel_name, waveform_name_or_handle):  # noqa: N802
-        if self._defaults['DeleteWaveformDispatch']['return'] != 0:
-            return self._defaults['DeleteWaveformDispatch']['return']
-        return self._defaults['DeleteWaveformDispatch']['return']
 
     def niFgen_Disable(self, vi):  # noqa: N802
         if self._defaults['Disable']['return'] != 0:
@@ -804,11 +793,6 @@ class SideEffectsHelper(object):
             return self._defaults['SetNamedWaveformNextWritePosition']['return']
         return self._defaults['SetNamedWaveformNextWritePosition']['return']
 
-    def niFgen_SetNextWritePositionDispatcher(self, vi, channel_name, waveform_name_or_handle, relative_to, offset):  # noqa: N802
-        if self._defaults['SetNextWritePositionDispatcher']['return'] != 0:
-            return self._defaults['SetNextWritePositionDispatcher']['return']
-        return self._defaults['SetNextWritePositionDispatcher']['return']
-
     def niFgen_SetWaveformNextWritePosition(self, vi, channel_name, waveform_handle, relative_to, offset):  # noqa: N802
         if self._defaults['SetWaveformNextWritePosition']['return'] != 0:
             return self._defaults['SetWaveformNextWritePosition']['return']
@@ -853,11 +837,6 @@ class SideEffectsHelper(object):
         if self._defaults['WriteWaveform']['return'] != 0:
             return self._defaults['WriteWaveform']['return']
         return self._defaults['WriteWaveform']['return']
-
-    def niFgen_WriteWaveformDispatcher(self, vi, channel_name, waveform_name_or_handle, size, data):  # noqa: N802
-        if self._defaults['WriteWaveformDispatcher']['return'] != 0:
-            return self._defaults['WriteWaveformDispatcher']['return']
-        return self._defaults['WriteWaveformDispatcher']['return']
 
     def niFgen_close(self, vi):  # noqa: N802
         if self._defaults['close']['return'] != 0:
@@ -958,8 +937,6 @@ class SideEffectsHelper(object):
         mock_library.niFgen_DeleteNamedWaveform.return_value = 0
         mock_library.niFgen_DeleteScript.side_effect = MockFunctionCallError("niFgen_DeleteScript")
         mock_library.niFgen_DeleteScript.return_value = 0
-        mock_library.niFgen_DeleteWaveformDispatch.side_effect = MockFunctionCallError("niFgen_DeleteWaveformDispatch")
-        mock_library.niFgen_DeleteWaveformDispatch.return_value = 0
         mock_library.niFgen_Disable.side_effect = MockFunctionCallError("niFgen_Disable")
         mock_library.niFgen_Disable.return_value = 0
         mock_library.niFgen_GetAttributeViBoolean.side_effect = MockFunctionCallError("niFgen_GetAttributeViBoolean")
@@ -1026,8 +1003,6 @@ class SideEffectsHelper(object):
         mock_library.niFgen_SetAttributeViString.return_value = 0
         mock_library.niFgen_SetNamedWaveformNextWritePosition.side_effect = MockFunctionCallError("niFgen_SetNamedWaveformNextWritePosition")
         mock_library.niFgen_SetNamedWaveformNextWritePosition.return_value = 0
-        mock_library.niFgen_SetNextWritePositionDispatcher.side_effect = MockFunctionCallError("niFgen_SetNextWritePositionDispatcher")
-        mock_library.niFgen_SetNextWritePositionDispatcher.return_value = 0
         mock_library.niFgen_SetWaveformNextWritePosition.side_effect = MockFunctionCallError("niFgen_SetWaveformNextWritePosition")
         mock_library.niFgen_SetWaveformNextWritePosition.return_value = 0
         mock_library.niFgen_UnlockSession.side_effect = MockFunctionCallError("niFgen_UnlockSession")
@@ -1044,8 +1019,6 @@ class SideEffectsHelper(object):
         mock_library.niFgen_WriteScript.return_value = 0
         mock_library.niFgen_WriteWaveform.side_effect = MockFunctionCallError("niFgen_WriteWaveform")
         mock_library.niFgen_WriteWaveform.return_value = 0
-        mock_library.niFgen_WriteWaveformDispatcher.side_effect = MockFunctionCallError("niFgen_WriteWaveformDispatcher")
-        mock_library.niFgen_WriteWaveformDispatcher.return_value = 0
         mock_library.niFgen_close.side_effect = MockFunctionCallError("niFgen_close")
         mock_library.niFgen_close.return_value = 0
         mock_library.niFgen_error_message.side_effect = MockFunctionCallError("niFgen_error_message")

--- a/generated/nifgen/unit_tests/_mock_helper.py
+++ b/generated/nifgen/unit_tests/_mock_helper.py
@@ -78,6 +78,8 @@ class SideEffectsHelper(object):
         self._defaults['DeleteNamedWaveform']['return'] = 0
         self._defaults['DeleteScript'] = {}
         self._defaults['DeleteScript']['return'] = 0
+        self._defaults['DeleteWaveformDispatch'] = {}
+        self._defaults['DeleteWaveformDispatch']['return'] = 0
         self._defaults['Disable'] = {}
         self._defaults['Disable']['return'] = 0
         self._defaults['GetAttributeViBoolean'] = {}
@@ -187,6 +189,8 @@ class SideEffectsHelper(object):
         self._defaults['SetAttributeViString']['return'] = 0
         self._defaults['SetNamedWaveformNextWritePosition'] = {}
         self._defaults['SetNamedWaveformNextWritePosition']['return'] = 0
+        self._defaults['SetNextWritePositionDispatcher'] = {}
+        self._defaults['SetNextWritePositionDispatcher']['return'] = 0
         self._defaults['SetWaveformNextWritePosition'] = {}
         self._defaults['SetWaveformNextWritePosition']['return'] = 0
         self._defaults['UnlockSession'] = {}
@@ -409,6 +413,11 @@ class SideEffectsHelper(object):
         if self._defaults['DeleteScript']['return'] != 0:
             return self._defaults['DeleteScript']['return']
         return self._defaults['DeleteScript']['return']
+
+    def niFgen_DeleteWaveformDispatch(self, vi, channel_name, waveform_name_or_handle):  # noqa: N802
+        if self._defaults['DeleteWaveformDispatch']['return'] != 0:
+            return self._defaults['DeleteWaveformDispatch']['return']
+        return self._defaults['DeleteWaveformDispatch']['return']
 
     def niFgen_Disable(self, vi):  # noqa: N802
         if self._defaults['Disable']['return'] != 0:
@@ -795,6 +804,11 @@ class SideEffectsHelper(object):
             return self._defaults['SetNamedWaveformNextWritePosition']['return']
         return self._defaults['SetNamedWaveformNextWritePosition']['return']
 
+    def niFgen_SetNextWritePositionDispatcher(self, vi, channel_name, waveform_name_or_handle, relative_to, offset):  # noqa: N802
+        if self._defaults['SetNextWritePositionDispatcher']['return'] != 0:
+            return self._defaults['SetNextWritePositionDispatcher']['return']
+        return self._defaults['SetNextWritePositionDispatcher']['return']
+
     def niFgen_SetWaveformNextWritePosition(self, vi, channel_name, waveform_handle, relative_to, offset):  # noqa: N802
         if self._defaults['SetWaveformNextWritePosition']['return'] != 0:
             return self._defaults['SetWaveformNextWritePosition']['return']
@@ -944,6 +958,8 @@ class SideEffectsHelper(object):
         mock_library.niFgen_DeleteNamedWaveform.return_value = 0
         mock_library.niFgen_DeleteScript.side_effect = MockFunctionCallError("niFgen_DeleteScript")
         mock_library.niFgen_DeleteScript.return_value = 0
+        mock_library.niFgen_DeleteWaveformDispatch.side_effect = MockFunctionCallError("niFgen_DeleteWaveformDispatch")
+        mock_library.niFgen_DeleteWaveformDispatch.return_value = 0
         mock_library.niFgen_Disable.side_effect = MockFunctionCallError("niFgen_Disable")
         mock_library.niFgen_Disable.return_value = 0
         mock_library.niFgen_GetAttributeViBoolean.side_effect = MockFunctionCallError("niFgen_GetAttributeViBoolean")
@@ -1010,6 +1026,8 @@ class SideEffectsHelper(object):
         mock_library.niFgen_SetAttributeViString.return_value = 0
         mock_library.niFgen_SetNamedWaveformNextWritePosition.side_effect = MockFunctionCallError("niFgen_SetNamedWaveformNextWritePosition")
         mock_library.niFgen_SetNamedWaveformNextWritePosition.return_value = 0
+        mock_library.niFgen_SetNextWritePositionDispatcher.side_effect = MockFunctionCallError("niFgen_SetNextWritePositionDispatcher")
+        mock_library.niFgen_SetNextWritePositionDispatcher.return_value = 0
         mock_library.niFgen_SetWaveformNextWritePosition.side_effect = MockFunctionCallError("niFgen_SetWaveformNextWritePosition")
         mock_library.niFgen_SetWaveformNextWritePosition.return_value = 0
         mock_library.niFgen_UnlockSession.side_effect = MockFunctionCallError("niFgen_UnlockSession")

--- a/src/nifgen/metadata/functions_addon.py
+++ b/src/nifgen/metadata/functions_addon.py
@@ -359,12 +359,7 @@ waveform specified by the waveformHandle parameter. Subsequent writes to
 that waveform begin where the last write left off, unless this function
 is called again. The waveformHandle passed in must have been created by
 a call to the nifgen_AllocateWaveform function or one of the following
-niFgen CreateWaveform functions:
-
--  niFgen_CreateWaveformF64
--  niFgen_CreateWaveformI16
--  niFgen_CreateWaveformFromFileI16
--  niFgen_CreateWaveformFromFileF64
+niFgen_CreateWaveformF64 function.
 ''',
 },
     },

--- a/src/nifgen/metadata/functions_addon.py
+++ b/src/nifgen/metadata/functions_addon.py
@@ -316,7 +316,7 @@ nifgen_SetWaveformNextWritePosition function.''',
                 'direction': 'in',
                 'name': 'waveformNameOrHandle',
                 'type_in_documentation': 'str or int',
-                'type': 'ViInt32',  #TODO(marcoskirsch): Don't care, except for documentation
+                'type': 'ViInt32',
                 'documentation': {
                     'description': 'The name (str) or handle (int) of an arbitrary waveform previously allocated with niFgen_AllocateNamedWaveform or niFgen_AllocateWaveform.',
                 },
@@ -390,7 +390,7 @@ niFgen CreateWaveform functions:
                 'direction': 'in',
                 'name': 'waveformNameOrHandle',
                 'type_in_documentation': 'str or int',
-                'type': 'ViInt32',  #TODO(marcoskirsch): Don't care, except for documentation
+                'type': 'ViInt32',
                 'documentation': {
                     'description': 'The name (str) or handle (int) of an arbitrary waveform previously allocated with niFgen_AllocateNamedWaveform or niFgen_AllocateWaveform.',
                 },

--- a/src/nifgen/metadata/functions_addon.py
+++ b/src/nifgen/metadata/functions_addon.py
@@ -65,6 +65,10 @@ functions_codegen_method = {
     'GetExtCalLastDateAndTime':             { 'codegen_method': 'private', 'method_name_for_documentation': 'get_ext_cal_last_date_and_time',  },  # 'GetLastExtCalLastDateAndTime' Public wrapper to allow datetime
     'GetSelfCalLastDateAndTime':            { 'codegen_method': 'private', 'method_name_for_documentation': 'get_self_cal_last_date_and_time', },  # 'GetLastSelfCalLastDateAndTime' Public wrapper to allow datetime
     'self_test':                            { 'codegen_method': 'private', 'method_name_for_documentation': 'self_test',                       },  # 'fancy_self_test' Public wrapper that raises
+    'SetWaveformNextWritePosition':         { 'codegen_method': 'private', 'method_name_for_documentation': 'set_next_write_position',         },  # 'set_next_write_position' Public wrapper to combine named and not named
+    'SetNamedWaveformNextWritePosition':    { 'codegen_method': 'private', 'method_name_for_documentation': 'set_next_write_position',         },  # 'set_next_write_position' Public wrapper to combine named and not named
+    'DeleteNamedWaveform':                  { 'codegen_method': 'private', 'method_name_for_documentation': 'delete_waveform',                 },  # 'delete_waveform' Public wrapper to combine named and not named
+    'ClearArbWaveform':                     { 'codegen_method': 'private', 'method_name_for_documentation': 'delete_waveform',                 },  # 'delete_waveform' Public wrapper to combine named and not named
 }
 
 functions_locking = {
@@ -260,6 +264,7 @@ after the function runs.
             {
                 'direction': 'in',
                 'name': 'waveformNameOrHandle',
+                'type_in_documentation': 'str or int',
                 'type': 'ViInt32',  #TODO(marcoskirsch): Don't care, except for documentation
                 'documentation': {
                     'description': 'The name (str) or handle (int) of an arbitrary waveform previously allocated with niFgen_AllocateNamedWaveform or niFgen_AllocateWaveform.',
@@ -286,6 +291,114 @@ By default, subsequent calls to this function
 continue writing data from the position of the last sample written. You
 can set the write position and offset by calling the nifgen_SetNamedWaveformNextWritePosition
 nifgen_SetWaveformNextWritePosition function.''',
+        },
+    },
+    'SetNextWritePositionDispatcher': {
+        'returns': 'ViStatus',
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'vi',
+                'type': 'ViSession',
+                'documentation': {
+                    'description': 'Identifies your instrument session. **vi** is obtained from the niFgen_InitializeWithChannels function and identifies a particular instrument session.',
+                },
+            },
+            {
+                'direction': 'in',
+                'name': 'channelName',
+                'type': 'ViConstString',
+                'documentation': {
+                    'description': 'Specifies the channel on which to the waveform data should be loaded.',
+                },
+            },
+            {
+                'direction': 'in',
+                'name': 'waveformNameOrHandle',
+                'type_in_documentation': 'str or int',
+                'type': 'ViInt32',  #TODO(marcoskirsch): Don't care, except for documentation
+                'documentation': {
+                    'description': 'The name (str) or handle (int) of an arbitrary waveform previously allocated with niFgen_AllocateNamedWaveform or niFgen_AllocateWaveform.',
+                },
+            },
+            {
+                'direction': 'in',
+                'name': 'relativeTo',
+                'type': 'ViInt32',
+                'enum': 'RelativeTo',
+                'documentation': {
+                    'description': '''
+Specifies the reference position in the waveform. This position and
+**offset** together determine where to start loading data into the
+waveform.
+
+****Defined Values****
+''',
+'table_body': [['NIFGEN_VAL_WAVEFORM_POSITION_START (0)', 'Use the start of the waveform as the reference position.'], ['NIFGEN_VAL_WAVEFORM_POSITION_CURRENT (1)', 'Use the current position within the waveform as the reference position.']],
+},
+            },
+            {
+                'direction': 'in',
+                'name': 'offset',
+                'type': 'ViInt32',
+'documentation': {
+'description': '''
+Specifies the offset from **relativeTo** at which to start loading the
+data into the waveform.
+''',
+},
+            },
+        ],
+'documentation': {
+'description': '''
+Sets the position in the waveform at which the next waveform data is
+written. This function allows you to write to arbitrary locations within
+the waveform. These settings apply only to the next write to the
+waveform specified by the waveformHandle parameter. Subsequent writes to
+that waveform begin where the last write left off, unless this function
+is called again. The waveformHandle passed in must have been created by
+a call to the nifgen_AllocateWaveform function or one of the following
+niFgen CreateWaveform functions:
+
+-  niFgen_CreateWaveformF64
+-  niFgen_CreateWaveformI16
+-  niFgen_CreateWaveformFromFileI16
+-  niFgen_CreateWaveformFromFileF64
+''',
+},
+    },
+    'DeleteWaveformDispatch': {
+        'returns': 'ViStatus',
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'vi',
+                'type': 'ViSession',
+                'documentation': {
+                    'description': 'Identifies your instrument session. **vi** is obtained from niFgen_InitializeWithChannels function and identifies a particular instrument session.',
+                },
+            },
+            {
+                'direction': 'in',
+                'name': 'channelName',
+                'type': 'ViConstString',
+                'documentation': {
+                    'description': 'Specifies the channel onto which the named waveform is loaded.',
+                },
+            },
+            {
+                'direction': 'in',
+                'name': 'waveformNameOrHandle',
+                'type_in_documentation': 'str or int',
+                'type': 'ViInt32',  #TODO(marcoskirsch): Don't care, except for documentation
+                'documentation': {
+                    'description': 'The name (str) or handle (int) of an arbitrary waveform previously allocated with niFgen_AllocateNamedWaveform or niFgen_AllocateWaveform.',
+                },
+            },
+        ],
+        'documentation': {
+            'description': 'Removes a previously created arbitrary waveform from the signal generator memory and invalidates the waveform handle.',
+            'note': 'The signal generator must not be in the Generating state when you call this function.',
         },
     },
     # Public function that wraps driver function but returns datetime object instead of individual items
@@ -358,6 +471,8 @@ functions_python_name = {
     'AbortGeneration':                      { 'python_name': 'abort',                   },
     'CreateWaveformDispatcher':             { 'python_name': 'create_waveform'          },
     'WriteWaveformDispatcher':              { 'python_name': 'write_waveform'           },
+    'SetNextWritePositionDispatcher':       { 'python_name': 'set_next_write_position'  },
+    'DeleteWaveformDispatch':               { 'python_name': 'delete_waveform'  },
 }
 
 functions_method_templates = {
@@ -373,6 +488,12 @@ functions_method_templates = {
     ], },
     'WriteWaveformDispatcher':      { 'method_templates': [
         { 'session_filename': 'write_waveform', 'documentation_filename': 'default_method', 'method_python_name_suffix': '', },
+    ], },
+    'SetNextWritePositionDispatcher': { 'method_templates': [
+        { 'session_filename': 'set_next_write_position', 'documentation_filename': 'default_method', 'method_python_name_suffix': '', },
+    ], },
+    'DeleteWaveformDispatch':         { 'method_templates': [
+        { 'session_filename': 'delete_waveform', 'documentation_filename': 'default_method', 'method_python_name_suffix': '', },
     ], },
     'WriteWaveform':                { 'method_templates': [
         { 'session_filename': 'default_method', 'method_python_name_suffix': '', },

--- a/src/nifgen/metadata/functions_addon.py
+++ b/src/nifgen/metadata/functions_addon.py
@@ -248,7 +248,7 @@ after the function runs.
     },
 
     'WriteWaveformDispatcher': {
-        'codegen_method': 'public',
+        'codegen_method': 'python-only',
         'returns': 'ViStatus',
         'parameters': [
             {
@@ -294,6 +294,7 @@ nifgen_SetWaveformNextWritePosition function.''',
         },
     },
     'SetNextWritePositionDispatcher': {
+        'codegen_method': 'python-only',
         'returns': 'ViStatus',
         'parameters': [
             {
@@ -368,6 +369,7 @@ niFgen CreateWaveform functions:
 },
     },
     'DeleteWaveformDispatch': {
+        'codegen_method': 'python-only',
         'returns': 'ViStatus',
         'parameters': [
             {

--- a/src/nifgen/metadata/functions_addon.py
+++ b/src/nifgen/metadata/functions_addon.py
@@ -267,7 +267,7 @@ after the function runs.
                 'type_in_documentation': 'str or int',
                 'type': 'ViInt32',  #TODO(marcoskirsch): Don't care, except for documentation
                 'documentation': {
-                    'description': 'The name (str) or handle (int) of an arbitrary waveform previously allocated with niFgen_AllocateNamedWaveform or niFgen_AllocateWaveform.',
+                    'description': 'The name (str) or handle (int) of an arbitrary waveform previously allocated with niFgen_AllocateNamedWaveform, niFgen_AllocateWaveform or niFgen_CreateWaveformF64.',
                 },
             },
             {
@@ -319,7 +319,7 @@ nifgen_SetWaveformNextWritePosition function.''',
                 'type_in_documentation': 'str or int',
                 'type': 'ViInt32',
                 'documentation': {
-                    'description': 'The name (str) or handle (int) of an arbitrary waveform previously allocated with niFgen_AllocateNamedWaveform or niFgen_AllocateWaveform.',
+                    'description': 'The name (str) or handle (int) of an arbitrary waveform previously allocated with niFgen_AllocateNamedWaveform, niFgen_AllocateWaveform or niFgen_CreateWaveformF64.',
                 },
             },
             {
@@ -389,12 +389,12 @@ niFgen_CreateWaveformF64 function.
                 'type_in_documentation': 'str or int',
                 'type': 'ViInt32',
                 'documentation': {
-                    'description': 'The name (str) or handle (int) of an arbitrary waveform previously allocated with niFgen_AllocateNamedWaveform or niFgen_AllocateWaveform.',
+                    'description': 'The name (str) or handle (int) of an arbitrary waveform previously allocated with niFgen_AllocateNamedWaveform, niFgen_AllocateWaveform or niFgen_CreateWaveformF64.',
                 },
             },
         ],
         'documentation': {
-            'description': 'Removes a previously created arbitrary waveform from the signal generator memory and invalidates the waveform handle.',
+            'description': 'Removes a previously created arbitrary waveform from the signal generator memory.',
             'note': 'The signal generator must not be in the Generating state when you call this function.',
         },
     },

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -198,7 +198,7 @@ def test_clear_waveform_memory(session):
     session.clear_user_standard_waveform()
     session.configure_arb_sequence(0, 1.0, 0)
     session.clear_arb_sequence(-1)
-    session.clear_arb_waveform(-1)
+    session.delete_waveform(-1)
 
 
 def test_query_arb_seq_capabilities(session):
@@ -345,7 +345,7 @@ def test_write_waveform_wrong_type(session):
 
 
 def test_set_waveform_next_write_position(session):
-    session.set_waveform_next_write_position(session.allocate_waveform(10), nifgen.RelativeTo.START, 5)
+    session.set_next_write_position(session.allocate_waveform(10), nifgen.RelativeTo.START, 5)
 
 
 def test_write_waveform_from_filei64(session):
@@ -359,10 +359,10 @@ def test_named_waveform_operations(session):
     waveform_data_1 = [x * (1.0 / 256.0) for x in range(256)]
     waveform_data_2 = [x * (-1.0 / 256.0) for x in range(256)]
     session.allocate_named_waveform(waveform_name, waveform_size)
-    session.set_named_waveform_next_write_position(waveform_name, nifgen.RelativeTo.START, write_offset)
+    session.set_next_write_position(waveform_name, nifgen.RelativeTo.START, write_offset)
     session.write_waveform(waveform_name, waveform_data_1)
     session.write_waveform(waveform_name, waveform_data_2)
-    session.delete_named_waveform(waveform_name)
+    session.delete_waveform(waveform_name)
 
 
 def test_write_waveform_from_file_f64(session):

--- a/src/nifgen/templates/session.py/delete_waveform.py.mako
+++ b/src/nifgen/templates/session.py/delete_waveform.py.mako
@@ -1,0 +1,15 @@
+<%page args="f, config, method_template"/>\
+<%
+    '''Dispatches to the appropriate "write waveform" method based on the waveform type.'''
+    import build.helper as helper
+%>\
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+        '''${f['python_name']}
+
+        ${helper.get_function_docstring(f, False, config, indent=8)}
+        '''
+        if isinstance(waveform_name_or_handle, str):
+            return self._delete_named_waveform(waveform_name_or_handle)
+        else:
+            return self._clear_arb_waveform(waveform_name_or_handle)
+

--- a/src/nifgen/templates/session.py/set_next_write_position.py.mako
+++ b/src/nifgen/templates/session.py/set_next_write_position.py.mako
@@ -1,0 +1,15 @@
+<%page args="f, config, method_template"/>\
+<%
+    '''Dispatches to the appropriate "write waveform" method based on the waveform type.'''
+    import build.helper as helper
+%>\
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+        '''${f['python_name']}
+
+        ${helper.get_function_docstring(f, False, config, indent=8)}
+        '''
+        if isinstance(waveform_name_or_handle, str):
+            return self._set_named_waveform_next_write_position(waveform_name_or_handle, relative_to, offset)
+        else:
+            return self._set_waveform_next_write_position(waveform_name_or_handle, relative_to, offset)
+


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- [X] I've ~~added~~updated tests applicable for this pull request
### What does this Pull Request accomplish?
* Combines methods that use `waveform_handle` or `waveform_name` into a single method
  * Internally calls the correct method
* `set_waveform_next_write_position()` and `set_named_waveform_next_write_position()` becomes `set_next_write_position()`
* `clear_arb_waveform()` and `delete_named_waveform()` becomes `delete_waveform()`
### List issues fixed by this Pull Request below, if any.
* Fix #862 

### What testing has been done?
* Unit
* System