### PR TITLE
Remove _get/set_attribute_vi_session methods from nidigital

### DIFF
--- a/generated/nidigital/_library.py
+++ b/generated/nidigital/_library.py
@@ -75,7 +75,6 @@ class Library(object):
         self.niDigital_GetAttributeViInt32_cfunc = None
         self.niDigital_GetAttributeViInt64_cfunc = None
         self.niDigital_GetAttributeViReal64_cfunc = None
-        self.niDigital_GetAttributeViSession_cfunc = None
         self.niDigital_GetAttributeViString_cfunc = None
         self.niDigital_GetChannelName_cfunc = None
         self.niDigital_GetChannelNameFromString_cfunc = None
@@ -127,7 +126,6 @@ class Library(object):
         self.niDigital_SetAttributeViInt32_cfunc = None
         self.niDigital_SetAttributeViInt64_cfunc = None
         self.niDigital_SetAttributeViReal64_cfunc = None
-        self.niDigital_SetAttributeViSession_cfunc = None
         self.niDigital_SetAttributeViString_cfunc = None
         self.niDigital_TDR_cfunc = None
         self.niDigital_UnloadAllPatterns_cfunc = None
@@ -600,14 +598,6 @@ class Library(object):
                 self.niDigital_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetAttributeViReal64_cfunc(vi, channel_name, attribute, value)
 
-    def niDigital_GetAttributeViSession(self, vi, channel_name, attribute, value):  # noqa: N802
-        with self._func_lock:
-            if self.niDigital_GetAttributeViSession_cfunc is None:
-                self.niDigital_GetAttributeViSession_cfunc = self._library.niDigital_GetAttributeViSession
-                self.niDigital_GetAttributeViSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViSession)]  # noqa: F405
-                self.niDigital_GetAttributeViSession_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDigital_GetAttributeViSession_cfunc(vi, channel_name, attribute, value)
-
     def niDigital_GetAttributeViString(self, vi, channel_name, attribute, buffer_size, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetAttributeViString_cfunc is None:
@@ -1015,14 +1005,6 @@ class Library(object):
                 self.niDigital_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niDigital_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_SetAttributeViReal64_cfunc(vi, channel_name, attribute, value)
-
-    def niDigital_SetAttributeViSession(self, vi, channel_name, attribute, value):  # noqa: N802
-        with self._func_lock:
-            if self.niDigital_SetAttributeViSession_cfunc is None:
-                self.niDigital_SetAttributeViSession_cfunc = self._library.niDigital_SetAttributeViSession
-                self.niDigital_SetAttributeViSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViSession]  # noqa: F405
-                self.niDigital_SetAttributeViSession_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDigital_SetAttributeViSession_cfunc(vi, channel_name, attribute, value)
 
     def niDigital_SetAttributeViString(self, vi, channel_name, attribute, value):  # noqa: N802
         with self._func_lock:

--- a/generated/nidigital/session.py
+++ b/generated/nidigital/session.py
@@ -1021,36 +1021,6 @@ class _SessionBase(object):
         return float(value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_session(self, attribute):
-        r'''_get_attribute_vi_session
-
-        TBD
-
-        Tip:
-        This method requires repeated capabilities (channels). If called directly on the
-        nidigital.Session object, then the method will use all repeated capabilities in the session.
-        You can specify a subset of repeated capabilities using the Python index notation on an
-        nidigital.Session repeated capabilities container, and calling this method on the result.:
-
-            session.channels[0,1]._get_attribute_vi_session(property)
-
-        Args:
-            attribute (int):
-
-
-        Returns:
-            value (int):
-
-        '''
-        vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        channel_name_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
-        attribute_ctype = _visatype.ViAttr(attribute)  # case S150
-        value_ctype = _visatype.ViSession()  # case S220
-        error_code = self._library.niDigital_GetAttributeViSession(vi_ctype, channel_name_ctype, attribute_ctype, None if value_ctype is None else (ctypes.pointer(value_ctype)))
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return int(value_ctype.value)
-
-    @ivi_synchronized
     def _get_attribute_vi_string(self, attribute):
         r'''_get_attribute_vi_string
 
@@ -1714,34 +1684,6 @@ class _SessionBase(object):
         attribute_ctype = _visatype.ViAttr(attribute)  # case S150
         value_ctype = _visatype.ViReal64(value)  # case S150
         error_code = self._library.niDigital_SetAttributeViReal64(vi_ctype, channel_name_ctype, attribute_ctype, value_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return
-
-    @ivi_synchronized
-    def _set_attribute_vi_session(self, attribute, value):
-        r'''_set_attribute_vi_session
-
-        TBD
-
-        Tip:
-        This method requires repeated capabilities (channels). If called directly on the
-        nidigital.Session object, then the method will use all repeated capabilities in the session.
-        You can specify a subset of repeated capabilities using the Python index notation on an
-        nidigital.Session repeated capabilities container, and calling this method on the result.:
-
-            session.channels[0,1]._set_attribute_vi_session(property, value)
-
-        Args:
-            attribute (int):
-
-            value (int):
-
-        '''
-        vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        channel_name_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
-        attribute_ctype = _visatype.ViAttr(attribute)  # case S150
-        value_ctype = _visatype.ViSession(value)  # case S150
-        error_code = self._library.niDigital_SetAttributeViSession(vi_ctype, channel_name_ctype, attribute_ctype, value_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 

--- a/generated/nidigital/unit_tests/_mock_helper.py
+++ b/generated/nidigital/unit_tests/_mock_helper.py
@@ -146,9 +146,6 @@ class SideEffectsHelper(object):
         self._defaults['GetAttributeViReal64'] = {}
         self._defaults['GetAttributeViReal64']['return'] = 0
         self._defaults['GetAttributeViReal64']['value'] = None
-        self._defaults['GetAttributeViSession'] = {}
-        self._defaults['GetAttributeViSession']['return'] = 0
-        self._defaults['GetAttributeViSession']['value'] = None
         self._defaults['GetAttributeViString'] = {}
         self._defaults['GetAttributeViString']['return'] = 0
         self._defaults['GetAttributeViString']['value'] = None
@@ -287,8 +284,6 @@ class SideEffectsHelper(object):
         self._defaults['SetAttributeViInt64']['return'] = 0
         self._defaults['SetAttributeViReal64'] = {}
         self._defaults['SetAttributeViReal64']['return'] = 0
-        self._defaults['SetAttributeViSession'] = {}
-        self._defaults['SetAttributeViSession']['return'] = 0
         self._defaults['SetAttributeViString'] = {}
         self._defaults['SetAttributeViString']['return'] = 0
         self._defaults['TDR'] = {}
@@ -716,16 +711,6 @@ class SideEffectsHelper(object):
         if value is not None:
             value.contents.value = self._defaults['GetAttributeViReal64']['value']
         return self._defaults['GetAttributeViReal64']['return']
-
-    def niDigital_GetAttributeViSession(self, vi, channel_name, attribute, value):  # noqa: N802
-        if self._defaults['GetAttributeViSession']['return'] != 0:
-            return self._defaults['GetAttributeViSession']['return']
-        # value
-        if self._defaults['GetAttributeViSession']['value'] is None:
-            raise MockFunctionCallError("niDigital_GetAttributeViSession", param='value')
-        if value is not None:
-            value.contents.value = self._defaults['GetAttributeViSession']['value']
-        return self._defaults['GetAttributeViSession']['return']
 
     def niDigital_GetAttributeViString(self, vi, channel_name, attribute, buffer_size, value):  # noqa: N802
         if self._defaults['GetAttributeViString']['return'] != 0:
@@ -1207,11 +1192,6 @@ class SideEffectsHelper(object):
             return self._defaults['SetAttributeViReal64']['return']
         return self._defaults['SetAttributeViReal64']['return']
 
-    def niDigital_SetAttributeViSession(self, vi, channel_name, attribute, value):  # noqa: N802
-        if self._defaults['SetAttributeViSession']['return'] != 0:
-            return self._defaults['SetAttributeViSession']['return']
-        return self._defaults['SetAttributeViSession']['return']
-
     def niDigital_SetAttributeViString(self, vi, channel_name, attribute, value):  # noqa: N802
         if self._defaults['SetAttributeViString']['return'] != 0:
             return self._defaults['SetAttributeViString']['return']
@@ -1446,8 +1426,6 @@ class SideEffectsHelper(object):
         mock_library.niDigital_GetAttributeViInt64.return_value = 0
         mock_library.niDigital_GetAttributeViReal64.side_effect = MockFunctionCallError("niDigital_GetAttributeViReal64")
         mock_library.niDigital_GetAttributeViReal64.return_value = 0
-        mock_library.niDigital_GetAttributeViSession.side_effect = MockFunctionCallError("niDigital_GetAttributeViSession")
-        mock_library.niDigital_GetAttributeViSession.return_value = 0
         mock_library.niDigital_GetAttributeViString.side_effect = MockFunctionCallError("niDigital_GetAttributeViString")
         mock_library.niDigital_GetAttributeViString.return_value = 0
         mock_library.niDigital_GetChannelName.side_effect = MockFunctionCallError("niDigital_GetChannelName")
@@ -1550,8 +1528,6 @@ class SideEffectsHelper(object):
         mock_library.niDigital_SetAttributeViInt64.return_value = 0
         mock_library.niDigital_SetAttributeViReal64.side_effect = MockFunctionCallError("niDigital_SetAttributeViReal64")
         mock_library.niDigital_SetAttributeViReal64.return_value = 0
-        mock_library.niDigital_SetAttributeViSession.side_effect = MockFunctionCallError("niDigital_SetAttributeViSession")
-        mock_library.niDigital_SetAttributeViSession.return_value = 0
         mock_library.niDigital_SetAttributeViString.side_effect = MockFunctionCallError("niDigital_SetAttributeViString")
         mock_library.niDigital_SetAttributeViString.return_value = 0
         mock_library.niDigital_TDR.side_effect = MockFunctionCallError("niDigital_TDR")

--- a/src/nidigital/metadata/functions.py
+++ b/src/nidigital/metadata/functions.py
@@ -1685,7 +1685,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'GetAttributeViSession': {
-        'codegen_method': 'private',
+        'codegen_method': 'no',
         'documentation': {
             'description': 'TBD'
         },
@@ -3138,7 +3138,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'SetAttributeViSession': {
-        'codegen_method': 'private',
+        'codegen_method': 'no',
         'documentation': {
             'description': 'TBD'
         },


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
~~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
~~- [ ] I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

Remove _get/set_attribute_vi_session methods from nidigital, as they are not needed.

### List issues fixed by this Pull Request below, if any.
None

### What testing has been done?

Visual inspection
