### PR TITLE
Make nifgen send_software_edge_trigger() private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ All notable changes to this project will be documented in this file.
             * `configure_digital_edge_script_trigger()` - use `session.digital_edge_script_trigger_source` & `session.digital_edge_script_trigger_edge`
             * `configure_digital_level_script_trigger()` - use `session.digital_level_script_trigger_source` & `session.digital_level_script_trigger_active_level`
             * `configure_digital_edge_start_trigger()` - use `session.digital_edge_start_trigger_source` & `session.digital_edge_start_trigger_edge`
+        * Removed `send_software_edge_trigger()` - [#850](https://github.com/ni/nimi-python/issues/850)
 * ### NI-SCOPE
     * #### Added
         * `niscope_fetch_forever.py` example

--- a/docs/nifgen/class.rst
+++ b/docs/nifgen/class.rst
@@ -466,8 +466,6 @@ nifgen.Session
     +-----------------------------------------------------+
     | :py:func:`self_test`                                |
     +-----------------------------------------------------+
-    | :py:func:`send_software_edge_trigger`               |
-    +-----------------------------------------------------+
     | :py:func:`set_next_write_position`                  |
     +-----------------------------------------------------+
     | :py:func:`unlock`                                   |
@@ -6244,44 +6242,6 @@ self_test
 
 
 
-send_software_edge_trigger
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-    .. py:currentmodule:: nifgen.Session
-
-    .. py:method:: send_software_edge_trigger(trigger, trigger_id)
-
-            Sends a command to trigger the signal generator. This VI can act as an
-            override for an external edge trigger.
-
-            
-
-            .. note:: This VI does not override external digital edge triggers of the
-                NI 5401/5411/5431.
-
-
-
-            :param trigger:
-
-
-                Sets the clock mode of the signal generator.
-
-                ****Defined Values****
-
-                +----------------------------------------------+
-                | :py:data:`~nifgen.ClockMode.DIVIDE_DOWN`     |
-                +----------------------------------------------+
-                | :py:data:`~nifgen.ClockMode.HIGH_RESOLUTION` |
-                +----------------------------------------------+
-                | :py:data:`~nifgen.ClockMode.AUTOMATIC`       |
-                +----------------------------------------------+
-
-
-            :type trigger: :py:data:`nifgen.Trigger`
-            :param trigger_id:
-
-            :type trigger_id: str
-
 set_next_write_position
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -6801,8 +6761,6 @@ Methods
 | :py:func:`nifgen.Session.self_cal`                                 |
 +--------------------------------------------------------------------+
 | :py:func:`nifgen.Session.self_test`                                |
-+--------------------------------------------------------------------+
-| :py:func:`nifgen.Session.send_software_edge_trigger`               |
 +--------------------------------------------------------------------+
 | :py:func:`nifgen.Session.set_next_write_position`                  |
 +--------------------------------------------------------------------+

--- a/docs/nifgen/enums.rst
+++ b/docs/nifgen/enums.rst
@@ -702,19 +702,6 @@ TerminalConfiguration
 
 
 
-Trigger
--------
-
-.. py:class:: Trigger
-
-    .. py:attribute:: Trigger.START
-
-
-
-    .. py:attribute:: Trigger.SCRIPT
-
-
-
 TriggerMode
 -----------
 

--- a/generated/nifgen/_library.py
+++ b/generated/nifgen/_library.py
@@ -68,7 +68,6 @@ class Library(object):
         self.niFgen_ResetDevice_cfunc = None
         self.niFgen_ResetWithDefaults_cfunc = None
         self.niFgen_SelfCal_cfunc = None
-        self.niFgen_SendSoftwareEdgeTrigger_cfunc = None
         self.niFgen_SetAttributeViBoolean_cfunc = None
         self.niFgen_SetAttributeViInt32_cfunc = None
         self.niFgen_SetAttributeViReal64_cfunc = None
@@ -494,14 +493,6 @@ class Library(object):
                 self.niFgen_SelfCal_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_SelfCal_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SelfCal_cfunc(vi)
-
-    def niFgen_SendSoftwareEdgeTrigger(self, vi, trigger, trigger_id):  # noqa: N802
-        with self._func_lock:
-            if self.niFgen_SendSoftwareEdgeTrigger_cfunc is None:
-                self.niFgen_SendSoftwareEdgeTrigger_cfunc = self._library.niFgen_SendSoftwareEdgeTrigger
-                self.niFgen_SendSoftwareEdgeTrigger_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
-                self.niFgen_SendSoftwareEdgeTrigger_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFgen_SendSoftwareEdgeTrigger_cfunc(vi, trigger, trigger_id)
 
     def niFgen_SetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:

--- a/generated/nifgen/enums.py
+++ b/generated/nifgen/enums.py
@@ -302,11 +302,6 @@ class TerminalConfiguration(Enum):
     '''
 
 
-class Trigger(Enum):
-    START = 1004
-    SCRIPT = 103
-
-
 class TriggerMode(Enum):
     SINGLE = 1
     '''

--- a/generated/nifgen/session.py
+++ b/generated/nifgen/session.py
@@ -4220,42 +4220,6 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def send_software_edge_trigger(self, trigger, trigger_id):
-        '''send_software_edge_trigger
-
-        Sends a command to trigger the signal generator. This VI can act as an
-        override for an external edge trigger.
-
-        Note:
-        This VI does not override external digital edge triggers of the
-        NI 5401/5411/5431.
-
-        Args:
-            trigger (enums.Trigger): Sets the clock mode of the signal generator.
-
-                ****Defined Values****
-
-                +---------------------------+
-                | ClockMode.DIVIDE_DOWN     |
-                +---------------------------+
-                | ClockMode.HIGH_RESOLUTION |
-                +---------------------------+
-                | ClockMode.AUTOMATIC       |
-                +---------------------------+
-
-            trigger_id (str):
-
-        '''
-        if type(trigger) is not enums.Trigger:
-            raise TypeError('Parameter mode must be of type ' + str(enums.Trigger))
-        vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        trigger_ctype = _visatype.ViInt32(trigger.value)  # case S130
-        trigger_id_ctype = ctypes.create_string_buffer(trigger_id.encode(self._encoding))  # case C020
-        error_code = self._library.niFgen_SendSoftwareEdgeTrigger(vi_ctype, trigger_ctype, trigger_id_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return
-
-    @ivi_synchronized
     def wait_until_done(self, max_time=datetime.timedelta(seconds=10.0)):
         '''wait_until_done
 

--- a/generated/nifgen/unit_tests/_mock_helper.py
+++ b/generated/nifgen/unit_tests/_mock_helper.py
@@ -169,8 +169,6 @@ class SideEffectsHelper(object):
         self._defaults['ResetWithDefaults']['return'] = 0
         self._defaults['SelfCal'] = {}
         self._defaults['SelfCal']['return'] = 0
-        self._defaults['SendSoftwareEdgeTrigger'] = {}
-        self._defaults['SendSoftwareEdgeTrigger']['return'] = 0
         self._defaults['SetAttributeViBoolean'] = {}
         self._defaults['SetAttributeViBoolean']['return'] = 0
         self._defaults['SetAttributeViInt32'] = {}
@@ -742,11 +740,6 @@ class SideEffectsHelper(object):
             return self._defaults['SelfCal']['return']
         return self._defaults['SelfCal']['return']
 
-    def niFgen_SendSoftwareEdgeTrigger(self, vi, trigger, trigger_id):  # noqa: N802
-        if self._defaults['SendSoftwareEdgeTrigger']['return'] != 0:
-            return self._defaults['SendSoftwareEdgeTrigger']['return']
-        return self._defaults['SendSoftwareEdgeTrigger']['return']
-
     def niFgen_SetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         if self._defaults['SetAttributeViBoolean']['return'] != 0:
             return self._defaults['SetAttributeViBoolean']['return']
@@ -964,8 +957,6 @@ class SideEffectsHelper(object):
         mock_library.niFgen_ResetWithDefaults.return_value = 0
         mock_library.niFgen_SelfCal.side_effect = MockFunctionCallError("niFgen_SelfCal")
         mock_library.niFgen_SelfCal.return_value = 0
-        mock_library.niFgen_SendSoftwareEdgeTrigger.side_effect = MockFunctionCallError("niFgen_SendSoftwareEdgeTrigger")
-        mock_library.niFgen_SendSoftwareEdgeTrigger.return_value = 0
         mock_library.niFgen_SetAttributeViBoolean.side_effect = MockFunctionCallError("niFgen_SetAttributeViBoolean")
         mock_library.niFgen_SetAttributeViBoolean.return_value = 0
         mock_library.niFgen_SetAttributeViInt32.side_effect = MockFunctionCallError("niFgen_SetAttributeViInt32")

--- a/src/nifgen/metadata/functions_addon.py
+++ b/src/nifgen/metadata/functions_addon.py
@@ -72,6 +72,7 @@ functions_codegen_method = {
     'SetNamedWaveformNextWritePosition':    { 'codegen_method': 'private', 'method_name_for_documentation': 'set_next_write_position',         },  # 'set_next_write_position' Public wrapper to combine named and not named
     'DeleteNamedWaveform':                  { 'codegen_method': 'private', 'method_name_for_documentation': 'delete_waveform',                 },  # 'delete_waveform' Public wrapper to combine named and not named
     'ClearArbWaveform':                     { 'codegen_method': 'private', 'method_name_for_documentation': 'delete_waveform',                 },  # 'delete_waveform' Public wrapper to combine named and not named
+    'SendSoftwareEdgeTrigger':              { 'codegen_method': 'no',       },  # See #850
 }
 
 functions_locking = {

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -400,11 +400,13 @@ def test_fir_filter_coefficients():
 '''
 
 
+'''
 def test_send_software_edge_trigger(session):
     waveform_data = [x * (1.0 / 256.0) for x in range(256)]
     session.create_waveform(waveform_data)
     with session.initiate():
         session.send_software_edge_trigger(nifgen.Trigger.SCRIPT, 'ScriptTrigger0')
+'''
 
 
 def test_channel_format_types():


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- [X] I've ~~added~~removed tests applicable for this pull request
### What does this Pull Request accomplish?
* Make nifgen send_software_edge_trigger() private
* This is the first step for #850 
* Next step will be to create fancy wrapper(s) that will send the correct trigger depending on if it is sent from `session` or from the `script_trigger` repeated capabilities container.

### ~~List issues fixed by this Pull Request below, if any.~~

### What testing has been done?
* Unit
* System