### PR TITLE
Remove  __getitem__ from Session

### DIFF
--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -200,19 +200,6 @@ constructor_params = helper.filter_parameters(init_function, helper.ParameterUsa
             raise AttributeError("'{0}' object has no attribute '{1}'".format(type(self).__name__, key))
         object.__setattr__(self, key, value)
 
-    def __getitem__(self, key):
-% if len(config['repeated_capabilities']) > 0:
-<%
-        rep_caps = []
-        for rep_cap in config['repeated_capabilities']:
-            rep_caps.append(rep_cap['python_name'])
-        r = ', '.join(rep_caps)
-%>\
-        raise TypeError("'Session' object is not subscriptable. Did you mean to use a repeated capabilities container: (${r})?")
-% else:
-        raise TypeError("'Session' object is not subscriptable")
-% endif
-
     def _get_error_description(self, error_code):
         '''_get_error_description
 

--- a/generated/nidcpower/session.py
+++ b/generated/nidcpower/session.py
@@ -2211,9 +2211,6 @@ class _SessionBase(object):
             raise AttributeError("'{0}' object has no attribute '{1}'".format(type(self).__name__, key))
         object.__setattr__(self, key, value)
 
-    def __getitem__(self, key):
-        raise TypeError("'Session' object is not subscriptable. Did you mean to use a repeated capabilities container: (channels)?")
-
     def _get_error_description(self, error_code):
         '''_get_error_description
 

--- a/generated/nidmm/session.py
+++ b/generated/nidmm/session.py
@@ -537,9 +537,6 @@ class _SessionBase(object):
             raise AttributeError("'{0}' object has no attribute '{1}'".format(type(self).__name__, key))
         object.__setattr__(self, key, value)
 
-    def __getitem__(self, key):
-        raise TypeError("'Session' object is not subscriptable")
-
     def _get_error_description(self, error_code):
         '''_get_error_description
 

--- a/generated/nifake/session.py
+++ b/generated/nifake/session.py
@@ -189,9 +189,6 @@ class _SessionBase(object):
             raise AttributeError("'{0}' object has no attribute '{1}'".format(type(self).__name__, key))
         object.__setattr__(self, key, value)
 
-    def __getitem__(self, key):
-        raise TypeError("'Session' object is not subscriptable. Did you mean to use a repeated capabilities container: (channels)?")
-
     def _get_error_description(self, error_code):
         '''_get_error_description
 

--- a/generated/nifgen/session.py
+++ b/generated/nifgen/session.py
@@ -954,9 +954,6 @@ class _SessionBase(object):
             raise AttributeError("'{0}' object has no attribute '{1}'".format(type(self).__name__, key))
         object.__setattr__(self, key, value)
 
-    def __getitem__(self, key):
-        raise TypeError("'Session' object is not subscriptable. Did you mean to use a repeated capabilities container: (channels, script_triggers, markers)?")
-
     def _get_error_description(self, error_code):
         '''_get_error_description
 

--- a/generated/niscope/session.py
+++ b/generated/niscope/session.py
@@ -1392,9 +1392,6 @@ class _SessionBase(object):
             raise AttributeError("'{0}' object has no attribute '{1}'".format(type(self).__name__, key))
         object.__setattr__(self, key, value)
 
-    def __getitem__(self, key):
-        raise TypeError("'Session' object is not subscriptable. Did you mean to use a repeated capabilities container: (channels)?")
-
     def _get_error_description(self, error_code):
         '''_get_error_description
 

--- a/generated/nise/session.py
+++ b/generated/nise/session.py
@@ -77,9 +77,6 @@ class _SessionBase(object):
             raise AttributeError("'{0}' object has no attribute '{1}'".format(type(self).__name__, key))
         object.__setattr__(self, key, value)
 
-    def __getitem__(self, key):
-        raise TypeError("'Session' object is not subscriptable")
-
     def _get_error_description(self, error_code):
         '''_get_error_description
 

--- a/generated/niswitch/session.py
+++ b/generated/niswitch/session.py
@@ -571,9 +571,6 @@ class _SessionBase(object):
             raise AttributeError("'{0}' object has no attribute '{1}'".format(type(self).__name__, key))
         object.__setattr__(self, key, value)
 
-    def __getitem__(self, key):
-        raise TypeError("'Session' object is not subscriptable. Did you mean to use a repeated capabilities container: (channels)?")
-
     def _get_error_description(self, error_code):
         '''_get_error_description
 


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [X] ~~I've added tests applicable for this pull request~~
### What does this Pull Request accomplish?
* Remove `__getitem__()` from `Session`
    * Was originally implemented to help clarify that indexing for repeated capabilities belongs on the repeated capabilities containers
    * That was only during the prerelease stage and is now properly documented

### List issues fixed by this Pull Request below, if any.
* Fix #955 

### What testing has been done?
* Unit
* System
