### PR TITLE
Use 5433 for system test

### DIFF
--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -147,7 +147,7 @@ def test_get_ext_cal_last_date_and_time(session):
         session.get_ext_cal_last_date_and_time()
         assert False, "If we hit this, it means a simulated 5433 now works properly for this. You can now remove the check for -1074135040"
     except nifgen.Error as e:
-        assert e.code == -1074118632 or e.code == -1074135040  # This operation is not supported for simulated device or Unrecoveable failure
+        assert e.code == -1074118632 or e.code == -1074135040  # This operation is not supported for simulated device or Unrecoverable Failure
 
 
 def test_get_ext_cal_last_temp(session):

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -145,9 +145,9 @@ def test_disable(session):
 def test_get_ext_cal_last_date_and_time(session):
     try:
         session.get_ext_cal_last_date_and_time()
-        assert False
+        assert False, "If we hit this, it means a simulated 5433 now works properly for this. You can now remove the check for -1074135040"
     except nifgen.Error as e:
-        assert e.code == -1074118632  # This operation is not supported for simulated device
+        assert e.code == -1074118632 or e.code == -1074135040  # This operation is not supported for simulated device or Unrecoveable failure
 
 
 def test_get_ext_cal_last_temp(session):

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -142,13 +142,12 @@ def test_disable(session):
     assert channel.output_enabled is False
 
 
-def test_get_ext_cal_last_date_and_time():
-    with nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:5421;BoardType:PXI') as session:  # 5433 throws out unrecoverable error on calling get_ext_cal_last_date_and_time()
-        try:
-            session.get_ext_cal_last_date_and_time()
-            assert False
-        except nifgen.Error as e:
-            assert e.code == -1074118632  # This operation is not supported for simulated device
+def test_get_ext_cal_last_date_and_time(session):
+    try:
+        session.get_ext_cal_last_date_and_time()
+        assert False
+    except nifgen.Error as e:
+        assert e.code == -1074118632  # This operation is not supported for simulated device
 
 
 def test_get_ext_cal_last_temp(session):


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [X] I've ~~added~~updated tests applicable for this pull request

### What does this Pull Request accomplish?
* Switch to using 5433 to avoid random error from parallel execution

### ~~List issues fixed by this Pull Request below, if any.~~
### What testing has been done?
* System