### PR TITLE
Change type of applicable time-based method parameters and properties to datetime.timedelta

### DIFF
--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -181,14 +181,14 @@ apply_tdr_offsets
                 
 
 
-            :type offsets: list of float
+            :type offsets: list of float in seconds or datetime.timedelta
 
 burst_pattern
 -------------
 
     .. py:currentmodule:: nidigital.Session
 
-    .. py:method:: burst_pattern(site_list, start_label, select_digital_function=True, wait_until_done=True, timeout=10.0)
+    .. py:method:: burst_pattern(site_list, start_label, select_digital_function=True, wait_until_done=True, timeout=datetime.timedelta(seconds=10.0))
 
             TBD
 
@@ -230,7 +230,7 @@ burst_pattern
                 
 
 
-            :type timeout: float
+            :type timeout: float in seconds or datetime.timedelta
 
 clear_error
 -----------
@@ -434,7 +434,7 @@ configure_time_set_compare_edges_strobe
                 
 
 
-            :type strobe_edge: float
+            :type strobe_edge: float in seconds or datetime.timedelta
 
 configure_time_set_compare_edges_strobe2x
 -----------------------------------------
@@ -467,14 +467,14 @@ configure_time_set_compare_edges_strobe2x
                 
 
 
-            :type strobe_edge: float
+            :type strobe_edge: float in seconds or datetime.timedelta
             :param strobe2_edge:
 
 
                 
 
 
-            :type strobe2_edge: float
+            :type strobe2_edge: float in seconds or datetime.timedelta
 
 configure_time_set_drive_edges
 ------------------------------
@@ -514,28 +514,28 @@ configure_time_set_drive_edges
                 
 
 
-            :type drive_on_edge: float
+            :type drive_on_edge: float in seconds or datetime.timedelta
             :param drive_data_edge:
 
 
                 
 
 
-            :type drive_data_edge: float
+            :type drive_data_edge: float in seconds or datetime.timedelta
             :param drive_return_edge:
 
 
                 
 
 
-            :type drive_return_edge: float
+            :type drive_return_edge: float in seconds or datetime.timedelta
             :param drive_off_edge:
 
 
                 
 
 
-            :type drive_off_edge: float
+            :type drive_off_edge: float in seconds or datetime.timedelta
 
 configure_time_set_drive_edges2x
 --------------------------------
@@ -575,42 +575,42 @@ configure_time_set_drive_edges2x
                 
 
 
-            :type drive_on_edge: float
+            :type drive_on_edge: float in seconds or datetime.timedelta
             :param drive_data_edge:
 
 
                 
 
 
-            :type drive_data_edge: float
+            :type drive_data_edge: float in seconds or datetime.timedelta
             :param drive_return_edge:
 
 
                 
 
 
-            :type drive_return_edge: float
+            :type drive_return_edge: float in seconds or datetime.timedelta
             :param drive_off_edge:
 
 
                 
 
 
-            :type drive_off_edge: float
+            :type drive_off_edge: float in seconds or datetime.timedelta
             :param drive_data2_edge:
 
 
                 
 
 
-            :type drive_data2_edge: float
+            :type drive_data2_edge: float in seconds or datetime.timedelta
             :param drive_return2_edge:
 
 
                 
 
 
-            :type drive_return2_edge: float
+            :type drive_return2_edge: float in seconds or datetime.timedelta
 
 configure_time_set_drive_format
 -------------------------------
@@ -683,7 +683,7 @@ configure_time_set_edge
                 
 
 
-            :type time: float
+            :type time: float in seconds or datetime.timedelta
 
 configure_time_set_edge_multiplier
 ----------------------------------
@@ -744,7 +744,7 @@ configure_time_set_period
                 
 
 
-            :type period: float
+            :type period: float in seconds or datetime.timedelta
 
 configure_voltage_levels
 ------------------------
@@ -2183,7 +2183,7 @@ tdr
 
             :type apply_offsets: bool
 
-            :rtype: list of float
+            :rtype: list of datetime.timedelta
             :return:
 
 
