### PR TITLE
Update method names in nifake to be language-agnostic

### DIFF
--- a/generated/nifake/nifake/_library.py
+++ b/generated/nifake/nifake/_library.py
@@ -21,7 +21,7 @@ class Library(object):
         self._library = ctypes_library
         # We cache the cfunc object from the ctypes.CDLL object
         self.niFake_Abort_cfunc = None
-        self.niFake_AcceptListOfTimeValues_cfunc = None
+        self.niFake_AcceptListOfDurationsInSeconds_cfunc = None
         self.niFake_BoolArrayOutputFunction_cfunc = None
         self.niFake_DoubleAllTheNums_cfunc = None
         self.niFake_EnumArrayOutputFunction_cfunc = None
@@ -61,7 +61,7 @@ class Library(object):
         self.niFake_Read_cfunc = None
         self.niFake_ReadFromChannel_cfunc = None
         self.niFake_ReturnANumberAndAString_cfunc = None
-        self.niFake_ReturnListOfTimedeltas_cfunc = None
+        self.niFake_ReturnListOfDurationsInSeconds_cfunc = None
         self.niFake_ReturnMultipleTypes_cfunc = None
         self.niFake_SetAttributeViBoolean_cfunc = None
         self.niFake_SetAttributeViInt32_cfunc = None
@@ -87,13 +87,13 @@ class Library(object):
                 self.niFake_Abort_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_Abort_cfunc(vi)
 
-    def niFake_AcceptListOfTimeValues(self, vi, count, delays):  # noqa: N802
+    def niFake_AcceptListOfDurationsInSeconds(self, vi, count, delays):  # noqa: N802
         with self._func_lock:
-            if self.niFake_AcceptListOfTimeValues_cfunc is None:
-                self.niFake_AcceptListOfTimeValues_cfunc = self._library.niFake_AcceptListOfTimeValues
-                self.niFake_AcceptListOfTimeValues_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
-                self.niFake_AcceptListOfTimeValues_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_AcceptListOfTimeValues_cfunc(vi, count, delays)
+            if self.niFake_AcceptListOfDurationsInSeconds_cfunc is None:
+                self.niFake_AcceptListOfDurationsInSeconds_cfunc = self._library.niFake_AcceptListOfDurationsInSeconds
+                self.niFake_AcceptListOfDurationsInSeconds_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
+                self.niFake_AcceptListOfDurationsInSeconds_cfunc.restype = ViStatus  # noqa: F405
+        return self.niFake_AcceptListOfDurationsInSeconds_cfunc(vi, count, delays)
 
     def niFake_BoolArrayOutputFunction(self, vi, number_of_elements, an_array):  # noqa: N802
         with self._func_lock:
@@ -407,13 +407,13 @@ class Library(object):
                 self.niFake_ReturnANumberAndAString_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ReturnANumberAndAString_cfunc(vi, a_number, a_string)
 
-    def niFake_ReturnListOfTimedeltas(self, vi, number_of_elements, timedeltas):  # noqa: N802
+    def niFake_ReturnListOfDurationsInSeconds(self, vi, number_of_elements, timedeltas):  # noqa: N802
         with self._func_lock:
-            if self.niFake_ReturnListOfTimedeltas_cfunc is None:
-                self.niFake_ReturnListOfTimedeltas_cfunc = self._library.niFake_ReturnListOfTimedeltas
-                self.niFake_ReturnListOfTimedeltas_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
-                self.niFake_ReturnListOfTimedeltas_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFake_ReturnListOfTimedeltas_cfunc(vi, number_of_elements, timedeltas)
+            if self.niFake_ReturnListOfDurationsInSeconds_cfunc is None:
+                self.niFake_ReturnListOfDurationsInSeconds_cfunc = self._library.niFake_ReturnListOfDurationsInSeconds
+                self.niFake_ReturnListOfDurationsInSeconds_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
+                self.niFake_ReturnListOfDurationsInSeconds_cfunc.restype = ViStatus  # noqa: F405
+        return self.niFake_ReturnListOfDurationsInSeconds_cfunc(vi, number_of_elements, timedeltas)
 
     def niFake_ReturnMultipleTypes(self, vi, a_boolean, an_int32, an_int64, an_int_enum, a_float, a_float_enum, array_size, an_array, string_size, a_string):  # noqa: N802
         with self._func_lock:

