### PR TITLE
Fix ViSession attribute type for nitclk

### DIFF
--- a/build/templates/_attributes.py.mako
+++ b/build/templates/_attributes.py.mako
@@ -119,10 +119,10 @@ class AttributeSessionReference(Attribute):
     def __get__(self, session, session_type):
         # Import here to avoid a circular dependency when initial import happens
         from ${module_name}.session import SessionReference
-        return SessionReference(session._get_attribute_vi_int32(self._attribute_id))
+        return SessionReference(session._get_attribute_vi_session(self._attribute_id))
 
     def __set__(self, session, value):
-        session._set_attribute_vi_int32(self._attribute_id, _converters.convert_to_nitclk_session_number(value))
+        session._set_attribute_vi_session(self._attribute_id, _converters.convert_to_nitclk_session_number(value))
 
 
 

--- a/generated/nidcpower/_attributes.py
+++ b/generated/nidcpower/_attributes.py
@@ -115,10 +115,10 @@ class AttributeSessionReference(Attribute):
     def __get__(self, session, session_type):
         # Import here to avoid a circular dependency when initial import happens
         from nidcpower.session import SessionReference
-        return SessionReference(session._get_attribute_vi_int32(self._attribute_id))
+        return SessionReference(session._get_attribute_vi_session(self._attribute_id))
 
     def __set__(self, session, value):
-        session._set_attribute_vi_int32(self._attribute_id, _converters.convert_to_nitclk_session_number(value))
+        session._set_attribute_vi_session(self._attribute_id, _converters.convert_to_nitclk_session_number(value))
 
 
 

--- a/generated/nidigital/_attributes.py
+++ b/generated/nidigital/_attributes.py
@@ -115,10 +115,10 @@ class AttributeSessionReference(Attribute):
     def __get__(self, session, session_type):
         # Import here to avoid a circular dependency when initial import happens
         from nidigital.session import SessionReference
-        return SessionReference(session._get_attribute_vi_int32(self._attribute_id))
+        return SessionReference(session._get_attribute_vi_session(self._attribute_id))
 
     def __set__(self, session, value):
-        session._set_attribute_vi_int32(self._attribute_id, _converters.convert_to_nitclk_session_number(value))
+        session._set_attribute_vi_session(self._attribute_id, _converters.convert_to_nitclk_session_number(value))
 
 
 

--- a/generated/nidmm/_attributes.py
+++ b/generated/nidmm/_attributes.py
@@ -115,10 +115,10 @@ class AttributeSessionReference(Attribute):
     def __get__(self, session, session_type):
         # Import here to avoid a circular dependency when initial import happens
         from nidmm.session import SessionReference
-        return SessionReference(session._get_attribute_vi_int32(self._attribute_id))
+        return SessionReference(session._get_attribute_vi_session(self._attribute_id))
 
     def __set__(self, session, value):
-        session._set_attribute_vi_int32(self._attribute_id, _converters.convert_to_nitclk_session_number(value))
+        session._set_attribute_vi_session(self._attribute_id, _converters.convert_to_nitclk_session_number(value))
 
 
 

--- a/generated/nifake/_attributes.py
+++ b/generated/nifake/_attributes.py
@@ -115,10 +115,10 @@ class AttributeSessionReference(Attribute):
     def __get__(self, session, session_type):
         # Import here to avoid a circular dependency when initial import happens
         from nifake.session import SessionReference
-        return SessionReference(session._get_attribute_vi_int32(self._attribute_id))
+        return SessionReference(session._get_attribute_vi_session(self._attribute_id))
 
     def __set__(self, session, value):
-        session._set_attribute_vi_int32(self._attribute_id, _converters.convert_to_nitclk_session_number(value))
+        session._set_attribute_vi_session(self._attribute_id, _converters.convert_to_nitclk_session_number(value))
 
 
 

--- a/generated/nifgen/_attributes.py
+++ b/generated/nifgen/_attributes.py
@@ -115,10 +115,10 @@ class AttributeSessionReference(Attribute):
     def __get__(self, session, session_type):
         # Import here to avoid a circular dependency when initial import happens
         from nifgen.session import SessionReference
-        return SessionReference(session._get_attribute_vi_int32(self._attribute_id))
+        return SessionReference(session._get_attribute_vi_session(self._attribute_id))
 
     def __set__(self, session, value):
-        session._set_attribute_vi_int32(self._attribute_id, _converters.convert_to_nitclk_session_number(value))
+        session._set_attribute_vi_session(self._attribute_id, _converters.convert_to_nitclk_session_number(value))
 
 
 

