### PR TITLE
error message clean up

### DIFF
--- a/generated/nidcpower/session.py
+++ b/generated/nidcpower/session.py
@@ -2850,7 +2850,6 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return channel_name_ctype.value.decode(self._encoding)
 
-    @ivi_synchronized
     def _get_error(self):
         '''_get_error
 
@@ -3596,7 +3595,6 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return
 
-    @ivi_synchronized
     def _error_message(self, error_code):
         '''_error_message
 

--- a/generated/nidmm/session.py
+++ b/generated/nidmm/session.py
@@ -777,7 +777,6 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return attribute_value_ctype.value.decode(self._encoding)
 
-    @ivi_synchronized
     def _get_error(self):
         '''_get_error
 
@@ -1070,7 +1069,6 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return
 
-    @ivi_synchronized
     def _error_message(self, error_code):
         '''_error_message
 

--- a/generated/nifake/session.py
+++ b/generated/nifake/session.py
@@ -361,7 +361,6 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return attribute_value_ctype.value.decode(self._encoding)
 
-    @ivi_synchronized
     def _get_error(self):
         '''_get_error
 
@@ -610,7 +609,6 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return
 
-    @ivi_synchronized
     def _error_message(self, error_code):
         '''_error_message
 

--- a/generated/nifgen/session.py
+++ b/generated/nifgen/session.py
@@ -2145,7 +2145,6 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return attribute_value_ctype.value.decode(self._encoding)
 
-    @ivi_synchronized
     def _get_error(self):
         '''_get_error
 
@@ -3019,7 +3018,6 @@ class _SessionBase(object):
 
         return self._write_named_waveform_f64(waveform_name_or_handle, data) if use_named else self._write_waveform(waveform_name_or_handle, data)
 
-    @ivi_synchronized
     def _error_message(self, error_code):
         '''_error_message
 

--- a/generated/niscope/_library.py
+++ b/generated/niscope/_library.py
@@ -73,6 +73,7 @@ class Library(object):
         self.niScope_SetAttributeViString_cfunc = None
         self.niScope_UnlockSession_cfunc = None
         self.niScope_close_cfunc = None
+        self.niScope_error_message_cfunc = None
         self.niScope_reset_cfunc = None
         self.niScope_self_test_cfunc = None
 
@@ -507,6 +508,14 @@ class Library(object):
                 self.niScope_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_close_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_close_cfunc(vi)
+
+    def niScope_error_message(self, vi, error_code, error_message):  # noqa: N802
+        with self._func_lock:
+            if self.niScope_error_message_cfunc is None:
+                self.niScope_error_message_cfunc = self._library.niScope_error_message
+                self.niScope_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
+                self.niScope_error_message_cfunc.restype = ViStatus  # noqa: F405
+        return self.niScope_error_message_cfunc(vi, error_code, error_message)
 
     def niScope_reset(self, vi):  # noqa: N802
         with self._func_lock:

--- a/generated/niscope/session.py
+++ b/generated/niscope/session.py
@@ -3168,7 +3168,6 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return [float(coefficients_ctype[i]) for i in range(number_of_coefficients_ctype.value)]
 
