### PR TITLE
Fixing spacing in waveform_info.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to this project will be documented in this file.
 * ### NI-SCOPE
     * #### Added
     * #### Changed
+        * Format of the waveform_info type
     * #### Removed
 
 ## 1.0.0 - 2018-06-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ All notable changes to this project will be documented in this file.
 * ### NI-SCOPE
     * #### Added
     * #### Changed
-        * Format of the waveform_info type
+        * Format of output of wavefrom_info.__str__()
     * #### Removed
 
 ## 1.0.0 - 2018-06-08

--- a/generated/nifake/setup.py
+++ b/generated/nifake/setup.py
@@ -63,6 +63,7 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: System :: Hardware :: Hardware Drivers"

--- a/generated/niscope/setup.py
+++ b/generated/niscope/setup.py
@@ -63,6 +63,7 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: System :: Hardware :: Hardware Drivers"

--- a/generated/niscope/waveform_info.py
+++ b/generated/niscope/waveform_info.py
@@ -77,8 +77,8 @@ class WaveformInfo(object):
         row_format_s = '{:<20}: {:}'
         string_representation = ''
         try:
-            string_representation += row_format_s.format('channel', self.channel)
-            string_representation += row_format_d.format('record', self.record)
+            string_representation += row_format_s.format('channel', self.channel) + '\n'
+            string_representation += row_format_d.format('record', self.record) + '\n'
         except AttributeError:
             pass
         string_representation += row_format_g.format('Absolute X0', self.absolute_initial_x) + '\n'
@@ -89,9 +89,9 @@ class WaveformInfo(object):
         except AttributeError:
             pass
         string_representation += row_format_g.format('offset', self.offset) + '\n'
-        string_representation += row_format_g.format('gain', self.gain)
+        string_representation += row_format_g.format('gain', self.gain) + '\n'
         try:
-            string_representation += row_format_g.format('wfm length', len(self.samples))
+            string_representation += row_format_g.format('wfm length', len(self.samples)) + '\n'
         except AttributeError:
             pass
         return string_representation

--- a/src/niscope/custom_types/waveform_info.py
+++ b/src/niscope/custom_types/waveform_info.py
@@ -77,8 +77,8 @@ class WaveformInfo(object):
         row_format_s = '{:<20}: {:}'
         string_representation = ''
         try:
-            string_representation += row_format_s.format('channel', self.channel)
-            string_representation += row_format_d.format('record', self.record)
+            string_representation += row_format_s.format('channel', self.channel) + '\n'
+            string_representation += row_format_d.format('record', self.record) + '\n'
         except AttributeError:
             pass
         string_representation += row_format_g.format('Absolute X0', self.absolute_initial_x) + '\n'
@@ -89,9 +89,9 @@ class WaveformInfo(object):
         except AttributeError:
             pass
         string_representation += row_format_g.format('offset', self.offset) + '\n'
-        string_representation += row_format_g.format('gain', self.gain)
+        string_representation += row_format_g.format('gain', self.gain) + '\n'
         try:
-            string_representation += row_format_g.format('wfm length', len(self.samples))
+            string_representation += row_format_g.format('wfm length', len(self.samples)) + '\n'
         except AttributeError:
             pass
         return string_representation


### PR DESCRIPTION
- [x ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

### What does this Pull Request accomplish?

Previously when we would call `print(waveform[0])` it would show information that needed additional spacing. 

Old

```
channel             : 0record              : 0Absolute X0         : 0
Relative X0         : -9.99999e-06
dt                  : 2e-08
offset              : 0
gain                : 1wfm length          : 1,000
```

New

```
channel             : 0
record              : 0
Absolute X0         : 0
Relative X0         : -9.99999e-06
dt                  : 2e-08
offset              : 0
gain                : 1
wfm length          : 1,000
```

### What testing has been done?

Ran tox.
Ran example with `print(waveform[0])`
