### PR TITLE
Remove python 2.7 and 3.4 from the list of versions to test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 [tox]
-envlist = py{27,34,35,36,37,38,py,py3}-test
+envlist = py{35,36,37,38,py3}-test
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 skipsdist = true


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [X] ~~I've added tests applicable for this pull request~~
### What does this Pull Request accomplish?
* Should have been removed when removing python 2.7 & 3.4 support

### ~~List issues fixed by this Pull Request below, if any.~~
### What testing has been done?
* Unit
* System
* Visual inspection of versions tests