### PR TITLE
Allow concurrent builds on nimi-bot

### DIFF
--- a/tools/system_test_jobs.groovy
+++ b/tools/system_test_jobs.groovy
@@ -19,6 +19,7 @@ def genJob(driver, platform) {
         description "Run system tests for ${driver} on ${platform}"
 
         label(platform)
+        concurrentBuild()
 
         parameters {
             stringParam('sha1', 'master', 'SHA to build')


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [X] ~~I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?
* Sets allow concurrent builds flag on all jobs
    * Since the builds are different PRs there is no reason not to allow them
* This has already been added to nimi-bot, this is just to update the script in git
### ~~List issues fixed by this Pull Request below, if any.~~
### What testing has been done?
* System