### PR TITLE
update NI-SCOPE library name for Linux

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ following installed:
             - Can not use spaces, instead you can use wildcards
             - Ex: c:\Program*\Python*\python.exe
         - path 2
-            - Should be the path to the 64 bit python 3 where pythone.exe exists
+            - Should be the path to the 64 bit python 3 where python3.exe exists
         - Ex: `"c:\Program Files (x86)\Python27\python" -m tox --scan c:/Program*/Python*/python.exe c:/Program*/Python*/python3.exe`
         - This should list out each version of python installed plus one more for python3
 

--- a/generated/niscope/_library_singleton.py
+++ b/generated/niscope/_library_singleton.py
@@ -10,7 +10,7 @@ import threading
 
 _instance = None
 _instance_lock = threading.Lock()
-_library_info = {'Linux': {'64bit': {'name': 'libniScope_64.so', 'type': 'cdll'}},
+_library_info = {'Linux': {'64bit': {'name': 'libniscope.so', 'type': 'cdll'}},
                  'Windows': {'32bit': {'name': 'niscope_32.dll', 'type': 'windll'},
                              '64bit': {'name': 'niscope_64.dll', 'type': 'cdll'}}}
 

--- a/src/niscope/metadata/config.py
+++ b/src/niscope/metadata/config.py
@@ -13,7 +13,7 @@ config = {
             '64bit': {'name': 'niscope_64.dll', 'type': 'cdll'},
         },
         'Linux': {
-            '64bit': {'name': 'libniScope_64.so', 'type': 'cdll'},
+            '64bit': {'name': 'libniscope.so', 'type': 'cdll'},
         },
     },
     'context_manager_name': {


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~

I don't consider this a client facing change since no one is using NI-SCOPE on Linux yet. When Linux is officially supported, then CHANGELOG should be updated to reflect the addition of Linux support.

~~- [ ] I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

update NI-SCOPE library name for Linux

### ~~List issues fixed by this Pull Request below, if any.~~

### What testing has been done?

I ran the NI-SCOPE examples (in ./src/niscope/examples) on a pre-release build of the NI-SCOPE Linux driver.
