### PR TITLE
Fix attribute name that is incorrect in extracted metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 * ### NI-DMM
     * #### Added
     * #### Changed
+        * Fixed name `freq_voltage_autorange` became `freq_voltage_auto_range`
     * #### Removed
 * ### NI-ModInst
     * #### Added

--- a/docs/nidmm/class.rst
+++ b/docs/nidmm/class.rst
@@ -160,7 +160,7 @@ nidmm.Session
     +------------------------------------------+----------------------------------------------+
     | :py:attr:`driver_setup`                  | str                                          |
     +------------------------------------------+----------------------------------------------+
-    | :py:attr:`freq_voltage_autorange`        | float                                        |
+    | :py:attr:`freq_voltage_auto_range`       | float                                        |
     +------------------------------------------+----------------------------------------------+
     | :py:attr:`freq_voltage_range`            | float                                        |
     +------------------------------------------+----------------------------------------------+
@@ -799,12 +799,12 @@ driver_setup
                 - LabVIEW Property: **Inherent IVI Attributes:User Options:Driver Setup**
                 - C Attribute: **NIDMM_ATTR_DRIVER_SETUP**
 
-freq_voltage_autorange
-~~~~~~~~~~~~~~~~~~~~~~
+freq_voltage_auto_range
+~~~~~~~~~~~~~~~~~~~~~~~
 
     .. py:currentmodule:: nidmm.Session
 
-    .. py:attribute:: freq_voltage_autorange
+    .. py:attribute:: freq_voltage_auto_range
 
         For the NI 4070/4071/4072 only, specifies the value of the frequency voltage range.  If Auto Ranging, shows the actual value of the active frequency voltage range.  If not Auto Ranging, the value of this property is the same as that of  :py:data:`nidmm.Session.freq_voltage_range`.
 
@@ -826,7 +826,7 @@ freq_voltage_autorange
             This property corresponds to the following LabVIEW Property or C Attribute:
 
                 - LabVIEW Property: **Configuration:Measurement Options:Frequency Voltage Auto Range Value**
-                - C Attribute: **NIDMM_ATTR_FREQ_VOLTAGE_AUTORANGE**
+                - C Attribute: **NIDMM_ATTR_FREQ_VOLTAGE_AUTO_RANGE**
 
 freq_voltage_range
 ~~~~~~~~~~~~~~~~~~
@@ -4446,7 +4446,7 @@ Properties
 +--------------------------------------------------------+----------------------------------------------+
 | :py:attr:`nidmm.Session.driver_setup`                  | str                                          |
 +--------------------------------------------------------+----------------------------------------------+
-| :py:attr:`nidmm.Session.freq_voltage_autorange`        | float                                        |
+| :py:attr:`nidmm.Session.freq_voltage_auto_range`       | float                                        |
 +--------------------------------------------------------+----------------------------------------------+
 | :py:attr:`nidmm.Session.freq_voltage_range`            | float                                        |
 +--------------------------------------------------------+----------------------------------------------+

--- a/generated/nidmm/session.py
+++ b/generated/nidmm/session.py
@@ -204,7 +204,7 @@ class _SessionBase(object):
     Some cases exist where the end-user must specify instrument driver options  at initialization time.  An example of this is specifying a particular  instrument model from among a family of instruments that the driver supports.   This is useful when using simulation.  The end-user can specify  driver-specific options through the DriverSetup keyword in the optionsString  parameter to the niDMM Init With Options.vi.
     If the user does not specify a Driver Setup string, this property returns  an empty string.
     '''
-    freq_voltage_autorange = _attributes.AttributeViReal64(1150044)
+    freq_voltage_auto_range = _attributes.AttributeViReal64(1150044)
     '''Type: float
 
     For the NI 4070/4071/4072 only, specifies the value of the frequency voltage range.  If Auto Ranging, shows the actual value of the active frequency voltage range.  If not Auto Ranging, the value of this property is the same as that of  freq_voltage_range.

--- a/src/nidmm/metadata/attributes_addon.py
+++ b/src/nidmm/metadata/attributes_addon.py
@@ -43,6 +43,9 @@ attributes_converters = {
                'type_in_documentation': 'float in seconds or datetime.timedelta', },  # SAMPLE_INTERVAL
 }
 
+attributes_name = {
+    1150044: { 'name': 'FREQ_VOLTAGE_AUTO_RANGE', },  # extracted metadata has incorrect name #874, internal NI CAR 699520
+}
 
 attributes_remove_enum = {
     1250003: { "enum": None                         },  # RESOLUTION, Don't use enum since simple value will do


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- [X] ~~I've added tests applicable for this pull request~~
### What does this Pull Request accomplish?
* Fix attribute name that is incorrect in extracted metadata
  * `freq_voltage_autorange` --> `freq_voltage_auto_range`
### List issues fixed by this Pull Request below, if any.
* Fix #874 

### What testing has been done?
* Unit
* System
* Visual inspection of generated files