@@ -2251,7 +2251,7 @@ wait_until_done
 
     .. py:currentmodule:: nidigital.Session
 
-    .. py:method:: wait_until_done(timeout=10.0)
+    .. py:method:: wait_until_done(timeout=datetime.timedelta(seconds=10.0))
 
             TBD
 
@@ -2265,7 +2265,7 @@ wait_until_done
                 
 
 
-            :type timeout: float
+            :type timeout: float in seconds or datetime.timedelta
 
 write_sequencer_flag
 --------------------
@@ -2952,17 +2952,17 @@ frequency_counter_measurement_time
 
         The following table lists the characteristics of this property.
 
-            +----------------+------------+
-            | Characteristic | Value      |
-            +================+============+
-            | Datatype       | float      |
-            +----------------+------------+
-            | Permissions    | read-write |
-            +----------------+------------+
-            | Channel Based  | Yes        |
-            +----------------+------------+
-            | Resettable     | Yes        |
-            +----------------+------------+
+            +----------------+----------------------------------------+
+            | Characteristic | Value                                  |
+            +================+========================================+
+            | Datatype       | float in seconds or datetime.timedelta |
+            +----------------+----------------------------------------+
+            | Permissions    | read-write                             |
+            +----------------+----------------------------------------+
+            | Channel Based  | Yes                                    |
+            +----------------+----------------------------------------+
+            | Resettable     | Yes                                    |
+            +----------------+----------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -4358,17 +4358,17 @@ tdr_offset
 
         The following table lists the characteristics of this property.
 
-            +----------------+------------+
-            | Characteristic | Value      |
-            +================+============+
-            | Datatype       | float      |
-            +----------------+------------+
-            | Permissions    | read-write |
-            +----------------+------------+
-            | Channel Based  | Yes        |
-            +----------------+------------+
-            | Resettable     | Yes        |
-            +----------------+------------+
+            +----------------+----------------------------------------+
+            | Characteristic | Value                                  |
+            +================+========================================+
+            | Datatype       | float in seconds or datetime.timedelta |
+            +----------------+----------------------------------------+
+            | Permissions    | read-write                             |
+            +----------------+----------------------------------------+
+            | Channel Based  | Yes                                    |
+            +----------------+----------------------------------------+
+            | Resettable     | Yes                                    |
+            +----------------+----------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -4413,17 +4413,17 @@ timing_absolute_delay
 
         The following table lists the characteristics of this property.
 
-            +----------------+------------+
-            | Characteristic | Value      |
-            +================+============+
-            | Datatype       | float      |
-            +----------------+------------+
-            | Permissions    | read-write |
-            +----------------+------------+
-            | Channel Based  | No         |
-            +----------------+------------+
-            | Resettable     | Yes        |
-            +----------------+------------+
+            +----------------+----------------------------------------+
+            | Characteristic | Value                                  |
+            +================+========================================+
+            | Datatype       | float in seconds or datetime.timedelta |
+            +----------------+----------------------------------------+
+            | Permissions    | read-write                             |
+            +----------------+----------------------------------------+
+            | Channel Based  | No                                     |
+            +----------------+----------------------------------------+
+            | Resettable     | Yes                                    |
+            +----------------+----------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -451,7 +451,7 @@ class _SessionBase(object):
     nidigital.Session repeated capabilities container, and calling set/get value on the result.
     '''
     timing_absolute_delay = _attributes.AttributeViReal64TimeDeltaSeconds(1150072)
-    '''Type: float
+    '''Type: float in seconds or datetime.timedelta
 
     Tip:
     This property can use repeated capabilities. If set or get directly on the
@@ -615,7 +615,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def burst_pattern(self, start_label, select_digital_function=True, wait_until_done=True, timeout=10.0):
+    def burst_pattern(self, start_label, select_digital_function=True, wait_until_done=True, timeout=datetime.timedelta(seconds=10.0)):
         r'''burst_pattern
 
         TBD
