### PR TITLE
Add @wraps to @ivi_synchronized

### DIFF
--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -23,6 +23,7 @@ ${template_parameters['encoding_tag']}
 import array  # noqa: F401
 import ctypes
 import datetime
+from functools import wraps
 
 % if attributes:
 import ${module_name}._attributes as _attributes
@@ -89,6 +90,7 @@ class ${session_context_manager}(object):
 % endif
 # From https://stackoverflow.com/questions/5929107/decorators-with-parameters
 def ivi_synchronized(f):
+    @wraps(f)
     def aux(*xs, **kws):
         session = xs[0]  # parameter 0 is 'self' which is the session object
         with session.lock():

--- a/generated/nidcpower/session.py
+++ b/generated/nidcpower/session.py
@@ -3,6 +3,7 @@
 import array  # noqa: F401
 import ctypes
 import datetime
+from functools import wraps
 
 import nidcpower._attributes as _attributes
 import nidcpower._converters as _converters
@@ -61,6 +62,7 @@ class _Acquisition(object):
 
 # From https://stackoverflow.com/questions/5929107/decorators-with-parameters
 def ivi_synchronized(f):
+    @wraps(f)
     def aux(*xs, **kws):
         session = xs[0]  # parameter 0 is 'self' which is the session object
         with session.lock():

--- a/generated/nidmm/session.py
+++ b/generated/nidmm/session.py
@@ -3,6 +3,7 @@
 import array  # noqa: F401
 import ctypes
 import datetime
+from functools import wraps
 
 import nidmm._attributes as _attributes
 import nidmm._converters as _converters
@@ -61,6 +62,7 @@ class _Acquisition(object):
 
 # From https://stackoverflow.com/questions/5929107/decorators-with-parameters
 def ivi_synchronized(f):
+    @wraps(f)
     def aux(*xs, **kws):
         session = xs[0]  # parameter 0 is 'self' which is the session object
         with session.lock():

--- a/generated/nifake/session.py
+++ b/generated/nifake/session.py
@@ -3,6 +3,7 @@
 import array  # noqa: F401
 import ctypes
 import datetime
+from functools import wraps
 
 import nifake._attributes as _attributes
 import nifake._converters as _converters
@@ -63,6 +64,7 @@ class _Acquisition(object):
 
 # From https://stackoverflow.com/questions/5929107/decorators-with-parameters
 def ivi_synchronized(f):
+    @wraps(f)
     def aux(*xs, **kws):
         session = xs[0]  # parameter 0 is 'self' which is the session object
         with session.lock():

--- a/generated/nifake/unit_tests/test_session.py
+++ b/generated/nifake/unit_tests/test_session.py
@@ -1238,6 +1238,16 @@ class TestSession(object):
             except TypeError:
                 pass
 
+    def test_function_name(self):
+        with nifake.Session('dev1') as session:
+            # Pick a function that uses @ivi_synchronized
+            assert session.bool_array_output_function.__name__ == 'bool_array_output_function'
+            # Pick several functions that do not use @ivi_synchronized to make sure they don't break in the future
+            assert session.lock.__name__ == 'lock'
+            assert session._error_message.__name__ == '_error_message'
+            assert session.initiate.__name__ == 'initiate'
+            # Cannot use session.<property>.__name__ since that invokes the get attribute value
+
 
 # not session tests per se
 def test_diagnostic_information():

--- a/generated/nifgen/session.py
+++ b/generated/nifgen/session.py
@@ -3,6 +3,7 @@
 import array  # noqa: F401
 import ctypes
 import datetime
+from functools import wraps
 
 import nifgen._attributes as _attributes
 import nifgen._converters as _converters
@@ -61,6 +62,7 @@ class _Generation(object):
 
 # From https://stackoverflow.com/questions/5929107/decorators-with-parameters
 def ivi_synchronized(f):
+    @wraps(f)
     def aux(*xs, **kws):
         session = xs[0]  # parameter 0 is 'self' which is the session object
         with session.lock():

--- a/generated/niscope/session.py
+++ b/generated/niscope/session.py
@@ -3,6 +3,7 @@
 import array  # noqa: F401
 import ctypes
 import datetime
+from functools import wraps
 
 import niscope._attributes as _attributes
 import niscope._converters as _converters
@@ -63,6 +64,7 @@ class _Acquisition(object):
 
 # From https://stackoverflow.com/questions/5929107/decorators-with-parameters
 def ivi_synchronized(f):
+    @wraps(f)
     def aux(*xs, **kws):
         session = xs[0]  # parameter 0 is 'self' which is the session object
         with session.lock():

--- a/generated/niswitch/session.py
+++ b/generated/niswitch/session.py
@@ -3,6 +3,7 @@
 import array  # noqa: F401
 import ctypes
 import datetime
+from functools import wraps
 
 import niswitch._attributes as _attributes
 import niswitch._converters as _converters
@@ -61,6 +62,7 @@ class _Scan(object):
 
 # From https://stackoverflow.com/questions/5929107/decorators-with-parameters
 def ivi_synchronized(f):
+    @wraps(f)
     def aux(*xs, **kws):
         session = xs[0]  # parameter 0 is 'self' which is the session object
         with session.lock():

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -1238,6 +1238,17 @@ class TestSession(object):
             except TypeError:
                 pass
 
+    def test_function_name(self):
+        with nifake.Session('dev1') as session:
+            # Pick a function that uses @ivi_synchronized
+            assert session.bool_array_output_function.__name__ == 'bool_array_output_function'
+            # Pick several functions that do not use @ivi_synchronized to make sure they don't break in the future
+            assert session.lock.__name__ == 'lock'
+            assert session._error_message.__name__ == '_error_message'
+            assert session.initiate.__name__ == 'initiate'
+            # Cannot use session.<property>.__name__ since that invokes the get attribute value and the returned value
+            # (string, int, float) don't have __name__ properties
+
 
 # not session tests per se
 def test_diagnostic_information():


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [X] I've added tests applicable for this pull request
### What does this Pull Request accomplish?
* Use [wraps](https://docs.python.org/3/library/functools.html#functools.wraps) for `@ivi_synchronized`. This ensures `session.<method>.__name__` returns the method name instead of the helper method in `@ivi_synchronized`
* Add test for both ivi_synchronized methods and non-ivi_synchronized methods

### List issues fixed by this Pull Request below, if any.
* Fix #952 

### What testing has been done?
* Unit
* System
