### PR TITLE
Skip numpy tests when running under PyPy

### DIFF
--- a/build/templates/tox-system_tests.ini.mako
+++ b/build/templates/tox-system_tests.ini.mako
@@ -64,8 +64,8 @@ deps =
     ${module_name}-system_tests: pytest==4.6.5;platform_python_implementation=='PyPy'
     ${module_name}-system_tests: pytest;platform_python_implementation=='CPython'
     ${module_name}-system_tests: coverage
-    ${module_name}-system_tests: numpy
-    ${module_name}-system_tests: scipy
+    ${module_name}-system_tests: numpy;platform_python_implementation=='CPython'
+    ${module_name}-system_tests: scipy;platform_python_implementation=='CPython'
     ${module_name}-system_tests: fasteners
     ${module_name}-coverage: coverage
     ${module_name}-coverage: codecov

--- a/generated/nidcpower/tox-system_tests.ini
+++ b/generated/nidcpower/tox-system_tests.ini
@@ -38,8 +38,8 @@ deps =
     nidcpower-system_tests: pytest==4.6.5;platform_python_implementation=='PyPy'
     nidcpower-system_tests: pytest;platform_python_implementation=='CPython'
     nidcpower-system_tests: coverage
-    nidcpower-system_tests: numpy
-    nidcpower-system_tests: scipy
+    nidcpower-system_tests: numpy;platform_python_implementation=='CPython'
+    nidcpower-system_tests: scipy;platform_python_implementation=='CPython'
     nidcpower-system_tests: fasteners
     nidcpower-coverage: coverage
     nidcpower-coverage: codecov

--- a/generated/nidigital/tox-system_tests.ini
+++ b/generated/nidigital/tox-system_tests.ini
@@ -43,8 +43,8 @@ deps =
     nidigital-system_tests: pytest==4.6.5;platform_python_implementation=='PyPy'
     nidigital-system_tests: pytest;platform_python_implementation=='CPython'
     nidigital-system_tests: coverage
-    nidigital-system_tests: numpy
-    nidigital-system_tests: scipy
+    nidigital-system_tests: numpy;platform_python_implementation=='CPython'
+    nidigital-system_tests: scipy;platform_python_implementation=='CPython'
     nidigital-system_tests: fasteners
     nidigital-coverage: coverage
     nidigital-coverage: codecov

--- a/generated/nidmm/tox-system_tests.ini
+++ b/generated/nidmm/tox-system_tests.ini
@@ -38,8 +38,8 @@ deps =
     nidmm-system_tests: pytest==4.6.5;platform_python_implementation=='PyPy'
     nidmm-system_tests: pytest;platform_python_implementation=='CPython'
     nidmm-system_tests: coverage
-    nidmm-system_tests: numpy
-    nidmm-system_tests: scipy
+    nidmm-system_tests: numpy;platform_python_implementation=='CPython'
+    nidmm-system_tests: scipy;platform_python_implementation=='CPython'
     nidmm-system_tests: fasteners
     nidmm-coverage: coverage
     nidmm-coverage: codecov

--- a/generated/nifake/tox-system_tests.ini
+++ b/generated/nifake/tox-system_tests.ini
@@ -43,8 +43,8 @@ deps =
     nifake-system_tests: pytest==4.6.5;platform_python_implementation=='PyPy'
     nifake-system_tests: pytest;platform_python_implementation=='CPython'
     nifake-system_tests: coverage
-    nifake-system_tests: numpy
-    nifake-system_tests: scipy
+    nifake-system_tests: numpy;platform_python_implementation=='CPython'
+    nifake-system_tests: scipy;platform_python_implementation=='CPython'
     nifake-system_tests: fasteners
     nifake-coverage: coverage
     nifake-coverage: codecov

--- a/generated/nifgen/tox-system_tests.ini
+++ b/generated/nifgen/tox-system_tests.ini
@@ -43,8 +43,8 @@ deps =
     nifgen-system_tests: pytest==4.6.5;platform_python_implementation=='PyPy'
     nifgen-system_tests: pytest;platform_python_implementation=='CPython'
     nifgen-system_tests: coverage
-    nifgen-system_tests: numpy
-    nifgen-system_tests: scipy
+    nifgen-system_tests: numpy;platform_python_implementation=='CPython'
+    nifgen-system_tests: scipy;platform_python_implementation=='CPython'
     nifgen-system_tests: fasteners
     nifgen-coverage: coverage
     nifgen-coverage: codecov

