### PR TITLE
Disallow repeated capability on session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
     * #### Added
     * #### Changed
     * #### Removed
+        * Explicitly disallow using a repeated capability on Session. `session['0'].vertical_range = 1.0` will no longer work. Instead use `session.channels['0'].vertical_range = 1.0` - [#853](https://github.com/ni/nimi-python/issues/853)
 * ### NI-DMM
     * #### Added
     * #### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file.
     * #### Added
     * #### Changed
     * #### Removed
-        * Explicitly disallow using a repeated capability on Session. `session['0'].vertical_range = 1.0` will no longer work. Instead use `session.channels['0'].vertical_range = 1.0` - [#853](https://github.com/ni/nimi-python/issues/853)
+        * Explicitly disallow using a repeated capability on Session. `session[0].vertical_range = 1.0` will no longer work. Instead use `session.channels[0].vertical_range = 1.0` - [#853](https://github.com/ni/nimi-python/issues/853)
 * ### NI-DMM
     * #### Added
     * #### Changed

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -190,6 +190,9 @@ constructor_params = helper.filter_parameters(init_function, helper.ParameterUsa
             raise AttributeError("'{0}' object has no attribute '{1}'".format(type(self).__name__, key))
         object.__setattr__(self, key, value)
 
+    def __getitem__(self, key):
+        raise AttributeError('Repeated capabilities not supported on Session, use repeated capability container specific to {}'.format(key))
+
     def _get_error_description(self, error_code):
         '''_get_error_description
 

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -192,6 +192,7 @@ constructor_params = helper.filter_parameters(init_function, helper.ParameterUsa
 
     def __getitem__(self, key):
         raise AttributeError('Repeated capabilities not supported on Session, use repeated capability container specific to {}'.format(key))
+        raise TypeError("'Session' object does not support indexing. You should use the applicable repeated capabilities container(s): {}".format(', '.join(rep_caps)))
 
     def _get_error_description(self, error_code):
         '''_get_error_description

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -191,7 +191,10 @@ constructor_params = helper.filter_parameters(init_function, helper.ParameterUsa
         object.__setattr__(self, key, value)
 
     def __getitem__(self, key):
-        raise AttributeError('Repeated capabilities not supported on Session, use repeated capability container specific to {}'.format(key))
+        rep_caps = []
+% for rep_cap in config['repeated_capabilities']:
+        rep_caps.append("${rep_cap['python_name']}")
+% endfor
         raise TypeError("'Session' object does not support indexing. You should use the applicable repeated capabilities container(s): {}".format(', '.join(rep_caps)))
 
     def _get_error_description(self, error_code):

--- a/generated/nidcpower/session.py
+++ b/generated/nidcpower/session.py
@@ -2253,7 +2253,9 @@ class _SessionBase(object):
         object.__setattr__(self, key, value)
 
     def __getitem__(self, key):
-        raise AttributeError('Repeated capabilities not supported on Session, use repeated capability container specific to {}'.format(key))
+        rep_caps = []
+        rep_caps.append("channels")
+        raise TypeError("'Session' object does not support indexing. You should use the applicable repeated capabilities container(s): {}".format(', '.join(rep_caps)))
 
     def _get_error_description(self, error_code):
         '''_get_error_description

--- a/generated/nidcpower/session.py
+++ b/generated/nidcpower/session.py
@@ -2252,6 +2252,9 @@ class _SessionBase(object):
             raise AttributeError("'{0}' object has no attribute '{1}'".format(type(self).__name__, key))
         object.__setattr__(self, key, value)
 
+    def __getitem__(self, key):
+        raise AttributeError('Repeated capabilities not supported on Session, use repeated capability container specific to {}'.format(key))
+
     def _get_error_description(self, error_code):
         '''_get_error_description
 

--- a/generated/nidmm/session.py
+++ b/generated/nidmm/session.py
@@ -562,7 +562,8 @@ class _SessionBase(object):
         object.__setattr__(self, key, value)
 
     def __getitem__(self, key):
-        raise AttributeError('Repeated capabilities not supported on Session, use repeated capability container specific to {}'.format(key))
+        rep_caps = []
+        raise TypeError("'Session' object does not support indexing. You should use the applicable repeated capabilities container(s): {}".format(', '.join(rep_caps)))
 
     def _get_error_description(self, error_code):
         '''_get_error_description

--- a/generated/nidmm/session.py
+++ b/generated/nidmm/session.py
@@ -590,6 +590,9 @@ class _SessionBase(object):
             raise AttributeError("'{0}' object has no attribute '{1}'".format(type(self).__name__, key))
         object.__setattr__(self, key, value)
 
+    def __getitem__(self, key):
+        raise AttributeError('Repeated capabilities not supported on Session, use repeated capability container specific to {}'.format(key))
+
     def _get_error_description(self, error_code):
         '''_get_error_description
 

--- a/generated/nifake/session.py
+++ b/generated/nifake/session.py
@@ -187,7 +187,9 @@ class _SessionBase(object):
         object.__setattr__(self, key, value)
 
     def __getitem__(self, key):
-        raise AttributeError('Repeated capabilities not supported on Session, use repeated capability container specific to {}'.format(key))
+        rep_caps = []
+        rep_caps.append("channels")
+        raise TypeError("'Session' object does not support indexing. You should use the applicable repeated capabilities container(s): {}".format(', '.join(rep_caps)))
 
     def _get_error_description(self, error_code):
         '''_get_error_description

--- a/generated/nifake/session.py
+++ b/generated/nifake/session.py
@@ -186,6 +186,9 @@ class _SessionBase(object):
             raise AttributeError("'{0}' object has no attribute '{1}'".format(type(self).__name__, key))
         object.__setattr__(self, key, value)
 
+    def __getitem__(self, key):
+        raise AttributeError('Repeated capabilities not supported on Session, use repeated capability container specific to {}'.format(key))
+
     def _get_error_description(self, error_code):
         '''_get_error_description
 

--- a/generated/nifake/unit_tests/test_session.py
+++ b/generated/nifake/unit_tests/test_session.py
@@ -1216,7 +1216,7 @@ class TestSession(object):
             try:
                 session['100'].read_write_double = 5.0
                 assert False
-            except AttributeError:
+            except TypeError:
                 pass
 
 

--- a/generated/nifake/unit_tests/test_session.py
+++ b/generated/nifake/unit_tests/test_session.py
@@ -1211,6 +1211,14 @@ class TestSession(object):
         assert _matchers.CustomTypeMatcher(nifake.custom_struct, nifake.custom_struct(cs[0])).__repr__() == "CustomTypeMatcher(<class 'nifake.custom_struct.custom_struct'>, custom_struct(data=None, struct_int=42, struct_double=4.2))"
         assert _matchers.CustomTypeBufferMatcher(nifake.custom_struct, cs_ctype).__repr__() == "CustomTypeBufferMatcher(<class 'nifake.custom_struct.custom_struct'>, [custom_struct(data=None, struct_int=42, struct_double=4.2), custom_struct(data=None, struct_int=43, struct_double=4.3), custom_struct(data=None, struct_int=42, struct_double=4.3)])"
 
+    def test_channel_on_session(self):
+        with nifake.Session('dev1') as session:
+            try:
+                session['100'].read_write_double = 5.0
+                assert False
+            except AttributeError:
+                pass
+
 
 # not a session test per se
 def test_diagnostic_information():

--- a/generated/nifgen/session.py
+++ b/generated/nifgen/session.py
@@ -862,7 +862,11 @@ class _SessionBase(object):
         object.__setattr__(self, key, value)
 
     def __getitem__(self, key):
-        raise AttributeError('Repeated capabilities not supported on Session, use repeated capability container specific to {}'.format(key))
+        rep_caps = []
+        rep_caps.append("channels")
+        rep_caps.append("script_triggers")
+        rep_caps.append("markers")
+        raise TypeError("'Session' object does not support indexing. You should use the applicable repeated capabilities container(s): {}".format(', '.join(rep_caps)))
 
     def _get_error_description(self, error_code):
         '''_get_error_description

--- a/generated/nifgen/session.py
+++ b/generated/nifgen/session.py
@@ -861,6 +861,9 @@ class _SessionBase(object):
             raise AttributeError("'{0}' object has no attribute '{1}'".format(type(self).__name__, key))
         object.__setattr__(self, key, value)
 
+    def __getitem__(self, key):
+        raise AttributeError('Repeated capabilities not supported on Session, use repeated capability container specific to {}'.format(key))
+
     def _get_error_description(self, error_code):
         '''_get_error_description
 

--- a/generated/niscope/session.py
+++ b/generated/niscope/session.py
@@ -1393,7 +1393,9 @@ class _SessionBase(object):
         object.__setattr__(self, key, value)
 
     def __getitem__(self, key):
-        raise AttributeError('Repeated capabilities not supported on Session, use repeated capability container specific to {}'.format(key))
+        rep_caps = []
+        rep_caps.append("channels")
+        raise TypeError("'Session' object does not support indexing. You should use the applicable repeated capabilities container(s): {}".format(', '.join(rep_caps)))
 
     def _get_error_description(self, error_code):
         '''_get_error_description

--- a/generated/niscope/session.py
+++ b/generated/niscope/session.py
@@ -1392,6 +1392,9 @@ class _SessionBase(object):
             raise AttributeError("'{0}' object has no attribute '{1}'".format(type(self).__name__, key))
         object.__setattr__(self, key, value)
 
+    def __getitem__(self, key):
+        raise AttributeError('Repeated capabilities not supported on Session, use repeated capability container specific to {}'.format(key))
+
     def _get_error_description(self, error_code):
         '''_get_error_description
 

--- a/generated/niswitch/session.py
+++ b/generated/niswitch/session.py
@@ -582,7 +582,9 @@ class _SessionBase(object):
         object.__setattr__(self, key, value)
 
     def __getitem__(self, key):
-        raise AttributeError('Repeated capabilities not supported on Session, use repeated capability container specific to {}'.format(key))
+        rep_caps = []
+        rep_caps.append("channels")
+        raise TypeError("'Session' object does not support indexing. You should use the applicable repeated capabilities container(s): {}".format(', '.join(rep_caps)))
 
     def _get_error_description(self, error_code):
         '''_get_error_description

--- a/generated/niswitch/session.py
+++ b/generated/niswitch/session.py
@@ -611,6 +611,9 @@ class _SessionBase(object):
             raise AttributeError("'{0}' object has no attribute '{1}'".format(type(self).__name__, key))
         object.__setattr__(self, key, value)
 
+    def __getitem__(self, key):
+        raise AttributeError('Repeated capabilities not supported on Session, use repeated capability container specific to {}'.format(key))
+
     def _get_error_description(self, error_code):
         '''_get_error_description
 

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -1216,7 +1216,7 @@ class TestSession(object):
             try:
                 session['100'].read_write_double = 5.0
                 assert False
-            except AttributeError:
+            except TypeError:
                 pass
 
 

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -1211,6 +1211,14 @@ class TestSession(object):
         assert _matchers.CustomTypeMatcher(nifake.custom_struct, nifake.custom_struct(cs[0])).__repr__() == "CustomTypeMatcher(<class 'nifake.custom_struct.custom_struct'>, custom_struct(data=None, struct_int=42, struct_double=4.2))"
         assert _matchers.CustomTypeBufferMatcher(nifake.custom_struct, cs_ctype).__repr__() == "CustomTypeBufferMatcher(<class 'nifake.custom_struct.custom_struct'>, [custom_struct(data=None, struct_int=42, struct_double=4.2), custom_struct(data=None, struct_int=43, struct_double=4.3), custom_struct(data=None, struct_int=42, struct_double=4.3)])"
 
+    def test_channel_on_session(self):
+        with nifake.Session('dev1') as session:
+            try:
+                session['100'].read_write_double = 5.0
+                assert False
+            except AttributeError:
+                pass
+
 
 # not a session test per se
 def test_diagnostic_information():


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- [X] I've added tests applicable for this pull request
### What does this Pull Request accomplish?
* Disallow repeated capability on session
* Explicitly disallow using a repeated capability on Session. `session[0].vertical_range = 1.0` will no longer work. Instead use `session.channels[0].vertical_range = 1.0`
### List issues fixed by this Pull Request below, if any.
* Fix #853 

### What testing has been done?
* Unit
* System