--- a/generated/niscope/_attributes.py
+++ b/generated/niscope/_attributes.py
@@ -115,10 +115,10 @@ class AttributeSessionReference(Attribute):
     def __get__(self, session, session_type):
         # Import here to avoid a circular dependency when initial import happens
         from niscope.session import SessionReference
-        return SessionReference(session._get_attribute_vi_int32(self._attribute_id))
+        return SessionReference(session._get_attribute_vi_session(self._attribute_id))
 
     def __set__(self, session, value):
-        session._set_attribute_vi_int32(self._attribute_id, _converters.convert_to_nitclk_session_number(value))
+        session._set_attribute_vi_session(self._attribute_id, _converters.convert_to_nitclk_session_number(value))
 
 
 

--- a/generated/niswitch/_attributes.py
+++ b/generated/niswitch/_attributes.py
@@ -115,10 +115,10 @@ class AttributeSessionReference(Attribute):
     def __get__(self, session, session_type):
         # Import here to avoid a circular dependency when initial import happens
         from niswitch.session import SessionReference
-        return SessionReference(session._get_attribute_vi_int32(self._attribute_id))
+        return SessionReference(session._get_attribute_vi_session(self._attribute_id))
 
     def __set__(self, session, value):
-        session._set_attribute_vi_int32(self._attribute_id, _converters.convert_to_nitclk_session_number(value))
+        session._set_attribute_vi_session(self._attribute_id, _converters.convert_to_nitclk_session_number(value))
 
 
 

--- a/generated/nitclk/_attributes.py
+++ b/generated/nitclk/_attributes.py
@@ -115,10 +115,10 @@ class AttributeSessionReference(Attribute):
     def __get__(self, session, session_type):
         # Import here to avoid a circular dependency when initial import happens
         from nitclk.session import SessionReference
-        return SessionReference(session._get_attribute_vi_int32(self._attribute_id))
+        return SessionReference(session._get_attribute_vi_session(self._attribute_id))
 
     def __set__(self, session, value):
-        session._set_attribute_vi_int32(self._attribute_id, _converters.convert_to_nitclk_session_number(value))
+        session._set_attribute_vi_session(self._attribute_id, _converters.convert_to_nitclk_session_number(value))
 
 
 

--- a/src/nitclk/metadata/attributes.py
+++ b/src/nitclk/metadata/attributes.py
@@ -33,7 +33,7 @@ attributes = {
         'lv_property': 'Start Trigger Master Session',
         'name': 'START_TRIGGER_MASTER_SESSION',
         'resettable': False,
-        'type': 'ViInt32',
+        'type': 'ViSession',
         'type_in_documentation': 'nimi-python Session class, nitclk.SessionReference, NI-TClk Session Number'
     },
     4: {
@@ -46,7 +46,7 @@ attributes = {
         'lv_property': 'Reference Trigger Master Session',
         'name': 'REF_TRIGGER_MASTER_SESSION',
         'resettable': False,
-        'type': 'ViInt32',
+        'type': 'ViSession',
         'type_in_documentation': 'nimi-python Session class, nitclk.SessionReference, NI-TClk Session Number'
     },
     5: {
@@ -59,7 +59,7 @@ attributes = {
         'lv_property': 'Script Trigger Master Session',
         'name': 'SCRIPT_TRIGGER_MASTER_SESSION',
         'resettable': False,
-        'type': 'ViInt32',
+        'type': 'ViSession',
         'type_in_documentation': 'nimi-python Session class, nitclk.SessionReference, NI-TClk Session Number'
     },
     6: {
@@ -72,7 +72,7 @@ attributes = {
         'lv_property': 'Pause Trigger Master Session',
         'name': 'PAUSE_TRIGGER_MASTER_SESSION',
         'resettable': False,
-        'type': 'ViInt32',
+        'type': 'ViSession',
         'type_in_documentation': 'nimi-python Session class, nitclk.SessionReference, NI-TClk Session Number'
     },
     8: {
@@ -141,7 +141,7 @@ attributes = {
         'lv_property': 'Sequencer Flag Master Session',
         'name': 'SEQUENCER_FLAG_MASTER_SESSION',
         'resettable': False,
-        'type': 'ViInt32',
+        'type': 'ViSession',
         'type_in_documentation': 'nimi-python Session class, nitclk.SessionReference, NI-TClk Session Number'
     }
 }


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [X] ~~I've added tests applicable for this pull request~~
### What does this Pull Request accomplish?
* nitclk session type attributes are actually type `ViSession` and not `ViInt32`
* Also, functions are `GetAttributeViSession()`/`SetAttributeViSession()` and not `GetAttributeViInt32()`/`SetAttributeViInt32()`

### ~~List issues fixed by this Pull Request below, if any.~~

### What testing has been done?
* Visual inspection