--- a/generated/nimodinst/tox-system_tests.ini
+++ b/generated/nimodinst/tox-system_tests.ini
@@ -38,8 +38,8 @@ deps =
     nimodinst-system_tests: pytest==4.6.5;platform_python_implementation=='PyPy'
     nimodinst-system_tests: pytest;platform_python_implementation=='CPython'
     nimodinst-system_tests: coverage
-    nimodinst-system_tests: numpy
-    nimodinst-system_tests: scipy
+    nimodinst-system_tests: numpy;platform_python_implementation=='CPython'
+    nimodinst-system_tests: scipy;platform_python_implementation=='CPython'
     nimodinst-system_tests: fasteners
     nimodinst-coverage: coverage
     nimodinst-coverage: codecov

--- a/generated/niscope/tox-system_tests.ini
+++ b/generated/niscope/tox-system_tests.ini
@@ -43,8 +43,8 @@ deps =
     niscope-system_tests: pytest==4.6.5;platform_python_implementation=='PyPy'
     niscope-system_tests: pytest;platform_python_implementation=='CPython'
     niscope-system_tests: coverage
-    niscope-system_tests: numpy
-    niscope-system_tests: scipy
+    niscope-system_tests: numpy;platform_python_implementation=='CPython'
+    niscope-system_tests: scipy;platform_python_implementation=='CPython'
     niscope-system_tests: fasteners
     niscope-coverage: coverage
     niscope-coverage: codecov

--- a/generated/nise/tox-system_tests.ini
+++ b/generated/nise/tox-system_tests.ini
@@ -38,8 +38,8 @@ deps =
     nise-system_tests: pytest==4.6.5;platform_python_implementation=='PyPy'
     nise-system_tests: pytest;platform_python_implementation=='CPython'
     nise-system_tests: coverage
-    nise-system_tests: numpy
-    nise-system_tests: scipy
+    nise-system_tests: numpy;platform_python_implementation=='CPython'
+    nise-system_tests: scipy;platform_python_implementation=='CPython'
     nise-system_tests: fasteners
     nise-coverage: coverage
     nise-coverage: codecov

--- a/generated/niswitch/tox-system_tests.ini
+++ b/generated/niswitch/tox-system_tests.ini
@@ -38,8 +38,8 @@ deps =
     niswitch-system_tests: pytest==4.6.5;platform_python_implementation=='PyPy'
     niswitch-system_tests: pytest;platform_python_implementation=='CPython'
     niswitch-system_tests: coverage
-    niswitch-system_tests: numpy
-    niswitch-system_tests: scipy
+    niswitch-system_tests: numpy;platform_python_implementation=='CPython'
+    niswitch-system_tests: scipy;platform_python_implementation=='CPython'
     niswitch-system_tests: fasteners
     niswitch-coverage: coverage
     niswitch-coverage: codecov

--- a/generated/nitclk/tox-system_tests.ini
+++ b/generated/nitclk/tox-system_tests.ini
@@ -38,8 +38,8 @@ deps =
     nitclk-system_tests: pytest==4.6.5;platform_python_implementation=='PyPy'
     nitclk-system_tests: pytest;platform_python_implementation=='CPython'
     nitclk-system_tests: coverage
-    nitclk-system_tests: numpy
-    nitclk-system_tests: scipy
+    nitclk-system_tests: numpy;platform_python_implementation=='CPython'
+    nitclk-system_tests: scipy;platform_python_implementation=='CPython'
     nitclk-system_tests: fasteners
     nitclk-coverage: coverage
     nitclk-coverage: codecov

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -3,6 +3,7 @@ import collections
 import os
 
 import numpy
+import platform
 import pytest
 
 import nidigital
@@ -122,7 +123,13 @@ def get_test_file_path(test_name, file_name):
     return os.path.join(test_files_base_dir, test_name, file_name)
 
 
-@pytest.fixture(params=[array.array, numpy.array, list])
+# PyPy doesn't support numpy easily so we do not test with a numpy array
+if platform.python_implementation() == 'PyPy':
+    iterative_types = [array.array, list]
+else:
+    iterative_types = [array.array, numpy.array, list]
+
+@pytest.fixture(params=iterative_types)
 def source_waveform_type(request):
     return request.param
 

--- a/src/nidmm/system_tests/test_system_nidmm.py
+++ b/src/nidmm/system_tests/test_system_nidmm.py
@@ -3,6 +3,7 @@ import math
 import nidmm
 import numpy
 import os
+import platform
 import pytest
 import tempfile
 import time
