### PR TITLE
Add tests for get_pin_results_pin_information

### DIFF
--- a/src/nidigital/system_tests/test_files/pin_map.pinmap
+++ b/src/nidigital/system_tests/test_files/pin_map.pinmap
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<PinMap xmlns="http://www.ni.com/TestStand/SemiconductorModule/PinMap.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.5">
+	<Instruments>
+		<NIDigitalPatternInstrument name="PXI1Slot2" numberOfChannels="32" group="Digital" />
+		<NIDigitalPatternInstrument name="PXI1Slot5" numberOfChannels="32" group="Digital" />
+	</Instruments>
+	<Pins>
+		<DUTPin name="PinA" />
+		<DUTPin name="PinB" />
+		<DUTPin name="PinC" />
+		<SystemPin name="SysPin" />
+	</Pins>
+	<PinGroups>
+		<PinGroup name="DutPins">
+			<PinReference pin="PinA" />
+			<PinReference pin="PinB" />
+			<PinReference pin="PinC" />
+		</PinGroup>
+		<PinGroup name="SysPins">
+			<PinReference pin="SysPin" />
+		</PinGroup>
+	</PinGroups>
+	<Sites>
+		<Site siteNumber="0" />
+		<Site siteNumber="1" />
+	</Sites>
+	<Connections>
+		<Connection pin="PinA" siteNumber="0" instrument="PXI1Slot2" channel="0" />
+		<Connection pin="PinA" siteNumber="1" instrument="PXI1Slot5" channel="0" />
+		<Connection pin="PinB" siteNumber="0" instrument="PXI1Slot2" channel="1" />
+		<Connection pin="PinB" siteNumber="1" instrument="PXI1Slot5" channel="1" />
+		<Connection pin="PinC" siteNumber="0" instrument="PXI1Slot2" channel="2" />
+		<Connection pin="PinC" siteNumber="1" instrument="PXI1Slot5" channel="2" />
+		<SystemConnection pin="SysPin" instrument="PXI1Slot2" channel="3" />
+	</Connections>
+</PinMap>

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -70,10 +70,6 @@ def test_tdr_some_channels(multi_instrument_session):
     assert fetched_offsets == applied_offsets
 
 
-def test_get_pin_results_pin_information(multi_instrument_session):
-    pass
-
-
 def test_source_waveform_parallel_broadcast(multi_instrument_session):
     test_name = test_source_waveform_parallel_broadcast.__name__
     configure_session(multi_instrument_session, test_name)

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -239,3 +239,17 @@ def test_fetch_capture_waveform(multi_instrument_session):
     assert fetched_site == 1
     assert len(fetched_waveform[fetched_site]) == num_samples
 
+
+def test_get_pin_results_pin_information(multi_instrument_session):
+    multi_instrument_session.load_pin_map(os.path.join(test_files_base_dir, "pin_map.pinmap"))
+
+    fully_qualified_channels = [instr[1] + '/0', instr[0] + '/1', instr[1] + '/11']
+    pin_info = multi_instrument_session.channels[fully_qualified_channels].get_pin_results_pin_information()
+
+    pins = [i.pin_name for i in pin_info]
+    sites = [i.site_number for i in pin_info]
+    channels = [i.channel_name for i in pin_info]
+
+    assert pins == ['PinA', 'PinB', '']
+    assert sites == [1, 0, -1]
+    assert channels == fully_qualified_channels


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~

- [x] I've added tests applicable for this pull request


### What does this Pull Request accomplish?

Add tests for `get_pin_results_pin_information`. This method was made "fancy" in Python:
- Instead of returning pin indices, we call `get_pin_name` and return pin names
- Instead of returning channel numbers (int), we return fully-qualified channel names
 - Instead of returning 3 different arrays (as in C API), we return a list of `collections.namedtuple('PinInformation', ['pin_name', 'site_number', 'channel_name'])`

### List issues fixed by this Pull Request below, if any.

None

### What testing has been done?

Ran tests