### PR TITLE
Cleans up build on Travis CI and fix pypy/pypy3 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 group: travis_latest
 language: python
-jobs:
+matrix:
     include:
       # We put 3.6 first since this is where flake8 and docs are tested
       - python: 3.6
@@ -22,7 +22,6 @@ jobs:
       - python: nightly
         dist: xenial
         sudo: true
-matrix:
     allow_failures:
         - python: 3.8-dev
         - python: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ matrix:
     allow_failures:
         - python: 3.8-dev
         - python: nightly
-        - python: pypy3.5-6.0
 
 install:
   - travis_retry pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ matrix:
       - python: 3.6
       # We put pypy towards the beginning because for some reason the build takes much longer, this starts it earlier 
       # so multiple others can be running while these continue to run.
-      - python: pypy2.7-6.0
-      - python: pypy3.5-6.0
+      - python: pypy
+      - python: pypy3
       - python: 2.7
       - python: 3.4
       - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - travis_retry pip install --upgrade tox tox-travis coveralls codecov
 
 script:
-  - tox -e clean,build_test,codegen PRINT=1 PYTHON_CMD=python
+  - tox -e clean,build_test,codegen PRINT=1
   - tox
 
 after_success:

--- a/tox.ini
+++ b/tox.ini
@@ -174,14 +174,12 @@ deps =
     build_test: pytest
     build_test: coverage
     build_test: mako
-    build_test: flake8==2.6.2
     build_test: hacking
     build_test: pep8-naming
     codegen: enum34;python_version<"3.4"
     codegen: mako
     codegen: wheel
     codegen: setuptools
-    flake8: flake8==2.6.2
     flake8: hacking
     flake8: pep8-naming
     docs: sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -161,7 +161,15 @@ deps =
     test: mock
     test: mako
     test: six
-    test: numpy<1.16
+    py27-test: numpy
+    py34-test: numpy
+    py35-test: numpy
+    py36-test: numpy
+    py37-test: numpy
+    py38-test: numpy
+    # pypy doesn't work with numpy >= 1.16
+    pypy-test: numpy<1.16
+    pypy3-test: numpy<1.16
     build_test: enum34;python_version<"3.4"
     build_test: pytest
     build_test: coverage
@@ -187,7 +195,7 @@ deps =
     system_tests: pytest
     system_tests: coverage
     system_tests: six
-    system_tests: numpy<1.16
+    system_tests: numpy
     system_tests: scipy
     nidcpower_system_tests: enum34;python_version<"3.4"
     nidcpower_system_tests: singledispatch;python_version<"3.4"
@@ -204,19 +212,19 @@ deps =
     nidmm_system_tests: pytest
     nidmm_system_tests: nidmm
     nidmm_system_tests: pytest-json
-    nidmm_system_tests: numpy<1.16
+    nidmm_system_tests: numpy
     nifgen_system_tests: enum34;python_version<"3.4"
     nifgen_system_tests: singledispatch;python_version<"3.4"
     nifgen_system_tests: pytest
     nifgen_system_tests: nifgen
     nifgen_system_tests: pytest-json
-    nifgen_system_tests: numpy<1.16
+    nifgen_system_tests: numpy
     niscope_system_tests: enum34;python_version<"3.4"
     niscope_system_tests: singledispatch;python_version<"3.4"
     niscope_system_tests: pytest
     niscope_system_tests: niscope
     niscope_system_tests: pytest-json
-    niscope_system_tests: numpy<1.16
+    niscope_system_tests: numpy
     niswitch_system_tests: enum34;python_version<"3.4"
     niswitch_system_tests: singledispatch;python_version<"3.4"
     niswitch_system_tests: pytest

--- a/tox.ini
+++ b/tox.ini
@@ -65,7 +65,7 @@ commands =
     build_test: flake8 --config=./tox.ini build/
     test: python --version
     test: python -c "import platform; print(platform.architecture())"
-    test: python -m pip install pip --upgrade pip
+    test: python -m pip install --upgrade pip
     test: coverage run --rcfile=tools/coverage_unit_tests.rc --append --source nifake -m py.test bin/nifake/nifake {posargs} -s
     test: coverage run --rcfile=tools/coverage_unit_tests.rc --append --source nimodinst -m py.test bin/nimodinst/nimodinst {posargs} -s
     test: coverage report --rcfile=tools/coverage_unit_tests.rc

--- a/tox.ini
+++ b/tox.ini
@@ -28,22 +28,6 @@ description =
     nimodinst_system_tests: Run system tests for nimodinst
     nise_system_tests: Run system tests for nise
 
-basepython =
-    clean: python
-    build_test: python
-    codegen: python3
-    py27: python2.7
-    py34: python3.4
-    py35: python3.5
-    py36: python3.6
-    py37: python3.7
-    py38: python3.8
-    pypy: pypy
-    pypy3: pypy3
-    flake8: python3
-    docs: python
-    pkg: python
-
 changedir =
     build_test: .
     test: .


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [X] ~~I've added tests applicable for this pull request~~
### What does this Pull Request accomplish?
* Cleans up build on Travis CI
    * pypy3 now passes
    * Don't pin `flake8` dependency
        * `hacking` is top level package and will pull in `flake8`
        * `hacking` does not work with latest flake and if we explicitly add `flake8`, we have to manually pin it to a version `hacking` works with
        * By not listing `flake8` at all, we let pip pull in a compatible version
    * Don't list `basepython` in tox.ini
        * Either never needed or not needed any more
        * Breaks pypy/pypy3 build by listing
    * numpy does not currently work with pypy/pypy3-7.1.1 numpy/numpy#13807
        * Only limit numpy dependency for pypy/pypy3 builds to <1.16, allow other builds to use latest
* Python 3.8 still broken - see numpy/numpy#13790 and linked Python issues for discussion possible solutions
    * There doesn't look like we will need to do anything

### List issues fixed by this Pull Request below, if any.
* Fix #993 

### What testing has been done?
* Unit
* System