--- a/generated/nifake/nifake/session.py
+++ b/generated/nifake/nifake/session.py
@@ -785,8 +785,8 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def accept_list_of_time_values(self, delays):
-        r'''accept_list_of_time_values
+    def accept_list_of_durations_in_seconds(self, delays):
+        r'''accept_list_of_durations_in_seconds
 
         Accepts list of floats or datetime.timedelta instances representing time delays.
 
@@ -797,7 +797,7 @@ class Session(_SessionBase):
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         count_ctype = _visatype.ViInt32(0 if delays is None else len(delays))  # case S160
         delays_ctype = get_ctypes_pointer_for_buffer(value=_converters.convert_timedeltas_to_seconds_real64(delays), library_type=_visatype.ViReal64)  # case B520
-        error_code = self._library.niFake_AcceptListOfTimeValues(vi_ctype, count_ctype, delays_ctype)
+        error_code = self._library.niFake_AcceptListOfDurationsInSeconds(vi_ctype, count_ctype, delays_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -1116,7 +1116,7 @@ class Session(_SessionBase):
         This method returns an array for use in python-code size mechanism.
 
         Returns:
-            array_out (list of float): Array of double using puthon-code size mechanism
+            array_out (list of float): Array of double using python-code size mechanism
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -1560,8 +1560,8 @@ class Session(_SessionBase):
         return int(a_number_ctype.value), a_string_ctype.value.decode(self._encoding)
 
     @ivi_synchronized
-    def return_list_of_timedeltas(self, number_of_elements):
-        r'''return_list_of_timedeltas
+    def return_list_of_durations_in_seconds(self, number_of_elements):
+        r'''return_list_of_durations_in_seconds
 
         Returns a list of datetime.timedelta instances.
 
@@ -1570,14 +1570,14 @@ class Session(_SessionBase):
 
 
         Returns:
-            timedeltas (datetime.timedelta): Contains a list of datetime.timedelta instances
+            timedeltas (datetime.timedelta): Contains a list of datetime.timedelta instances.
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         number_of_elements_ctype = _visatype.ViInt32(number_of_elements)  # case S210
         timedeltas_size = number_of_elements  # case B600
         timedeltas_ctype = get_ctypes_pointer_for_buffer(library_type=_visatype.ViReal64, size=timedeltas_size)  # case B600
-        error_code = self._library.niFake_ReturnListOfTimedeltas(vi_ctype, number_of_elements_ctype, timedeltas_ctype)
+        error_code = self._library.niFake_ReturnListOfDurationsInSeconds(vi_ctype, number_of_elements_ctype, timedeltas_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return _converters.convert_seconds_real64_to_timedeltas([float(timedeltas_ctype[i]) for i in range(number_of_elements_ctype.value)])
 

--- a/generated/nifake/nifake/unit_tests/_mock_helper.py
+++ b/generated/nifake/nifake/unit_tests/_mock_helper.py
@@ -18,8 +18,8 @@ class SideEffectsHelper(object):
         self._defaults = {}
         self._defaults['Abort'] = {}
         self._defaults['Abort']['return'] = 0
-        self._defaults['AcceptListOfTimeValues'] = {}
-        self._defaults['AcceptListOfTimeValues']['return'] = 0
+        self._defaults['AcceptListOfDurationsInSeconds'] = {}
+        self._defaults['AcceptListOfDurationsInSeconds']['return'] = 0
         self._defaults['BoolArrayOutputFunction'] = {}
         self._defaults['BoolArrayOutputFunction']['return'] = 0
         self._defaults['BoolArrayOutputFunction']['anArray'] = None
@@ -139,9 +139,9 @@ class SideEffectsHelper(object):
         self._defaults['ReturnANumberAndAString']['return'] = 0
         self._defaults['ReturnANumberAndAString']['aNumber'] = None
         self._defaults['ReturnANumberAndAString']['aString'] = None
-        self._defaults['ReturnListOfTimedeltas'] = {}
-        self._defaults['ReturnListOfTimedeltas']['return'] = 0
-        self._defaults['ReturnListOfTimedeltas']['timedeltas'] = None
+        self._defaults['ReturnListOfDurationsInSeconds'] = {}
+        self._defaults['ReturnListOfDurationsInSeconds']['return'] = 0
+        self._defaults['ReturnListOfDurationsInSeconds']['timedeltas'] = None
         self._defaults['ReturnMultipleTypes'] = {}
         self._defaults['ReturnMultipleTypes']['return'] = 0
         self._defaults['ReturnMultipleTypes']['aBoolean'] = None
@@ -199,10 +199,10 @@ class SideEffectsHelper(object):
             return self._defaults['Abort']['return']
         return self._defaults['Abort']['return']
 
-    def niFake_AcceptListOfTimeValues(self, vi, count, delays):  # noqa: N802
-        if self._defaults['AcceptListOfTimeValues']['return'] != 0:
-            return self._defaults['AcceptListOfTimeValues']['return']
-        return self._defaults['AcceptListOfTimeValues']['return']
+    def niFake_AcceptListOfDurationsInSeconds(self, vi, count, delays):  # noqa: N802
+        if self._defaults['AcceptListOfDurationsInSeconds']['return'] != 0:
+            return self._defaults['AcceptListOfDurationsInSeconds']['return']
+        return self._defaults['AcceptListOfDurationsInSeconds']['return']
 
     def niFake_BoolArrayOutputFunction(self, vi, number_of_elements, an_array):  # noqa: N802
         if self._defaults['BoolArrayOutputFunction']['return'] != 0:
@@ -675,13 +675,13 @@ class SideEffectsHelper(object):
             a_string[i] = test_value[i]
         return self._defaults['ReturnANumberAndAString']['return']
 
-    def niFake_ReturnListOfTimedeltas(self, vi, number_of_elements, timedeltas):  # noqa: N802
-        if self._defaults['ReturnListOfTimedeltas']['return'] != 0:
-            return self._defaults['ReturnListOfTimedeltas']['return']
+    def niFake_ReturnListOfDurationsInSeconds(self, vi, number_of_elements, timedeltas):  # noqa: N802
+        if self._defaults['ReturnListOfDurationsInSeconds']['return'] != 0:
+            return self._defaults['ReturnListOfDurationsInSeconds']['return']
         # timedeltas
-        if self._defaults['ReturnListOfTimedeltas']['timedeltas'] is None:
-            raise MockFunctionCallError("niFake_ReturnListOfTimedeltas", param='timedeltas')
-        test_value = self._defaults['ReturnListOfTimedeltas']['timedeltas']
+        if self._defaults['ReturnListOfDurationsInSeconds']['timedeltas'] is None:
+            raise MockFunctionCallError("niFake_ReturnListOfDurationsInSeconds", param='timedeltas')
+        test_value = self._defaults['ReturnListOfDurationsInSeconds']['timedeltas']
         try:
             timedeltas_ref = timedeltas.contents
         except AttributeError:
@@ -689,7 +689,7 @@ class SideEffectsHelper(object):
         assert len(timedeltas_ref) >= len(test_value)
         for i in range(len(test_value)):
             timedeltas_ref[i] = test_value[i]
-        return self._defaults['ReturnListOfTimedeltas']['return']
+        return self._defaults['ReturnListOfDurationsInSeconds']['return']
 
     def niFake_ReturnMultipleTypes(self, vi, a_boolean, an_int32, an_int64, an_int_enum, a_float, a_float_enum, array_size, an_array, string_size, a_string):  # noqa: N802
         if self._defaults['ReturnMultipleTypes']['return'] != 0:
@@ -854,8 +854,8 @@ class SideEffectsHelper(object):
     def set_side_effects_and_return_values(self, mock_library):
         mock_library.niFake_Abort.side_effect = MockFunctionCallError("niFake_Abort")
         mock_library.niFake_Abort.return_value = 0
-        mock_library.niFake_AcceptListOfTimeValues.side_effect = MockFunctionCallError("niFake_AcceptListOfTimeValues")
-        mock_library.niFake_AcceptListOfTimeValues.return_value = 0
+        mock_library.niFake_AcceptListOfDurationsInSeconds.side_effect = MockFunctionCallError("niFake_AcceptListOfDurationsInSeconds")
+        mock_library.niFake_AcceptListOfDurationsInSeconds.return_value = 0
         mock_library.niFake_BoolArrayOutputFunction.side_effect = MockFunctionCallError("niFake_BoolArrayOutputFunction")
         mock_library.niFake_BoolArrayOutputFunction.return_value = 0
         mock_library.niFake_DoubleAllTheNums.side_effect = MockFunctionCallError("niFake_DoubleAllTheNums")
@@ -934,8 +934,8 @@ class SideEffectsHelper(object):
         mock_library.niFake_ReadFromChannel.return_value = 0
         mock_library.niFake_ReturnANumberAndAString.side_effect = MockFunctionCallError("niFake_ReturnANumberAndAString")
         mock_library.niFake_ReturnANumberAndAString.return_value = 0
-        mock_library.niFake_ReturnListOfTimedeltas.side_effect = MockFunctionCallError("niFake_ReturnListOfTimedeltas")
-        mock_library.niFake_ReturnListOfTimedeltas.return_value = 0
+        mock_library.niFake_ReturnListOfDurationsInSeconds.side_effect = MockFunctionCallError("niFake_ReturnListOfDurationsInSeconds")
+        mock_library.niFake_ReturnListOfDurationsInSeconds.return_value = 0
         mock_library.niFake_ReturnMultipleTypes.side_effect = MockFunctionCallError("niFake_ReturnMultipleTypes")
         mock_library.niFake_ReturnMultipleTypes.return_value = 0
         mock_library.niFake_SetAttributeViBoolean.side_effect = MockFunctionCallError("niFake_SetAttributeViBoolean")

--- a/generated/nifake/nifake/unit_tests/test_session.py
+++ b/generated/nifake/nifake/unit_tests/test_session.py
@@ -1414,51 +1414,51 @@ class TestSession(object):
             assert str(type(session.tclk)) == "<class 'nitclk.session.SessionReference'>"
 
     def test_accept_list_of_time_values_as_floats(self):
-        self.patched_library.niFake_AcceptListOfTimeValues.side_effect = self.side_effects_helper.niFake_AcceptListOfTimeValues
+        self.patched_library.niFake_AcceptListOfDurationsInSeconds.side_effect = self.side_effects_helper.niFake_AcceptListOfDurationsInSeconds
         delays = [-1.5, 2.0]
         with nifake.Session('dev1') as session:
-            session.accept_list_of_time_values(delays)
-            self.patched_library.niFake_AcceptListOfTimeValues.assert_called_once_with(
+            session.accept_list_of_durations_in_seconds(delays)
+            self.patched_library.niFake_AcceptListOfDurationsInSeconds.assert_called_once_with(
                 _matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST),
                 _matchers.ViInt32Matcher(len(delays)),
                 _matchers.ViReal64BufferMatcher(delays)
             )
 
     def test_accept_array_of_time_values_as_floats(self):
-        self.patched_library.niFake_AcceptListOfTimeValues.side_effect = self.side_effects_helper.niFake_AcceptListOfTimeValues
+        self.patched_library.niFake_AcceptListOfDurationsInSeconds.side_effect = self.side_effects_helper.niFake_AcceptListOfDurationsInSeconds
         time_values = [-1.5, 2.0]
         delays = array.array('d', time_values)
         with nifake.Session('dev1') as session:
-            session.accept_list_of_time_values(delays)
-            self.patched_library.niFake_AcceptListOfTimeValues.assert_called_once_with(
+            session.accept_list_of_durations_in_seconds(delays)
+            self.patched_library.niFake_AcceptListOfDurationsInSeconds.assert_called_once_with(
                 _matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST),
                 _matchers.ViInt32Matcher(len(delays)),
                 _matchers.ViReal64BufferMatcher(time_values)
             )
 
     def test_accept_list_of_time_values_as_timedelta_instances(self):
-        self.patched_library.niFake_AcceptListOfTimeValues.side_effect = self.side_effects_helper.niFake_AcceptListOfTimeValues
+        self.patched_library.niFake_AcceptListOfDurationsInSeconds.side_effect = self.side_effects_helper.niFake_AcceptListOfDurationsInSeconds
         time_values = [-1.5, 2.0]
         delays = [datetime.timedelta(seconds=i) for i in time_values]
         with nifake.Session('dev1') as session:
-            session.accept_list_of_time_values(delays)
-            self.patched_library.niFake_AcceptListOfTimeValues.assert_called_once_with(
+            session.accept_list_of_durations_in_seconds(delays)
+            self.patched_library.niFake_AcceptListOfDurationsInSeconds.assert_called_once_with(
                 _matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST),
                 _matchers.ViInt32Matcher(len(delays)),
                 _matchers.ViReal64BufferMatcher(time_values)
             )
 
     def test_return_timedeltas(self):
-        self.patched_library.niFake_ReturnListOfTimedeltas.side_effect = self.side_effects_helper.niFake_ReturnListOfTimedeltas
+        self.patched_library.niFake_ReturnListOfDurationsInSeconds.side_effect = self.side_effects_helper.niFake_ReturnListOfDurationsInSeconds
         time_values = [-1.5, 2.0]
         time_values_ctype = (nifake._visatype.ViReal64 * len(time_values))(*time_values)
         expected_timedeltas = [datetime.timedelta(seconds=i) for i in time_values]
-        self.side_effects_helper['ReturnListOfTimedeltas']['timedeltas'] = time_values_ctype
+        self.side_effects_helper['ReturnListOfDurationsInSeconds']['timedeltas'] = time_values_ctype
         with nifake.Session('dev1') as session:
-            returned_timedeltas = session.return_list_of_timedeltas(len(expected_timedeltas))
+            returned_timedeltas = session.return_list_of_durations_in_seconds(len(expected_timedeltas))
             assert len(returned_timedeltas) == len(expected_timedeltas)
             assert returned_timedeltas == expected_timedeltas
-            self.patched_library.niFake_ReturnListOfTimedeltas.assert_called_once_with(
+            self.patched_library.niFake_ReturnListOfDurationsInSeconds.assert_called_once_with(
                 _matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST),
                 _matchers.ViInt32Matcher(len(time_values)),
                 _matchers.ViReal64BufferMatcher(len(time_values))

--- a/src/nifake/metadata/attributes.py
+++ b/src/nifake/metadata/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 1.2.0d6
+# This file is generated from NI-FAKE API metadata version 1.2.0d9
 attributes = {
     1000000: {
         'access': 'read-write',

--- a/src/nifake/metadata/config.py
+++ b/src/nifake/metadata/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 1.2.0d6
+# This file is generated from NI-FAKE API metadata version 1.2.0d9
 config = {
-    'api_version': '1.2.0d6',
+    'api_version': '1.2.0d9',
     'c_function_prefix': 'niFake_',
     'close_function': 'close',
     'context_manager_name': {

--- a/src/nifake/metadata/enums.py
+++ b/src/nifake/metadata/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 1.2.0d6
+# This file is generated from NI-FAKE API metadata version 1.2.0d9
 enums = {
     'BeautifulColor': {
         'values': [

--- a/src/nifake/metadata/functions.py
+++ b/src/nifake/metadata/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 1.2.0d6
+# This file is generated from NI-FAKE API metadata version 1.2.0d9
 functions = {
     'Abort': {
         'codegen_method': 'public',
@@ -14,6 +14,45 @@ functions = {
                 },
                 'name': 'vi',
                 'type': 'ViSession'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'AcceptListOfDurationsInSeconds': {
+        'codegen_method': 'public',
+        'documentation': {
+            'description': 'Accepts list of floats or datetime.timedelta instances representing time delays.'
+        },
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Identifies a particular instrument session.'
+                },
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Count of input values.'
+                },
+                'name': 'count',
+                'type': 'ViInt32'
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'A collection of time delay values.'
+                },
+                'name': 'delays',
+                'python_api_converter_name': 'convert_timedeltas_to_seconds_real64',
+                'size': {
+                    'mechanism': 'len',
+                    'value': 'count'
+                },
+                'type': 'ViReal64[]',
+                'type_in_documentation': 'float in seconds or datetime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -194,12 +233,12 @@ functions = {
                 'direction': 'out',
                 'name': 'configuration',
                 'python_api_converter_name': 'convert_to_bytes',
-                'type_in_documentation': 'bytes',
                 'size': {
                     'mechanism': 'ivi-dance',
                     'value': 'sizeInBytes'
                 },
                 'type': 'ViInt8[]',
+                'type_in_documentation': 'bytes',
                 'use_array': True
             }
         ],
@@ -526,7 +565,7 @@ functions = {
             {
                 'direction': 'out',
                 'documentation': {
-                    'description': 'Array of double using puthon-code size mechanism'
+                    'description': 'Array of double using python-code size mechanism'
                 },
                 'name': 'arrayOut',
                 'size': {
@@ -1132,12 +1171,12 @@ functions = {
                 'direction': 'in',
                 'name': 'configuration',
                 'python_api_converter_name': 'convert_to_bytes',
-                'type_in_documentation': 'bytes',
                 'size': {
                     'mechanism': 'len',
                     'value': 'sizeInBytes'
                 },
-                'type': 'ViInt8[]'
+                'type': 'ViInt8[]',
+                'type_in_documentation': 'bytes'
             }
         ],
         'returns': 'ViStatus'
@@ -1688,6 +1727,45 @@ functions = {
                     'value': 256
                 },
                 'type': 'ViChar[]'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'ReturnListOfDurationsInSeconds': {
+        'codegen_method': 'public',
+        'documentation': {
+            'description': 'Returns a list of datetime.timedelta instances.'
+        },
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Identifies a particular instrument session.'
+                },
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Number of elements in output.'
+                },
+                'name': 'numberOfElements',
+                'type': 'ViInt32'
+            },
+            {
+                'direction': 'out',
+                'documentation': {
+                    'description': 'Contains a list of datetime.timedelta instances.'
+                },
+                'name': 'timedeltas',
+                'python_api_converter_name': 'convert_seconds_real64_to_timedeltas',
+                'size': {
+                    'mechanism': 'passed-in',
+                    'value': 'numberOfElements'
+                },
+                'type': 'ViReal64[]',
+                'type_in_documentation': 'datetime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -2274,84 +2352,6 @@ functions = {
                 },
                 'type': 'ViReal64[]',
                 'use_array': True
-            }
-        ],
-        'returns': 'ViStatus'
-    },
-    'AcceptListOfTimeValues': {
-        'codegen_method': 'public',
-        'documentation': {
-            'description': 'Accepts list of floats or datetime.timedelta instances representing time delays.',
-        },
-        'parameters': [
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
-                'name': 'vi',
-                'type': 'ViSession'
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Count of input values.'
-                },
-                'name': 'count',
-                'type': 'ViInt32'
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'A collection of time delay values.'
-                },
-                'name': 'delays',
-                'python_api_converter_name': 'convert_timedeltas_to_seconds_real64',
-                'size': {
-                    'mechanism': 'len',
-                    'value': 'count'
-                },
-                'type': 'ViReal64[]',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
-            },
-        ],
-        'returns': 'ViStatus'
-    },
-    'ReturnListOfTimedeltas': {
-        'codegen_method': 'public',
-        'documentation': {
-            'description': 'Returns a list of datetime.timedelta instances.',
-        },
-        'parameters': [
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
-                'name': 'vi',
-                'type': 'ViSession'
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Number of elements in output.'
-                },
-                'name': 'numberOfElements',
-                'type': 'ViInt32'
-            },
-            {
-                'direction': 'out',
-                'documentation': {
-                    'description': 'Contains a list of datetime.timedelta instances'
-                },
-                'name': 'timedeltas',
-                'python_api_converter_name': 'convert_seconds_real64_to_timedeltas',
-                'size': {
-                    'mechanism': 'passed-in',
-                    'value': 'numberOfElements'
-                },
-                'type': 'ViReal64[]',
-                'type_in_documentation': 'datetime.timedelta'
             }
         ],
         'returns': 'ViStatus'

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -1414,51 +1414,51 @@ class TestSession(object):
             assert str(type(session.tclk)) == "<class 'nitclk.session.SessionReference'>"
 
     def test_accept_list_of_time_values_as_floats(self):
-        self.patched_library.niFake_AcceptListOfTimeValues.side_effect = self.side_effects_helper.niFake_AcceptListOfTimeValues
+        self.patched_library.niFake_AcceptListOfDurationsInSeconds.side_effect = self.side_effects_helper.niFake_AcceptListOfDurationsInSeconds
         delays = [-1.5, 2.0]
         with nifake.Session('dev1') as session:
-            session.accept_list_of_time_values(delays)
-            self.patched_library.niFake_AcceptListOfTimeValues.assert_called_once_with(
+            session.accept_list_of_durations_in_seconds(delays)
+            self.patched_library.niFake_AcceptListOfDurationsInSeconds.assert_called_once_with(
                 _matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST),
                 _matchers.ViInt32Matcher(len(delays)),
                 _matchers.ViReal64BufferMatcher(delays)
             )
 
     def test_accept_array_of_time_values_as_floats(self):
-        self.patched_library.niFake_AcceptListOfTimeValues.side_effect = self.side_effects_helper.niFake_AcceptListOfTimeValues
+        self.patched_library.niFake_AcceptListOfDurationsInSeconds.side_effect = self.side_effects_helper.niFake_AcceptListOfDurationsInSeconds
         time_values = [-1.5, 2.0]
         delays = array.array('d', time_values)
         with nifake.Session('dev1') as session:
-            session.accept_list_of_time_values(delays)
-            self.patched_library.niFake_AcceptListOfTimeValues.assert_called_once_with(
+            session.accept_list_of_durations_in_seconds(delays)
+            self.patched_library.niFake_AcceptListOfDurationsInSeconds.assert_called_once_with(
                 _matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST),
                 _matchers.ViInt32Matcher(len(delays)),
                 _matchers.ViReal64BufferMatcher(time_values)
             )
 
     def test_accept_list_of_time_values_as_timedelta_instances(self):
-        self.patched_library.niFake_AcceptListOfTimeValues.side_effect = self.side_effects_helper.niFake_AcceptListOfTimeValues
+        self.patched_library.niFake_AcceptListOfDurationsInSeconds.side_effect = self.side_effects_helper.niFake_AcceptListOfDurationsInSeconds
         time_values = [-1.5, 2.0]
         delays = [datetime.timedelta(seconds=i) for i in time_values]
         with nifake.Session('dev1') as session:
-            session.accept_list_of_time_values(delays)
-            self.patched_library.niFake_AcceptListOfTimeValues.assert_called_once_with(
+            session.accept_list_of_durations_in_seconds(delays)
+            self.patched_library.niFake_AcceptListOfDurationsInSeconds.assert_called_once_with(
                 _matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST),
                 _matchers.ViInt32Matcher(len(delays)),
                 _matchers.ViReal64BufferMatcher(time_values)
             )
 
     def test_return_timedeltas(self):
-        self.patched_library.niFake_ReturnListOfTimedeltas.side_effect = self.side_effects_helper.niFake_ReturnListOfTimedeltas
+        self.patched_library.niFake_ReturnListOfDurationsInSeconds.side_effect = self.side_effects_helper.niFake_ReturnListOfDurationsInSeconds
         time_values = [-1.5, 2.0]
         time_values_ctype = (nifake._visatype.ViReal64 * len(time_values))(*time_values)
         expected_timedeltas = [datetime.timedelta(seconds=i) for i in time_values]
-        self.side_effects_helper['ReturnListOfTimedeltas']['timedeltas'] = time_values_ctype
+        self.side_effects_helper['ReturnListOfDurationsInSeconds']['timedeltas'] = time_values_ctype
         with nifake.Session('dev1') as session:
-            returned_timedeltas = session.return_list_of_timedeltas(len(expected_timedeltas))
+            returned_timedeltas = session.return_list_of_durations_in_seconds(len(expected_timedeltas))
             assert len(returned_timedeltas) == len(expected_timedeltas)
             assert returned_timedeltas == expected_timedeltas
-            self.patched_library.niFake_ReturnListOfTimedeltas.assert_called_once_with(
+            self.patched_library.niFake_ReturnListOfDurationsInSeconds.assert_called_once_with(
                 _matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST),
                 _matchers.ViInt32Matcher(len(time_values)),
                 _matchers.ViReal64BufferMatcher(len(time_values))


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Update method names in nifake to be language-agnostic:
- `accept_list_of_time_values` changed to `accept_list_of_durations_in_seconds`
- `return_list_of_timedeltas` changed to `return_list_of_durations_in_seconds`

Note: These changes are sourced from internal metadata.

### List issues fixed by this Pull Request below, if any.

None

### What testing has been done?

Ran unit tests
