### PR TITLE
Update Examples URL in documentation of master version

### DIFF
--- a/build/rules.mak
+++ b/build/rules.mak
@@ -43,7 +43,7 @@ $(foreach d,$(MKDIRECTORIES),$(eval $(call mkdir_rule,$(d))))
 # examples.rst needs to use find since there may be folders of files and it needs to be recursive. wildcard is not recursive
 $(MODULE_DIR)/session.py: $(wildcard $(TEMPLATE_DIR)/session.py/*.mako) $(wildcard $(DRIVER_DIR)/templates/session.py/*.mako)
 $(DRIVER_DOCS_DIR)/class.rst: $(wildcard $(TEMPLATE_DIR)/functions.rst/*.mako) $(wildcard $(DRIVER_DIR)/templates/functions.rst/*.mako)
-$(DRIVER_DOCS_DIR)/examples.rst: $(EXAMPLE_FILES)
+$(DRIVER_DOCS_DIR)/examples.rst: $(EXAMPLE_FILES) $(MODULE_DIR)/VERSION
 
 $(MODULE_DIR)/%.py: %.py.mako $(BUILD_HELPER_SCRIPTS) $(METADATA_FILES)
 	$(call trace_to_console, "Generating",$@)

--- a/build/templates/examples.rst.mako
+++ b/build/templates/examples.rst.mako
@@ -26,9 +26,7 @@
     if v.dev is None and v.pre is None:
         examples_link_text = '`You can download all {0} examples here <{1}>`_'.format(module_name, released_url)
     else:
-        master_url = 'https://github.com/ni/nimi-python/tree/master/src/{}/examples'.format(module_name)
-        examples_link_text = '`You can download all {0} examples for master version here <{1}>`_'.format(module_name, master_url)
-        examples_link_text += '\n\n`You can download all {0} examples for latest version here <{1}>`_'.format(module_name, released_url)
+        examples_link_text = '`You can download all {0} examples for latest version here <{1}>`_'.format(module_name, released_url)
 %>\
 ${helper.get_rst_header_snippet('Examples', '=')}
 

--- a/build/templates/examples.rst.mako
+++ b/build/templates/examples.rst.mako
@@ -11,7 +11,10 @@
     examples = sorted(examples)
 
     # If there is no dev or pre ('a', 'b', 'rc'), then the url should link to the (soon to exist) release
-    # Otherwise we should just point to master
+    # Otherwise, there should be a link to examples folder in src, in addition to url to latest released release
+    with open('./LATEST_RELEASE') as vf:
+        latest_release_version = vf.read().strip()
+    released_url = 'https://github.com/ni/nimi-python/releases/download/{0}/{1}_examples.zip'.format(latest_release_version, module_name)
 
     # We need to use the global version and not the module version since the release version will match the global version
     # and may not match the module version
@@ -21,15 +24,15 @@
     from packaging.version import Version
     v = Version(global_version)
     if v.dev is None and v.pre is None:
-        url = 'https://github.com/ni/nimi-python/releases/download/{0}/{1}_examples.zip'.format(global_version, module_name)
+        examples_link_text = '`You can download all {0} examples here <{1}>`_'.format(module_name, released_url)
     else:
-        with open('./LATEST_RELEASE') as vf:
-            latest_release_version = vf.read().strip()
-        url = 'https://github.com/ni/nimi-python/releases/download/{0}/{1}_examples.zip'.format(latest_release_version, module_name)
+        master_url = 'https://github.com/ni/nimi-python/tree/master/src/{}/examples'.format(module_name)
+        examples_link_text = '`You can download all {0} examples for master version here <{1}>`_'.format(module_name, master_url)
+        examples_link_text += '\n\n`You can download all {0} examples for latest version here <{1}>`_'.format(module_name, released_url)
 %>\
 ${helper.get_rst_header_snippet('Examples', '=')}
 
-`You can download all ${module_name} examples here <${url}>`_
+${examples_link_text}
 
 % for e in examples:
 ${helper.get_rst_header_snippet(e, '-')}

--- a/docs/nidcpower/examples.rst
+++ b/docs/nidcpower/examples.rst
@@ -1,8 +1,6 @@
 Examples
 ========
 
-`You can download all nidcpower examples for master version here <https://github.com/ni/nimi-python/tree/master/src/nidcpower/examples>`_
-
 `You can download all nidcpower examples for latest version here <https://github.com/ni/nimi-python/releases/download/1.2.0/nidcpower_examples.zip>`_
 
 nidcpower_advanced_sequence.py

--- a/docs/nidcpower/examples.rst
+++ b/docs/nidcpower/examples.rst
@@ -1,7 +1,9 @@
 Examples
 ========
 
-`You can download all nidcpower examples here <https://github.com/ni/nimi-python/releases/download/1.2.0/nidcpower_examples.zip>`_
+`You can download all nidcpower examples for master version here <https://github.com/ni/nimi-python/tree/master/src/nidcpower/examples>`_
+
+`You can download all nidcpower examples for latest version here <https://github.com/ni/nimi-python/releases/download/1.2.0/nidcpower_examples.zip>`_
 
 nidcpower_advanced_sequence.py
 ------------------------------

--- a/docs/nidigital/examples.rst
+++ b/docs/nidigital/examples.rst
@@ -1,8 +1,6 @@
 Examples
 ========
 
-`You can download all nidigital examples for master version here <https://github.com/ni/nimi-python/tree/master/src/nidigital/examples>`_
-
 `You can download all nidigital examples for latest version here <https://github.com/ni/nimi-python/releases/download/1.2.0/nidigital_examples.zip>`_
 
 nidigital_do_nothing.py

--- a/docs/nidigital/examples.rst
+++ b/docs/nidigital/examples.rst
@@ -1,7 +1,9 @@
 Examples
 ========
 
-`You can download all nidigital examples here <https://github.com/ni/nimi-python/releases/download/1.2.0/nidigital_examples.zip>`_
+`You can download all nidigital examples for master version here <https://github.com/ni/nimi-python/tree/master/src/nidigital/examples>`_
+
+`You can download all nidigital examples for latest version here <https://github.com/ni/nimi-python/releases/download/1.2.0/nidigital_examples.zip>`_
 
 nidigital_do_nothing.py
 -----------------------

--- a/docs/nidmm/examples.rst
+++ b/docs/nidmm/examples.rst
@@ -1,8 +1,6 @@
 Examples
 ========
 
-`You can download all nidmm examples for master version here <https://github.com/ni/nimi-python/tree/master/src/nidmm/examples>`_
-
 `You can download all nidmm examples for latest version here <https://github.com/ni/nimi-python/releases/download/1.2.0/nidmm_examples.zip>`_
 
 nidmm_fetch_waveform.py

--- a/docs/nidmm/examples.rst
+++ b/docs/nidmm/examples.rst
@@ -1,7 +1,9 @@
 Examples
 ========
 
-`You can download all nidmm examples here <https://github.com/ni/nimi-python/releases/download/1.2.0/nidmm_examples.zip>`_
+`You can download all nidmm examples for master version here <https://github.com/ni/nimi-python/tree/master/src/nidmm/examples>`_
+
+`You can download all nidmm examples for latest version here <https://github.com/ni/nimi-python/releases/download/1.2.0/nidmm_examples.zip>`_
 
 nidmm_fetch_waveform.py
 -----------------------

--- a/docs/nifgen/examples.rst
+++ b/docs/nifgen/examples.rst
@@ -1,8 +1,6 @@
 Examples
 ========
 
-`You can download all nifgen examples for master version here <https://github.com/ni/nimi-python/tree/master/src/nifgen/examples>`_
-
 `You can download all nifgen examples for latest version here <https://github.com/ni/nimi-python/releases/download/1.2.0/nifgen_examples.zip>`_
 
 nifgen_arb_waveform.py

--- a/docs/nifgen/examples.rst
+++ b/docs/nifgen/examples.rst
@@ -1,7 +1,9 @@
 Examples
 ========
 
-`You can download all nifgen examples here <https://github.com/ni/nimi-python/releases/download/1.2.0/nifgen_examples.zip>`_
+`You can download all nifgen examples for master version here <https://github.com/ni/nimi-python/tree/master/src/nifgen/examples>`_
+
+`You can download all nifgen examples for latest version here <https://github.com/ni/nimi-python/releases/download/1.2.0/nifgen_examples.zip>`_
 
 nifgen_arb_waveform.py
 ----------------------

--- a/docs/nimodinst/examples.rst
+++ b/docs/nimodinst/examples.rst
@@ -1,8 +1,6 @@
 Examples
 ========
 
-`You can download all nimodinst examples for master version here <https://github.com/ni/nimi-python/tree/master/src/nimodinst/examples>`_
-
 `You can download all nimodinst examples for latest version here <https://github.com/ni/nimi-python/releases/download/1.2.0/nimodinst_examples.zip>`_
 
 nimodinst_all_devices.py

--- a/docs/nimodinst/examples.rst
+++ b/docs/nimodinst/examples.rst
@@ -1,7 +1,9 @@
 Examples
 ========
 
-`You can download all nimodinst examples here <https://github.com/ni/nimi-python/releases/download/1.2.0/nimodinst_examples.zip>`_
+`You can download all nimodinst examples for master version here <https://github.com/ni/nimi-python/tree/master/src/nimodinst/examples>`_
+
+`You can download all nimodinst examples for latest version here <https://github.com/ni/nimi-python/releases/download/1.2.0/nimodinst_examples.zip>`_
 
 nimodinst_all_devices.py
 ------------------------

--- a/docs/niscope/examples.rst
+++ b/docs/niscope/examples.rst
@@ -1,8 +1,6 @@
 Examples
 ========
 
-`You can download all niscope examples for master version here <https://github.com/ni/nimi-python/tree/master/src/niscope/examples>`_
-
 `You can download all niscope examples for latest version here <https://github.com/ni/nimi-python/releases/download/1.2.0/niscope_examples.zip>`_
 
 niscope_fetch.py

--- a/docs/niscope/examples.rst
+++ b/docs/niscope/examples.rst
@@ -1,7 +1,9 @@
 Examples
 ========
 
-`You can download all niscope examples here <https://github.com/ni/nimi-python/releases/download/1.2.0/niscope_examples.zip>`_
+`You can download all niscope examples for master version here <https://github.com/ni/nimi-python/tree/master/src/niscope/examples>`_
+
+`You can download all niscope examples for latest version here <https://github.com/ni/nimi-python/releases/download/1.2.0/niscope_examples.zip>`_
 
 niscope_fetch.py
 ----------------

--- a/docs/nise/examples.rst
+++ b/docs/nise/examples.rst
@@ -1,7 +1,9 @@
 Examples
 ========
 
-`You can download all nise examples here <https://github.com/ni/nimi-python/releases/download/1.2.0/nise_examples.zip>`_
+`You can download all nise examples for master version here <https://github.com/ni/nimi-python/tree/master/src/nise/examples>`_
+
+`You can download all nise examples for latest version here <https://github.com/ni/nimi-python/releases/download/1.2.0/nise_examples.zip>`_
 
 nise_basic_example.py
 ---------------------

--- a/docs/nise/examples.rst
+++ b/docs/nise/examples.rst
@@ -1,8 +1,6 @@
 Examples
 ========
 
-`You can download all nise examples for master version here <https://github.com/ni/nimi-python/tree/master/src/nise/examples>`_
-
 `You can download all nise examples for latest version here <https://github.com/ni/nimi-python/releases/download/1.2.0/nise_examples.zip>`_
 
 nise_basic_example.py

--- a/docs/niswitch/examples.rst
+++ b/docs/niswitch/examples.rst
@@ -1,8 +1,6 @@
 Examples
 ========
 
-`You can download all niswitch examples for master version here <https://github.com/ni/nimi-python/tree/master/src/niswitch/examples>`_
-
 `You can download all niswitch examples for latest version here <https://github.com/ni/nimi-python/releases/download/1.2.0/niswitch_examples.zip>`_
 
 niswitch_connect_channels.py

--- a/docs/niswitch/examples.rst
+++ b/docs/niswitch/examples.rst
@@ -1,7 +1,9 @@
 Examples
 ========
 
-`You can download all niswitch examples here <https://github.com/ni/nimi-python/releases/download/1.2.0/niswitch_examples.zip>`_
+`You can download all niswitch examples for master version here <https://github.com/ni/nimi-python/tree/master/src/niswitch/examples>`_
+
+`You can download all niswitch examples for latest version here <https://github.com/ni/nimi-python/releases/download/1.2.0/niswitch_examples.zip>`_
 
 niswitch_connect_channels.py
 ----------------------------

--- a/docs/nitclk/examples.rst
+++ b/docs/nitclk/examples.rst
@@ -1,7 +1,9 @@
 Examples
 ========
 
-`You can download all nitclk examples here <https://github.com/ni/nimi-python/releases/download/1.2.0/nitclk_examples.zip>`_
+`You can download all nitclk examples for master version here <https://github.com/ni/nimi-python/tree/master/src/nitclk/examples>`_
+
+`You can download all nitclk examples for latest version here <https://github.com/ni/nimi-python/releases/download/1.2.0/nitclk_examples.zip>`_
 
 nitclk_configure.py
 -------------------

--- a/docs/nitclk/examples.rst
+++ b/docs/nitclk/examples.rst
@@ -1,8 +1,6 @@
 Examples
 ========
 
-`You can download all nitclk examples for master version here <https://github.com/ni/nimi-python/tree/master/src/nitclk/examples>`_
-
 `You can download all nitclk examples for latest version here <https://github.com/ni/nimi-python/releases/download/1.2.0/nitclk_examples.zip>`_
 
 nitclk_configure.py

--- a/tools/build_release.py
+++ b/tools/build_release.py
@@ -39,6 +39,7 @@ Steps
         * Commit to branch
     * `python3 tools/build_release.py --update --release`
         * This will update all the versions to remove any '.devN'
+        * Update contents of LATEST_RELEASE with the version of the release being created.
         * Commit to branch
     * `python3 tools/build_release.py --build`
         * Clean and build to update generated files with new version
@@ -51,7 +52,6 @@ Steps
     * Merge the pull request to origin/master
     * Create a release on GitHub using the portion from the changelog for this release for the description
         * Add the ZIP files under `generated/examples` for each module as a release artifact.
-        * Update contents of LATEST_RELEASE with the version of the release being created.
     * Create and checkout another branch for post-release changes
     * `python3 tools/build_release.py --update`
         * This will update the version to X.X.(N+1).dev0


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

- In the master version of documentation, update the text to provide links to two versions of examples:
   1. master version
    2. latest release version
- Fix the dependency of examples.rst in `rules.mak` so that the examples URL gets updated when making a release
- Update the build script to instruct developer to update `LASTEST_RELEASE` file before `--build` step

### List issues fixed by this Pull Request below, if any.

TODO: List of issues.

* Fix #1322
* Fix #1326

### What testing has been done?

Visual inspection of generated `examples.html`