### PR TITLE
nidcpower system_tests - stop using DAQmx-framework devices

### DIFF
--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -22,12 +22,8 @@ def multiple_channel_session():
         yield simulated_session
 
 
-def test_self_test():
-    # TODO(frank): self_test does not work with simulated PXIe-4162 modules due to internal NI bug.
-    # Update to use the session created with 'session' function above after internal NI bug is fixed.
-    with nidcpower.Session('', '', False, 'Simulate=1, DriverSetup=Model:4143; BoardType:PXIe') as session:
-        # We should not get an assert if self_test passes
-        session.self_test()
+def test_self_test(session):
+    session.self_test()
 
 
 def test_self_cal(session):
@@ -82,17 +78,14 @@ def test_read_current_temperature(session):
     assert temperature == 25.0
 
 
-def test_reset_device():
-    # TODO(frank): reset_device does not work with simulated PXIe-4162 modules due to internal NI bug.
-    # Update to use the session created with 'session' function above after internal NI bug is fixed.
-    with nidcpower.Session('', '', False, 'Simulate=1, DriverSetup=Model:4143; BoardType:PXIe') as session:
-        channel = session.channels['0']
-        default_output_function = channel.output_function
-        assert default_output_function == nidcpower.OutputFunction.DC_VOLTAGE
-        channel.output_function = nidcpower.OutputFunction.DC_CURRENT
-        session.reset_device()
-        function_after_reset = channel.output_function
-        assert function_after_reset == default_output_function
+def test_reset_device(session):
+    channel = session.channels['0']
+    default_output_function = channel.output_function
+    assert default_output_function == nidcpower.OutputFunction.DC_VOLTAGE
+    channel.output_function = nidcpower.OutputFunction.DC_CURRENT
+    session.reset_device()
+    function_after_reset = channel.output_function
+    assert function_after_reset == default_output_function
 
 
 def test_reset_with_default(session):


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [X] ~~I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?
* No longer used devices whose driver internally uses the DAQmx framework.
* This was being done as a workaround for a driver bug that has been since fixed: `self_test()` and `device_reset()` didn't work on simulated 416x. 416x does not use the DAQmx framework.
* Opening sessions to devices that internally use DAQmx framework is very slow.
* Opening sessions in parallel to devices that internally use DAQmx framework intermittently fails. We want to overhaul our system testing to parallelize so need to work around this internal NI driver runtime bug.

### ~~List issues fixed by this Pull Request below, if any.~~
### What testing has been done?
* System