### PR TITLE
Add check for top level metadata that exists in addon but not in the sourced metadata

### DIFF
--- a/build/helper/metadata_merge_dicts.py
+++ b/build/helper/metadata_merge_dicts.py
@@ -39,9 +39,21 @@ def merge_dicts(into, outof, use_re):
     merged with all key matches in into.
     '''
     for item in sorted(outof):
+        # If we're not using regex's then this is an easy check
+        if not use_re and item not in into and dict_name is not None:
+            raise KeyError('Key {0} from {1} is not in the destination'.format(item, dict_name))
+        # If we are using regex's we need to seach all keys to see if any match
+        if use_re and dict_name is not None:
+            key_exists = False
+            for item2 in into:
+                if re.search(item, item2):
+                    key_exists = True
+            if not key_exists:
+                raise KeyError('Key {0} from {1} is not in the destination'.format(item, dict_name))
+
         if type(outof[item]) is dict:
             if item in into:
-                merge_dicts(into[item], outof[item], use_re)
+                merge_dicts(into[item], outof[item], use_re, None)
             elif type(into) is list:
                 for item2 in outof[item]:
                     into[item][item2] = outof[item][item2]
@@ -53,7 +65,7 @@ def merge_dicts(into, outof, use_re):
                     for item2 in into:
                         if use_re is True and re.search(item, item2):
                             assert type(into[item2]) is dict
-                            merge_dicts(into[item2], outof[item], use_re)
+                            merge_dicts(into[item2], outof[item], use_re, None)
         else:
             into[item] = outof[item]
 
@@ -61,7 +73,7 @@ def merge_dicts(into, outof, use_re):
 # Unit Tests
 def _do_the_test_merge_dicts(a, b, expected, use_re):
     actual = a.copy()
-    merge_dicts(actual, b, use_re)
+    merge_dicts(actual, b, use_re, 'test')
     assert expected == actual, "\na = {0}\nb = {1}\nexpected = {2}\nactual = {3}".format(a, b, expected, actual)
 
 

--- a/build/helper/metadata_merge_dicts.py
+++ b/build/helper/metadata_merge_dicts.py
@@ -10,8 +10,8 @@ def merge_helper(metadata, metadata_type, config, use_re):
     metadata_module = 'metadata.{0}_addon'.format(metadata_type)
     if 'modules' in config and metadata_module in config['modules']:
         for m in dir(config['modules'][metadata_module]):
-            if m.startswith('{0}_'.format(metadata_type)):
-                merge_dicts(metadata, config['modules'][metadata_module].__getattribute__(m), use_re)
+            if m.startswith('{0}_'.format(metadata_type)) and m != '{0}_additional_{0}'.format(metadata_type):
+                merge_dicts(metadata, config['modules'][metadata_module].__getattribute__(m), use_re, m)
             # We need to explicitly copy new entries
             if m == '{0}_additional_{0}'.format(metadata_type):
                 outof = config['modules'][metadata_module].__getattribute__(m)
@@ -30,7 +30,7 @@ def merge_helper(metadata, metadata_type, config, use_re):
     return metadata
 
 
-def merge_dicts(into, outof, use_re):
+def merge_dicts(into, outof, use_re, dict_name):
     '''merge_dicts
 
     Recursively merges the contents of dictionary 'outof' into dictionary 'into'.
@@ -84,31 +84,17 @@ def test_merge_dict_second_is_empty():
     _do_the_test_merge_dicts(a, b, expected, use_re=True)
 
 
-def test_merge_dict_simple():
-    a = {'a': 1, 'b': 2}
-    b = {'c': 3}
-    expected = {'a': 1, 'b': 2, 'c': 3}
-    _do_the_test_merge_dicts(a, b, expected, use_re=True)
-
-
-def test_merge_dict_first_is_empty():
-    a = {}
-    b = {'a': 1, 'b': 2}
-    expected = {'a': 1, 'b': 2}
-    _do_the_test_merge_dicts(a, b, expected, use_re=True)
-
-
 def test_merge_dict_key_exists():
     a = {'a': 1, 'b': 2}
-    b = {'b': 3, 'c': 4}
-    expected = {'a': 1, 'b': 3, 'c': 4}
+    b = {'b': 3}
+    expected = {'a': 1, 'b': 3}
     _do_the_test_merge_dicts(a, b, expected, use_re=True)
 
 
 def test_merge_dict_recurse():
     a = {'a': 1, 'b': {'b1': 5, 'b2': 6}}
