### PR TITLE
Explain why niscope test code uses persistent simulation

### DIFF
--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -8,7 +8,15 @@ import sys
 import tempfile
 
 
-# We need a lock file so multiple tests aren't hitting the simulated HW at the same time
+# There are system tests below that need either a PXI-5124 or a PXI-5142 instead of the PXIe-5164 we use everywhere else
+# because of specific capabilities on those models. Due to internal NI bug 969274, opening a simulated session to those models
+# sometimes fails. As a workaround, the nimi-bot VMs are configured with one simulated instrument of each kind respectively
+# named "5124" and "5142". If you want to run these tests on your own system, you will need to create these two simulated
+# instruments.
+# In addition, we need a global lock in order to keep us from opening more than one session to the same simulated instrument
+# at the same time. This is because NI-SCOPE (like other MI driver runtimes) disallow two simultaneous sessions to the same
+# instrument, even when the instrument is simulated. This will impact the performance at which system tests run because we
+# parallelize at the tox level :(.
 daqmx_sim_5124_lock_file = os.path.join(tempfile.gettempdir(), 'daqmx_5124.lock')
 daqmx_sim_5124_lock = fasteners.InterProcessLock(daqmx_sim_5124_lock_file)
 daqmx_sim_5142_lock_file = os.path.join(tempfile.gettempdir(), 'daqmx_5142.lock')


### PR DESCRIPTION
It was not obvious to me, it will be much less obvious to someone who hasn't been involved in the project from day one.