### PR TITLE
Fix enum.HardwareState values to match niFgen.h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 * ### NI-FGEN
     * #### Added
     * #### Changed
+        * Enum values for `HardwareState` were incorrect - fix to match niFgen.h
     * #### Removed
 * ### NI-SCOPE
     * #### Added

--- a/src/nifgen/metadata/enums_addon.py
+++ b/src/nifgen/metadata/enums_addon.py
@@ -110,19 +110,19 @@ enums_additional_enums = {
             },
             {
                 'name': 'NIFGEN_VAL_WAITING_FOR_START_TRIGGER',
-                'value': 1,
+                'value': 100,
             },
             {
                 'name': 'NIFGEN_VAL_RUNNING',
-                'value': 2,
+                'value': 200,
             },
             {
                 'name': 'NIFGEN_VAL_DONE',
-                'value': 3,
+                'value': 600,
             },
             {
                 'name': 'NIFGEN_VAL_HARDWARE_ERROR',
-                'value': 4,
+                'value': 1000,
             },
         ],
     },


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- [X] ~~I've added tests applicable for this pull request~~
### What does this Pull Request accomplish?
* Fix the values in the `HardwareState` enum to match the values in niFgen.h

### ~~List issues fixed by this Pull Request below, if any.~~
### What testing has been done?
* System
* Unit