### PR TITLE
Change the type of method parameters and properties in nidigital to enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ All notable changes to this project will be documented in this file.
     * #### Added
         * `get_pattern_pin_names` - [#1292](https://github.com/ni/nimi-python/issues/1292)
     * #### Changed
-        * Change the type of method parameters and properties to enums - [#1066](https://github.com/ni/nimi-python/issues/1066)
+        * Change the type of applicable method parameters and properties to enums - [#1066](https://github.com/ni/nimi-python/issues/1066)
     * #### Removed
         * `get_pattern_pin_list`, `get_pattern_pin_indexes` and `get_pin_name` - [#1292](https://github.com/ni/nimi-python/issues/1292)
 * ### NI-TClk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable changes to this project will be documented in this file.
     * #### Added
         * `get_pattern_pin_names` - [#1292](https://github.com/ni/nimi-python/issues/1292)
     * #### Changed
+        * Change the type of method parameters and properties to enums - [#1066](https://github.com/ni/nimi-python/issues/1066)
     * #### Removed
         * `get_pattern_pin_list`, `get_pattern_pin_indexes` and `get_pin_name` - [#1292](https://github.com/ni/nimi-python/issues/1292)
 * ### NI-TClk

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -3054,17 +3054,17 @@ history_ram_cycles_to_acquire
 
         The following table lists the characteristics of this property.
 
-            +----------------+---------------------------+
-            | Characteristic | Value                     |
-            +================+===========================+
-            | Datatype       | enums.HramCyclesToAcquire |
-            +----------------+---------------------------+
-            | Permissions    | read-write                |
-            +----------------+---------------------------+
-            | Channel Based  | No                        |
-            +----------------+---------------------------+
-            | Resettable     | Yes                       |
-            +----------------+---------------------------+
+            +----------------+---------------------------------+
+            | Characteristic | Value                           |
+            +================+=================================+
+            | Datatype       | enums.HistoryRAMCyclesToAcquire |
+            +----------------+---------------------------------+
+            | Permissions    | read-write                      |
+            +----------------+---------------------------------+
+            | Channel Based  | No                              |
+            +----------------+---------------------------------+
+            | Resettable     | Yes                             |
+            +----------------+---------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -3158,17 +3158,17 @@ history_ram_trigger_type
 
         The following table lists the characteristics of this property.
 
-            +----------------+-----------------------+
-            | Characteristic | Value                 |
-            +================+=======================+
-            | Datatype       | enums.HramTriggerType |
-            +----------------+-----------------------+
-            | Permissions    | read-write            |
-            +----------------+-----------------------+
-            | Channel Based  | No                    |
-            +----------------+-----------------------+
-            | Resettable     | Yes                   |
-            +----------------+-----------------------+
+            +----------------+-----------------------------+
+            | Characteristic | Value                       |
+            +================+=============================+
+            | Datatype       | enums.HistoryRAMTriggerType |
+            +----------------+-----------------------------+
+            | Permissions    | read-write                  |
+            +----------------+-----------------------------+
+            | Channel Based  | No                          |
+            +----------------+-----------------------------+
+            | Resettable     | Yes                         |
+            +----------------+-----------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -507,7 +507,7 @@ configure_time_set_drive_edges
                 
 
 
-            :type format: int
+            :type format: :py:data:`nidigital.DriveEdgeSetFormat`
             :param drive_on_edge:
 
 
@@ -568,7 +568,7 @@ configure_time_set_drive_edges2x
                 
 
 
-            :type format: int
+            :type format: :py:data:`nidigital.DriveEdgeSetFormat`
             :param drive_on_edge:
 
 
@@ -643,7 +643,7 @@ configure_time_set_drive_format
                 
 
 
-            :type drive_format: int
+            :type drive_format: :py:data:`nidigital.DriveEdgeSetFormat`
 
 configure_time_set_edge
 -----------------------
@@ -676,7 +676,7 @@ configure_time_set_edge
                 
 
 
-            :type edge: int
+            :type edge: :py:data:`nidigital.TimeSetEdge`
             :param time:
 
 
@@ -892,7 +892,7 @@ create_capture_waveform_serial
                 
 
 
-            :type bit_order: int
+            :type bit_order: :py:data:`nidigital.BitOrder`
 
 create_source_waveform_from_file_tdms
 -------------------------------------
@@ -960,7 +960,7 @@ create_source_waveform_parallel
                 
 
 
-            :type data_mapping: int
+            :type data_mapping: :py:data:`nidigital.SourceMemoryDataMapping`
 
 create_source_waveform_serial
 -----------------------------
@@ -993,7 +993,7 @@ create_source_waveform_serial
                 
 
 
-            :type data_mapping: int
+            :type data_mapping: :py:data:`nidigital.SourceMemoryDataMapping`
             :param sample_width:
 
 
@@ -1007,7 +1007,7 @@ create_source_waveform_serial
                 
 
 
-            :type bit_order: int
+            :type bit_order: :py:data:`nidigital.BitOrder`
 
 create_time_set
 ---------------
@@ -1553,7 +1553,7 @@ get_time_set_drive_format
 
             :type time_set: str
 
-            :rtype: int
+            :rtype: :py:data:`nidigital.DriveEdgeSetFormat`
             :return:
 
 
@@ -1592,7 +1592,7 @@ get_time_set_edge
                 
 
 
-            :type edge: int
+            :type edge: :py:data:`nidigital.TimeSetEdge`
 
             :rtype: float
             :return:
@@ -1937,7 +1937,7 @@ ppmu_measure
                 
 
 
-            :type measurement_type: int
+            :type measurement_type: :py:data:`nidigital.PPMUMeasurementType`
 
             :rtype: list of float
             :return:
@@ -1984,7 +1984,7 @@ read_sequencer_flag
                 
 
 
-            :type flag: str
+            :type flag: :py:data:`nidigital.SequencerFlag`
 
             :rtype: bool
             :return:
@@ -2013,7 +2013,7 @@ read_sequencer_register
                 
 
 
-            :type reg: str
+            :type reg: :py:data:`nidigital.SequencerRegister`
 
             :rtype: int
             :return:
@@ -2041,7 +2041,7 @@ read_static
                 nidigital.Session repeated capabilities container, and calling this method on the result.
 
 
-            :rtype: list of int
+            :rtype: list of :py:data:`nidigital.DigitalState`
             :return:
 
 
@@ -2284,7 +2284,7 @@ write_sequencer_flag
                 
 
 
-            :type flag: str
+            :type flag: :py:data:`nidigital.SequencerFlag`
             :param value:
 
 
@@ -2312,7 +2312,7 @@ write_sequencer_register
                 
 
 
-            :type reg: str
+            :type reg: :py:data:`nidigital.SequencerRegister`
             :param value:
 
 
@@ -2431,7 +2431,7 @@ write_static
                 
 
 
-            :type state: int
+            :type state: :py:data:`nidigital.DigitalState`
 
 
 Properties
@@ -2675,17 +2675,17 @@ conditional_jump_trigger_type
 
         The following table lists the characteristics of this property.
 
-            +----------------+------------+
-            | Characteristic | Value      |
-            +================+============+
-            | Datatype       | int        |
-            +----------------+------------+
-            | Permissions    | read-write |
-            +----------------+------------+
-            | Channel Based  | Yes        |
-            +----------------+------------+
-            | Resettable     | Yes        |
-            +----------------+------------+
+            +----------------+-------------------+
+            | Characteristic | Value             |
+            +================+===================+
+            | Datatype       | enums.TriggerType |
+            +----------------+-------------------+
+            | Permissions    | read-write        |
+            +----------------+-------------------+
+            | Channel Based  | Yes               |
+            +----------------+-------------------+
+            | Resettable     | Yes               |
+            +----------------+-------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -3054,17 +3054,17 @@ history_ram_cycles_to_acquire
 
         The following table lists the characteristics of this property.
 
-            +----------------+------------+
-            | Characteristic | Value      |
-            +================+============+
-            | Datatype       | int        |
-            +----------------+------------+
-            | Permissions    | read-write |
-            +----------------+------------+
-            | Channel Based  | No         |
-            +----------------+------------+
-            | Resettable     | Yes        |
-            +----------------+------------+
+            +----------------+---------------------------+
+            | Characteristic | Value                     |
+            +================+===========================+
+            | Datatype       | enums.HramCyclesToAcquire |
+            +----------------+---------------------------+
+            | Permissions    | read-write                |
+            +----------------+---------------------------+
+            | Channel Based  | No                        |
+            +----------------+---------------------------+
+            | Resettable     | Yes                       |
+            +----------------+---------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -3158,17 +3158,17 @@ history_ram_trigger_type
 
         The following table lists the characteristics of this property.
 
-            +----------------+------------+
-            | Characteristic | Value      |
-            +================+============+
-            | Datatype       | int        |
-            +----------------+------------+
-            | Permissions    | read-write |
-            +----------------+------------+
-            | Channel Based  | No         |
-            +----------------+------------+
-            | Resettable     | Yes        |
-            +----------------+------------+
+            +----------------+-----------------------+
+            | Characteristic | Value                 |
+            +================+=======================+
+            | Datatype       | enums.HramTriggerType |
+            +----------------+-----------------------+
+            | Permissions    | read-write            |
+            +----------------+-----------------------+
+            | Channel Based  | No                    |
+            +----------------+-----------------------+
+            | Resettable     | Yes                   |
+            +----------------+-----------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -3682,17 +3682,17 @@ ppmu_current_limit_behavior
 
         The following table lists the characteristics of this property.
 
-            +----------------+------------+
-            | Characteristic | Value      |
-            +================+============+
-            | Datatype       | int        |
-            +----------------+------------+
-            | Permissions    | read-write |
-            +----------------+------------+
-            | Channel Based  | Yes        |
-            +----------------+------------+
-            | Resettable     | Yes        |
-            +----------------+------------+
+            +----------------+--------------------------------+
+            | Characteristic | Value                          |
+            +================+================================+
+            | Datatype       | enums.PPMUCurrentLimitBehavior |
+            +----------------+--------------------------------+
+            | Permissions    | read-write                     |
+            +----------------+--------------------------------+
+            | Channel Based  | Yes                            |
+            +----------------+--------------------------------+
+            | Resettable     | Yes                            |
+            +----------------+--------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -4275,17 +4275,17 @@ start_trigger_type
 
         The following table lists the characteristics of this property.
 
-            +----------------+------------+
-            | Characteristic | Value      |
-            +================+============+
-            | Datatype       | int        |
-            +----------------+------------+
-            | Permissions    | read-write |
-            +----------------+------------+
-            | Channel Based  | No         |
-            +----------------+------------+
-            | Resettable     | Yes        |
-            +----------------+------------+
+            +----------------+-------------------+
+            | Characteristic | Value             |
+            +================+===================+
+            | Datatype       | enums.TriggerType |
+            +----------------+-------------------+
+            | Permissions    | read-write        |
+            +----------------+-------------------+
+            | Channel Based  | No                |
+            +----------------+-------------------+
+            | Resettable     | Yes               |
+            +----------------+-------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:

--- a/docs/nidigital/enums.rst
+++ b/docs/nidigital/enums.rst
@@ -111,33 +111,33 @@ DriveEdgeSetFormat
 
 
 
-HramCyclesToAcquire
--------------------
+HistoryRAMCyclesToAcquire
+-------------------------
 
-.. py:class:: HramCyclesToAcquire
+.. py:class:: HistoryRAMCyclesToAcquire
 
-    .. py:attribute:: HramCyclesToAcquire.FAILED
-
-
-
-    .. py:attribute:: HramCyclesToAcquire.ALL
+    .. py:attribute:: HistoryRAMCyclesToAcquire.FAILED
 
 
 
-HramTriggerType
----------------
-
-.. py:class:: HramTriggerType
-
-    .. py:attribute:: HramTriggerType.FIRST_FAILURE
+    .. py:attribute:: HistoryRAMCyclesToAcquire.ALL
 
 
 
-    .. py:attribute:: HramTriggerType.CYCLE_NUMBER
+HistoryRAMTriggerType
+---------------------
+
+.. py:class:: HistoryRAMTriggerType
+
+    .. py:attribute:: HistoryRAMTriggerType.FIRST_FAILURE
 
 
 
-    .. py:attribute:: HramTriggerType.PATTERN_LABEL
+    .. py:attribute:: HistoryRAMTriggerType.CYCLE_NUMBER
+
+
+
+    .. py:attribute:: HistoryRAMTriggerType.PATTERN_LABEL
 
 
 

--- a/docs/nidigital/enums.rst
+++ b/docs/nidigital/enums.rst
@@ -15,6 +15,19 @@ ApertureTimeUnits
 
 
 
+BitOrder
+--------
+
+.. py:class:: BitOrder
+
+    .. py:attribute:: BitOrder.MSB
+
+
+
+    .. py:attribute:: BitOrder.LSB
+
+
+
 DigitalEdge
 -----------
 
@@ -77,6 +90,79 @@ DigitalState
 
 
 
+DriveEdgeSetFormat
+------------------
+
+.. py:class:: DriveEdgeSetFormat
+
+    .. py:attribute:: DriveEdgeSetFormat.NR
+
+
+
+    .. py:attribute:: DriveEdgeSetFormat.RL
+
+
+
+    .. py:attribute:: DriveEdgeSetFormat.RH
+
+
+
+    .. py:attribute:: DriveEdgeSetFormat.SBC
+
+
+
+HramCyclesToAcquire
+-------------------
+
+.. py:class:: HramCyclesToAcquire
+
+    .. py:attribute:: HramCyclesToAcquire.FAILED
+
+
+
+    .. py:attribute:: HramCyclesToAcquire.ALL
+
+
+
+HramTriggerType
+---------------
+
+.. py:class:: HramTriggerType
+
+    .. py:attribute:: HramTriggerType.FIRST_FAILURE
+
+
+
+    .. py:attribute:: HramTriggerType.CYCLE_NUMBER
+
+
+
+    .. py:attribute:: HramTriggerType.PATTERN_LABEL
+
+
+
+PPMUCurrentLimitBehavior
+------------------------
+
+.. py:class:: PPMUCurrentLimitBehavior
+
+    .. py:attribute:: PPMUCurrentLimitBehavior.REGULATE
+
+
+
+PPMUMeasurementType
+-------------------
+
+.. py:class:: PPMUMeasurementType
+
+    .. py:attribute:: PPMUMeasurementType.CURRENT
+
+
+
+    .. py:attribute:: PPMUMeasurementType.VOLTAGE
+
+
+
 PPMUOutputFunction
 ------------------
 
@@ -111,6 +197,96 @@ SelectedFunction
 
 
 
+SequencerFlag
+-------------
+
+.. py:class:: SequencerFlag
+
+    .. py:attribute:: SequencerFlag.FLAG0
+
+
+
+    .. py:attribute:: SequencerFlag.FLAG1
+
+
+
+    .. py:attribute:: SequencerFlag.FLAG2
+
+
+
+    .. py:attribute:: SequencerFlag.FLAG3
+
+
+
+SequencerRegister
+-----------------
+
+.. py:class:: SequencerRegister
+
+    .. py:attribute:: SequencerRegister.REGISTER0
+
+
+
+    .. py:attribute:: SequencerRegister.REGISTER1
+
+
+
+    .. py:attribute:: SequencerRegister.REGISTER2
+
+
+
+    .. py:attribute:: SequencerRegister.REGISTER3
+
+
+
+    .. py:attribute:: SequencerRegister.REGISTER4
+
+
+
+    .. py:attribute:: SequencerRegister.REGISTER5
+
+
+
+    .. py:attribute:: SequencerRegister.REGISTER6
+
+
+
+    .. py:attribute:: SequencerRegister.REGISTER7
+
+
+
+    .. py:attribute:: SequencerRegister.REGISTER8
+
+
+
+    .. py:attribute:: SequencerRegister.REGISTER9
+
+
+
+    .. py:attribute:: SequencerRegister.REGISTER10
+
+
+
+    .. py:attribute:: SequencerRegister.REGISTER11
+
+
+
+    .. py:attribute:: SequencerRegister.REGISTER12
+
+
+
+    .. py:attribute:: SequencerRegister.REGISTER13
+
+
+
+    .. py:attribute:: SequencerRegister.REGISTER14
+
+
+
+    .. py:attribute:: SequencerRegister.REGISTER15
+
+
+
 SiteResult
 ----------
 
@@ -121,6 +297,19 @@ SiteResult
 
 
     .. py:attribute:: SiteResult.CAPTURE_WAVEFORM
+
+
+
+SourceMemoryDataMapping
+-----------------------
+
+.. py:class:: SourceMemoryDataMapping
+
+    .. py:attribute:: SourceMemoryDataMapping.BROADCAST
+
+
+
+    .. py:attribute:: SourceMemoryDataMapping.SITE_UNIQUE
 
 
 
@@ -151,6 +340,60 @@ TerminationMode
 
 
     .. py:attribute:: TerminationMode.HIGH_Z
+
+
+
+TimeSetEdge
+-----------
+
+.. py:class:: TimeSetEdge
+
+    .. py:attribute:: TimeSetEdge.DRIVE_ON
+
+
+
+    .. py:attribute:: TimeSetEdge.DRIVE_DATA
+
+
+
+    .. py:attribute:: TimeSetEdge.DRIVE_RETURN
+
+
+
+    .. py:attribute:: TimeSetEdge.DRIVE_OFF
+
+
+
+    .. py:attribute:: TimeSetEdge.COMPARE_STROBE
+
+
+
+    .. py:attribute:: TimeSetEdge.DRIVE_DATA2
+
+
+
+    .. py:attribute:: TimeSetEdge.DRIVE_RETURN2
+
+
+
+    .. py:attribute:: TimeSetEdge.COMPARE_STROBE2
+
+
+
+TriggerType
+-----------
+
+.. py:class:: TriggerType
+
+    .. py:attribute:: TriggerType.NONE
+
+
+
+    .. py:attribute:: TriggerType.DIGITAL_EDGE
+
+
+
+    .. py:attribute:: TriggerType.SOFTWARE
 
 
 

--- a/generated/nidigital/nidigital/enums.py
+++ b/generated/nidigital/nidigital/enums.py
@@ -8,6 +8,11 @@ class ApertureTimeUnits(Enum):
     SECONDS = 2100
 
 
+class BitOrder(Enum):
+    MSB = 2500
+    LSB = 2501
+
+
 class DigitalEdge(Enum):
     RISING = 1800
     FALLING = 1801
@@ -27,6 +32,33 @@ class DigitalState(Enum):
     PIN_STATE_NOT_ACQUIRED = 255
 
 
+class DriveEdgeSetFormat(Enum):
+    NR = 1500
+    RL = 1501
+    RH = 1502
+    SBC = 1503
+
+
+class HramCyclesToAcquire(Enum):
+    FAILED = 2303
+    ALL = 2304
+
+
+class HramTriggerType(Enum):
+    FIRST_FAILURE = 2200
+    CYCLE_NUMBER = 2201
+    PATTERN_LABEL = 2202
+
+
+class PPMUCurrentLimitBehavior(Enum):
+    REGULATE = 3100
+
+
+class PPMUMeasurementType(Enum):
+    CURRENT = 2400
+    VOLTAGE = 2401
+
+
 class PPMUOutputFunction(Enum):
     VOLTAGE = 1300
     CURRENT = 1301
@@ -39,9 +71,40 @@ class SelectedFunction(Enum):
     DISCONNECT = 1103
 
 
+class SequencerFlag(Enum):
+    FLAG0 = 'seqflag0'
+    FLAG1 = 'seqflag1'
+    FLAG2 = 'seqflag2'
+    FLAG3 = 'seqflag3'
+
+
+class SequencerRegister(Enum):
+    REGISTER0 = 'reg0'
+    REGISTER1 = 'reg1'
+    REGISTER2 = 'reg2'
+    REGISTER3 = 'reg3'
+    REGISTER4 = 'reg4'
+    REGISTER5 = 'reg5'
+    REGISTER6 = 'reg6'
+    REGISTER7 = 'reg7'
+    REGISTER8 = 'reg8'
+    REGISTER9 = 'reg9'
+    REGISTER10 = 'reg10'
+    REGISTER11 = 'reg11'
+    REGISTER12 = 'reg12'
+    REGISTER13 = 'reg13'
+    REGISTER14 = 'reg14'
+    REGISTER15 = 'reg15'
+
+
 class SiteResult(Enum):
     PASS_FAIL = 3300
     CAPTURE_WAVEFORM = 3301
+
+
+class SourceMemoryDataMapping(Enum):
+    BROADCAST = 2600
+    SITE_UNIQUE = 2601
 
 
 class TDREndpointTermination(Enum):
@@ -53,3 +116,20 @@ class TerminationMode(Enum):
     ACTIVE_LOAD = 1200
     VTERM = 1201
     HIGH_Z = 1202
+
+
+class TimeSetEdge(Enum):
+    DRIVE_ON = 2800
+    DRIVE_DATA = 2801
+    DRIVE_RETURN = 2802
+    DRIVE_OFF = 2803
+    COMPARE_STROBE = 2804
+    DRIVE_DATA2 = 2805
+    DRIVE_RETURN2 = 2806
+    COMPARE_STROBE2 = 2807
+
+
+class TriggerType(Enum):
+    NONE = 1700
+    DIGITAL_EDGE = 1701
+    SOFTWARE = 1702

--- a/generated/nidigital/nidigital/enums.py
+++ b/generated/nidigital/nidigital/enums.py
@@ -39,12 +39,12 @@ class DriveEdgeSetFormat(Enum):
     SBC = 1503
 
 
-class HramCyclesToAcquire(Enum):
+class HistoryRAMCyclesToAcquire(Enum):
     FAILED = 2303
     ALL = 2304
 
 
-class HramTriggerType(Enum):
+class HistoryRAMTriggerType(Enum):
     FIRST_FAILURE = 2200
     CYCLE_NUMBER = 2201
     PATTERN_LABEL = 2202

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -178,8 +178,8 @@ class _SessionBase(object):
     You can specify a subset of repeated capabilities using the Python index notation on an
     nidigital.Session repeated capabilities container, and calling set/get value on the result.
     '''
-    conditional_jump_trigger_type = _attributes.AttributeViInt32(1150033)
-    '''Type: int
+    conditional_jump_trigger_type = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.TriggerType, 1150033)
+    '''Type: enums.TriggerType
 
     Tip:
     This property can use repeated capabilities. If set or get directly on the
@@ -240,11 +240,11 @@ class _SessionBase(object):
     group_capabilities = _attributes.AttributeViString(1050401)
     halt_on_keep_alive_opcode = _attributes.AttributeViBoolean(1150062)
     history_ram_buffer_size_per_site = _attributes.AttributeViInt64(1150079)
-    history_ram_cycles_to_acquire = _attributes.AttributeViInt32(1150047)
+    history_ram_cycles_to_acquire = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.HramCyclesToAcquire, 1150047)
     history_ram_max_samples_to_acquire_per_site = _attributes.AttributeViInt32(1150077)
     history_ram_number_of_samples_is_finite = _attributes.AttributeViBoolean(1150078)
     history_ram_pretrigger_samples = _attributes.AttributeViInt32(1150048)
-    history_ram_trigger_type = _attributes.AttributeViInt32(1150043)
+    history_ram_trigger_type = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.HramTriggerType, 1150043)
     instrument_firmware_revision = _attributes.AttributeViString(1050510)
     '''Type: str
 
@@ -335,8 +335,8 @@ class _SessionBase(object):
     You can specify a subset of repeated capabilities using the Python index notation on an
     nidigital.Session repeated capabilities container, and calling set/get value on the result.
     '''
-    ppmu_current_limit_behavior = _attributes.AttributeViInt32(1150064)
-    '''Type: int
+    ppmu_current_limit_behavior = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.PPMUCurrentLimitBehavior, 1150064)
+    '''Type: enums.PPMUCurrentLimitBehavior
 
     Tip:
     This property can use repeated capabilities. If set or get directly on the
@@ -421,7 +421,7 @@ class _SessionBase(object):
     specific_driver_vendor = _attributes.AttributeViString(1050513)
     start_label = _attributes.AttributeViString(1150023)
     start_trigger_terminal_name = _attributes.AttributeViString(1150039)
-    start_trigger_type = _attributes.AttributeViInt32(1150029)
+    start_trigger_type = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.TriggerType, 1150029)
     supported_instrument_models = _attributes.AttributeViString(1050327)
     tdr_endpoint_termination = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.TDREndpointTermination, 1150081)
     tdr_offset = _attributes.AttributeViReal64(1150051)
@@ -724,7 +724,7 @@ class _SessionBase(object):
         Args:
             time_set (str):
 
-            format (int):
+            format (enums.DriveEdgeSetFormat):
 
             drive_on_edge (float):
 
@@ -735,10 +735,12 @@ class _SessionBase(object):
             drive_off_edge (float):
 
         '''
+        if type(format) is not enums.DriveEdgeSetFormat:
+            raise TypeError('Parameter format must be of type ' + str(enums.DriveEdgeSetFormat))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         pin_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         time_set_ctype = ctypes.create_string_buffer(time_set.encode(self._encoding))  # case C020
-        format_ctype = _visatype.ViInt32(format)  # case S150
+        format_ctype = _visatype.ViInt32(format.value)  # case S130
         drive_on_edge_ctype = _visatype.ViReal64(drive_on_edge)  # case S150
         drive_data_edge_ctype = _visatype.ViReal64(drive_data_edge)  # case S150
         drive_return_edge_ctype = _visatype.ViReal64(drive_return_edge)  # case S150
@@ -762,7 +764,7 @@ class _SessionBase(object):
         Args:
             time_set (str):
 
-            format (int):
+            format (enums.DriveEdgeSetFormat):
 
             drive_on_edge (float):
 
@@ -777,10 +779,12 @@ class _SessionBase(object):
             drive_return2_edge (float):
 
         '''
+        if type(format) is not enums.DriveEdgeSetFormat:
+            raise TypeError('Parameter format must be of type ' + str(enums.DriveEdgeSetFormat))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         pin_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         time_set_ctype = ctypes.create_string_buffer(time_set.encode(self._encoding))  # case C020
-        format_ctype = _visatype.ViInt32(format)  # case S150
+        format_ctype = _visatype.ViInt32(format.value)  # case S130
         drive_on_edge_ctype = _visatype.ViReal64(drive_on_edge)  # case S150
         drive_data_edge_ctype = _visatype.ViReal64(drive_data_edge)  # case S150
         drive_return_edge_ctype = _visatype.ViReal64(drive_return_edge)  # case S150
@@ -806,13 +810,15 @@ class _SessionBase(object):
         Args:
             time_set (str):
 
-            drive_format (int):
+            drive_format (enums.DriveEdgeSetFormat):
 
         '''
+        if type(drive_format) is not enums.DriveEdgeSetFormat:
+            raise TypeError('Parameter drive_format must be of type ' + str(enums.DriveEdgeSetFormat))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         pin_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         time_set_ctype = ctypes.create_string_buffer(time_set.encode(self._encoding))  # case C020
-        drive_format_ctype = _visatype.ViInt32(drive_format)  # case S150
+        drive_format_ctype = _visatype.ViInt32(drive_format.value)  # case S130
         error_code = self._library.niDigital_ConfigureTimeSetDriveFormat(vi_ctype, pin_list_ctype, time_set_ctype, drive_format_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
@@ -832,15 +838,17 @@ class _SessionBase(object):
         Args:
             time_set (str):
 
-            edge (int):
+            edge (enums.TimeSetEdge):
 
             time (float):
 
         '''
+        if type(edge) is not enums.TimeSetEdge:
+            raise TypeError('Parameter edge must be of type ' + str(enums.TimeSetEdge))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         pin_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         time_set_ctype = ctypes.create_string_buffer(time_set.encode(self._encoding))  # case C020
-        edge_ctype = _visatype.ViInt32(edge)  # case S150
+        edge_ctype = _visatype.ViInt32(edge.value)  # case S130
         time_ctype = _visatype.ViReal64(time)  # case S150
         error_code = self._library.niDigital_ConfigureTimeSetEdge(vi_ctype, pin_list_ctype, time_set_ctype, edge_ctype, time_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
@@ -947,14 +955,16 @@ class _SessionBase(object):
 
             sample_width (int):
 
-            bit_order (int):
+            bit_order (enums.BitOrder):
 
         '''
+        if type(bit_order) is not enums.BitOrder:
+            raise TypeError('Parameter bit_order must be of type ' + str(enums.BitOrder))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         pin_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         waveform_name_ctype = ctypes.create_string_buffer(waveform_name.encode(self._encoding))  # case C020
         sample_width_ctype = _visatype.ViUInt32(sample_width)  # case S150
-        bit_order_ctype = _visatype.ViInt32(bit_order)  # case S150
+        bit_order_ctype = _visatype.ViInt32(bit_order.value)  # case S130
         error_code = self._library.niDigital_CreateCaptureWaveformSerial(vi_ctype, pin_list_ctype, waveform_name_ctype, sample_width_ctype, bit_order_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
@@ -974,13 +984,15 @@ class _SessionBase(object):
         Args:
             waveform_name (str):
 
-            data_mapping (int):
+            data_mapping (enums.SourceMemoryDataMapping):
 
         '''
+        if type(data_mapping) is not enums.SourceMemoryDataMapping:
+            raise TypeError('Parameter data_mapping must be of type ' + str(enums.SourceMemoryDataMapping))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         pin_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         waveform_name_ctype = ctypes.create_string_buffer(waveform_name.encode(self._encoding))  # case C020
-        data_mapping_ctype = _visatype.ViInt32(data_mapping)  # case S150
+        data_mapping_ctype = _visatype.ViInt32(data_mapping.value)  # case S130
         error_code = self._library.niDigital_CreateSourceWaveformParallel(vi_ctype, pin_list_ctype, waveform_name_ctype, data_mapping_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
@@ -1000,19 +1012,23 @@ class _SessionBase(object):
         Args:
             waveform_name (str):
 
-            data_mapping (int):
+            data_mapping (enums.SourceMemoryDataMapping):
 
             sample_width (int):
 
-            bit_order (int):
+            bit_order (enums.BitOrder):
 
         '''
+        if type(data_mapping) is not enums.SourceMemoryDataMapping:
+            raise TypeError('Parameter data_mapping must be of type ' + str(enums.SourceMemoryDataMapping))
+        if type(bit_order) is not enums.BitOrder:
+            raise TypeError('Parameter bit_order must be of type ' + str(enums.BitOrder))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         pin_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         waveform_name_ctype = ctypes.create_string_buffer(waveform_name.encode(self._encoding))  # case C020
-        data_mapping_ctype = _visatype.ViInt32(data_mapping)  # case S150
+        data_mapping_ctype = _visatype.ViInt32(data_mapping.value)  # case S130
         sample_width_ctype = _visatype.ViUInt32(sample_width)  # case S150
-        bit_order_ctype = _visatype.ViInt32(bit_order)  # case S150
+        bit_order_ctype = _visatype.ViInt32(bit_order.value)  # case S130
         error_code = self._library.niDigital_CreateSourceWaveformSerial(vi_ctype, pin_list_ctype, waveform_name_ctype, data_mapping_ctype, sample_width_ctype, bit_order_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
@@ -1565,7 +1581,7 @@ class _SessionBase(object):
 
 
         Returns:
-            format (int):
+            format (enums.DriveEdgeSetFormat):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -1574,7 +1590,7 @@ class _SessionBase(object):
         format_ctype = _visatype.ViInt32()  # case S220
         error_code = self._library.niDigital_GetTimeSetDriveFormat(vi_ctype, pin_ctype, time_set_ctype, None if format_ctype is None else (ctypes.pointer(format_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return int(format_ctype.value)
+        return enums.DriveEdgeSetFormat(format_ctype.value)
 
     @ivi_synchronized
     def get_time_set_edge(self, time_set, edge):
@@ -1591,17 +1607,19 @@ class _SessionBase(object):
         Args:
             time_set (str):
 
-            edge (int):
+            edge (enums.TimeSetEdge):
 
 
         Returns:
             time (float):
 
         '''
+        if type(edge) is not enums.TimeSetEdge:
+            raise TypeError('Parameter edge must be of type ' + str(enums.TimeSetEdge))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         pin_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         time_set_ctype = ctypes.create_string_buffer(time_set.encode(self._encoding))  # case C020
-        edge_ctype = _visatype.ViInt32(edge)  # case S150
+        edge_ctype = _visatype.ViInt32(edge.value)  # case S130
         time_ctype = _visatype.ViReal64()  # case S220
         error_code = self._library.niDigital_GetTimeSetEdge(vi_ctype, pin_ctype, time_set_ctype, edge_ctype, None if time_ctype is None else (ctypes.pointer(time_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
@@ -1693,16 +1711,18 @@ class _SessionBase(object):
         nidigital.Session repeated capabilities container, and calling this method on the result.
 
         Args:
-            measurement_type (int):
+            measurement_type (enums.PPMUMeasurementType):
 
 
         Returns:
             measurements (list of float):
 
         '''
+        if type(measurement_type) is not enums.PPMUMeasurementType:
+            raise TypeError('Parameter measurement_type must be of type ' + str(enums.PPMUMeasurementType))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         channel_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
-        measurement_type_ctype = _visatype.ViInt32(measurement_type)  # case S150
+        measurement_type_ctype = _visatype.ViInt32(measurement_type.value)  # case S130
         buffer_size_ctype = _visatype.ViInt32(0)  # case S190
         measurements_ctype = None  # case B610
         actual_num_read_ctype = _visatype.ViInt32()  # case S220
@@ -1746,7 +1766,7 @@ class _SessionBase(object):
         nidigital.Session repeated capabilities container, and calling this method on the result.
 
         Returns:
-            data (list of int):
+            data (list of enums.DigitalState):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -1761,7 +1781,7 @@ class _SessionBase(object):
         data_ctype = get_ctypes_pointer_for_buffer(library_type=_visatype.ViUInt8, size=data_size)  # case B620
         error_code = self._library.niDigital_ReadStatic(vi_ctype, channel_list_ctype, buffer_size_ctype, data_ctype, None if actual_num_read_ctype is None else (ctypes.pointer(actual_num_read_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return [int(data_ctype[i]) for i in range(buffer_size_ctype.value)]
+        return [enums.DigitalState(data_ctype[i]) for i in range(buffer_size_ctype.value)]
 
     @ivi_synchronized
     def reset_attribute(self, attribute_id):
@@ -1976,12 +1996,14 @@ class _SessionBase(object):
         nidigital.Session repeated capabilities container, and calling this method on the result.
 
         Args:
-            state (int):
+            state (enums.DigitalState):
 
         '''
+        if type(state) is not enums.DigitalState:
+            raise TypeError('Parameter state must be of type ' + str(enums.DigitalState))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         channel_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
-        state_ctype = _visatype.ViUInt8(state)  # case S150
+        state_ctype = _visatype.ViUInt8(state.value)  # case S130
         error_code = self._library.niDigital_WriteStatic(vi_ctype, channel_list_ctype, state_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
@@ -2914,15 +2936,17 @@ class Session(_SessionBase):
         TBD
 
         Args:
-            flag (str):
+            flag (enums.SequencerFlag):
 
 
         Returns:
             value (bool):
 
         '''
+        if type(flag) is not enums.SequencerFlag:
+            raise TypeError('Parameter flag must be of type ' + str(enums.SequencerFlag))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        flag_ctype = ctypes.create_string_buffer(flag.encode(self._encoding))  # case C020
+        flag_ctype = ctypes.create_string_buffer(flag.value.encode(self._encoding))  # case C030
         value_ctype = _visatype.ViBoolean()  # case S220
         error_code = self._library.niDigital_ReadSequencerFlag(vi_ctype, flag_ctype, None if value_ctype is None else (ctypes.pointer(value_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
@@ -2935,15 +2959,17 @@ class Session(_SessionBase):
         TBD
 
         Args:
-            reg (str):
+            reg (enums.SequencerRegister):
 
 
         Returns:
             value (int):
 
         '''
+        if type(reg) is not enums.SequencerRegister:
+            raise TypeError('Parameter reg must be of type ' + str(enums.SequencerRegister))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        reg_ctype = ctypes.create_string_buffer(reg.encode(self._encoding))  # case C020
+        reg_ctype = ctypes.create_string_buffer(reg.value.encode(self._encoding))  # case C030
         value_ctype = _visatype.ViInt32()  # case S220
         error_code = self._library.niDigital_ReadSequencerRegister(vi_ctype, reg_ctype, None if value_ctype is None else (ctypes.pointer(value_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
@@ -3045,13 +3071,15 @@ class Session(_SessionBase):
         TBD
 
         Args:
-            flag (str):
+            flag (enums.SequencerFlag):
 
             value (bool):
 
         '''
+        if type(flag) is not enums.SequencerFlag:
+            raise TypeError('Parameter flag must be of type ' + str(enums.SequencerFlag))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        flag_ctype = ctypes.create_string_buffer(flag.encode(self._encoding))  # case C020
+        flag_ctype = ctypes.create_string_buffer(flag.value.encode(self._encoding))  # case C030
         value_ctype = _visatype.ViBoolean(value)  # case S150
         error_code = self._library.niDigital_WriteSequencerFlag(vi_ctype, flag_ctype, value_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
@@ -3064,13 +3092,15 @@ class Session(_SessionBase):
         TBD
 
         Args:
-            reg (str):
+            reg (enums.SequencerRegister):
 
             value (int):
 
         '''
+        if type(reg) is not enums.SequencerRegister:
+            raise TypeError('Parameter reg must be of type ' + str(enums.SequencerRegister))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        reg_ctype = ctypes.create_string_buffer(reg.encode(self._encoding))  # case C020
+        reg_ctype = ctypes.create_string_buffer(reg.value.encode(self._encoding))  # case C030
         value_ctype = _visatype.ViInt32(value)  # case S150
         error_code = self._library.niDigital_WriteSequencerRegister(vi_ctype, reg_ctype, value_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -240,11 +240,11 @@ class _SessionBase(object):
     group_capabilities = _attributes.AttributeViString(1050401)
     halt_on_keep_alive_opcode = _attributes.AttributeViBoolean(1150062)
     history_ram_buffer_size_per_site = _attributes.AttributeViInt64(1150079)
-    history_ram_cycles_to_acquire = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.HramCyclesToAcquire, 1150047)
+    history_ram_cycles_to_acquire = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.HistoryRAMCyclesToAcquire, 1150047)
     history_ram_max_samples_to_acquire_per_site = _attributes.AttributeViInt32(1150077)
     history_ram_number_of_samples_is_finite = _attributes.AttributeViBoolean(1150078)
     history_ram_pretrigger_samples = _attributes.AttributeViInt32(1150048)
-    history_ram_trigger_type = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.HramTriggerType, 1150043)
+    history_ram_trigger_type = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.HistoryRAMTriggerType, 1150043)
     instrument_firmware_revision = _attributes.AttributeViString(1050510)
     '''Type: str
 

--- a/src/nidigital/metadata/attributes.py
+++ b/src/nidigital/metadata/attributes.py
@@ -390,7 +390,7 @@ attributes = {
     1150043: {
         'access': 'read-write',
         'channel_based': False,
-        'enum': 'HramTriggerType',
+        'enum': 'HistoryRAMTriggerType',
         'name': 'HISTORY_RAM_TRIGGER_TYPE',
         'resettable': True,
         'type': 'ViInt32'
@@ -419,7 +419,7 @@ attributes = {
     1150047: {
         'access': 'read-write',
         'channel_based': False,
-        'enum': 'HramCyclesToAcquire',
+        'enum': 'HistoryRAMCyclesToAcquire',
         'name': 'HISTORY_RAM_CYCLES_TO_ACQUIRE',
         'resettable': True,
         'type': 'ViInt32'

--- a/src/nidigital/metadata/attributes.py
+++ b/src/nidigital/metadata/attributes.py
@@ -287,6 +287,7 @@ attributes = {
     1150029: {
         'access': 'read-write',
         'channel_based': False,
+        'enum': 'TriggerType',
         'name': 'START_TRIGGER_TYPE',
         'resettable': True,
         'type': 'ViInt32'
@@ -316,6 +317,7 @@ attributes = {
     1150033: {
         'access': 'read-write',
         'channel_based': True,
+        'enum': 'TriggerType',
         'name': 'CONDITIONAL_JUMP_TRIGGER_TYPE',
         'resettable': True,
         'type': 'ViInt32'
@@ -388,6 +390,7 @@ attributes = {
     1150043: {
         'access': 'read-write',
         'channel_based': False,
+        'enum': 'HramTriggerType',
         'name': 'HISTORY_RAM_TRIGGER_TYPE',
         'resettable': True,
         'type': 'ViInt32'
@@ -416,6 +419,7 @@ attributes = {
     1150047: {
         'access': 'read-write',
         'channel_based': False,
+        'enum': 'HramCyclesToAcquire',
         'name': 'HISTORY_RAM_CYCLES_TO_ACQUIRE',
         'resettable': True,
         'type': 'ViInt32'
@@ -486,6 +490,7 @@ attributes = {
     1150064: {
         'access': 'read-write',
         'channel_based': True,
+        'enum': 'PPMUCurrentLimitBehavior',
         'name': 'PPMU_CURRENT_LIMIT_BEHAVIOR',
         'resettable': True,
         'type': 'ViInt32'

--- a/src/nidigital/metadata/enums.py
+++ b/src/nidigital/metadata/enums.py
@@ -127,7 +127,7 @@ enums = {
             }
         ]
     },
-    'HramCyclesToAcquire': {
+    'HistoryRAMCyclesToAcquire': {
         'values': [
             {
                 'name': 'NIDIGITAL_VAL_FAILED_CYCLES',
@@ -139,7 +139,7 @@ enums = {
             }
         ]
     },
-    'HramTriggerType': {
+    'HistoryRAMTriggerType': {
         'values': [
             {
                 'name': 'NIDIGITAL_VAL_FIRST_FAILURE',

--- a/src/nidigital/metadata/enums_addon.py
+++ b/src/nidigital/metadata/enums_addon.py
@@ -2,10 +2,4 @@
 # Any changes to the API should be made here. enums.py is code generated
 
 enums_override_metadata = {
-    # Codegen deduces the enum types to generate based on usage of enum types in public metadata.
-    # DigitalState is not specified in metadata of any public methods or properties but it is a
-    # member of class returned by fancy HRAM fetch method. So we need to explicitly mark it public.
-    'DigitalState': {
-        'codegen_method': 'public',
-    },
 }

--- a/src/nidigital/metadata/functions.py
+++ b/src/nidigital/metadata/functions.py
@@ -373,6 +373,7 @@ functions = {
             },
             {
                 'direction': 'in',
+                'enum': 'DriveEdgeSetFormat',
                 'name': 'format',
                 'type': 'ViInt32'
             },
@@ -423,6 +424,7 @@ functions = {
             },
             {
                 'direction': 'in',
+                'enum': 'DriveEdgeSetFormat',
                 'name': 'format',
                 'type': 'ViInt32'
             },
@@ -483,6 +485,7 @@ functions = {
             },
             {
                 'direction': 'in',
+                'enum': 'DriveEdgeSetFormat',
                 'name': 'driveFormat',
                 'type': 'ViInt32'
             }
@@ -513,6 +516,7 @@ functions = {
             },
             {
                 'direction': 'in',
+                'enum': 'TimeSetEdge',
                 'name': 'edge',
                 'type': 'ViInt32'
             },
@@ -697,6 +701,7 @@ functions = {
             },
             {
                 'direction': 'in',
+                'enum': 'BitOrder',
                 'name': 'bitOrder',
                 'type': 'ViInt32'
             }
@@ -755,6 +760,7 @@ functions = {
             },
             {
                 'direction': 'in',
+                'enum': 'SourceMemoryDataMapping',
                 'name': 'dataMapping',
                 'type': 'ViInt32'
             }
@@ -785,6 +791,7 @@ functions = {
             },
             {
                 'direction': 'in',
+                'enum': 'SourceMemoryDataMapping',
                 'name': 'dataMapping',
                 'type': 'ViInt32'
             },
@@ -795,6 +802,7 @@ functions = {
             },
             {
                 'direction': 'in',
+                'enum': 'BitOrder',
                 'name': 'bitOrder',
                 'type': 'ViInt32'
             }
@@ -1763,6 +1771,7 @@ functions = {
             },
             {
                 'direction': 'out',
+                'enum': 'DriveEdgeSetFormat',
                 'name': 'format',
                 'type': 'ViInt32'
             }
@@ -1793,6 +1802,7 @@ functions = {
             },
             {
                 'direction': 'in',
+                'enum': 'TimeSetEdge',
                 'name': 'edge',
                 'type': 'ViInt32'
             },
@@ -2121,6 +2131,7 @@ functions = {
             },
             {
                 'direction': 'in',
+                'enum': 'PPMUMeasurementType',
                 'name': 'measurementType',
                 'type': 'ViInt32'
             },
@@ -2179,6 +2190,7 @@ functions = {
             },
             {
                 'direction': 'in',
+                'enum': 'SequencerFlag',
                 'name': 'flag',
                 'type': 'ViConstString'
             },
@@ -2202,6 +2214,7 @@ functions = {
             },
             {
                 'direction': 'in',
+                'enum': 'SequencerRegister',
                 'name': 'reg',
                 'type': 'ViConstString'
             },
@@ -2235,6 +2248,7 @@ functions = {
             },
             {
                 'direction': 'out',
+                'enum': 'DigitalState',
                 'name': 'data',
                 'size': {
                     'mechanism': 'ivi-dance-with-a-twist',
@@ -2605,6 +2619,7 @@ functions = {
             },
             {
                 'direction': 'in',
+                'enum': 'SequencerFlag',
                 'name': 'flag',
                 'type': 'ViConstString'
             },
@@ -2628,6 +2643,7 @@ functions = {
             },
             {
                 'direction': 'in',
+                'enum': 'SequencerRegister',
                 'name': 'reg',
                 'type': 'ViConstString'
             },
@@ -2756,6 +2772,7 @@ functions = {
             },
             {
                 'direction': 'in',
+                'enum': 'DigitalState',
                 'name': 'state',
                 'type': 'ViUInt8'
             }

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -297,8 +297,8 @@ def configure_for_history_ram_test(session):
 
     session.load_pattern(get_test_file_path(test_files_folder, 'pattern.digipat'))
 
-    session.history_ram_trigger_type = nidigital.HramTriggerType.FIRST_FAILURE
-    session.history_ram_cycles_to_acquire = nidigital.HramCyclesToAcquire.ALL
+    session.history_ram_trigger_type = nidigital.HistoryRAMTriggerType.FIRST_FAILURE
+    session.history_ram_cycles_to_acquire = nidigital.HistoryRAMCyclesToAcquire.ALL
     session.history_ram_pretrigger_samples = 0
     session.history_ram_number_of_samples_is_finite = True
 

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -34,9 +34,11 @@ def test_pins_rep_cap(multi_instrument_session):
 
     # Methods that accept pin_list parameter
     multi_instrument_session.create_time_set('t0')
-    multi_instrument_session.pins['PinA', 'PinB'].configure_time_set_drive_format('t0', 1501)
-    drive_format = multi_instrument_session.pins['PinA', 'PinB'].get_time_set_drive_format('t0')
-    assert drive_format == 1501
+    multi_instrument_session.pins['PinA', 'PinB'].configure_time_set_drive_format(
+        time_set='t0',
+        drive_format=nidigital.DriveEdgeSetFormat.RL)
+    drive_format = multi_instrument_session.pins['PinA', 'PinB'].get_time_set_drive_format(time_set='t0')
+    assert drive_format == nidigital.DriveEdgeSetFormat.RL
 
 
 def test_property_boolean(multi_instrument_session):
@@ -96,7 +98,9 @@ def test_source_waveform_parallel_broadcast(multi_instrument_session):
 
     multi_instrument_session.load_pattern(get_test_file_path(test_name, 'pattern.digipat'))
 
-    multi_instrument_session.pins['LowPins'].create_source_waveform_parallel(waveform_name='src_wfm', data_mapping=2600)
+    multi_instrument_session.pins['LowPins'].create_source_waveform_parallel(
+        waveform_name='src_wfm',
+        data_mapping=nidigital.SourceMemoryDataMapping.BROADCAST)
 
     multi_instrument_session.write_source_waveform_broadcast(
         waveform_name='src_wfm',
@@ -144,9 +148,11 @@ def test_source_waveform_parallel_site_unique(multi_instrument_session, source_w
     multi_instrument_session.load_pattern(get_test_file_path(test_name, 'pattern.digipat'))
 
     num_samples = 256
-    multi_instrument_session.write_sequencer_register(reg='reg0', value=num_samples)
+    multi_instrument_session.write_sequencer_register(reg=nidigital.SequencerRegister.REGISTER0, value=num_samples)
 
-    multi_instrument_session.pins['LowPins'].create_source_waveform_parallel(waveform_name='src_wfm', data_mapping=2601)
+    multi_instrument_session.pins['LowPins'].create_source_waveform_parallel(
+        waveform_name='src_wfm',
+        data_mapping=nidigital.SourceMemoryDataMapping.SITE_UNIQUE)
 
     if source_waveform_type == array.array:
         source_waveform = {
@@ -194,9 +200,11 @@ def test_fetch_capture_waveform(multi_instrument_session):
     multi_instrument_session.load_pattern(get_test_file_path(test_name, 'pattern.digipat'))
 
     num_samples = 256
-    multi_instrument_session.write_sequencer_register(reg='reg0', value=num_samples)
+    multi_instrument_session.write_sequencer_register(reg=nidigital.SequencerRegister.REGISTER0, value=num_samples)
 
-    multi_instrument_session.pins['LowPins'].create_source_waveform_parallel(waveform_name='src_wfm', data_mapping=2600)
+    multi_instrument_session.pins['LowPins'].create_source_waveform_parallel(
+        waveform_name='src_wfm',
+        data_mapping=nidigital.SourceMemoryDataMapping.BROADCAST)
     source_waveform = [i for i in range(num_samples)]
     multi_instrument_session.write_source_waveform_broadcast(waveform_name='src_wfm', waveform_data=source_waveform)
 
@@ -289,8 +297,8 @@ def configure_for_history_ram_test(session):
 
     session.load_pattern(get_test_file_path(test_files_folder, 'pattern.digipat'))
 
-    session.history_ram_trigger_type = 2200
-    session.history_ram_cycles_to_acquire = 2304
+    session.history_ram_trigger_type = nidigital.HramTriggerType.FIRST_FAILURE
+    session.history_ram_cycles_to_acquire = nidigital.HramCyclesToAcquire.ALL
     session.history_ram_pretrigger_samples = 0
     session.history_ram_number_of_samples_is_finite = True
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

- Change the type of method parameters and properties in nidigital to enums, where possible.
- Do not use the abbreviation for History RAM - HRAM in public API.

### List issues fixed by this Pull Request below, if any.

* Fix #1066 
* Fix #1244 

### What testing has been done?

Visual inspection of generated files and running existing system tests