@@ -222,6 +223,7 @@ def test_fetch_waveform(session):
         assert isinstance(measurements[1], float)
 
 
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy')
 def test_fetch_waveform_into(session):
     number_of_points_to_read = 100
     session.configure_waveform_acquisition(nidmm.Function.WAVEFORM_VOLTAGE, 10, 1800000, number_of_points_to_read)

--- a/src/nidmm/system_tests/test_system_nidmm.py
+++ b/src/nidmm/system_tests/test_system_nidmm.py
@@ -223,7 +223,7 @@ def test_fetch_waveform(session):
         assert isinstance(measurements[1], float)
 
 
-@pytest.mark.skipif(platform.python_implementation() == 'PyPy')
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy', reason='numpy not supported on PyPy')
 def test_fetch_waveform_into(session):
     number_of_points_to_read = 100
     session.configure_waveform_acquisition(nidmm.Function.WAVEFORM_VOLTAGE, 10, 1800000, number_of_points_to_read)

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -107,14 +107,14 @@ def test_create_waveform_from_list(session):
     assert type(session.create_waveform(data)) is int
 
 
-@pytest.mark.skipif(platform.python_implementation() == 'PyPy')
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy', reason='numpy not supported on PyPy')
 def test_create_waveform_from_numpy_array_float64(session):
     data = numpy.ndarray(10000, dtype=numpy.float64)
     data.fill(0.5)
     assert type(session.create_waveform(data)) is int
 
 
-@pytest.mark.skipif(platform.python_implementation() == 'PyPy')
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy', reason='numpy not supported on PyPy')
 def test_create_waveform_numpy_array_int16(session):
     data = numpy.ndarray(10000, dtype=numpy.int16)
     data.fill(256)
@@ -330,14 +330,14 @@ def test_write_waveform_from_list(session):
     session.write_waveform(session.allocate_waveform(len(data)), data)
 
 
-@pytest.mark.skipif(platform.python_implementation() == 'PyPy')
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy', reason='numpy not supported on PyPy')
 def test_write_waveform_from_numpy_array_float64(session):
     data = numpy.ndarray(10000, dtype=numpy.float64)
     data.fill(0.5)
     session.write_waveform(session.allocate_waveform(len(data)), data)
 
 
-@pytest.mark.skipif(platform.python_implementation() == 'PyPy')
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy', reason='numpy not supported on PyPy')
 def test_write_waveform_numpy_array_int16(session):
     data = numpy.ndarray(10000, dtype=numpy.int16)
     data.fill(256)
@@ -350,7 +350,7 @@ def test_write_named_waveform_from_list(session):
     session.write_waveform('foo', data)
 
 
-@pytest.mark.skipif(platform.python_implementation() == 'PyPy')
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy', reason='numpy not supported on PyPy')
 def test_write_named_waveform_from_numpy_array_float64(session):
     data = numpy.ndarray(10000, dtype=numpy.float64)
     data.fill(0.5)
@@ -358,7 +358,7 @@ def test_write_named_waveform_from_numpy_array_float64(session):
     session.write_waveform('foo', data)
 
 
-@pytest.mark.skipif(platform.python_implementation() == 'PyPy')
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy', reason='numpy not supported on PyPy')
 def test_write_named_waveform_numpy_array_int16(session):
     data = numpy.ndarray(10000, dtype=numpy.int16)
     data.fill(256)

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -3,6 +3,7 @@ import fasteners
 import nifgen
 import numpy
 import os
+import platform
 import pytest
 import tempfile
 
@@ -106,23 +107,31 @@ def test_create_waveform_from_list(session):
     assert type(session.create_waveform(data)) is int
 
 
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy')
 def test_create_waveform_from_numpy_array_float64(session):
     data = numpy.ndarray(10000, dtype=numpy.float64)
     data.fill(0.5)
     assert type(session.create_waveform(data)) is int
 
 
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy')
 def test_create_waveform_numpy_array_int16(session):
     data = numpy.ndarray(10000, dtype=numpy.int16)
     data.fill(256)
     assert type(session.create_waveform(data)) is int
 
 
-invalid_waveforms = ['Not waveform data',
-                     numpy.zeros(100, dtype=numpy.uint16),
-                     numpy.zeros(100, dtype=numpy.float32),
-                     42,
-                     3.14159, ]
+# PyPy does not easily support numpy so we don't test with that
+if platform.python_implementation() == 'PyPy':
+    invalid_waveforms = ['Not waveform data',
+                         42,
+                         3.14159, ]
+else:
+    invalid_waveforms = ['Not waveform data',
+                         numpy.zeros(100, dtype=numpy.uint16),
+                         numpy.zeros(100, dtype=numpy.float32),
+                         42,
+                         3.14159, ]
 
 
 def test_create_waveform_wrong_type(session):
