### PR TITLE
Modify metadata to add rep cap tip to get_site_pass_fail docstring

### DIFF
--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -1459,6 +1459,11 @@ get_site_pass_fail
             
 
 
+            .. tip:: This method requires repeated capabilities. If called directly on the
+                nidigital.Session object, then the method will use all repeated capabilities in the session.
+                You can specify a subset of repeated capabilities using the Python index notation on an
+                nidigital.Session repeated capabilities container, and calling this method on the result.
+
 
             :rtype: { int: bool, int: bool, ... }
             :return:

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -1404,6 +1404,12 @@ class _SessionBase(object):
 
         Returns dictionary where each key is a site number and value is pass/fail
 
+        Tip:
+        This method requires repeated capabilities. If called directly on the
+        nidigital.Session object, then the method will use all repeated capabilities in the session.
+        You can specify a subset of repeated capabilities using the Python index notation on an
+        nidigital.Session repeated capabilities container, and calling this method on the result.
+
         Returns:
             pass_fail ({ int: bool, int: bool, ... }): Dictionary where each key is a site number and value is pass/fail
 

--- a/src/nidigital/metadata/functions_addon.py
+++ b/src/nidigital/metadata/functions_addon.py
@@ -88,7 +88,6 @@ functions_additional_get_site_pass_fail = {
     'FancyGetSitePassFail': {
         'python_name': 'get_site_pass_fail',
         'codegen_method': 'python-only',
-        'render_in_session_base': True,
         'method_templates': [
             {
                 'documentation_filename': 'default_method',
@@ -104,6 +103,13 @@ functions_additional_get_site_pass_fail = {
                 'direction': 'in',
                 'name': 'vi',
                 'type': 'ViSession'
+            },
+            {
+                'direction': 'in',
+                'is_repeated_capability': True,
+                'repeated_capability_type': 'sites',
+                'name': 'siteList',
+                'type': 'ViConstString'
             },
             {
                 'direction': 'out',


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Add rep cap tip to `get_site_pass_fail` docstring, by adding `site_list` parameter to metadata. This is workaround for #1343. Proper fix is tracked by #1342.

### List issues fixed by this Pull Request below, if any.

* Fix #1343

### What testing has been done?

Visual inspection of generated files. Running of existing system tests.