### PR TITLE
Use persistent DAQmx simulated device for nifgen system tests

### DIFF
--- a/build/templates/tox-system_tests.ini.mako
+++ b/build/templates/tox-system_tests.ini.mako
@@ -62,6 +62,7 @@ deps =
     ${module_name}-system_tests: numpy
     ${module_name}-system_tests: scipy
     ${module_name}-system_tests: codecov
+    ${module_name}-system_tests: nimodinst
 
 passenv = 
     GIT_BRANCH

--- a/generated/nidcpower/tox-system_tests.ini
+++ b/generated/nidcpower/tox-system_tests.ini
@@ -36,6 +36,7 @@ deps =
     nidcpower-system_tests: numpy
     nidcpower-system_tests: scipy
     nidcpower-system_tests: codecov
+    nidcpower-system_tests: nimodinst
 
 passenv = 
     GIT_BRANCH

--- a/generated/nidigital/tox-system_tests.ini
+++ b/generated/nidigital/tox-system_tests.ini
@@ -41,6 +41,7 @@ deps =
     nidigital-system_tests: numpy
     nidigital-system_tests: scipy
     nidigital-system_tests: codecov
+    nidigital-system_tests: nimodinst
 
 passenv = 
     GIT_BRANCH

--- a/generated/nidmm/tox-system_tests.ini
+++ b/generated/nidmm/tox-system_tests.ini
@@ -36,6 +36,7 @@ deps =
     nidmm-system_tests: numpy
     nidmm-system_tests: scipy
     nidmm-system_tests: codecov
+    nidmm-system_tests: nimodinst
 
 passenv = 
     GIT_BRANCH

--- a/generated/nifake/tox-system_tests.ini
+++ b/generated/nifake/tox-system_tests.ini
@@ -41,6 +41,7 @@ deps =
     nifake-system_tests: numpy
     nifake-system_tests: scipy
     nifake-system_tests: codecov
+    nifake-system_tests: nimodinst
 
 passenv = 
     GIT_BRANCH

--- a/generated/nifgen/tox-system_tests.ini
+++ b/generated/nifgen/tox-system_tests.ini
@@ -41,6 +41,7 @@ deps =
     nifgen-system_tests: numpy
     nifgen-system_tests: scipy
     nifgen-system_tests: codecov
+    nifgen-system_tests: nimodinst
 
 passenv = 
     GIT_BRANCH

--- a/generated/nimodinst/tox-system_tests.ini
+++ b/generated/nimodinst/tox-system_tests.ini
@@ -36,6 +36,7 @@ deps =
     nimodinst-system_tests: numpy
     nimodinst-system_tests: scipy
     nimodinst-system_tests: codecov
+    nimodinst-system_tests: nimodinst
 
 passenv = 
     GIT_BRANCH

--- a/generated/niscope/tox-system_tests.ini
+++ b/generated/niscope/tox-system_tests.ini
@@ -41,6 +41,7 @@ deps =
     niscope-system_tests: numpy
     niscope-system_tests: scipy
     niscope-system_tests: codecov
+    niscope-system_tests: nimodinst
 
 passenv = 
     GIT_BRANCH

--- a/generated/nise/tox-system_tests.ini
+++ b/generated/nise/tox-system_tests.ini
@@ -36,6 +36,7 @@ deps =
     nise-system_tests: numpy
     nise-system_tests: scipy
     nise-system_tests: codecov
+    nise-system_tests: nimodinst
 
 passenv = 
     GIT_BRANCH

--- a/generated/niswitch/tox-system_tests.ini
+++ b/generated/niswitch/tox-system_tests.ini
@@ -36,6 +36,7 @@ deps =
     niswitch-system_tests: numpy
     niswitch-system_tests: scipy
     niswitch-system_tests: codecov
+    niswitch-system_tests: nimodinst
 
 passenv = 
     GIT_BRANCH

--- a/generated/nitclk/tox-system_tests.ini
+++ b/generated/nitclk/tox-system_tests.ini
@@ -36,6 +36,7 @@ deps =
     nitclk-system_tests: numpy
     nitclk-system_tests: scipy
     nitclk-system_tests: codecov
+    nitclk-system_tests: nimodinst
 
 passenv = 
     GIT_BRANCH

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -10,11 +10,11 @@ import tempfile
 # Set up some global information we need
 test_files_base_dir = os.path.join(os.path.dirname(__file__))
 # Make sure the persistent simulated 5421 has been created
-daqmx_sim_device = None
+daqmx_sim_5421 = None
 with nimodinst.Session('nifgen') as session:
     for dev in session:
-        if dev.device_name in ['5421']:
-            daqmx_sim_device = dev.device_name
+        if dev.device_name == '5421':
+            daqmx_sim_5421 = dev.device_name
 
 
 def get_test_file_path(file_name):
@@ -60,10 +60,10 @@ def test_method_get_self_cal_supported(session):
     assert session.get_self_cal_supported() in [True, False]
 
 