-    b = {'b': {'b3': 7}, 'c': 4}
-    expected = {'a': 1, 'b': {'b1': 5, 'b2': 6, 'b3': 7}, 'c': 4}
+    b = {'b': {'b3': 7}}
+    expected = {'a': 1, 'b': {'b1': 5, 'b2': 6, 'b3': 7}}
     _do_the_test_merge_dicts(a, b, expected, use_re=True)
 
 
@@ -140,4 +126,13 @@ def test_merge_dict_with_regex_off():
     _do_the_test_merge_dicts(a, b, expected, use_re=False)
 
 
+def test_merge_dict_top_level_key_missing():
+    a = {'a': 1, 'b': 2}
+    b = {'b': 3, 'c': 4}
+    expected = {'a': 1, 'b': 3, 'c': 4}
+    try:
+        _do_the_test_merge_dicts(a, b, expected, use_re=True)
+        assert False
+    except KeyError:
+        pass
 

--- a/src/nidcpower/metadata/functions_addon.py
+++ b/src/nidcpower/metadata/functions_addon.py
@@ -25,7 +25,6 @@ functions_codegen_method = {
     'ResetInterchangeCheck':                      { 'codegen_method': 'no',       },  # Not applicable to Python API
     'ClearInterchangeWarnings':                   { 'codegen_method': 'no',       },  # Not applicable to Python API
     'GetNextCoercionRecord':                      { 'codegen_method': 'no',       },  # Not applicable to Python API
-    'error_query':                                { 'codegen_method': 'no',       },
     'ConfigureAutoZero':                          { 'codegen_method': 'no',       },
     'ConfigureCurrent.+':                         { 'codegen_method': 'no',       },
     'ConfigureOutput.+':                          { 'codegen_method': 'no',       },

--- a/src/nidmm/metadata/attributes_addon.py
+++ b/src/nidmm/metadata/attributes_addon.py
@@ -4,15 +4,7 @@
 # We are not code genning attributes that have been marked as obsolete prior to the initial
 # Python API bindings release
 attributes_codegen_method = {
-    1150008: { "codegen_method": "no" },  # START_TRIGGER
-    1150009: { "codegen_method": "no" },  # START_TRIG_SLOPE
-    1150011: { "codegen_method": "no" },  # SAMPLE_TRIGGER_DELAY
-    1150012: { "codegen_method": "no" },  # OLD_TRIGGER_MODEL
-    1150004: { "codegen_method": "no" },  # CHAN_NAMES
     1150001: { "codegen_method": "no" },  # ID_QUERY_RESPONSE
-    1150005: { "codegen_method": "no" },  # AI_NUM_CHANNELS
-    1150006: { "codegen_method": "no" },  # FILTER_NOTCH
-    1150007: { "codegen_method": "no" },  # CONVER_PER_SAMPLE
     1150031: { "codegen_method": "no" },  # SAMPLE_DELAY_MODE
     1050401: { "codegen_method": "no" },  # GROUP_CAPABILITIES - IVI Attribute - #824
     1050021: { "codegen_method": "no" },  # INTERCHANGE_CHECK - IVI Attribute - #824
@@ -28,9 +20,6 @@ attributes_codegen_method = {
     1050501: { "codegen_method": "no" },  # ENGINE_MAJOR_VERSION - IVI Attribute - #824
     1050502: { "codegen_method": "no" },  # ENGINE_MINOR_VERSION - IVI Attribute - #824
     1050553: { "codegen_method": "no" },  # ENGINE_REVISION - IVI Attribute - #824
-    1050321: { "codegen_method": "no" },  # VISA_RM_SESSION - IVI Attribute - #824
-    1050051: { "codegen_method": "no" },  # DEFER_UPDATE - IVI Attribute - #824
-    1050052: { "codegen_method": "no" },  # RETURN_DEFERRED_VALUES - IVI Attribute - #824
     1050004: { "codegen_method": "no" },  # CACHE - IVI Attribute - #824
     1150034: { "codegen_method": "no" },  # LATENCY - EOL hardware only - #875
     1150003: { "codegen_method": "no" },  # SHUNT_VALUE - EOL hardware only - #875

--- a/src/nifake/metadata/functions_addon.py
+++ b/src/nifake/metadata/functions_addon.py
@@ -45,7 +45,7 @@ functions_enums = {
 functions_buffer_info = {
     'GetError':                              { 'parameters': { 3: { 'size': {'mechanism':'ivi-dance', 'value':'bufferSize'}, }, }, },
     'GetAttributeViString':                  { 'parameters': { 4: { 'size': {'mechanism':'ivi-dance', 'value':'bufferSize'}, }, }, },
-    'GetAStringWithSpecifiedMaximumSize':    { 'parameters': { 1: { 'size': {'mechanism':'passed-in', 'value':'bufferSize'}, }, }, },
+    # 'GetAStringWithSpecifiedMaximumSize':    { 'parameters': { 1: { 'size': {'mechanism':'passed-in', 'value':'bufferSize'}, }, }, },
     'ReturnANumberAndAString':               { 'parameters': { 2: { 'size': {'mechanism':'fixed', 'value':256}, }, }, },
     'GetAStringOfFixedMaximumSize':          { 'parameters': { 1: { 'size': {'mechanism':'fixed', 'value':256}, }, }, },
     'error_message':                         { 'parameters': { 2: { 'size': {'mechanism':'fixed', 'value':256}, }, }, }, # From documentation

--- a/src/nifgen/metadata/attributes_addon.py
+++ b/src/nifgen/metadata/attributes_addon.py
@@ -38,13 +38,7 @@ attributes_codegen_method = {
     1050515: { "codegen_method": "no" },  # SPECIFIC_DRIVER_CLASS_SPEC_MAJOR_VERSION - IVI Attribute - #824
     1050516: { "codegen_method": "no" },  # SPECIFIC_DRIVER_CLASS_SPEC_MINOR_VERSION - IVI Attribute - #824
     1050302: { "codegen_method": "no" },  # SPECIFIC_PREFIX - IVI Attribute - #824
-    1050501: { "codegen_method": "no" },  # ENGINE_MAJOR_VERSION - IVI Attribute - #824
-    1050502: { "codegen_method": "no" },  # ENGINE_MINOR_VERSION - IVI Attribute - #824
-    1050553: { "codegen_method": "no" },  # ENGINE_REVISION - IVI Attribute - #824
-    1050321: { "codegen_method": "no" },  # VISA_RM_SESSION - IVI Attribute - #824
     1050322: { "codegen_method": "no" },  # IO_SESSION - IVI Attribute - #824
-    1050051: { "codegen_method": "no" },  # DEFER_UPDATE - IVI Attribute - #824
-    1050052: { "codegen_method": "no" },  # RETURN_DEFERRED_VALUES - IVI Attribute - #824
     1050101: { "codegen_method": "no" },  # PRIMARY_ERROR - IVI Attribute - #824
     1050102: { "codegen_method": "no" },  # SECONDARY_ERROR - IVI Attribute - #824
     1050103: { "codegen_method": "no" },  # ERROR_ELABORATION - IVI Attribute - #824

--- a/src/nimodinst/metadata/functions_addon.py
+++ b/src/nimodinst/metadata/functions_addon.py
@@ -25,10 +25,4 @@ functions_is_error_handling = {
     'GetExtendedErrorInfo': { 'is_error_handling': True },
 }
 
-# Default values for method parameters
-functions_default_value = {
-    'InitWithOptions':  { 'parameters': { 1: { 'default_value': False, },
-                                          2: { 'default_value': False, },
-                                          3: { 'default_value': '""', }, }, },
-}
 

--- a/src/niscope/metadata/attributes_addon.py
+++ b/src/niscope/metadata/attributes_addon.py
@@ -57,19 +57,7 @@ attributes_converters = {
 # Python API bindings release
 # We also do not need to codegen attributes that apply to P2P since it is not supported in Python
 attributes_codegen_method = {
-    1150010: { "codegen_method": "no" },  # TRIGGER_OUTPUT_EVENT
-    1150011: { "codegen_method": "no" },  # TRIGGER_OUTPUT_SOURCE
     1150091: { "codegen_method": "no" },  # EXPORT_SAMP_CLK_OUTPUT_TERM
-    1150054: { "codegen_method": "no" },  # RTSI0_TRIGGER_OUTPUT_EVENT
-    1150055: { "codegen_method": "no" },  # RTSI1_TRIGGER_OUTPUT_EVENT
-    1150056: { "codegen_method": "no" },  # RTSI2_TRIGGER_OUTPUT_EVENT
-    1150057: { "codegen_method": "no" },  # RTSI3_TRIGGER_OUTPUT_EVENT
-    1150058: { "codegen_method": "no" },  # RTSI4_TRIGGER_OUTPUT_EVENT
-    1150059: { "codegen_method": "no" },  # RTSI5_TRIGGER_OUTPUT_EVENT
-    1150060: { "codegen_method": "no" },  # RTSI6_TRIGGER_OUTPUT_EVENT
-    1150061: { "codegen_method": "no" },  # PFI1_TRIGGER_OUTPUT_EVENT
-    1150062: { "codegen_method": "no" },  # PFI2_TRIGGER_OUTPUT_EVENT
-    1150063: { "codegen_method": "no" },  # STAR_TRIGGER_OUTPUT_EVENT
     1151000: { "codegen_method": "no" },  # DDC_NCO_FREQUENCY
     1151001: { "codegen_method": "no" },  # DDC_NCO_PHASE
     1151003: { "codegen_method": "no" },  # DDC_ENABLE
@@ -181,15 +169,6 @@ attributes_codegen_method = {
     1050516: { "codegen_method": "no" },  # SPECIFIC_DRIVER_CLASS_SPEC_MINOR_VERSION - IVI Attribute - #824
     1050003: { "codegen_method": "no" },  # QUERY_INSTR_STATUS - IVI Attribute - #824
     1050302: { "codegen_method": "no" },  # SPECIFIC_PREFIX - IVI Attribute - #824
-    1050501: { "codegen_method": "no" },  # ENGINE_MAJOR_VERSION - IVI Attribute - #824
-    1050502: { "codegen_method": "no" },  # ENGINE_MINOR_VERSION - IVI Attribute - #824
-    1050553: { "codegen_method": "no" },  # ENGINE_REVISION - IVI Attribute - #824
-    1050322: { "codegen_method": "no" },  # IO_SESSION - IVI Attribute - #824
-    1050051: { "codegen_method": "no" },  # DEFER_UPDATE - IVI Attribute - #824
-    1050052: { "codegen_method": "no" },  # RETURN_DEFERRED_VALUES - IVI Attribute - #824
-    1050101: { "codegen_method": "no" },  # PRIMARY_ERROR - IVI Attribute - #824
-    1050102: { "codegen_method": "no" },  # SECONDARY_ERROR - IVI Attribute - #824
-    1050103: { "codegen_method": "no" },  # ERROR_ELABORATION - IVI Attribute - #824
     1050004: { "codegen_method": "no" },  # CACHE - IVI Attribute - #824
     1150077: { "codegen_method": "private" },  # FETCH_RELATIVE_TO - Fetch attribute
     1150078: { "codegen_method": "private" },  # FETCH_OFFSET - Fetch attribute

--- a/src/niscope/metadata/functions_addon.py
+++ b/src/niscope/metadata/functions_addon.py
@@ -14,9 +14,9 @@ functions_codegen_method = {
     'error_message':                    { 'codegen_method': 'private',  },
     'GetError':                         { 'codegen_method': 'private',  },
     'ClearError':                       { 'codegen_method': 'no',       },
-    '.+ExtCal':                         { 'codegen_method': 'no',       },  # External Calibration is not supported by the Python API
-    'CalAdjust.+':                      { 'codegen_method': 'no',       },  # External Calibration is not supported by the Python API
-    '.+UserDefined.+':                  { 'codegen_method': 'no',       },
+    # '.+ExtCal':                         { 'codegen_method': 'no',       },  # External Calibration is not supported by the Python API
+    # 'CalAdjust.+':                      { 'codegen_method': 'no',       },  # External Calibration is not supported by the Python API
+    # '.+UserDefined.+':                  { 'codegen_method': 'no',       },
     'SetAttributeViSession':            { 'codegen_method': 'no',       },
     'GetAttributeViSession':            { 'codegen_method': 'no',       },
     'GetNextInterchangeWarning':        { 'codegen_method': 'no',       },  # Not applicable to Python API
@@ -121,7 +121,7 @@ functions_buffer_info = {
     'GetError':                                 { 'parameters': { 3: { 'size': {'mechanism':'ivi-dance', 'value':'bufferSize'}, }, }, },
     'self_test':                                { 'parameters': { 2: { 'size': {'mechanism':'fixed', 'value':256}, }, }, }, # From documentation
     'GetAttributeViString':                     { 'parameters': { 4: { 'size': {'mechanism':'ivi-dance', 'value':'bufSize'}, }, }, },
-    'GetCalUserDefinedInfo':                    { 'parameters': { 1: { 'size': {'mechanism':'fixed', 'value':256}, }, }, }, # From LabVIEW VI, even though niDMM_GetCalUserDefinedInfoMaxSize() exists.
+    # 'GetCalUserDefinedInfo':                    { 'parameters': { 1: { 'size': {'mechanism':'fixed', 'value':256}, }, }, }, # From LabVIEW VI, even though niDMM_GetCalUserDefinedInfoMaxSize() exists.
     'error_message':                            { 'parameters': { 2: { 'size': {'mechanism':'fixed', 'value':256}, }, }, }, # From documentation
     'ConfigureEqualizationFilterCoefficients':  { 'parameters': { 3: { 'size': {'mechanism':'len', 'value':'numberOfCoefficients'}, }, }, },
     'GetEqualizationFilterCoefficients':        { 'parameters': { 3: { 'size': {'mechanism':'passed-in', 'value':'numberOfCoefficients'}, }, }, },

--- a/src/niscope/metadata/functions_addon.py
+++ b/src/niscope/metadata/functions_addon.py
@@ -14,9 +14,6 @@ functions_codegen_method = {
     'error_message':                    { 'codegen_method': 'private',  },
     'GetError':                         { 'codegen_method': 'private',  },
     'ClearError':                       { 'codegen_method': 'no',       },
-    # '.+ExtCal':                         { 'codegen_method': 'no',       },  # External Calibration is not supported by the Python API
-    # 'CalAdjust.+':                      { 'codegen_method': 'no',       },  # External Calibration is not supported by the Python API
-    # '.+UserDefined.+':                  { 'codegen_method': 'no',       },
     'SetAttributeViSession':            { 'codegen_method': 'no',       },
     'GetAttributeViSession':            { 'codegen_method': 'no',       },
     'GetNextInterchangeWarning':        { 'codegen_method': 'no',       },  # Not applicable to Python API

--- a/src/niswitch/metadata/attributes_addon.py
+++ b/src/niswitch/metadata/attributes_addon.py
@@ -5,14 +5,6 @@
 # Python API bindings release
 attributes_codegen_method = {
     1150001: { "codegen_method": "no" },  # SERIAL_NUMBER_I32
-    1050501: { "codegen_method": "no" },  # ENGINE_MAJOR_VERSION - IVI Attribute - #824
-    1050502: { "codegen_method": "no" },  # ENGINE_MINOR_VERSION - IVI Attribute - #824
-    1050553: { "codegen_method": "no" },  # ENGINE_REVISION - IVI Attribute - #824
-    1050101: { "codegen_method": "no" },  # PRIMARY_ERROR - IVI Attribute - #824
-    1050102: { "codegen_method": "no" },  # SECONDARY_ERROR - IVI Attribute - #824
-    1050103: { "codegen_method": "no" },  # ERROR_ELABORATION - IVI Attribute - #824
-    1050324: { "codegen_method": "no" },  # IO_SESSION_TYPE - IVI Attribute - #824
-    1050322: { "codegen_method": "no" },  # IO_SESSION - IVI Attribute - #824
     1050401: { "codegen_method": "no" },  # GROUP_CAPABILITIES - IVI Attribute - #824
     1050021: { "codegen_method": "no" },  # INTERCHANGE_CHECK - IVI Attribute - #824
     1050002: { "codegen_method": "no" },  # RANGE_CHECK - IVI Attribute - #824


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [x] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [x] I've added tests applicable for this pull request
### What does this Pull Request accomplish?
* Added check for top level metadata that exists in addon but not in the sourced metadata
* `*_additional_*` is the only dictionary that is allowed to add top level items
* There were enough items that were uncovered by this check I decided to make this a separate PR instead of including it with the additional test called for by issue #900 
* In general, I deleted if the only reference was to disable code generation, and commented out if there was other information trying to be set
### List issues fixed by this Pull Request below, if any.
* First part of fixing #900

### What testing has been done?
* Unit