-    @ivi_synchronized
     def _get_error(self):
         '''_get_error
 
@@ -3673,6 +3672,26 @@ class _SessionBase(object):
         error_code = self._library.niScope_UnlockSession(vi_ctype, None)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return
+
+    def _error_message(self, error_code):
+        '''_error_message
+
+        Takes the **Error_Code** returned by the instrument driver methods, interprets it, and returns it as a user-readable string.
+
+        Args:
+            error_code (int): The **error_code** returned from the instrument. The default is 0, indicating VI_SUCCESS.
+
+
+        Returns:
+            error_message (str): The error information formatted into a string.
+
+        '''
+        vi_ctype = _visatype.ViSession(self._vi)  # case S110
+        error_code_ctype = _visatype.ViStatus(error_code)  # case S150
+        error_message_ctype = (_visatype.ViChar * 256)()  # case C070
+        error_code = self._library.niScope_error_message(vi_ctype, error_code_ctype, error_message_ctype)
+        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
+        return error_message_ctype.value.decode(self._encoding)
 
 
 class Session(_SessionBase):

--- a/generated/niscope/unit_tests/_mock_helper.py
+++ b/generated/niscope/unit_tests/_mock_helper.py
@@ -157,6 +157,9 @@ class SideEffectsHelper(object):
         self._defaults['UnlockSession']['callerHasLock'] = None
         self._defaults['close'] = {}
         self._defaults['close']['return'] = 0
+        self._defaults['error_message'] = {}
+        self._defaults['error_message']['return'] = 0
+        self._defaults['error_message']['errorMessage'] = None
         self._defaults['reset'] = {}
         self._defaults['reset']['return'] = 0
         self._defaults['self_test'] = {}
@@ -736,6 +739,20 @@ class SideEffectsHelper(object):
             return self._defaults['close']['return']
         return self._defaults['close']['return']
 
+    def niScope_error_message(self, vi, error_code, error_message):  # noqa: N802
+        if self._defaults['error_message']['return'] != 0:
+            return self._defaults['error_message']['return']
+        # error_message
+        if self._defaults['error_message']['errorMessage'] is None:
+            raise MockFunctionCallError("niScope_error_message", param='errorMessage')
+        test_value = self._defaults['error_message']['errorMessage']
+        if sys.version_info.major > 2 and type(test_value) is str:
+            test_value = test_value.encode('ascii')
+        assert len(error_message) >= len(test_value)
+        for i in range(len(test_value)):
+            error_message[i] = test_value[i]
+        return self._defaults['error_message']['return']
+
     def niScope_reset(self, vi):  # noqa: N802
         if self._defaults['reset']['return'] != 0:
             return self._defaults['reset']['return']
@@ -870,6 +887,8 @@ class SideEffectsHelper(object):
         mock_library.niScope_UnlockSession.return_value = 0
         mock_library.niScope_close.side_effect = MockFunctionCallError("niScope_close")
         mock_library.niScope_close.return_value = 0
+        mock_library.niScope_error_message.side_effect = MockFunctionCallError("niScope_error_message")
+        mock_library.niScope_error_message.return_value = 0
         mock_library.niScope_reset.side_effect = MockFunctionCallError("niScope_reset")
         mock_library.niScope_reset.return_value = 0
         mock_library.niScope_self_test.side_effect = MockFunctionCallError("niScope_self_test")

--- a/generated/niswitch/session.py
+++ b/generated/niswitch/session.py
@@ -867,7 +867,6 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return attribute_value_ctype.value.decode(self._encoding)
 
-    @ivi_synchronized
     def _get_error(self):
         '''_get_error
 
@@ -1235,7 +1234,6 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return
 