@@ -633,7 +633,7 @@ class _SessionBase(object):
 
             wait_until_done (bool):
 
-            timeout (float):
+            timeout (float in seconds or datetime.timedelta):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -641,7 +641,7 @@ class _SessionBase(object):
         start_label_ctype = ctypes.create_string_buffer(start_label.encode(self._encoding))  # case C020
         select_digital_function_ctype = _visatype.ViBoolean(select_digital_function)  # case S150
         wait_until_done_ctype = _visatype.ViBoolean(wait_until_done)  # case S150
-        timeout_ctype = _visatype.ViReal64(timeout)  # case S150
+        timeout_ctype = _converters.convert_timedelta_to_seconds_real64(timeout)  # case S140
         error_code = self._library.niDigital_BurstPattern(vi_ctype, site_list_ctype, start_label_ctype, select_digital_function_ctype, wait_until_done_ctype, timeout_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -228,8 +228,8 @@ class _SessionBase(object):
     nidigital.Session repeated capabilities container, and calling set/get value on the result.
     '''
     exported_start_trigger_output_terminal = _attributes.AttributeViString(1150032)
-    frequency_counter_measurement_time = _attributes.AttributeViReal64(1150069)
-    '''Type: float
+    frequency_counter_measurement_time = _attributes.AttributeViReal64TimeDeltaSeconds(1150069)
+    '''Type: float in seconds or datetime.timedelta
 
     Tip:
     This property can use repeated capabilities. If set or get directly on the
@@ -424,8 +424,8 @@ class _SessionBase(object):
     start_trigger_type = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.TriggerType, 1150029)
     supported_instrument_models = _attributes.AttributeViString(1050327)
     tdr_endpoint_termination = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.TDREndpointTermination, 1150081)
-    tdr_offset = _attributes.AttributeViReal64(1150051)
-    '''Type: float
+    tdr_offset = _attributes.AttributeViReal64TimeDeltaSeconds(1150051)
+    '''Type: float in seconds or datetime.timedelta
 
     Tip:
     This property can use repeated capabilities. If set or get directly on the
@@ -442,7 +442,7 @@ class _SessionBase(object):
     You can specify a subset of repeated capabilities using the Python index notation on an
     nidigital.Session repeated capabilities container, and calling set/get value on the result.
     '''
-    timing_absolute_delay = _attributes.AttributeViReal64(1150072)
+    timing_absolute_delay = _attributes.AttributeViReal64TimeDeltaSeconds(1150072)
     timing_absolute_delay_enabled = _attributes.AttributeViBoolean(1150071)
     vih = _attributes.AttributeViReal64(1150008)
     '''Type: float
@@ -552,13 +552,13 @@ class _SessionBase(object):
         nidigital.Session repeated capabilities container, and calling this method on the result.
 
         Args:
-            offsets (list of float):
+            offsets (list of float in seconds or datetime.timedelta):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         channel_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         num_offsets_ctype = _visatype.ViInt32(0 if offsets is None else len(offsets))  # case S160
-        offsets_ctype = get_ctypes_pointer_for_buffer(value=offsets, library_type=_visatype.ViReal64)  # case B550
+        offsets_ctype = get_ctypes_pointer_for_buffer(value=_converters.convert_timedeltas_to_seconds_real64(offsets), library_type=_visatype.ViReal64)  # case B520
         error_code = self._library.niDigital_ApplyTDROffsets(vi_ctype, channel_list_ctype, num_offsets_ctype, offsets_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
@@ -669,13 +669,13 @@ class _SessionBase(object):
         Args:
             time_set (str):
 
-            strobe_edge (float):
+            strobe_edge (float in seconds or datetime.timedelta):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         pin_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         time_set_ctype = ctypes.create_string_buffer(time_set.encode(self._encoding))  # case C020
-        strobe_edge_ctype = _visatype.ViReal64(strobe_edge)  # case S150
+        strobe_edge_ctype = _converters.convert_timedelta_to_seconds_real64(strobe_edge)  # case S140
         error_code = self._library.niDigital_ConfigureTimeSetCompareEdgesStrobe(vi_ctype, pin_list_ctype, time_set_ctype, strobe_edge_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
@@ -695,16 +695,16 @@ class _SessionBase(object):
         Args:
             time_set (str):
 
-            strobe_edge (float):
+            strobe_edge (float in seconds or datetime.timedelta):
 
-            strobe2_edge (float):
+            strobe2_edge (float in seconds or datetime.timedelta):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         pin_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         time_set_ctype = ctypes.create_string_buffer(time_set.encode(self._encoding))  # case C020
-        strobe_edge_ctype = _visatype.ViReal64(strobe_edge)  # case S150
-        strobe2_edge_ctype = _visatype.ViReal64(strobe2_edge)  # case S150
+        strobe_edge_ctype = _converters.convert_timedelta_to_seconds_real64(strobe_edge)  # case S140
+        strobe2_edge_ctype = _converters.convert_timedelta_to_seconds_real64(strobe2_edge)  # case S140
         error_code = self._library.niDigital_ConfigureTimeSetCompareEdgesStrobe2x(vi_ctype, pin_list_ctype, time_set_ctype, strobe_edge_ctype, strobe2_edge_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
@@ -726,13 +726,13 @@ class _SessionBase(object):
 
             format (enums.DriveEdgeSetFormat):
 
-            drive_on_edge (float):
+            drive_on_edge (float in seconds or datetime.timedelta):
 
-            drive_data_edge (float):
+            drive_data_edge (float in seconds or datetime.timedelta):
 
-            drive_return_edge (float):
+            drive_return_edge (float in seconds or datetime.timedelta):
 
-            drive_off_edge (float):
+            drive_off_edge (float in seconds or datetime.timedelta):
 
         '''
         if type(format) is not enums.DriveEdgeSetFormat:
@@ -741,10 +741,10 @@ class _SessionBase(object):
         pin_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         time_set_ctype = ctypes.create_string_buffer(time_set.encode(self._encoding))  # case C020
         format_ctype = _visatype.ViInt32(format.value)  # case S130
-        drive_on_edge_ctype = _visatype.ViReal64(drive_on_edge)  # case S150
-        drive_data_edge_ctype = _visatype.ViReal64(drive_data_edge)  # case S150
-        drive_return_edge_ctype = _visatype.ViReal64(drive_return_edge)  # case S150
-        drive_off_edge_ctype = _visatype.ViReal64(drive_off_edge)  # case S150
+        drive_on_edge_ctype = _converters.convert_timedelta_to_seconds_real64(drive_on_edge)  # case S140
+        drive_data_edge_ctype = _converters.convert_timedelta_to_seconds_real64(drive_data_edge)  # case S140
+        drive_return_edge_ctype = _converters.convert_timedelta_to_seconds_real64(drive_return_edge)  # case S140
+        drive_off_edge_ctype = _converters.convert_timedelta_to_seconds_real64(drive_off_edge)  # case S140
         error_code = self._library.niDigital_ConfigureTimeSetDriveEdges(vi_ctype, pin_list_ctype, time_set_ctype, format_ctype, drive_on_edge_ctype, drive_data_edge_ctype, drive_return_edge_ctype, drive_off_edge_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
@@ -766,17 +766,17 @@ class _SessionBase(object):
 
             format (enums.DriveEdgeSetFormat):
 
-            drive_on_edge (float):
+            drive_on_edge (float in seconds or datetime.timedelta):
 
-            drive_data_edge (float):
+            drive_data_edge (float in seconds or datetime.timedelta):
 
-            drive_return_edge (float):
+            drive_return_edge (float in seconds or datetime.timedelta):
 
-            drive_off_edge (float):
+            drive_off_edge (float in seconds or datetime.timedelta):
 
-            drive_data2_edge (float):
+            drive_data2_edge (float in seconds or datetime.timedelta):
 
-            drive_return2_edge (float):
+            drive_return2_edge (float in seconds or datetime.timedelta):
 
         '''
         if type(format) is not enums.DriveEdgeSetFormat:
@@ -785,12 +785,12 @@ class _SessionBase(object):
         pin_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         time_set_ctype = ctypes.create_string_buffer(time_set.encode(self._encoding))  # case C020
         format_ctype = _visatype.ViInt32(format.value)  # case S130
-        drive_on_edge_ctype = _visatype.ViReal64(drive_on_edge)  # case S150
-        drive_data_edge_ctype = _visatype.ViReal64(drive_data_edge)  # case S150
-        drive_return_edge_ctype = _visatype.ViReal64(drive_return_edge)  # case S150
-        drive_off_edge_ctype = _visatype.ViReal64(drive_off_edge)  # case S150
-        drive_data2_edge_ctype = _visatype.ViReal64(drive_data2_edge)  # case S150
-        drive_return2_edge_ctype = _visatype.ViReal64(drive_return2_edge)  # case S150
+        drive_on_edge_ctype = _converters.convert_timedelta_to_seconds_real64(drive_on_edge)  # case S140
+        drive_data_edge_ctype = _converters.convert_timedelta_to_seconds_real64(drive_data_edge)  # case S140
+        drive_return_edge_ctype = _converters.convert_timedelta_to_seconds_real64(drive_return_edge)  # case S140
+        drive_off_edge_ctype = _converters.convert_timedelta_to_seconds_real64(drive_off_edge)  # case S140
+        drive_data2_edge_ctype = _converters.convert_timedelta_to_seconds_real64(drive_data2_edge)  # case S140
+        drive_return2_edge_ctype = _converters.convert_timedelta_to_seconds_real64(drive_return2_edge)  # case S140
         error_code = self._library.niDigital_ConfigureTimeSetDriveEdges2x(vi_ctype, pin_list_ctype, time_set_ctype, format_ctype, drive_on_edge_ctype, drive_data_edge_ctype, drive_return_edge_ctype, drive_off_edge_ctype, drive_data2_edge_ctype, drive_return2_edge_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
@@ -840,7 +840,7 @@ class _SessionBase(object):
 
             edge (enums.TimeSetEdge):
 
-            time (float):
+            time (float in seconds or datetime.timedelta):
 
         '''
         if type(edge) is not enums.TimeSetEdge:
@@ -849,7 +849,7 @@ class _SessionBase(object):
         pin_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         time_set_ctype = ctypes.create_string_buffer(time_set.encode(self._encoding))  # case C020
         edge_ctype = _visatype.ViInt32(edge.value)  # case S130
-        time_ctype = _visatype.ViReal64(time)  # case S150
+        time_ctype = _converters.convert_timedelta_to_seconds_real64(time)  # case S140
         error_code = self._library.niDigital_ConfigureTimeSetEdge(vi_ctype, pin_list_ctype, time_set_ctype, edge_ctype, time_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
@@ -1953,7 +1953,7 @@ class _SessionBase(object):
 
 
         Returns:
-            offsets (list of float):
+            offsets (list of datetime.timedelta):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -1969,7 +1969,7 @@ class _SessionBase(object):
         offsets_ctype = get_ctypes_pointer_for_buffer(library_type=_visatype.ViReal64, size=offsets_size)  # case B620
         error_code = self._library.niDigital_TDR(vi_ctype, channel_list_ctype, apply_offsets_ctype, offsets_buffer_size_ctype, offsets_ctype, None if actual_num_offsets_ctype is None else (ctypes.pointer(actual_num_offsets_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return [float(offsets_ctype[i]) for i in range(offsets_buffer_size_ctype.value)]
+        return _converters.convert_seconds_real64_to_timedeltas([float(offsets_ctype[i]) for i in range(offsets_buffer_size_ctype.value)])
 
     def unlock(self):
         '''unlock
@@ -2191,7 +2191,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def burst_pattern(self, site_list, start_label, select_digital_function=True, wait_until_done=True, timeout=10.0):
+    def burst_pattern(self, site_list, start_label, select_digital_function=True, wait_until_done=True, timeout=datetime.timedelta(seconds=10.0)):
         r'''burst_pattern
 
         TBD
@@ -2205,7 +2205,7 @@ class Session(_SessionBase):
 
             wait_until_done (bool):
 
-            timeout (float):
+            timeout (float in seconds or datetime.timedelta):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -2213,7 +2213,7 @@ class Session(_SessionBase):
         start_label_ctype = ctypes.create_string_buffer(start_label.encode(self._encoding))  # case C020
         select_digital_function_ctype = _visatype.ViBoolean(select_digital_function)  # case S150
         wait_until_done_ctype = _visatype.ViBoolean(wait_until_done)  # case S150
-        timeout_ctype = _visatype.ViReal64(timeout)  # case S150
+        timeout_ctype = _converters.convert_timedelta_to_seconds_real64(timeout)  # case S140
         error_code = self._library.niDigital_BurstPattern(vi_ctype, site_list_ctype, start_label_ctype, select_digital_function_ctype, wait_until_done_ctype, timeout_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
@@ -2265,12 +2265,12 @@ class Session(_SessionBase):
         Args:
             time_set (str):
 
-            period (float):
+            period (float in seconds or datetime.timedelta):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         time_set_ctype = ctypes.create_string_buffer(time_set.encode(self._encoding))  # case C020
-        period_ctype = _visatype.ViReal64(period)  # case S150
+        period_ctype = _converters.convert_timedelta_to_seconds_real64(period)  # case S140
         error_code = self._library.niDigital_ConfigureTimeSetPeriod(vi_ctype, time_set_ctype, period_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
@@ -3069,17 +3069,17 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def wait_until_done(self, timeout=10.0):
+    def wait_until_done(self, timeout=datetime.timedelta(seconds=10.0)):
         r'''wait_until_done
 
         TBD
 
         Args:
-            timeout (float):
+            timeout (float in seconds or datetime.timedelta):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        timeout_ctype = _visatype.ViReal64(timeout)  # case S150
+        timeout_ctype = _converters.convert_timedelta_to_seconds_real64(timeout)  # case S140
         error_code = self._library.niDigital_WaitUntilDone(vi_ctype, timeout_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return

--- a/src/nidigital/metadata/attributes.py
+++ b/src/nidigital/metadata/attributes.py
@@ -433,10 +433,12 @@ attributes = {
     },
     1150051: {
         'access': 'read-write',
+        'attribute_class': 'AttributeViReal64TimeDeltaSeconds',
         'channel_based': True,
         'name': 'TDR_OFFSET',
         'resettable': True,
-        'type': 'ViReal64'
+        'type': 'ViReal64',
+        'type_in_documentation': 'float in seconds or datetime.timedelta'
     },
     1150052: {
         'access': 'read-write',
@@ -497,10 +499,12 @@ attributes = {
     },
     1150069: {
         'access': 'read-write',
+        'attribute_class': 'AttributeViReal64TimeDeltaSeconds',
         'channel_based': True,
         'name': 'FREQUENCY_COUNTER_MEASUREMENT_TIME',
         'resettable': True,
-        'type': 'ViReal64'
+        'type': 'ViReal64',
+        'type_in_documentation': 'float in seconds or datetime.timedelta'
     },
     1150071: {
         'access': 'read-write',
@@ -511,10 +515,12 @@ attributes = {
     },
     1150072: {
         'access': 'read-write',
+        'attribute_class': 'AttributeViReal64TimeDeltaSeconds',
         'channel_based': False,
         'name': 'TIMING_ABSOLUTE_DELAY',
         'resettable': True,
-        'type': 'ViReal64'
+        'type': 'ViReal64',
+        'type_in_documentation': 'float in seconds or datetime.timedelta'
     },
     1150073: {
         'access': 'read-write',

--- a/src/nidigital/metadata/functions.py
+++ b/src/nidigital/metadata/functions.py
@@ -96,11 +96,13 @@ functions = {
             {
                 'direction': 'in',
                 'name': 'offsets',
+                'python_api_converter_name': 'convert_timedeltas_to_seconds_real64',
                 'size': {
                     'mechanism': 'len',
                     'value': 'numOffsets'
                 },
-                'type': 'ViReal64[]'
+                'type': 'ViReal64[]',
+                'type_in_documentation': 'list of float in seconds or datetime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -138,10 +140,12 @@ functions = {
                 'type': 'ViBoolean'
             },
             {
-                'default_value': 10.0,
+                'default_value': 'datetime.timedelta(seconds=10.0)',
                 'direction': 'in',
                 'name': 'timeout',
-                'type': 'ViReal64'
+                'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
+                'type': 'ViReal64',
+                'type_in_documentation': 'float in seconds or datetime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -316,7 +320,9 @@ functions = {
             {
                 'direction': 'in',
                 'name': 'strobeEdge',
-                'type': 'ViReal64'
+                'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
+                'type': 'ViReal64',
+                'type_in_documentation': 'float in seconds or datetime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -346,12 +352,16 @@ functions = {
             {
                 'direction': 'in',
                 'name': 'strobeEdge',
-                'type': 'ViReal64'
+                'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
+                'type': 'ViReal64',
+                'type_in_documentation': 'float in seconds or datetime.timedelta'
             },
             {
                 'direction': 'in',
                 'name': 'strobe2Edge',
-                'type': 'ViReal64'
+                'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
+                'type': 'ViReal64',
+                'type_in_documentation': 'float in seconds or datetime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -387,22 +397,30 @@ functions = {
             {
                 'direction': 'in',
                 'name': 'driveOnEdge',
-                'type': 'ViReal64'
+                'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
+                'type': 'ViReal64',
+                'type_in_documentation': 'float in seconds or datetime.timedelta'
             },
             {
                 'direction': 'in',
                 'name': 'driveDataEdge',
-                'type': 'ViReal64'
+                'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
+                'type': 'ViReal64',
+                'type_in_documentation': 'float in seconds or datetime.timedelta'
             },
             {
                 'direction': 'in',
                 'name': 'driveReturnEdge',
-                'type': 'ViReal64'
+                'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
+                'type': 'ViReal64',
+                'type_in_documentation': 'float in seconds or datetime.timedelta'
             },
             {
                 'direction': 'in',
                 'name': 'driveOffEdge',
-                'type': 'ViReal64'
+                'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
+                'type': 'ViReal64',
+                'type_in_documentation': 'float in seconds or datetime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -438,32 +456,44 @@ functions = {
             {
                 'direction': 'in',
                 'name': 'driveOnEdge',
-                'type': 'ViReal64'
+                'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
+                'type': 'ViReal64',
+                'type_in_documentation': 'float in seconds or datetime.timedelta'
             },
             {
                 'direction': 'in',
                 'name': 'driveDataEdge',
-                'type': 'ViReal64'
+                'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
+                'type': 'ViReal64',
+                'type_in_documentation': 'float in seconds or datetime.timedelta'
             },
             {
                 'direction': 'in',
                 'name': 'driveReturnEdge',
-                'type': 'ViReal64'
+                'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
+                'type': 'ViReal64',
+                'type_in_documentation': 'float in seconds or datetime.timedelta'
             },
             {
                 'direction': 'in',
                 'name': 'driveOffEdge',
-                'type': 'ViReal64'
+                'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
+                'type': 'ViReal64',
+                'type_in_documentation': 'float in seconds or datetime.timedelta'
             },
             {
                 'direction': 'in',
                 'name': 'driveData2Edge',
-                'type': 'ViReal64'
+                'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
+                'type': 'ViReal64',
+                'type_in_documentation': 'float in seconds or datetime.timedelta'
             },
             {
                 'direction': 'in',
                 'name': 'driveReturn2Edge',
-                'type': 'ViReal64'
+                'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
+                'type': 'ViReal64',
+                'type_in_documentation': 'float in seconds or datetime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -530,7 +560,9 @@ functions = {
             {
                 'direction': 'in',
                 'name': 'time',
-                'type': 'ViReal64'
+                'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
+                'type': 'ViReal64',
+                'type_in_documentation': 'float in seconds or datetime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -583,7 +615,9 @@ functions = {
             {
                 'direction': 'in',
                 'name': 'period',
-                'type': 'ViReal64'
+                'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
+                'type': 'ViReal64',
+                'type_in_documentation': 'float in seconds or datetime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -2520,12 +2554,14 @@ functions = {
             {
                 'direction': 'out',
                 'name': 'offsets',
+                'python_api_converter_name': 'convert_seconds_real64_to_timedeltas',
                 'size': {
                     'mechanism': 'ivi-dance-with-a-twist',
                     'value': 'offsetsBufferSize',
                     'value_twist': 'actualNumOffsets'
                 },
-                'type': 'ViReal64[]'
+                'type': 'ViReal64[]',
+                'type_in_documentation': 'list of datetime.timedelta'
             },
             {
                 'direction': 'out',
@@ -2611,10 +2647,12 @@ functions = {
                 'type': 'ViSession'
             },
             {
-                'default_value': 10.0,
+                'default_value': 'datetime.timedelta(seconds=10.0)',
                 'direction': 'in',
                 'name': 'timeout',
-                'type': 'ViReal64'
+                'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
+                'type': 'ViReal64',
+                'type_in_documentation': 'float in seconds or datetime.timedelta'
             }
         ],
         'returns': 'ViStatus'

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -1,7 +1,7 @@
 import array
 import collections
-import os
 import datetime
+import os
 
 import numpy
 import pytest

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -1,6 +1,7 @@
 import array
 import collections
 import os
+import datetime
 
 import numpy
 import pytest
@@ -43,10 +44,12 @@ def test_pins_rep_cap(multi_instrument_session):
 
 def test_instruments_rep_cap(multi_instrument_session):
     multi_instrument_session.timing_absolute_delay_enabled = True
-    multi_instrument_session.instruments[instruments[0]].timing_absolute_delay = 5e-09
-    multi_instrument_session.instruments[instruments[1]].timing_absolute_delay = -5e-09
-    assert multi_instrument_session.instruments[instruments[0]].timing_absolute_delay == 5e-09
-    assert multi_instrument_session.instruments[instruments[1]].timing_absolute_delay == -5e-09
+    delay0 = datetime.timedelta(microseconds=5e-3)
+    delay1 = datetime.timedelta(microseconds=-5e-3)
+    multi_instrument_session.instruments[instruments[0]].timing_absolute_delay = delay0
+    multi_instrument_session.instruments[instruments[1]].timing_absolute_delay = delay1
+    assert multi_instrument_session.instruments[instruments[0]].timing_absolute_delay == delay0
+    assert multi_instrument_session.instruments[instruments[1]].timing_absolute_delay == delay1
 
     for instrument in instruments:
         assert multi_instrument_session.instruments[instrument].serial_number == '0'

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -446,12 +446,7 @@ def test_get_site_pass_fail(multi_instrument_session):
 
     multi_instrument_session.load_pattern(get_test_file_path(test_files_folder, 'pattern.digipat'))
 
-    multi_instrument_session.burst_pattern(
-        site_list='',
-        start_label='new_pattern',
-        select_digital_function=True,
-        wait_until_done=True,
-        timeout=5)
+    multi_instrument_session.burst_pattern(site_list='', start_label='new_pattern')
 
     pass_fail = multi_instrument_session.get_site_pass_fail(site_list='')
     assert pass_fail == {0: True, 1: True, 2: True, 3: True}


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

- [x] I've added tests applicable for this pull reques

### What does this Pull Request accomplish?

Change type of applicable time-based method parameters and properties to datetime.timedelta. Users would be able to pass either floats (to represent time in seconds) or datetime.timedelta objects. This will make nidigital consistent with other APIs in nimi-python.

### List issues fixed by this Pull Request below, if any.

* Fix #1216

### What testing has been done?

Ran system tests