-@pytest.mark.skipif(daqmx_sim_device is None, reason="No Simulated DAQmx device created")
+@pytest.mark.skipif(daqmx_sim_5421 is None, reason="No Simulated DAQmx device created")
 def test_get_self_cal_last_date_and_time():
     try:
-        with nifgen.Session(daqmx_sim_device, '0', False) as session:  # Simulated 5433 returns unrecoverable error when calling get_self_cal_last_date_and_time()
+        with nifgen.Session(daqmx_sim_5421, '0', False) as session:  # Simulated 5433 returns unrecoverable error when calling get_self_cal_last_date_and_time()
             session.get_self_cal_last_date_and_time()
             assert False
     except nifgen.Error as e:
@@ -171,9 +171,9 @@ def test_get_ext_cal_recommended_interval(session):
     assert interval.days == 730  # recommended external cal interval is 24 months
 
 
-@pytest.mark.skipif(daqmx_sim_device is None, reason="No Simulated DAQmx device created")
+@pytest.mark.skipif(daqmx_sim_5421 is None, reason="No Simulated DAQmx device created")
 def test_get_hardware_state():
-    with nifgen.Session(daqmx_sim_device, '0', False) as session:  # Function or method not supported for 5413/23/33
+    with nifgen.Session(daqmx_sim_5421, '0', False) as session:  # Function or method not supported for 5413/23/33
         assert session.get_hardware_state() == nifgen.HardwareState.IDLE
 
 
@@ -237,9 +237,9 @@ def test_create_arb_sequence(session):
     assert 1 == session.create_arb_sequence(waveform_handles_array, [10])
 
 
-@pytest.mark.skipif(daqmx_sim_device is None, reason="No Simulated DAQmx device created")
+@pytest.mark.skipif(daqmx_sim_5421 is None, reason="No Simulated DAQmx device created")
 def test_create_advanced_arb_sequence():
-    with nifgen.Session(daqmx_sim_device, '0', False) as session:  # TODO(marcoskirsch): Use 5433 once internal NI bug 677115 is fixed.
+    with nifgen.Session(daqmx_sim_5421, '0', False) as session:  # TODO(marcoskirsch): Use 5433 once internal NI bug 677115 is fixed.
         seq_handle_base = 100000  # This is not necessary on 5433 because handles start at 0.
         waveform_data = [x * (1.0 / 256.0) for x in range(256)]
         waveform_handles_array = [session.create_waveform(waveform_data), session.create_waveform(waveform_data), session.create_waveform(waveform_data)]
@@ -254,9 +254,9 @@ def test_create_advanced_arb_sequence():
         assert (marker_location_array, seq_handle_base + 3) == session.create_advanced_arb_sequence(waveform_handles_array, loop_counts_array=loop_counts_array, sample_counts_array=sample_counts_array, marker_location_array=marker_location_array)
 
 
-@pytest.mark.skipif(daqmx_sim_device is None, reason="No Simulated DAQmx device created")
+@pytest.mark.skipif(daqmx_sim_5421 is None, reason="No Simulated DAQmx device created")
 def test_create_advanced_arb_sequence_wrong_size():
-    with nifgen.Session(daqmx_sim_device, '0', False) as session:  # TODO(marcoskirsch): Use 5433 once internal NI bug 677115 is fixed.
+    with nifgen.Session(daqmx_sim_5421, '0', False) as session:  # TODO(marcoskirsch): Use 5433 once internal NI bug 677115 is fixed.
         waveform_data = [x * (1.0 / 256.0) for x in range(256)]
         waveform_handles_array = [session.create_waveform(waveform_data), session.create_waveform(waveform_data), session.create_waveform(waveform_data)]
         marker_location_array = [0, 16]

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -1,12 +1,20 @@
 import datetime
 import nifgen
+import nimodinst
 import numpy
 import os
 import pytest
 import tempfile
 
 
+# Set up some global information we need
 test_files_base_dir = os.path.join(os.path.dirname(__file__))
+# Make sure the persistent simulated 5421 has been created
+daqmx_sim_device = None
+with nimodinst.Session('nifgen') as session:
+    for dev in session:
+        if dev.device_name in ['5421']:
+            daqmx_sim_device = dev.device_name
 
 
 def get_test_file_path(file_name):

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -60,9 +60,10 @@ def test_method_get_self_cal_supported(session):
     assert session.get_self_cal_supported() in [True, False]
 
 
+@pytest.mark.skipif(daqmx_sim_device is None, reason="No Simulated DAQmx device created")
 def test_get_self_cal_last_date_and_time():
     try:
-        with nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:5421;BoardType:PXI') as session:  # Simulated 5433 returns unrecoverable error when calling get_self_cal_last_date_and_time()
+        with nifgen.Session(daqmx_sim_device, '0', False) as session:  # Simulated 5433 returns unrecoverable error when calling get_self_cal_last_date_and_time()
             session.get_self_cal_last_date_and_time()
             assert False
     except nifgen.Error as e:
@@ -170,8 +171,9 @@ def test_get_ext_cal_recommended_interval(session):
     assert interval.days == 730  # recommended external cal interval is 24 months
 
 