-    @ivi_synchronized
     def _error_message(self, error_code):
         '''_error_message
 

--- a/src/nidcpower/metadata/functions_addon.py
+++ b/src/nidcpower/metadata/functions_addon.py
@@ -59,6 +59,8 @@ functions_locking = {
                                          'python_name': 'unlock', },
     'InitializeWithChannels':          { 'use_session_lock': False,  },  # Session not valid during complete function call so cannot use session locking
     'close':                           { 'use_session_lock': False,  },  # Session not valid during complete function call so cannot use session locking
+    'error_message':                   { 'use_session_lock': False,  },  # No Session for function call so cannot use session locking
+    'GetError':                        { 'use_session_lock': False,  },  # Session may not be valid during function call so cannot use session locking
 }
 
 # Attach the given parameter to the given enum from enums.py

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -43,11 +43,14 @@ def test_get_attribute_string(session):
     assert model == 'NI PXIe-4162'
 
 
-def test_error_message(session):
-    # Calling the private function directly, as _get_error_message() only gets called when you have an invalid session,
-    # and there is no good way for us to invalidate a simulated session.
-    message = session._error_message(-1074135027)
-    assert message.find('Attribute is read-only.') != -1
+def test_error_message():
+    try:
+        # We pass in an invalid model name to force going to error_message
+        with nidcpower.Session('4162', [0, 1], False, 'Simulate=1, DriverSetup=Model:invalid_model; BoardType:PXIe'):
+            assert False
+    except nidcpower.Error as e:
+        assert e.code == -1074134964
+        assert e.description.find('The option string parameter contains an entry with an unknown option value.') != -1
 
 
 def test_get_error(session):
@@ -329,4 +332,5 @@ def test_channel_format_types():
         assert simulated_session.channel_count == 12
     with nidcpower.Session(resource_name='4162', reset=False, options='Simulate=1, DriverSetup=Model:4162; BoardType:PXIe') as simulated_session:
         assert simulated_session.channel_count == 12
+
 

--- a/src/nidmm/metadata/functions_addon.py
+++ b/src/nidmm/metadata/functions_addon.py
@@ -62,6 +62,8 @@ functions_locking = {
                                          'python_name': 'unlock', },
     'InitWithOptions':                 { 'use_session_lock': False,  },  # Session not valid during complete function call so cannot use session locking
     'close':                           { 'use_session_lock': False,  },  # Session not valid during complete function call so cannot use session locking
+    'error_message':                   { 'use_session_lock': False,  },  # No Session for function call so cannot use session locking
+    'GetError':                        { 'use_session_lock': False,  },  # Session may not be valid during function call so cannot use session locking
 }
 
 # Attach the given parameter to the given enum from enums.py

--- a/src/nidmm/system_tests/test_system_nidmm.py
+++ b/src/nidmm/system_tests/test_system_nidmm.py
@@ -312,11 +312,14 @@ def test_reset_method(session):
     assert default_function == function_after_reset
 
 
-def test_error_message(session):
-    # Calling the private function directly, as _get_error_message() only gets called when you have an invalid session,
-    # and there is no good way for us to invalidate a simulated session.
-    message = session._error_message(-1074118641)
-    assert message == 'The data is not available. This can be caused by calling Fetch or FetchMultiPoint before calling Initiate or after calling Abort.'
+def test_error_message():
+    try:
+        # We pass in an invalid model name to force going to error_message
+        with nidmm.Session('FakeDevice', False, True, 'Simulate=1, DriverSetup=Model:invalid_model; BoardType:PXIe'):
+            assert False
+    except nidmm.Error as e:
+        assert e.code == -1074134964
+        assert e.description.find('The option string parameter contains an entry with an unknown option value.') != -1
 
 
 # No boolean attributes that aren't IVI

--- a/src/nifake/metadata/functions_addon.py
+++ b/src/nifake/metadata/functions_addon.py
@@ -28,6 +28,8 @@ functions_locking = {
                                          'python_name': 'unlock', },
     'InitWithOptions':                 { 'use_session_lock': False,  },  # Session not valid during complete function call so cannot use session locking
     'close':                           { 'use_session_lock': False,  },  # Session not valid during complete function call so cannot use session locking
+    'error_message':                   { 'use_session_lock': False,  },  # No Session for function call so cannot use session locking
+    'GetError':                        { 'use_session_lock': False,  },  # Session may not be valid during function call so cannot use session locking
 }
 
 # Attach the given parameter to the given enum from enums.py

--- a/src/nifgen/metadata/functions_addon.py
+++ b/src/nifgen/metadata/functions_addon.py
@@ -78,6 +78,8 @@ functions_locking = {
                                          'python_name': 'unlock', },
     'InitializeWithChannels':          { 'use_session_lock': False,  },  # Session not valid during complete function call so cannot use session locking
     'close':                           { 'use_session_lock': False,  },  # Session not valid during complete function call so cannot use session locking
+    'error_message':                   { 'use_session_lock': False,  },  # No Session for function call so cannot use session locking
+    'GetError':                        { 'use_session_lock': False,  },  # Session may not be valid during function call so cannot use session locking
 }
 
 # Attach the given parameter to the given enum from enums.py

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -21,11 +21,14 @@ def test_get_attribute_string(session):
     assert model == 'NI PXIe-5433 (2CH)'
 
 
-def test_error_message(session):
-    # Calling the private function directly, as _get_error_message() only gets called when you have an invalid session,
-    # and there is no good way for us to invalidate a simulated session.
-    message = session._error_message(-1074135027)
-    assert message.find('Attribute is read-only.') != -1
+def test_error_message():
+    try:
+        # We pass in an invalid model name to force going to error_message
+        with nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:invalid_model (2CH);BoardType:PXIe'):
+            assert False
+    except nifgen.Error as e:
+        assert e.code == -1074134944
+        assert e.description.find('Insufficient location information or resource not present in the system.') != -1
 
 
 def test_get_error(session):

--- a/src/niscope/metadata/functions_addon.py
+++ b/src/niscope/metadata/functions_addon.py
@@ -696,6 +696,39 @@ channels, the acquisition type, and the number of records you specify.''',
             'description': 'Retrieves the custom coefficients for the equalization FIR filter on the device. This filter is designed to compensate the input signal for artifacts introduced to the signal outside of the digitizer. Because this filter is a generic FIR filter, any coefficients are valid. Coefficient values should be between +1 and –1.',
         },
     },
