### PR TITLE
Add support for string size mechanism of passed-in

### DIFF
--- a/build/helper/codegen_helper.py
+++ b/build/helper/codegen_helper.py
@@ -203,6 +203,7 @@ def _get_ctype_variable_definition_snippet_for_string(parameter, parameters, ivi
     C060. Output buffer with mechanism ivi-dance, GET_DATA:                    (visatype.ViChar * buffer_size_ctype.value)()
     C070. Output buffer with mechanism fixed-size:                             visatype.ViChar * 256
     C080. Output buffer with mechanism python-code:                            visatype.ViChar * <python_code>
+    C090. Output buffer with mechanism passed-in:                              visatype.ViChar * bufferSize
     '''
     definitions = []
     definition = None
@@ -230,6 +231,11 @@ def _get_ctype_variable_definition_snippet_for_string(parameter, parameters, ivi
         elif parameter['size']['mechanism'] == 'python-code':
             assert parameter['size']['value'] != 1, "Parameter {0} has 'direction':'out' and 'size':{1}... seems wrong. Check your metadata, maybe you forgot to specify?".format(parameter['name'], parameter['size'])
             definition = '({0}.ViChar * {2})()  # case C080'.format(module_name, parameter['ctypes_type'], parameter['size']['value'])
+
+        elif parameter['size']['mechanism'] == 'passed-in':
+            assert parameter['size']['value'] != 1, "Parameter {0} has 'direction':'out' and 'size':{1}... seems wrong. Check your metadata, maybe you forgot to specify?".format(parameter['name'], parameter['size'])
+            size_parameter = find_size_parameter(parameter, parameters)
+            definition = '({0}.ViChar * {2})()  # case C090'.format(module_name, parameter['ctypes_type'], size_parameter['python_name'])
 
         else:
             assert False, "Invalid mechanism for parameters with 'direction':'out': " + str(parameter)

--- a/generated/nifake/_library.py
+++ b/generated/nifake/_library.py
@@ -29,6 +29,7 @@ class Library(object):
         self.niFake_GetANumber_cfunc = None
         self.niFake_GetAStringOfFixedMaximumSize_cfunc = None
         self.niFake_GetAStringUsingPythonCode_cfunc = None
+        self.niFake_GetAStringWithSpecifiedMaximumSize_cfunc = None
         self.niFake_GetAnIviDanceString_cfunc = None
         self.niFake_GetArrayForPythonCodeCustomType_cfunc = None
         self.niFake_GetArrayForPythonCodeDouble_cfunc = None
@@ -143,6 +144,14 @@ class Library(object):
                 self.niFake_GetAStringUsingPythonCode_cfunc.argtypes = [ViSession, ViInt16, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_GetAStringUsingPythonCode_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAStringUsingPythonCode_cfunc(vi, a_number, a_string)
+
+    def niFake_GetAStringWithSpecifiedMaximumSize(self, vi, buffer_size, a_string):  # noqa: N802
+        with self._func_lock:
+            if self.niFake_GetAStringWithSpecifiedMaximumSize_cfunc is None:
+                self.niFake_GetAStringWithSpecifiedMaximumSize_cfunc = self._library.niFake_GetAStringWithSpecifiedMaximumSize
+                self.niFake_GetAStringWithSpecifiedMaximumSize_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
+                self.niFake_GetAStringWithSpecifiedMaximumSize_cfunc.restype = ViStatus  # noqa: F405
+        return self.niFake_GetAStringWithSpecifiedMaximumSize_cfunc(vi, buffer_size, a_string)
 
     def niFake_GetAnIviDanceString(self, vi, buffer_size, a_string):  # noqa: N802
         with self._func_lock:

--- a/generated/nifake/session.py
+++ b/generated/nifake/session.py
@@ -956,6 +956,27 @@ class Session(_SessionBase):
         return a_string_ctype.value.decode(self._encoding)
 
     @ivi_synchronized
+    def get_a_string_with_specified_maximum_size(self, buffer_size):
+        r'''get_a_string_with_specified_maximum_size
+
+        Returns multiple types.
+
+        Args:
+            buffer_size (int): Number of bytes allocated for aString
+
+
+        Returns:
+            a_string (str): An string with passed in size.
+
+        '''
+        vi_ctype = _visatype.ViSession(self._vi)  # case S110
+        buffer_size_ctype = _visatype.ViInt32(buffer_size)  # case S190
+        a_string_ctype = (_visatype.ViChar * buffer_size)()  # case C090
+        error_code = self._library.niFake_GetAStringWithSpecifiedMaximumSize(vi_ctype, buffer_size_ctype, a_string_ctype)
+        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
+        return a_string_ctype.value.decode(self._encoding)
+
+    @ivi_synchronized
     def get_an_ivi_dance_string(self):
         r'''get_an_ivi_dance_string
 

--- a/generated/nifake/session.py
+++ b/generated/nifake/session.py
@@ -959,7 +959,7 @@ class Session(_SessionBase):
     def get_a_string_with_specified_maximum_size(self, buffer_size):
         r'''get_a_string_with_specified_maximum_size
 
-        Returns multiple types.
+        Method to test getting a string with the size passed in as a parameter.
 
         Args:
             buffer_size (int): Number of bytes allocated for aString

--- a/generated/nifake/unit_tests/_mock_helper.py
+++ b/generated/nifake/unit_tests/_mock_helper.py
@@ -42,6 +42,9 @@ class SideEffectsHelper(object):
         self._defaults['GetAStringUsingPythonCode'] = {}
         self._defaults['GetAStringUsingPythonCode']['return'] = 0
         self._defaults['GetAStringUsingPythonCode']['aString'] = None
+        self._defaults['GetAStringWithSpecifiedMaximumSize'] = {}
+        self._defaults['GetAStringWithSpecifiedMaximumSize']['return'] = 0
+        self._defaults['GetAStringWithSpecifiedMaximumSize']['aString'] = None
         self._defaults['GetAnIviDanceString'] = {}
         self._defaults['GetAnIviDanceString']['return'] = 0
         self._defaults['GetAnIviDanceString']['aString'] = None
@@ -286,6 +289,20 @@ class SideEffectsHelper(object):
         for i in range(len(test_value)):
             a_string[i] = test_value[i]
         return self._defaults['GetAStringUsingPythonCode']['return']
+
+    def niFake_GetAStringWithSpecifiedMaximumSize(self, vi, buffer_size, a_string):  # noqa: N802
+        if self._defaults['GetAStringWithSpecifiedMaximumSize']['return'] != 0:
+            return self._defaults['GetAStringWithSpecifiedMaximumSize']['return']
+        # a_string
+        if self._defaults['GetAStringWithSpecifiedMaximumSize']['aString'] is None:
+            raise MockFunctionCallError("niFake_GetAStringWithSpecifiedMaximumSize", param='aString')
+        test_value = self._defaults['GetAStringWithSpecifiedMaximumSize']['aString']
+        if sys.version_info.major > 2 and type(test_value) is str:
+            test_value = test_value.encode('ascii')
+        assert len(a_string) >= len(test_value)
+        for i in range(len(test_value)):
+            a_string[i] = test_value[i]
+        return self._defaults['GetAStringWithSpecifiedMaximumSize']['return']
 
     def niFake_GetAnIviDanceString(self, vi, buffer_size, a_string):  # noqa: N802
         if self._defaults['GetAnIviDanceString']['return'] != 0:
@@ -786,6 +803,8 @@ class SideEffectsHelper(object):
         mock_library.niFake_GetAStringOfFixedMaximumSize.return_value = 0
         mock_library.niFake_GetAStringUsingPythonCode.side_effect = MockFunctionCallError("niFake_GetAStringUsingPythonCode")
         mock_library.niFake_GetAStringUsingPythonCode.return_value = 0
+        mock_library.niFake_GetAStringWithSpecifiedMaximumSize.side_effect = MockFunctionCallError("niFake_GetAStringWithSpecifiedMaximumSize")
+        mock_library.niFake_GetAStringWithSpecifiedMaximumSize.return_value = 0
         mock_library.niFake_GetAnIviDanceString.side_effect = MockFunctionCallError("niFake_GetAnIviDanceString")
         mock_library.niFake_GetAnIviDanceString.return_value = 0
         mock_library.niFake_GetArrayForPythonCodeCustomType.side_effect = MockFunctionCallError("niFake_GetArrayForPythonCodeCustomType")

--- a/generated/nifake/unit_tests/test_session.py
+++ b/generated/nifake/unit_tests/test_session.py
@@ -740,6 +740,18 @@ class TestSession(object):
             assert returned_string == expected_string
             self.patched_library.niFake_GetAStringUsingPythonCode.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViInt16Matcher(test_size), _matchers.ViCharBufferMatcher(test_size))
 
+    def test_get_a_string_of_specified_maximum_size(self):
+        test_size = 4
+        expected_string_size = test_size - 1
+        test_string = "A string that is larger than test_size."
+        expected_string = test_string[:expected_string_size]
+        self.patched_library.niFake_GetAStringWithSpecifiedMaximumSize.side_effect = self.side_effects_helper.niFake_GetAStringWithSpecifiedMaximumSize
+        self.side_effects_helper['GetAStringWithSpecifiedMaximumSize']['aString'] = expected_string
+        with nifake.Session('dev1') as session:
+            returned_string = session.get_a_string_with_specified_maximum_size(test_size)
+            assert returned_string == expected_string
+            self.patched_library.niFake_GetAStringWithSpecifiedMaximumSize.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViInt32Matcher(test_size), _matchers.ViCharBufferMatcher(test_size))
+
     def test_return_a_number_and_a_string(self):
         test_string = "this string"
         test_number = 13

--- a/src/nifake/metadata/functions.py
+++ b/src/nifake/metadata/functions.py
@@ -937,21 +937,21 @@ functions = {
                 },
             },
             {
-                'direction': 'out',
-                'enum': None,
-                'name': 'aString',
-                'type': 'ViChar[]',
-                'documentation': {
-                    'description': 'An string with passed in size.',
-                },
-            },
-            {
                 'direction': 'in',
                 'enum': None,
                 'name': 'bufferSize',
                 'type': 'ViInt32',
                 'documentation': {
                     'description': 'Number of bytes allocated for aString',
+                },
+            },
+            {
+                'direction': 'out',
+                'enum': None,
+                'name': 'aString',
+                'type': 'ViChar[]',
+                'documentation': {
+                    'description': 'An string with passed in size.',
                 },
             },
         ],

--- a/src/nifake/metadata/functions.py
+++ b/src/nifake/metadata/functions.py
@@ -923,6 +923,43 @@ functions = {
         },
     },
 
+    'GetAStringWithSpecifiedMaximumSize': {
+        'codegen_method': 'public',
+        'returns': 'ViStatus',
+        'parameters': [
+            {
+                'direction': 'in',
+                'enum': None,
+                'name': 'vi',
+                'type': 'ViSession',
+                'documentation': {
+                    'description': 'Identifies a particular instrument session.',
+                },
+            },
+            {
+                'direction': 'out',
+                'enum': None,
+                'name': 'aString',
+                'type': 'ViChar[]',
+                'documentation': {
+                    'description': 'An string with passed in size.',
+                },
+            },
+            {
+                'direction': 'in',
+                'enum': None,
+                'name': 'bufferSize',
+                'type': 'ViInt32',
+                'documentation': {
+                    'description': 'Number of bytes allocated for aString',
+                },
+            },
+        ],
+        'documentation': {
+            'description': 'Returns multiple types.',
+        },
+    },
+
     'GetANumber': {
         'codegen_method': 'public',
         'returns': 'ViStatus',

--- a/src/nifake/metadata/functions.py
+++ b/src/nifake/metadata/functions.py
@@ -956,7 +956,7 @@ functions = {
             },
         ],
         'documentation': {
-            'description': 'Returns multiple types.',
+            'description': 'Function to test getting a string with the size passed in as a parameter.',
         },
     },
 

--- a/src/nifake/metadata/functions_addon.py
+++ b/src/nifake/metadata/functions_addon.py
@@ -45,7 +45,7 @@ functions_enums = {
 functions_buffer_info = {
     'GetError':                              { 'parameters': { 3: { 'size': {'mechanism':'ivi-dance', 'value':'bufferSize'}, }, }, },
     'GetAttributeViString':                  { 'parameters': { 4: { 'size': {'mechanism':'ivi-dance', 'value':'bufferSize'}, }, }, },
-    # 'GetAStringWithSpecifiedMaximumSize':    { 'parameters': { 1: { 'size': {'mechanism':'passed-in', 'value':'bufferSize'}, }, }, },
+    'GetAStringWithSpecifiedMaximumSize':    { 'parameters': { 1: { 'size': {'mechanism':'passed-in', 'value':'bufferSize'}, }, }, },
     'ReturnANumberAndAString':               { 'parameters': { 2: { 'size': {'mechanism':'fixed', 'value':256}, }, }, },
     'GetAStringOfFixedMaximumSize':          { 'parameters': { 1: { 'size': {'mechanism':'fixed', 'value':256}, }, }, },
     'error_message':                         { 'parameters': { 2: { 'size': {'mechanism':'fixed', 'value':256}, }, }, }, # From documentation

--- a/src/nifake/metadata/functions_addon.py
+++ b/src/nifake/metadata/functions_addon.py
@@ -45,7 +45,7 @@ functions_enums = {
 functions_buffer_info = {
     'GetError':                              { 'parameters': { 3: { 'size': {'mechanism':'ivi-dance', 'value':'bufferSize'}, }, }, },
     'GetAttributeViString':                  { 'parameters': { 4: { 'size': {'mechanism':'ivi-dance', 'value':'bufferSize'}, }, }, },
-    'GetAStringWithSpecifiedMaximumSize':    { 'parameters': { 1: { 'size': {'mechanism':'passed-in', 'value':'bufferSize'}, }, }, },
+    'GetAStringWithSpecifiedMaximumSize':    { 'parameters': { 2: { 'size': {'mechanism':'passed-in', 'value':'bufferSize'}, }, }, },
     'ReturnANumberAndAString':               { 'parameters': { 2: { 'size': {'mechanism':'fixed', 'value':256}, }, }, },
     'GetAStringOfFixedMaximumSize':          { 'parameters': { 1: { 'size': {'mechanism':'fixed', 'value':256}, }, }, },
     'error_message':                         { 'parameters': { 2: { 'size': {'mechanism':'fixed', 'value':256}, }, }, }, # From documentation

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -740,6 +740,18 @@ class TestSession(object):
             assert returned_string == expected_string
             self.patched_library.niFake_GetAStringUsingPythonCode.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViInt16Matcher(test_size), _matchers.ViCharBufferMatcher(test_size))
 
+    def test_get_a_string_of_specified_maximum_size(self):
+        test_size = 4
+        expected_string_size = test_size - 1
+        test_string = "A string that is larger than test_size."
+        expected_string = test_string[:expected_string_size]
+        self.patched_library.niFake_GetAStringWithSpecifiedMaximumSize.side_effect = self.side_effects_helper.niFake_GetAStringWithSpecifiedMaximumSize
+        self.side_effects_helper['GetAStringWithSpecifiedMaximumSize']['aString'] = expected_string
+        with nifake.Session('dev1') as session:
+            returned_string = session.get_a_string_with_specified_maximum_size(test_size)
+            assert returned_string == expected_string
+            self.patched_library.niFake_GetAStringWithSpecifiedMaximumSize.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViInt32Matcher(test_size), _matchers.ViCharBufferMatcher(test_size))
+
     def test_return_a_number_and_a_string(self):
         test_string = "this string"
         test_number = 13

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,7 @@ commands =
     build_test: touch .coverage
     build_test: rm .coverage
     build_test: coverage run --rcfile=tools/coverage_unit_tests.rc --append --source build.helper -m py.test --pyargs build.helper
-    build_test: flake8 build/
+    build_test: flake8 --config=./tox.ini build/
     test: python --version
     test: python -c "import platform; print(platform.architecture())"
     test: python -m pip install pip --upgrade pip
@@ -92,22 +92,22 @@ commands =
     flake8: python --version
     flake8: python -c "import platform; print(platform.architecture())"
     flake8: python -m pip install pip --upgrade pip
-    flake8: flake8 bin/
-    flake8: flake8 src/nidcpower/system_tests/
-    flake8: flake8 src/nidcpower/examples/
-    flake8: flake8 src/nidmm/system_tests/
-    flake8: flake8 src/nidmm/examples/
-    flake8: flake8 src/nifgen/system_tests/
-    flake8: flake8 src/nifgen/examples/
-    flake8: flake8 src/niscope/system_tests/
-    flake8: flake8 src/niscope/examples/
-    flake8: flake8 src/niswitch/system_tests/
-    flake8: flake8 src/niswitch/examples/
-    flake8: flake8 src/nimodinst/system_tests/
-    flake8: flake8 src/nimodinst/examples/
-    flake8: flake8 src/nise/system_tests/
-    flake8: flake8 src/nise/examples/
-    flake8: flake8 tools/
+    flake8: flake8 --config=./tox.ini bin/
+    flake8: flake8 --config=./tox.ini src/nidcpower/system_tests/
+    flake8: flake8 --config=./tox.ini src/nidcpower/examples/
+    flake8: flake8 --config=./tox.ini src/nidmm/system_tests/
+    flake8: flake8 --config=./tox.ini src/nidmm/examples/
+    flake8: flake8 --config=./tox.ini src/nifgen/system_tests/
+    flake8: flake8 --config=./tox.ini src/nifgen/examples/
+    flake8: flake8 --config=./tox.ini src/niscope/system_tests/
+    flake8: flake8 --config=./tox.ini src/niscope/examples/
+    flake8: flake8 --config=./tox.ini src/niswitch/system_tests/
+    flake8: flake8 --config=./tox.ini src/niswitch/examples/
+    flake8: flake8 --config=./tox.ini src/nimodinst/system_tests/
+    flake8: flake8 --config=./tox.ini src/nimodinst/examples/
+    flake8: flake8 --config=./tox.ini src/nise/system_tests/
+    flake8: flake8 --config=./tox.ini src/nise/examples/
+    flake8: flake8 --config=./tox.ini tools/
     docs: python --version
     docs: python -c "import platform; print(platform.architecture())"
     docs: sphinx-build -b html -d {envtmpdir}/doctrees . ../bin/docs/html {posargs}
@@ -185,6 +185,7 @@ deps =
     flake8: flake8
     flake8: hacking
     flake8: pep8-naming
+    flake8: tox
     docs: sphinx
     docs: sphinx-rtd-theme
     pkg: check-manifest


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [X] I've added tests applicable for this pull request
### What does this Pull Request accomplish?
* Add support for string size mechanism of `passed-in`
* Add test in nifake to use new mechanism
* For some reason, after re-installing Windows, flake8 (of any version) would not look in `tox.ini` without telling it that that was the config file. I don't believe this will hurt and may keep this from happening to others.
### List issues fixed by this Pull Request below, if any.
* Fix #900 

### What testing has been done?
* Unit