+@pytest.mark.skipif(daqmx_sim_device is None, reason="No Simulated DAQmx device created")
 def test_get_hardware_state():
-    with nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:5421;BoardType:PXI') as session:  # Function or method not supported for 5413/23/33
+    with nifgen.Session(daqmx_sim_device, '0', False) as session:  # Function or method not supported for 5413/23/33
         assert session.get_hardware_state() == nifgen.HardwareState.IDLE
 
 
@@ -235,8 +237,9 @@ def test_create_arb_sequence(session):
     assert 1 == session.create_arb_sequence(waveform_handles_array, [10])
 
 
+@pytest.mark.skipif(daqmx_sim_device is None, reason="No Simulated DAQmx device created")
 def test_create_advanced_arb_sequence():
-    with nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:5421;BoardType:PXI') as session:  # TODO(marcoskirsch): Use 5433 once internal NI bug 677115 is fixed.
+    with nifgen.Session(daqmx_sim_device, '0', False) as session:  # TODO(marcoskirsch): Use 5433 once internal NI bug 677115 is fixed.
         seq_handle_base = 100000  # This is not necessary on 5433 because handles start at 0.
         waveform_data = [x * (1.0 / 256.0) for x in range(256)]
         waveform_handles_array = [session.create_waveform(waveform_data), session.create_waveform(waveform_data), session.create_waveform(waveform_data)]
@@ -251,8 +254,9 @@ def test_create_advanced_arb_sequence():
         assert (marker_location_array, seq_handle_base + 3) == session.create_advanced_arb_sequence(waveform_handles_array, loop_counts_array=loop_counts_array, sample_counts_array=sample_counts_array, marker_location_array=marker_location_array)
 
 
+@pytest.mark.skipif(daqmx_sim_device is None, reason="No Simulated DAQmx device created")
 def test_create_advanced_arb_sequence_wrong_size():
-    with nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:5421;BoardType:PXI') as session:  # TODO(marcoskirsch): Use 5433 once internal NI bug 677115 is fixed.
+    with nifgen.Session(daqmx_sim_device, '0', False) as session:  # TODO(marcoskirsch): Use 5433 once internal NI bug 677115 is fixed.
         waveform_data = [x * (1.0 / 256.0) for x in range(256)]
         waveform_handles_array = [session.create_waveform(waveform_data), session.create_waveform(waveform_data), session.create_waveform(waveform_data)]
         marker_location_array = [0, 16]

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -1,9 +1,21 @@
 import math
+import nimodinst
 import niscope
 import numpy
 import pytest
 import sys
 import tempfile
+
+
+# We look for persistent simulated DAQmx devices so we can skip the test if they don't exist
+daqmx_sim_5142 = None
+daqmx_sim_5124 = None
+with nimodinst.Session('niscope') as session:
+    for dev in session:
+        if dev.device_name == '5142':
+            daqmx_sim_5142 = dev.device_name
+        if dev.device_name == '5124':
+            daqmx_sim_5124 = dev.device_name
 
 
 @pytest.fixture(scope='function')

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -260,8 +260,9 @@ def test_configure_chan_characteristics(session):
     assert 50.0 == session.input_impedance
 
 
+@pytest.mark.skipif(daqmx_sim_5142 is None, reason="No Simulated DAQmx device created")
 def test_filter_coefficients():
-    with niscope.Session('FakeDevice', False, True, 'Simulate=1, DriverSetup=Model:5142; BoardType:PXI') as session:  # filter coefficients methods are available on devices with OSP
+    with niscope.Session(daqmx_sim_5142) as session:  # filter coefficients methods are available on devices with OSP
         assert [1.0] + [0.0] * 34 == session.get_equalization_filter_coefficients() # coefficients list should have 35 items
         try:
             filter_coefficients = [1.0, 0.0, 0.0]
@@ -348,8 +349,9 @@ def test_configure_trigger_software(session):
     session.configure_trigger_software()
 
 
+@pytest.mark.skipif(daqmx_sim_5124 is None, reason="No Simulated DAQmx device created")
 def test_configure_trigger_video():
-    with niscope.Session('FakeDevice', False, True, 'Simulate=1, DriverSetup=Model:5124; BoardType:PXI') as session:  # Unable to invoke configure_trigger_video method on 5164
+    with niscope.Session(daqmx_sim_5124) as session:  # Unable to invoke configure_trigger_video method on 5164
         session.configure_trigger_video('0', niscope.VideoSignalFormat.PAL, niscope.VideoTriggerEvent.FIELD1, niscope.VideoPolarity.POSITIVE, niscope.TriggerCoupling.DC)
         assert niscope.VideoSignalFormat.PAL == session.tv_trigger_signal_format
         assert niscope.VideoTriggerEvent.FIELD1 == session.tv_trigger_event


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [X] I've ~~added~~modified tests applicable for this pull request

### What does this Pull Request accomplish?
* Check for existing DAQmx simulated device
* Use this if it exists, otherwise, mark the test as skipped

### ~~List issues fixed by this Pull Request below, if any.~~

### What testing has been done?
* System tests