### PR TITLE
Remove u32 from write_source_waveform_broadcast_u32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable changes to this project will be documented in this file.
     * #### Changed
         * Fix get/set properties - [#1062](https://github.com/ni/nimi-python/issues/1062)
         * Removed array-size parameter from apply_tdr_offsets() and write_source_waveform_broadcast_u32() methods - [#1070](https://github.com/ni/nimi-python/issues/1070)
+        * Renamed `write_source_waveform_broadcast_u32()` to `write_source_waveform_broadcast()`
     * #### Removed
 * ### NI-TClk
     * #### Added

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -3265,12 +3265,12 @@ write_sequencer_register
 
             :type value: int
 
-write_source_waveform_broadcast_u32
------------------------------------
+write_source_waveform_broadcast
+-------------------------------
 
     .. py:currentmodule:: nidigital.Session
 
-    .. py:method:: write_source_waveform_broadcast_u32(waveform_name, waveform_data)
+    .. py:method:: write_source_waveform_broadcast(waveform_name, waveform_data)
 
             TBD
 

--- a/generated/nidigital/session.py
+++ b/generated/nidigital/session.py
@@ -3481,8 +3481,8 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def write_source_waveform_broadcast_u32(self, waveform_name, waveform_data):
-        r'''write_source_waveform_broadcast_u32
+    def write_source_waveform_broadcast(self, waveform_name, waveform_data):
+        r'''write_source_waveform_broadcast
 
         TBD
 

--- a/src/nidigital/metadata/functions.py
+++ b/src/nidigital/metadata/functions.py
@@ -3652,6 +3652,7 @@ functions = {
         'documentation': {
             'description': 'TBD'
         },
+        'python_name': 'write_source_waveform_broadcast',
         'parameters': [
             {
                 'direction': 'in',

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -70,7 +70,7 @@ def test_source_waveform_parallel_broadcast(multi_instrument_session):
         waveform_name='new_waveform',
         data_mapping=2600)
 
-    multi_instrument_session.write_source_waveform_broadcast_u32(
+    multi_instrument_session.write_source_waveform_broadcast(
         waveform_name='new_waveform',
         waveform_data=[i for i in range(4)])
 


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- [X] ~~I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?
* Renames `write_source_waveform_broadcast_u32()` to write_source_waveform_broadcast()`

### List issues fixed by this Pull Request below, if any.
* Fix #1105 

### What testing has been done?
* Visual inspection to generated files