### PR TITLE
Fixes in fetch_history_ram_cycle_information - handle empty HRAM case and fix converter name

### DIFF
--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -1301,7 +1301,7 @@ class _SessionBase(object):
             raise ValueError('samples_to_read should be greater than or equal to -1.')
 
         samples_available = self.get_history_ram_sample_count(site)
-        if position >= samples_available:
+        if position > samples_available:
             raise ValueError('position: Specified value = {0}, Maximum value = {1}.'.format(position, samples_available - 1))
 
         if samples_to_read == -1:
@@ -1317,7 +1317,7 @@ class _SessionBase(object):
                 .format(position, samples_to_read, samples_available - position))
 
         # Site can be 'N', N or 'siteN'. This will normalize all options to 'siteN' which is requried by the driver
-        site = _converters.convert_site_string(site)
+        site = _converters.convert_site_to_string(site)
         pattern_names = {}
         time_set_names = {}
         cycle_infos = []

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -443,6 +443,19 @@ def test_fetch_history_ram_cycle_information_samples_to_read_all(multi_instrumen
     ]
 
 
+def test_fetch_history_ram_cycle_information_no_failures(multi_instrument_session):
+    test_name = 'simple_pattern'
+    configure_session(multi_instrument_session, test_name)
+    multi_instrument_session.load_pattern(get_test_file_path(test_name, 'pattern.digipat'))
+    multi_instrument_session.burst_pattern(start_label='new_pattern')
+
+    history_ram_cycle_info = multi_instrument_session.fetch_history_ram_cycle_information(site='site0', position=0, samples_to_read=-1)
+    assert len(history_ram_cycle_info) == 0
+
+    history_ram_cycle_info = multi_instrument_session.fetch_history_ram_cycle_information(site='site0', position=0, samples_to_read=0)
+    assert len(history_ram_cycle_info) == 0
+
+
 def test_get_pattern_pin_names(multi_instrument_session):
     test_name = 'simple_pattern'
     configure_session(multi_instrument_session, test_name)

--- a/src/nidigital/templates/session.py/fancy_fetch_history_ram_cycle_information.py.mako
+++ b/src/nidigital/templates/session.py/fancy_fetch_history_ram_cycle_information.py.mako
@@ -15,7 +15,7 @@
             raise ValueError('samples_to_read should be greater than or equal to -1.')
 
         samples_available = self.get_history_ram_sample_count(site)
-        if position >= samples_available:
+        if position > samples_available:
             raise ValueError('position: Specified value = {0}, Maximum value = {1}.'.format(position, samples_available - 1))
 
         if samples_to_read == -1:
@@ -31,7 +31,7 @@
                 .format(position, samples_to_read, samples_available - position))
 
         # Site can be 'N', N or 'siteN'. This will normalize all options to 'siteN' which is requried by the driver
-        site = _converters.convert_site_string(site)
+        site = _converters.convert_site_to_string(site)
         pattern_names = {}
         time_set_names = {}
         cycle_infos = []


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

Fix two bugs in `fetch_history_ram_cycle_information`:
- Fix typo in the call to `convert_site_to_string` method
- If History RAM is empty and user asks for 0 samples (position = 0, samples_to_read = 0) or all samples (position = 0, samples_to_read = -1), `fetch_history_ram_cycle_information` used to throw. Updated logic to return an empty list instead.

### List issues fixed by this Pull Request below, if any.

* Fix #1346 
* Fix #1347 

### What testing has been done?

Added a new system test and ran all system tests and unit tests.