### PR TITLE
Changing _library_singleton.py to pass a relative path to ctypes.CDLL()

### DIFF
--- a/build/templates/_library_singleton.py.mako
+++ b/build/templates/_library_singleton.py.mako
@@ -10,6 +10,7 @@ module_name = config['module_name']
 import platform
 
 import ctypes
+import ctypes.util
 import ${module_name}._library as _library
 import ${module_name}.errors as errors
 import threading
@@ -22,7 +23,7 @@ _library_info = ${helper.get_dictionary_snippet(config['library_info'], indent=1
 
 def _get_library_name():
     try:
-        return _library_info[platform.system()][platform.architecture()[0]]['name']
+        return ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
     except KeyError:
         raise errors.UnsupportedConfigurationError
 

--- a/generated/nidcpower/_library_singleton.py
+++ b/generated/nidcpower/_library_singleton.py
@@ -4,6 +4,7 @@
 import platform
 
 import ctypes
+import ctypes.util
 import nidcpower._library as _library
 import nidcpower.errors as errors
 import threading
@@ -18,7 +19,7 @@ _library_info = {'Linux': {'64bit': {'name': 'libnidcpower.so', 'type': 'cdll'}}
 
 def _get_library_name():
     try:
-        return _library_info[platform.system()][platform.architecture()[0]]['name']
+        return ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
     except KeyError:
         raise errors.UnsupportedConfigurationError
 

--- a/generated/nidigital/_library_singleton.py
+++ b/generated/nidigital/_library_singleton.py
@@ -4,6 +4,7 @@
 import platform
 
 import ctypes
+import ctypes.util
 import nidigital._library as _library
 import nidigital.errors as errors
 import threading
@@ -18,7 +19,7 @@ _library_info = {'Linux': {'64bit': {'name': 'libnidigital.so', 'type': 'cdll'}}
 
 def _get_library_name():
     try:
-        return _library_info[platform.system()][platform.architecture()[0]]['name']
+        return ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
     except KeyError:
         raise errors.UnsupportedConfigurationError
 

--- a/generated/nidmm/_library_singleton.py
+++ b/generated/nidmm/_library_singleton.py
@@ -4,6 +4,7 @@
 import platform
 
 import ctypes
+import ctypes.util
 import nidmm._library as _library
 import nidmm.errors as errors
 import threading
@@ -18,7 +19,7 @@ _library_info = {'Linux': {'64bit': {'name': 'libnidmm.so', 'type': 'cdll'}},
 
 def _get_library_name():
     try:
-        return _library_info[platform.system()][platform.architecture()[0]]['name']
+        return ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
     except KeyError:
         raise errors.UnsupportedConfigurationError
 

--- a/generated/nifake/_library_singleton.py
+++ b/generated/nifake/_library_singleton.py
@@ -4,6 +4,7 @@
 import platform
 
 import ctypes
+import ctypes.util
 import nifake._library as _library
 import nifake.errors as errors
 import threading
@@ -18,7 +19,7 @@ _library_info = {'Linux': {'64bit': {'name': 'libnifake.so', 'type': 'cdll'}},
 
 def _get_library_name():
     try:
-        return _library_info[platform.system()][platform.architecture()[0]]['name']
+        return ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
     except KeyError:
         raise errors.UnsupportedConfigurationError
 

--- a/generated/nifgen/_library_singleton.py
+++ b/generated/nifgen/_library_singleton.py
@@ -4,6 +4,7 @@
 import platform
 
 import ctypes
+import ctypes.util
 import nifgen._library as _library
 import nifgen.errors as errors
 import threading
@@ -18,7 +19,7 @@ _library_info = {'Linux': {'64bit': {'name': 'libfgen.so', 'type': 'cdll'}},
 
 def _get_library_name():
     try:
-        return _library_info[platform.system()][platform.architecture()[0]]['name']
+        return ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
     except KeyError:
         raise errors.UnsupportedConfigurationError
 

--- a/generated/nimodinst/_library_singleton.py
+++ b/generated/nimodinst/_library_singleton.py
@@ -4,6 +4,7 @@
 import platform
 
 import ctypes
+import ctypes.util
 import nimodinst._library as _library
 import nimodinst.errors as errors
 import threading
@@ -18,7 +19,7 @@ _library_info = {'Linux': {'64bit': {'name': 'libnimodinst.so', 'type': 'cdll'}}
 
 def _get_library_name():
     try:
-        return _library_info[platform.system()][platform.architecture()[0]]['name']
+        return ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
     except KeyError:
         raise errors.UnsupportedConfigurationError
 

--- a/generated/niscope/_library_singleton.py
+++ b/generated/niscope/_library_singleton.py
@@ -4,6 +4,7 @@
 import platform
 
 import ctypes
+import ctypes.util
 import niscope._library as _library
 import niscope.errors as errors
 import threading
@@ -18,7 +19,7 @@ _library_info = {'Linux': {'64bit': {'name': 'libniscope.so', 'type': 'cdll'}},
 
 def _get_library_name():
     try:
-        return _library_info[platform.system()][platform.architecture()[0]]['name']
+        return ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
     except KeyError:
         raise errors.UnsupportedConfigurationError
 

--- a/generated/nise/_library_singleton.py
+++ b/generated/nise/_library_singleton.py
@@ -4,6 +4,7 @@
 import platform
 
 import ctypes
+import ctypes.util
 import nise._library as _library
 import nise.errors as errors
 import threading
@@ -18,7 +19,7 @@ _library_info = {'Linux': {'64bit': {'name': 'libnise.so', 'type': 'cdll'}},
 
 def _get_library_name():
     try:
-        return _library_info[platform.system()][platform.architecture()[0]]['name']
+        return ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
     except KeyError:
         raise errors.UnsupportedConfigurationError
 

--- a/generated/niswitch/_library_singleton.py
+++ b/generated/niswitch/_library_singleton.py
@@ -4,6 +4,7 @@
 import platform
 
 import ctypes
+import ctypes.util
 import niswitch._library as _library
 import niswitch.errors as errors
 import threading
@@ -18,7 +19,7 @@ _library_info = {'Linux': {'64bit': {'name': 'libniswitch.so', 'type': 'cdll'}},
 
 def _get_library_name():
     try:
-        return _library_info[platform.system()][platform.architecture()[0]]['name']
+        return ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
     except KeyError:
         raise errors.UnsupportedConfigurationError
 

--- a/generated/nitclk/_library_singleton.py
+++ b/generated/nitclk/_library_singleton.py
@@ -4,6 +4,7 @@
 import platform
 
 import ctypes
+import ctypes.util
 import nitclk._library as _library
 import nitclk.errors as errors
 import threading
@@ -18,7 +19,7 @@ _library_info = {'Linux': {'64bit': {'name': 'libnitclk.so', 'type': 'cdll'}},
 
 def _get_library_name():
     try:
-        return _library_info[platform.system()][platform.architecture()[0]]['name']
+        return ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
     except KeyError:
         raise errors.UnsupportedConfigurationError
 


### PR DESCRIPTION
 ctypes on python 3.8 requires full relative paths

- [ X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~

- ~~[ ] I've added tests applicable for this pull request~~

System tests in place should suffice.

### What does this Pull Request accomplish?

 on python 3.8 the API will always return driver not installed error because we are not using a full ablsolute path to the driver .dlls

### List issues fixed by this Pull Request below, if any.

python 3.8 can't load NI-SCOPE runtime

* Fix #1091 


### What testing has been done?

- ran system tests provided. 
- the error in the issue #1091 doesn't happen anymore. 
