### PR TITLE
Update burst_pattern method to return pass/fail results if wait_until_done is True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
     * #### Changed
         * Change the type of applicable method parameters and properties to enums - [#1066](https://github.com/ni/nimi-python/issues/1066)
         * `get_site_pass_fail` returns dictionary where each key is a site number and value is a bool indicating pass/fail - [#1297](https://github.com/ni/nimi-python/issues/1297)
+        * `burst_pattern` returns dictionary where each key is a site number and value is a bool indicating pass/fail, if `wait_until_done` is specified as `True` - [#1296](https://github.com/ni/nimi-python/issues/1296)
     * #### Removed
         * `get_pattern_pin_list`, `get_pattern_pin_indexes` and `get_pin_name` - [#1292](https://github.com/ni/nimi-python/issues/1292)
 * ### NI-DMM

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -190,7 +190,11 @@ burst_pattern
 
     .. py:method:: burst_pattern(site_list, start_label, select_digital_function=True, wait_until_done=True, timeout=10.0)
 
-            TBD
+            Uses the start_label you specify to burst the pattern on the sites you specify. If you
+            specify wait_until_done as True, waits for the burst to complete, and returns comparison results for each site.
+
+            Digital pins retain their state at the end of a pattern burst until the first vector of the pattern burst, a call to
+            :py:meth:`nidigital.Session.write_static`, or a call to :py:meth:`nidigital.Session.apply_levels_and_timing`.
 
             
 
@@ -231,6 +235,17 @@ burst_pattern
 
 
             :type timeout: float
+
+            :rtype: { int: bool, int: bool, ... }
+            :return:
+
+
+                    Dictionary where each key is a site number and value is pass/fail,
+                    if wait_until_done is specified as True. Else, None.
+
+                    
+
+
 
 clear_error
 -----------

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -2191,8 +2191,8 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def burst_pattern(self, site_list, start_label, select_digital_function=True, wait_until_done=True, timeout=10.0):
-        r'''burst_pattern
+    def _burst_pattern(self, site_list, start_label, select_digital_function=True, wait_until_done=True, timeout=10.0):
+        r'''_burst_pattern
 
         TBD
 
@@ -2374,6 +2374,40 @@ class Session(_SessionBase):
         error_code = self._library.niDigital_EnableSites(vi_ctype, site_list_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
+
+    @ivi_synchronized
+    def burst_pattern(self, site_list, start_label, select_digital_function=True, wait_until_done=True, timeout=10.0):
+        '''burst_pattern
+
+        Uses the start_label you specify to burst the pattern on the sites you specify. If you
+        specify wait_until_done as True, waits for the burst to complete, and returns comparison results for each site.
+
+        Digital pins retain their state at the end of a pattern burst until the first vector of the pattern burst, a call to
+        write_static, or a call to apply_levels_and_timing.
+
+        Args:
+            site_list (str):
+
+            start_label (str):
+
+            select_digital_function (bool):
+
+            wait_until_done (bool):
+
+            timeout (float):
+
+
+        Returns:
+            pass_fail ({ int: bool, int: bool, ... }): Dictionary where each key is a site number and value is pass/fail,
+                if wait_until_done is specified as True. Else, None.
+
+        '''
+        self._burst_pattern(site_list, start_label, select_digital_function, wait_until_done, timeout)
+
+        if wait_until_done:
+            return self.get_site_pass_fail(site_list)
+        else:
+            return None
 
     @ivi_synchronized
     def _fetch_capture_waveform(self, site_list, waveform_name, samples_to_read, timeout):

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -1171,7 +1171,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def burst_pattern(self, start_label, select_digital_function=True, wait_until_done=True, timeout=10.0):
+    def burst_pattern(self, start_label, select_digital_function=True, wait_until_done=True, timeout=datetime.timedelta(seconds=10.0)):
         '''burst_pattern
 
         Uses the start_label you specify to burst the pattern on the sites you specify. If you
@@ -1193,7 +1193,7 @@ class _SessionBase(object):
 
             wait_until_done (bool):
 
-            timeout (float):
+            timeout (float in seconds or datetime.timedelta):
 
 
         Returns:

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -615,8 +615,8 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def burst_pattern(self, start_label, select_digital_function=True, wait_until_done=True, timeout=10.0):
-        r'''burst_pattern
+    def _burst_pattern(self, start_label, select_digital_function=True, wait_until_done=True, timeout=10.0):
+        r'''_burst_pattern
 
         TBD
 
@@ -1169,6 +1169,44 @@ class _SessionBase(object):
         error_code = self._library.niDigital_EnableSites(vi_ctype, site_list_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
+
+    @ivi_synchronized
+    def burst_pattern(self, start_label, select_digital_function=True, wait_until_done=True, timeout=10.0):
+        '''burst_pattern
+
+        Uses the start_label you specify to burst the pattern on the sites you specify. If you
+        specify wait_until_done as True, waits for the burst to complete, and returns comparison results for each site.
+
+        Digital pins retain their state at the end of a pattern burst until the first vector of the pattern burst, a call to
+        write_static, or a call to apply_levels_and_timing.
+
+        Tip:
+        This method requires repeated capabilities. If called directly on the
+        nidigital.Session object, then the method will use all repeated capabilities in the session.
+        You can specify a subset of repeated capabilities using the Python index notation on an
+        nidigital.Session repeated capabilities container, and calling this method on the result.
+
+        Args:
+            start_label (str):
+
+            select_digital_function (bool):
+
+            wait_until_done (bool):
+
+            timeout (float):
+
+
+        Returns:
+            pass_fail ({ int: bool, int: bool, ... }): Dictionary where each key is a site number and value is pass/fail,
+                if wait_until_done is specified as True. Else, None.
+
+        '''
+        self._burst_pattern(start_label, select_digital_function, wait_until_done, timeout)
+
+        if wait_until_done:
+            return self.get_site_pass_fail()
+        else:
+            return None
 
     @ivi_synchronized
     def _fetch_capture_waveform(self, waveform_name, samples_to_read, timeout):
@@ -2483,65 +2521,6 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def apply_levels_and_timing(self, site_list, levels_sheet, timing_sheet, initial_state_high_pins="", initial_state_low_pins="", initial_state_tristate_pins=""):
-        r'''apply_levels_and_timing
-
-        TBD
-
-        Args:
-            site_list (str):
-
-            levels_sheet (str):
-
-            timing_sheet (str):
-
-            initial_state_high_pins (str):
-
-            initial_state_low_pins (str):
-
-            initial_state_tristate_pins (str):
-
-        '''
-        vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        site_list_ctype = ctypes.create_string_buffer(site_list.encode(self._encoding))  # case C020
-        levels_sheet_ctype = ctypes.create_string_buffer(levels_sheet.encode(self._encoding))  # case C020
-        timing_sheet_ctype = ctypes.create_string_buffer(timing_sheet.encode(self._encoding))  # case C020
-        initial_state_high_pins_ctype = ctypes.create_string_buffer(initial_state_high_pins.encode(self._encoding))  # case C020
-        initial_state_low_pins_ctype = ctypes.create_string_buffer(initial_state_low_pins.encode(self._encoding))  # case C020
-        initial_state_tristate_pins_ctype = ctypes.create_string_buffer(initial_state_tristate_pins.encode(self._encoding))  # case C020
-        error_code = self._library.niDigital_ApplyLevelsAndTiming(vi_ctype, site_list_ctype, levels_sheet_ctype, timing_sheet_ctype, initial_state_high_pins_ctype, initial_state_low_pins_ctype, initial_state_tristate_pins_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return
-
-    @ivi_synchronized
-    def _burst_pattern(self, site_list, start_label, select_digital_function=True, wait_until_done=True, timeout=10.0):
-        r'''_burst_pattern
-
-        TBD
-
-        Args:
-            site_list (str):
-
-            start_label (str):
-
-            select_digital_function (bool):
-
-            wait_until_done (bool):
-
-            timeout (float):
-
-        '''
-        vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        site_list_ctype = ctypes.create_string_buffer(site_list.encode(self._encoding))  # case C020
-        start_label_ctype = ctypes.create_string_buffer(start_label.encode(self._encoding))  # case C020
-        select_digital_function_ctype = _visatype.ViBoolean(select_digital_function)  # case S150
-        wait_until_done_ctype = _visatype.ViBoolean(wait_until_done)  # case S150
-        timeout_ctype = _visatype.ViReal64(timeout)  # case S150
-        error_code = self._library.niDigital_BurstPattern(vi_ctype, site_list_ctype, start_label_ctype, select_digital_function_ctype, wait_until_done_ctype, timeout_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return
-
-    @ivi_synchronized
     def clear_error(self):
         r'''clear_error
 
@@ -2649,154 +2628,6 @@ class Session(_SessionBase):
         error_code = self._library.niDigital_DeleteAllTimeSets(vi_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
-
-    @ivi_synchronized
-    def disable_sites(self, site_list):
-        r'''disable_sites
-
-        TBD
-
-        Args:
-            site_list (str):
-
-        '''
-        vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        site_list_ctype = ctypes.create_string_buffer(site_list.encode(self._encoding))  # case C020
-        error_code = self._library.niDigital_DisableSites(vi_ctype, site_list_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return
-
-    @ivi_synchronized
-    def enable_sites(self, site_list):
-        r'''enable_sites
-
-        TBD
-
-        Args:
-            site_list (str):
-
-        '''
-        vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        site_list_ctype = ctypes.create_string_buffer(site_list.encode(self._encoding))  # case C020
-        error_code = self._library.niDigital_EnableSites(vi_ctype, site_list_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return
-
-    @ivi_synchronized
-    def burst_pattern(self, site_list, start_label, select_digital_function=True, wait_until_done=True, timeout=10.0):
-        '''burst_pattern
-
-        Uses the start_label you specify to burst the pattern on the sites you specify. If you
-        specify wait_until_done as True, waits for the burst to complete, and returns comparison results for each site.
-
-        Digital pins retain their state at the end of a pattern burst until the first vector of the pattern burst, a call to
-        write_static, or a call to apply_levels_and_timing.
-
-        Args:
-            site_list (str):
-
-            start_label (str):
-
-            select_digital_function (bool):
-
-            wait_until_done (bool):
-
-            timeout (float):
-
-
-        Returns:
-            pass_fail ({ int: bool, int: bool, ... }): Dictionary where each key is a site number and value is pass/fail,
-                if wait_until_done is specified as True. Else, None.
-
-        '''
-        self._burst_pattern(site_list, start_label, select_digital_function, wait_until_done, timeout)
-
-        if wait_until_done:
-            return self.get_site_pass_fail(site_list)
-        else:
-            return None
-
-    @ivi_synchronized
-    def _fetch_capture_waveform(self, site_list, waveform_name, samples_to_read, timeout):
-        # This is slightly modified codegen from the function
-        # We cannot use codegen without major modifications to the code generator
-        # This function uses two 'ivi-dance' parameters and then multiplies them together - see
-        # the (modified) line below
-        # Also, we want to return the two sized that normally wouldn't be returned
-        vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        site_list_ctype = ctypes.create_string_buffer(site_list.encode(self._encoding))  # case C020
-        waveform_name_ctype = ctypes.create_string_buffer(waveform_name.encode(self._encoding))  # case C020
-        samples_to_read_ctype = _visatype.ViInt32(samples_to_read)  # case S150
-        timeout_ctype = _converters.convert_timedelta_to_seconds_real64(timeout)  # case S140
-        data_buffer_size_ctype = _visatype.ViInt32(0)  # case S190
-        data_ctype = None  # case B610
-        actual_num_waveforms_ctype = _visatype.ViInt32()  # case S220
-        actual_samples_per_waveform_ctype = _visatype.ViInt32()  # case S220
-        error_code = self._library.niDigital_FetchCaptureWaveformU32(vi_ctype, site_list_ctype, waveform_name_ctype, samples_to_read_ctype, timeout_ctype, data_buffer_size_ctype, data_ctype, None if actual_num_waveforms_ctype is None else (ctypes.pointer(actual_num_waveforms_ctype)), None if actual_samples_per_waveform_ctype is None else (ctypes.pointer(actual_samples_per_waveform_ctype)))
-        errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
-        data_buffer_size_ctype = _visatype.ViInt32(actual_num_waveforms_ctype.value * actual_samples_per_waveform_ctype.value)  # case S200 (modified)
-        data_size = actual_num_waveforms_ctype.value * actual_samples_per_waveform_ctype.value  # case B620 (modified)
-        data_array = array.array("L", [0] * data_size)  # case B620
-        data_ctype = get_ctypes_pointer_for_buffer(value=data_array, library_type=_visatype.ViUInt32)  # case B620
-        error_code = self._library.niDigital_FetchCaptureWaveformU32(vi_ctype, site_list_ctype, waveform_name_ctype, samples_to_read_ctype, timeout_ctype, data_buffer_size_ctype, data_ctype, None if actual_num_waveforms_ctype is None else (ctypes.pointer(actual_num_waveforms_ctype)), None if actual_samples_per_waveform_ctype is None else (ctypes.pointer(actual_samples_per_waveform_ctype)))
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return data_array, actual_num_waveforms_ctype.value, actual_samples_per_waveform_ctype.value  # (modified)
-
-    def fetch_capture_waveform(self, site_list, waveform_name, samples_to_read, timeout=datetime.timedelta(seconds=10.0)):
-        '''fetch_capture_waveform
-
-        Returns dictionary where each key is the site number and the value is array.array of unsigned int
-
-        Args:
-            site_list (str):
-
-            waveform_name (str):
-
-            samples_to_read (int):
-
-            timeout (float or datetime.timedelta):
-
-
-        Returns:
-            waveform ({ site: data, site: data, ... }): Dictionary where each key is the site number and the value is array.array of unsigned int
-
-        '''
-        data, actual_num_waveforms, actual_samples_per_waveform = self._fetch_capture_waveform(site_list, waveform_name, samples_to_read, timeout)
-
-        # Get the site list
-        site_list = self.get_site_results_site_numbers(site_list, enums.SiteResult.CAPTURE_WAVEFORM)
-        assert len(site_list) == actual_num_waveforms
-
-        waveforms = {}
-
-        mv = memoryview(data)
-
-        for i in range(actual_num_waveforms):
-            start = i * actual_samples_per_waveform
-            end = start + actual_samples_per_waveform
-            waveforms[site_list[i]] = mv[start:end]
-
-        return waveforms
-
-    @ivi_synchronized
-    def get_site_pass_fail(self, site_list):
-        '''get_site_pass_fail
-
-        Returns dictionary where each key is a site number and value is pass/fail
-
-        Args:
-            site_list (str):
-
-
-        Returns:
-            pass_fail ({ int: bool, int: bool, ... }): Dictionary where each key is a site number and value is pass/fail
-
-        '''
-        result_list = self._get_site_pass_fail(site_list)
-        site_list = self.get_site_results_site_numbers(site_list, enums.SiteResult.PASS_FAIL)
-        assert len(site_list) == len(result_list)
-
-        return dict(zip(site_list, result_list))
 
     @ivi_synchronized
     def self_test(self):

--- a/src/nidigital/metadata/functions.py
+++ b/src/nidigital/metadata/functions.py
@@ -106,6 +106,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'BurstPattern': {
+        'codegen_method': 'private',
         'documentation': {
             'description': 'TBD'
         },

--- a/src/nidigital/metadata/functions_addon.py
+++ b/src/nidigital/metadata/functions_addon.py
@@ -16,9 +16,12 @@ functions_additional_burst_pattern = {
             }
         ],
         'documentation': {
-            'description': """\nUses the start_label you specify to burst the pattern on the sites you
-specify. Digital pins retain their state at the end of a pattern burst until the first vector of the pattern
-burst, a call to niDigital_WriteStatic, or a call to niDigital_ApplyLevelsAndTiming.
+            'description': """\nUses the start_label you specify to burst the pattern on the sites you specify. If you
+specify wait_until_done as True, waits for the burst to complete, and returns comparison results for each site.
+
+Digital pins retain their state at the end of a pattern burst until the first vector of the pattern burst, a call to
+niDigital_WriteStatic, or a call to niDigital_ApplyLevelsAndTiming.
+
 """
         },
         'parameters': [
@@ -38,16 +41,19 @@ burst, a call to niDigital_WriteStatic, or a call to niDigital_ApplyLevelsAndTim
                 'type': 'ViConstString'
             },
             {
+                'default_value': True,
                 'direction': 'in',
                 'name': 'selectDigitalFunction',
                 'type': 'ViBoolean'
             },
             {
+                'default_value': True,
                 'direction': 'in',
                 'name': 'waitUntilDone',
                 'type': 'ViBoolean'
             },
             {
+                'default_value': 10.0,
                 'direction': 'in',
                 'name': 'timeout',
                 'type': 'ViReal64'
@@ -55,7 +61,7 @@ burst, a call to niDigital_WriteStatic, or a call to niDigital_ApplyLevelsAndTim
             {
                 'direction': 'out',
                 'documentation': {
-                    'description': '\nDictionary where each key is a site number and value is pass/fail\n'
+                    'description': '\nDictionary where each key is a site number and value is pass/fail,\nif wait_until_done is specified as True. Else, None.\n'
                 },
                 'name': 'passFail',
                 'size': {

--- a/src/nidigital/metadata/functions_addon.py
+++ b/src/nidigital/metadata/functions_addon.py
@@ -4,6 +4,83 @@
 functions_override_metadata = {
 }
 
+functions_additional_burst_pattern = {
+    'FancyBurstPattern': {
+        'python_name': 'burst_pattern',
+        'codegen_method': 'python-only',
+        'method_templates': [
+            {
+                'documentation_filename': 'default_method',
+                'method_python_name_suffix': '',
+                'session_filename': 'fancy_burst_pattern',
+            }
+        ],
+        'documentation': {
+            'description': """\nUses the start_label you specify to burst the pattern on the sites you
+specify. Digital pins retain their state at the end of a pattern burst until the first vector of the pattern
+burst, a call to niDigital_WriteStatic, or a call to niDigital_ApplyLevelsAndTiming.
+"""
+        },
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'in',
+                'name': 'siteList',
+                'type': 'ViConstString'
+            },
+            {
+                'direction': 'in',
+                'name': 'startLabel',
+                'type': 'ViConstString'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectDigitalFunction',
+                'type': 'ViBoolean'
+            },
+            {
+                'direction': 'in',
+                'name': 'waitUntilDone',
+                'type': 'ViBoolean'
+            },
+            {
+                'direction': 'in',
+                'name': 'timeout',
+                'type': 'ViReal64'
+            }
+        ],
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'in',
+                'name': 'siteList',
+                'type': 'ViConstString'
+            },
+            {
+                'direction': 'out',
+                'documentation': {
+                    'description': '\nDictionary where each key is a site number and value is pass/fail\n'
+                },
+                'name': 'passFail',
+                'size': {
+                    'mechanism': 'python-code',
+                    'value': None
+                },
+                'type': 'ViBoolean',
+                'type_in_documentation': '{ int: bool, int: bool, ... }',
+            },
+        ],
+    },
+}
+
 functions_additional_write_source_waveform_site_unique = {
     'FancyWriteSourceWaveformSiteUnique': {
         'python_name': 'write_source_waveform_site_unique',

--- a/src/nidigital/metadata/functions_addon.py
+++ b/src/nidigital/metadata/functions_addon.py
@@ -32,6 +32,8 @@ niDigital_WriteStatic, or a call to niDigital_ApplyLevelsAndTiming.
             },
             {
                 'direction': 'in',
+                'is_repeated_capability': True,
+                'repeated_capability_type': 'sites',
                 'name': 'siteList',
                 'type': 'ViConstString'
             },

--- a/src/nidigital/metadata/functions_addon.py
+++ b/src/nidigital/metadata/functions_addon.py
@@ -51,18 +51,6 @@ burst, a call to niDigital_WriteStatic, or a call to niDigital_ApplyLevelsAndTim
                 'direction': 'in',
                 'name': 'timeout',
                 'type': 'ViReal64'
-            }
-        ],
-        'parameters': [
-            {
-                'direction': 'in',
-                'name': 'vi',
-                'type': 'ViSession'
-            },
-            {
-                'direction': 'in',
-                'name': 'siteList',
-                'type': 'ViConstString'
             },
             {
                 'direction': 'out',

--- a/src/nidigital/metadata/functions_addon.py
+++ b/src/nidigital/metadata/functions_addon.py
@@ -55,10 +55,12 @@ niDigital_WriteStatic, or a call to niDigital_ApplyLevelsAndTiming.
                 'type': 'ViBoolean'
             },
             {
-                'default_value': 10.0,
+                'default_value': 'datetime.timedelta(seconds=10.0)',
                 'direction': 'in',
                 'name': 'timeout',
-                'type': 'ViReal64'
+                'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
+                'type': 'ViReal64',
+                'type_in_documentation': 'float in seconds or datetime.timedelta'
             },
             {
                 'direction': 'out',

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -92,6 +92,26 @@ def test_tdr_some_channels(multi_instrument_session):
     assert fetched_offsets == applied_offsets
 
 
+def test_burst_pattern_non_blocking(multi_instrument_session):
+    test_files_folder = 'simple_pattern'
+    configure_session(multi_instrument_session, test_files_folder)
+
+    multi_instrument_session.load_pattern(get_test_file_path(test_files_folder, 'pattern.digipat'))
+
+    result = multi_instrument_session.burst_pattern(site_list='', start_label='new_pattern', wait_until_done=False)
+    assert result is None
+
+
+def test_burst_pattern_blocking(multi_instrument_session):
+    test_files_folder = 'simple_pattern'
+    configure_session(multi_instrument_session, test_files_folder)
+
+    multi_instrument_session.load_pattern(get_test_file_path(test_files_folder, 'pattern.digipat'))
+
+    result = multi_instrument_session.burst_pattern(site_list='', start_label='new_pattern', wait_until_done=True)
+    assert result == {0: True, 1: True, 2: True, 3: True}
+
+
 def test_source_waveform_parallel_broadcast(multi_instrument_session):
     test_name = test_source_waveform_parallel_broadcast.__name__
     configure_session(multi_instrument_session, test_name)
@@ -106,9 +126,7 @@ def test_source_waveform_parallel_broadcast(multi_instrument_session):
         waveform_name='src_wfm',
         waveform_data=[i for i in range(4)])
 
-    multi_instrument_session.burst_pattern(site_list='', start_label='new_pattern')
-
-    pass_fail = multi_instrument_session.get_site_pass_fail(site_list='')
+    pass_fail = multi_instrument_session.burst_pattern(site_list='', start_label='new_pattern')
     assert pass_fail == {0: True, 1: True}
 
 

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -106,23 +106,23 @@ def test_tdr_some_channels(multi_instrument_session):
     assert fetched_offsets == applied_offsets
 
 
-def test_burst_pattern_non_blocking(multi_instrument_session):
+def test_burst_pattern_burst_only(multi_instrument_session):
     test_files_folder = 'simple_pattern'
     configure_session(multi_instrument_session, test_files_folder)
 
     multi_instrument_session.load_pattern(get_test_file_path(test_files_folder, 'pattern.digipat'))
 
-    result = multi_instrument_session.burst_pattern(site_list='', start_label='new_pattern', wait_until_done=False)
+    result = multi_instrument_session.burst_pattern(start_label='new_pattern', wait_until_done=False)
     assert result is None
 
 
-def test_burst_pattern_blocking(multi_instrument_session):
+def test_burst_pattern_pass_fail(multi_instrument_session):
     test_files_folder = 'simple_pattern'
     configure_session(multi_instrument_session, test_files_folder)
 
     multi_instrument_session.load_pattern(get_test_file_path(test_files_folder, 'pattern.digipat'))
 
-    result = multi_instrument_session.burst_pattern(site_list='', start_label='new_pattern', wait_until_done=True)
+    result = multi_instrument_session.burst_pattern(start_label='new_pattern', wait_until_done=True)
     assert result == {0: True, 1: True, 2: True, 3: True}
 
 
@@ -511,11 +511,7 @@ def test_get_site_pass_fail(multi_instrument_session):
 
     multi_instrument_session.load_pattern(get_test_file_path(test_files_folder, 'pattern.digipat'))
 
-    multi_instrument_session.burst_pattern(
-        start_label='new_pattern',
-        select_digital_function=True,
-        wait_until_done=True,
-        timeout=5)
+    multi_instrument_session.burst_pattern(start_label='new_pattern')
 
     pass_fail = multi_instrument_session.get_site_pass_fail()
     assert pass_fail == {0: True, 1: True, 2: True, 3: True}

--- a/src/nidigital/templates/session.py/fancy_burst_pattern.py.mako
+++ b/src/nidigital/templates/session.py/fancy_burst_pattern.py.mako
@@ -9,10 +9,10 @@
 
         ${helper.get_function_docstring(f, False, config, indent=8)}
         '''
-        self._burst_pattern(site_list, start_label, select_digital_function, wait_until_done, timeout)
+        self._burst_pattern(start_label, select_digital_function, wait_until_done, timeout)
 
         if wait_until_done:
-            return self.get_site_pass_fail(site_list)
+            return self.get_site_pass_fail()
         else:
             return None
 

--- a/src/nidigital/templates/session.py/fancy_burst_pattern.py.mako
+++ b/src/nidigital/templates/session.py/fancy_burst_pattern.py.mako
@@ -1,0 +1,18 @@
+<%page args="f, config, method_template"/>\
+<%
+    '''Forwards to _burst_pattern(). If wait_until_done is True, calls get_site_pass_fail() to obtain the pass/fail
+    results and returns it to the caller.'''
+    import build.helper as helper
+%>\
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+        '''${f['python_name']}
+
+        ${helper.get_function_docstring(f, False, config, indent=8)}
+        '''
+        self._burst_pattern(site_list, start_label, select_digital_function, wait_until_done, timeout)
+
+        if wait_until_done:
+            return self.get_site_pass_fail(site_list)
+        else:
+            return None
+


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

Update burst_pattern method to return pass/fail results if wait_until_done is True. With this change, users can use `burst_pattern` is two ways:
1. Does not wait for pattern burst to complete.
2. Waits for pattern burst to complete and expect pass-fail results to be returned. (Majority use-case)

### List issues fixed by this Pull Request below, if any.

* Fix #1296 

### What testing has been done?

Added and ran new system tests.