@@ -321,12 +330,14 @@ def test_write_waveform_from_list(session):
     session.write_waveform(session.allocate_waveform(len(data)), data)
 
 
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy')
 def test_write_waveform_from_numpy_array_float64(session):
     data = numpy.ndarray(10000, dtype=numpy.float64)
     data.fill(0.5)
     session.write_waveform(session.allocate_waveform(len(data)), data)
 
 
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy')
 def test_write_waveform_numpy_array_int16(session):
     data = numpy.ndarray(10000, dtype=numpy.int16)
     data.fill(256)
@@ -339,6 +350,7 @@ def test_write_named_waveform_from_list(session):
     session.write_waveform('foo', data)
 
 
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy')
 def test_write_named_waveform_from_numpy_array_float64(session):
     data = numpy.ndarray(10000, dtype=numpy.float64)
     data.fill(0.5)
@@ -346,6 +358,7 @@ def test_write_named_waveform_from_numpy_array_float64(session):
     session.write_waveform('foo', data)
 
 
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy')
 def test_write_named_waveform_numpy_array_int16(session):
     data = numpy.ndarray(10000, dtype=numpy.int16)
     data.fill(256)

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -87,7 +87,7 @@ def test_fetch_defaults(session):
         assert len(waveforms[i].samples) == test_record_length
 
 
-@pytest.mark.skipif(platform.python_implementation() == 'PyPy')
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy', reason='numpy not supported on PyPy')
 def test_fetch_binary8_into(session):
     test_voltage = 1.0
     test_record_length = 2000
@@ -112,7 +112,7 @@ def test_fetch_binary8_into(session):
             assert record_wfm[j] == waveform[i * test_record_length + j]
 
 
-@pytest.mark.skipif(platform.python_implementation() == 'PyPy')
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy', reason='numpy not supported on PyPy')
 def test_fetch_binary16_into(session):
     test_voltage = 1.0
     test_record_length = 2000
@@ -137,7 +137,7 @@ def test_fetch_binary16_into(session):
             assert record_wfm[j] == waveform[i * test_record_length + j]
 
 
-@pytest.mark.skipif(platform.python_implementation() == 'PyPy')
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy', reason='numpy not supported on PyPy')
 def test_fetch_binary32_into(session):
     test_voltage = 1.0
     test_record_length = 2000
@@ -162,7 +162,7 @@ def test_fetch_binary32_into(session):
             assert record_wfm[j] == waveform[i * test_record_length + j]
 
 
-@pytest.mark.skipif(platform.python_implementation() == 'PyPy')
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy', reason='numpy not supported on PyPy')
 def test_fetch_double_into(session):
     test_voltage = 1.0
     test_record_length = 2000

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -3,6 +3,7 @@ import math
 import niscope
 import numpy
 import os
+import platform
 import pytest
 import sys
 import tempfile
@@ -86,6 +87,7 @@ def test_fetch_defaults(session):
         assert len(waveforms[i].samples) == test_record_length
 
 
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy')
 def test_fetch_binary8_into(session):
     test_voltage = 1.0
     test_record_length = 2000
@@ -110,6 +112,7 @@ def test_fetch_binary8_into(session):
             assert record_wfm[j] == waveform[i * test_record_length + j]
 
 
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy')
 def test_fetch_binary16_into(session):
     test_voltage = 1.0
     test_record_length = 2000
@@ -134,6 +137,7 @@ def test_fetch_binary16_into(session):
             assert record_wfm[j] == waveform[i * test_record_length + j]
 
 
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy')
 def test_fetch_binary32_into(session):
     test_voltage = 1.0
     test_record_length = 2000
@@ -158,6 +162,7 @@ def test_fetch_binary32_into(session):
             assert record_wfm[j] == waveform[i * test_record_length + j]
 
 
+@pytest.mark.skipif(platform.python_implementation() == 'PyPy')
 def test_fetch_double_into(session):
     test_voltage = 1.0
     test_record_length = 2000


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [X] ~~I've added tests applicable for this pull request~~
### What does this Pull Request accomplish?
* Do not install `numpy` or `scipy` when running PyPy
    * There is not a precompiled wheel for PyPy3
    * Trying to compile numpy every time (or even just the times it would need to be installed or upgraded) would add a significant amount of time to the system tests
    * Vistual C++ is not installed on the test VMs
* Skip any test that uses `numpy` when running under PyPy
* Remove any `numpy` array from test data when running under PyPy
### ~~List issues fixed by this Pull Request below, if any.~~

### What testing has been done?
* System tests