### PR TITLE
Make rules cleanup for global files

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -20,7 +20,6 @@ _hide_cmds := @
 endif
 
 # We only add root files if we are building the 'all' target (nothing on the command line)
-$(warning $(MAKECMDGOALS))
 ifeq (,$(MAKECMDGOALS))
 ROOT_FILES := \
 	$(ROOT_DIR)/README.rst \
@@ -117,21 +116,35 @@ PYTHON_CMD ?= python3
 
 .PHONY: help Makefile
 
-global_files_start: $(DRIVERS)
+# For the global files, instead of trying to keep track of which files from the driver builds matter for any target,
+# we just say that if anything from any driver built, we will rebuld the global files
+export DRIVER_FILE_BUILT = bin/driver_file_built
+
+GLOBAL_FILES_STARTED_FILE = bin/printed_global_files
+$(GLOBAL_FILES_STARTED_FILE): $(DRIVER_FILE_BUILT)
 	@echo
 	@echo "Making Global Files"
+	@touch $(GLOBAL_FILES_STARTED_FILE)
 
-$(ROOT_DIR)/README.rst: global_files_start
+# Executes a command, then logs it to $(COMMAND_LOG).
+# $1 is the command.
+# We need our own copy that does not touch DRIVER_FILE_BUILT
+define global_log_command
+	$1
+	@echo '$1' >> $(COMMAND_LOG)
+endef
+
+$(ROOT_DIR)/README.rst: $(GLOBAL_FILES_STARTED_FILE)
 	$(call trace_to_console, "Creating Root",$(notdir $@))
-	$(_hide_cmds)$(call log_command,cat $(STATIC_DOCS_DIR)/status_project.inc $(STATIC_DOCS_DIR)/about.inc $(DOCS_DIR)/*/status.inc $(STATIC_DOCS_DIR)/installation.inc $(STATIC_DOCS_DIR)/contributing.inc $(STATIC_DOCS_DIR)/nidmm_usage.inc $(STATIC_DOCS_DIR)/support.inc $(STATIC_DOCS_DIR)/documentation.inc $(STATIC_DOCS_DIR)/license.inc > $@)
+	$(_hide_cmds)$(call global_log_command,cat $(STATIC_DOCS_DIR)/status_project.inc $(STATIC_DOCS_DIR)/about.inc $(DOCS_DIR)/*/status.inc $(STATIC_DOCS_DIR)/installation.inc $(STATIC_DOCS_DIR)/contributing.inc $(STATIC_DOCS_DIR)/nidmm_usage.inc $(STATIC_DOCS_DIR)/support.inc $(STATIC_DOCS_DIR)/documentation.inc $(STATIC_DOCS_DIR)/license.inc > $@)
 
-$(ROOT_DIR)/VERSION: global_files_start
+$(ROOT_DIR)/VERSION: $(GLOBAL_FILES_STARTED_FILE)
 	$(call trace_to_console, "Creating Root",$(notdir $@)) tools/update_version_file.py
-	$(_hide_cmds)$(call log_command,$(PYTHON_CMD) tools/update_version_file.py --output-file $@ $(foreach d,$(DRIVERS),--input-file bin/$(d)/$(d)/VERSION ))
+	$(_hide_cmds)$(call global_log_command,$(PYTHON_CMD) tools/update_version_file.py --output-file $@ $(foreach d,$(DRIVERS),--input-file bin/$(d)/$(d)/VERSION ))
 
-$(DOCS_DIR)/conf.py: build/templates/conf.py.mako $(ROOT_DIR)/VERSION tools/simple_mako.py
+$(DOCS_DIR)/conf.py: build/templates/conf.py.mako $(ROOT_DIR)/VERSION tools/simple_mako.py $(GLOBAL_FILES_STARTED_FILE)
 	$(call trace_to_console, "Creating Root",$(notdir $@))
-	$(_hide_cmds)$(call log_command,$(PYTHON_CMD) tools/simple_mako.py --output-file $@ --template $<)
+	$(_hide_cmds)$(call global_log_command,$(PYTHON_CMD) tools/simple_mako.py --output-file $@ --template $<)
 
 
 # Any step that any driver build does that would invalidate unit testing, flake8 or generated html

--- a/build/Makefile
+++ b/build/Makefile
@@ -61,6 +61,8 @@ endef
 $(foreach t,$(DEFAULT_TARGETS),$(eval $(call per_target,$(t))))
 
 SUPPRESS_ERROR_OUTPUT ?= 2> /dev/null
+
+# We need to ensure bin exists for Travis CI builds
 clean: start
 	@echo 'Cleaning...'
 	-@rm -Rf $(BIN_DIR) $(SUPPRESS_ERROR_OUTPUT) ||:
@@ -72,6 +74,7 @@ clean: start
 	-@rm -Rf $(ROOT_DIR)/.coverage $(SUPPRESS_ERROR_OUTPUT) ||:
 	-@rm -Rf $(ROOT_DIR)/README.rst $(SUPPRESS_ERROR_OUTPUT) ||:
 	-@rm -Rf $(ROOT_DIR)/docs/conf.py $(SUPPRESS_ERROR_OUTPUT) ||:
+	-@mkdir $(BIN_DIR) $(SUPPRESS_ERROR_OUTPUT) ||:
 
 start:
 	-@echo "# This is the list of commands that make invoked in order to build nimi-python. If" > $(COMMAND_LOG)

--- a/build/rules.mak
+++ b/build/rules.mak
@@ -21,8 +21,11 @@ $1:
 endef
 $(foreach d,$(MKDIRECTORIES),$(eval $(call mkdir_rule,$(d))))
 
+# We set up some additional dependencies for specific files
+# examples.rst needs to use find since there may be folders of files and it needs to be recursive. wildcard is not
 $(MODULE_DIR)/session.py: $(wildcard $(TEMPLATE_DIR)/session.py/*.mako) $(wildcard $(DRIVER_DIR)/templates/session.py/*.mako)
-$(DRIVER_DOCS_DIR)/functions.rst: $(wildcard $(TEMPLATE_DIR)/functions.rst/*.mako) $(wildcard $(DRIVER_DIR)/templates/functions.rst/*.mako)
+$(DRIVER_DOCS_DIR)/class.rst: $(wildcard $(TEMPLATE_DIR)/functions.rst/*.mako) $(wildcard $(DRIVER_DIR)/templates/functions.rst/*.mako)
+$(DRIVER_DOCS_DIR)/examples.rst: $(if $(wildcard src/$(DRIVER)/examples/*),$(shell find src/$(DRIVER)/examples/* -type f -print),)
 
 $(MODULE_DIR)/%.py: %.py.mako $(BUILD_HELPER_SCRIPTS) $(METADATA_FILES)
 	$(call trace_to_console, "Generating",$@)

--- a/build/tools.mak
+++ b/build/tools.mak
@@ -14,6 +14,7 @@ endef
 define log_command
 	$1
 	@echo '$1' >> $(COMMAND_LOG)
+	@touch $(DRIVER_FILE_BUILT)
 endef
 
 # Helper function for running a command with a tracking file


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [X] ~~I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?
* Cleans up dependencies for global files
    * They now properly build only when an actual dependency changes
    * Build is triggered when any driver file rebuilds

### List issues fixed by this Pull Request below, if any.
These no longer apply, but I think they were already fixed. Either way, they are fixed now so I am marking them as fixed by this PR.

* Fix #647 
* Fix #689 

### What testing has been done?
* Builds. Lots and lots of builds.