+    # niScope metadata is missing error_message but we need it for error handling
+    'error_message': {
+        'returns': 'ViStatus',
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'vi',
+                'type': 'ViSession',
+                'documentation': {
+                    'description': 'Identifies a particular instrument session. You obtain the **vi** parameter from niScope_init or niScope_InitWithOptions. The default is None.',
+                },
+            },
+            {
+                'direction': 'in',
+                'name': 'errorCode',
+                'type': 'ViStatus',
+                'documentation': {
+                    'description': 'The **error_code** returned from the instrument. The default is 0, indicating VI_SUCCESS.',
+                },
+            },
+            {
+                'direction': 'out',
+                'name': 'errorMessage',
+                'type': 'ViChar[ ]',
+                'documentation': {
+                    'description': 'The error information formatted into a string.',
+                },
+            },
+        ],
+        'documentation': {
+            'description': 'Takes the **Error_Code** returned by the instrument driver functions, interprets it, and returns it as a user-readable string.',
+        },
+    },
 }
 
 # Override the 'python' name for some functions.

--- a/src/niscope/metadata/functions_addon.py
+++ b/src/niscope/metadata/functions_addon.py
@@ -698,7 +698,7 @@ channels, the acquisition type, and the number of records you specify.''',
             'description': 'Retrieves the custom coefficients for the equalization FIR filter on the device. This filter is designed to compensate the input signal for artifacts introduced to the signal outside of the digitizer. Because this filter is a generic FIR filter, any coefficients are valid. Coefficient values should be between +1 and –1.',
         },
     },
-    # niScope metadata is missing error_message but we need it for error handling
+    # niScope metadata is missing error_message but we need it for error handling - NI internal CAR #700582
     'error_message': {
         'returns': 'ViStatus',
         'parameters': [

--- a/src/niscope/metadata/functions_addon.py
+++ b/src/niscope/metadata/functions_addon.py
@@ -85,6 +85,8 @@ functions_locking = {
                                          'python_name': 'unlock', },
     'InitWithOptions':                 { 'use_session_lock': False,  },  # Session not valid during complete function call so cannot use session locking
     'close':                           { 'use_session_lock': False,  },  # Session not valid during complete function call so cannot use session locking
+    'error_message':                   { 'use_session_lock': False,  },  # No Session for function call so cannot use session locking
+    'GetError':                        { 'use_session_lock': False,  },  # Session may not be valid during function call so cannot use session locking
 }
 
 # Attach the given parameter to the given enum from enums.py

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -231,6 +231,16 @@ def test_reset_with_defaults(session):
     assert session._meas_time_histogram_high_time == 0.0005
 
 
+def test_error_message():
+    try:
+        # We pass in an invalid model name to force going to error_message
+        with niscope.Session('FakeDevice', False, True, 'Simulate=1, DriverSetup=Model:invalid_model; BoardType:PXIe'):
+            assert False
+    except niscope.Error as e:
+        assert e.code == -1074118609
+        assert e.description.find('Simulation does not support the selected model and board type.') != -1
+
+
 def test_get_error(session):
     try:
         session.instrument_model = ''

--- a/src/niswitch/metadata/functions_addon.py
+++ b/src/niswitch/metadata/functions_addon.py
@@ -39,6 +39,8 @@ functions_locking = {
                                          'python_name': 'unlock', },
     'InitWithTopology':                { 'use_session_lock': False,  },  # Session not valid during complete function call so cannot use session locking
     'close':                           { 'use_session_lock': False,  },  # Session not valid during complete function call so cannot use session locking
+    'error_message':                   { 'use_session_lock': False,  },  # No Session for function call so cannot use session locking
+    'GetError':                        { 'use_session_lock': False,  },  # Session may not be valid during function call so cannot use session locking
 }
 
 # Override the 'python' name for some functions.

--- a/src/niswitch/system_tests/test_system_niswitch.py
+++ b/src/niswitch/system_tests/test_system_niswitch.py
@@ -151,8 +151,13 @@ def test_functions_disable(session):
     assert session.can_connect(channel1, channel2) == niswitch.PathCapability.PATH_AVAILABLE
 
 
-def test_error_message(session):
-    # Calling the private function directly, as _get_error_message() only gets called when you have an invalid session,
-    # and there is no good way for us to invalidate a simulated session.
-    message = session._error_message(-1074135027)
-    assert message.endswith('(Hex 0xBFFA000D) Attribute is read-only.')
+def test_error_message():
+    try:
+        # We pass in an invalid model name to force going to error_message
+        with niswitch.Session('', 'Invalid Topology', True, True):
+            assert False
+    except niswitch.Error as e:
+        assert e.code == -1074118654
+        assert e.description.find('Invalid resource name.') != -1
+
+


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [X] I've added tests applicable for this pull request
### What does this Pull Request accomplish?
* Add `error_message` to `niscope` - needed for complete error handling
* Don't acquire session lock around error handling methods
* Update error_message tests to catch more issues
### ~~List issues fixed by this Pull Request below, if any.~~
### What testing has been done?
* Unit
* System