### PR TITLE
Update enum types in nidigital to match the API in other ADEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ All notable changes to this project will be documented in this file.
     * #### Changed
         * Change the type of applicable method parameters and properties to enums - [#1066](https://github.com/ni/nimi-python/issues/1066)
         * `get_site_pass_fail` returns dictionary where each key is a site number and value is a bool indicating pass/fail - [#1297](https://github.com/ni/nimi-python/issues/1297)
+        * Update enum types to match the API in other ADEs - [#1330](https://github.com/ni/nimi-python/issues/1330):
+            * Update the names of many enum types. See [#1330](https://github.com/ni/nimi-python/issues/1330) for the full list.
+            * Added `WriteStaticPinState` enum type and changed the parameter type of `write_static` method to the newly added enum.
+            * Added `SoftwareTrigger` enum type and changed the parameter type of `send_software_edge_trigger` method to the newly added enum.
     * #### Removed
         * `get_pattern_pin_list`, `get_pattern_pin_indexes` and `get_pin_name` - [#1292](https://github.com/ni/nimi-python/issues/1292)
 * ### NI-DMM

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -500,7 +500,7 @@ configure_time_set_drive_edges
                 
 
 
-            :type format: :py:data:`nidigital.DriveEdgeSetFormat`
+            :type format: :py:data:`nidigital.DriveFormat`
             :param drive_on_edge:
 
 
@@ -561,7 +561,7 @@ configure_time_set_drive_edges2x
                 
 
 
-            :type format: :py:data:`nidigital.DriveEdgeSetFormat`
+            :type format: :py:data:`nidigital.DriveFormat`
             :param drive_on_edge:
 
 
@@ -636,7 +636,7 @@ configure_time_set_drive_format
                 
 
 
-            :type drive_format: :py:data:`nidigital.DriveEdgeSetFormat`
+            :type drive_format: :py:data:`nidigital.DriveFormat`
 
 configure_time_set_edge
 -----------------------
@@ -669,7 +669,7 @@ configure_time_set_edge
                 
 
 
-            :type edge: :py:data:`nidigital.TimeSetEdge`
+            :type edge: :py:data:`nidigital.TimeSetEdgeType`
             :param time:
 
 
@@ -953,7 +953,7 @@ create_source_waveform_parallel
                 
 
 
-            :type data_mapping: :py:data:`nidigital.SourceMemoryDataMapping`
+            :type data_mapping: :py:data:`nidigital.SourceDataMapping`
 
 create_source_waveform_serial
 -----------------------------
@@ -986,7 +986,7 @@ create_source_waveform_serial
                 
 
 
-            :type data_mapping: :py:data:`nidigital.SourceMemoryDataMapping`
+            :type data_mapping: :py:data:`nidigital.SourceDataMapping`
             :param sample_width:
 
 
@@ -1133,7 +1133,7 @@ fetch_history_ram_cycle_information
 
             If the pattern is using the edge multiplier feature, cycle numbers represent tester cycles, each of which may
             consist of multiple DUT cycles. When using pins with mixed edge multipliers, pins may return
-            :py:data:`~nidigital.DigitalState.PIN_STATE_NOT_ACQUIRED` for DUT cycles where those pins do not have edges defined.
+            :py:data:`~nidigital.PinState.PIN_STATE_NOT_ACQUIRED` for DUT cycles where those pins do not have edges defined.
 
             If pins are not specified, pin list from the pattern containing the start label is used. Call
             :py:meth:`nidigital.Session.get_pattern_pin_names` with the start label to retrieve the pins
@@ -1193,14 +1193,14 @@ fetch_history_ram_cycle_information
                     -  **scan_cycle_number** (int) Scan cycle number acquired by this History RAM sample. Scan cycle numbers
                        start at 0 from the first cycle of the scan vector. Scan cycle numbers are -1 for cycles that do not
                        have a scan opcode.
-                    -  **expected_pin_states** (list of list of enums.DigitalState) Pin states as expected by the loaded
+                    -  **expected_pin_states** (list of list of enums.PinState) Pin states as expected by the loaded
                        pattern in the order specified in the pin list. Pins without defined edges in the specified DUT cycle
-                       will have a value of :py:data:`~nidigital.DigitalState.PIN_STATE_NOT_ACQUIRED`.
+                       will have a value of :py:data:`~nidigital.PinState.PIN_STATE_NOT_ACQUIRED`.
                        Length of the outer list will be equal to the value of edge multiplier for the given vector.
                        Length of the inner list will be equal to the number of pins requested.
-                    -  **actual_pin_states** (list of list of enums.DigitalState) Pin states acquired by History RAM in the
+                    -  **actual_pin_states** (list of list of enums.PinState) Pin states acquired by History RAM in the
                        order specified in the pin list. Pins without defined edges in the specified DUT cycle will have a
-                       value of :py:data:`~nidigital.DigitalState.PIN_STATE_NOT_ACQUIRED`.
+                       value of :py:data:`~nidigital.PinState.PIN_STATE_NOT_ACQUIRED`.
                        Length of the outer list will be equal to the value of edge multiplier for the given vector.
                        Length of the inner list will be equal to the number of pins requested.
                     -  **per_pin_pass_fail** (list of list of bool) Pass fail information for pins in the order specified in
@@ -1494,7 +1494,7 @@ get_site_results_site_numbers
                 
 
 
-            :type site_result_type: :py:data:`nidigital.SiteResult`
+            :type site_result_type: :py:data:`nidigital.SiteResultType`
 
             :rtype: list of int
             :return:
@@ -1530,7 +1530,7 @@ get_time_set_drive_format
 
             :type time_set: str
 
-            :rtype: :py:data:`nidigital.DriveEdgeSetFormat`
+            :rtype: :py:data:`nidigital.DriveFormat`
             :return:
 
 
@@ -1569,7 +1569,7 @@ get_time_set_edge
                 
 
 
-            :type edge: :py:data:`nidigital.TimeSetEdge`
+            :type edge: :py:data:`nidigital.TimeSetEdgeType`
 
             :rtype: float
             :return:
@@ -2018,7 +2018,7 @@ read_static
                 nidigital.Session repeated capabilities container, and calling this method on the result.
 
 
-            :rtype: list of :py:data:`nidigital.DigitalState`
+            :rtype: list of :py:data:`nidigital.PinState`
             :return:
 
 
@@ -2123,7 +2123,7 @@ send_software_edge_trigger
                 
 
 
-            :type trigger: int
+            :type trigger: :py:data:`nidigital.SoftwareTrigger`
             :param trigger_identifier:
 
 
@@ -2408,7 +2408,7 @@ write_static
                 
 
 
-            :type state: :py:data:`nidigital.DigitalState`
+            :type state: :py:data:`nidigital.WriteStaticPinState`
 
 
 Properties
@@ -3543,17 +3543,17 @@ ppmu_aperture_time_units
 
         The following table lists the characteristics of this property.
 
-            +----------------+-------------------------+
-            | Characteristic | Value                   |
-            +================+=========================+
-            | Datatype       | enums.ApertureTimeUnits |
-            +----------------+-------------------------+
-            | Permissions    | read-write              |
-            +----------------+-------------------------+
-            | Channel Based  | Yes                     |
-            +----------------+-------------------------+
-            | Resettable     | Yes                     |
-            +----------------+-------------------------+
+            +----------------+-----------------------------+
+            | Characteristic | Value                       |
+            +================+=============================+
+            | Datatype       | enums.PPMUApertureTimeUnits |
+            +----------------+-----------------------------+
+            | Permissions    | read-write                  |
+            +----------------+-----------------------------+
+            | Channel Based  | Yes                         |
+            +----------------+-----------------------------+
+            | Resettable     | Yes                         |
+            +----------------+-----------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:

--- a/docs/nidigital/enums.rst
+++ b/docs/nidigital/enums.rst
@@ -6,15 +6,6 @@ Enums used in NI-Digital Pattern Driver
 .. py:currentmodule:: nidigital
 
 
-ApertureTimeUnits
------------------
-
-.. py:class:: ApertureTimeUnits
-
-    .. py:attribute:: ApertureTimeUnits.SECONDS
-
-
-
 BitOrder
 --------
 
@@ -41,73 +32,24 @@ DigitalEdge
 
 
 
-DigitalState
-------------
+DriveFormat
+-----------
 
-.. py:class:: DigitalState
+.. py:class:: DriveFormat
 
-    .. py:attribute:: DigitalState.ZERO
-
-
-
-    .. py:attribute:: DigitalState.ONE
+    .. py:attribute:: DriveFormat.NR
 
 
 
-    .. py:attribute:: DigitalState.L
+    .. py:attribute:: DriveFormat.RL
 
 
 
-    .. py:attribute:: DigitalState.H
+    .. py:attribute:: DriveFormat.RH
 
 
 
-    .. py:attribute:: DigitalState.X
-
-
-
-    .. py:attribute:: DigitalState.M
-
-
-
-    .. py:attribute:: DigitalState.V
-
-
-
-    .. py:attribute:: DigitalState.D
-
-
-
-    .. py:attribute:: DigitalState.E
-
-
-
-    .. py:attribute:: DigitalState.NOT_A_PIN_STATE
-
-
-
-    .. py:attribute:: DigitalState.PIN_STATE_NOT_ACQUIRED
-
-
-
-DriveEdgeSetFormat
-------------------
-
-.. py:class:: DriveEdgeSetFormat
-
-    .. py:attribute:: DriveEdgeSetFormat.NR
-
-
-
-    .. py:attribute:: DriveEdgeSetFormat.RL
-
-
-
-    .. py:attribute:: DriveEdgeSetFormat.RH
-
-
-
-    .. py:attribute:: DriveEdgeSetFormat.SBC
+    .. py:attribute:: DriveFormat.SBC
 
 
 
@@ -138,6 +80,15 @@ HistoryRAMTriggerType
 
 
     .. py:attribute:: HistoryRAMTriggerType.PATTERN_LABEL
+
+
+
+PPMUApertureTimeUnits
+---------------------
+
+.. py:class:: PPMUApertureTimeUnits
+
+    .. py:attribute:: PPMUApertureTimeUnits.SECONDS
 
 
 
@@ -173,6 +124,55 @@ PPMUOutputFunction
 
 
     .. py:attribute:: PPMUOutputFunction.CURRENT
+
+
+
+PinState
+--------
+
+.. py:class:: PinState
+
+    .. py:attribute:: PinState.ZERO
+
+
+
+    .. py:attribute:: PinState.ONE
+
+
+
+    .. py:attribute:: PinState.L
+
+
+
+    .. py:attribute:: PinState.H
+
+
+
+    .. py:attribute:: PinState.X
+
+
+
+    .. py:attribute:: PinState.M
+
+
+
+    .. py:attribute:: PinState.V
+
+
+
+    .. py:attribute:: PinState.D
+
+
+
+    .. py:attribute:: PinState.E
+
+
+
+    .. py:attribute:: PinState.NOT_A_PIN_STATE
+
+
+
+    .. py:attribute:: PinState.PIN_STATE_NOT_ACQUIRED
 
 
 
@@ -287,29 +287,42 @@ SequencerRegister
 
 
 
-SiteResult
-----------
+SiteResultType
+--------------
 
-.. py:class:: SiteResult
+.. py:class:: SiteResultType
 
-    .. py:attribute:: SiteResult.PASS_FAIL
-
-
-
-    .. py:attribute:: SiteResult.CAPTURE_WAVEFORM
+    .. py:attribute:: SiteResultType.PASS_FAIL
 
 
 
-SourceMemoryDataMapping
------------------------
-
-.. py:class:: SourceMemoryDataMapping
-
-    .. py:attribute:: SourceMemoryDataMapping.BROADCAST
+    .. py:attribute:: SiteResultType.CAPTURE_WAVEFORM
 
 
 
-    .. py:attribute:: SourceMemoryDataMapping.SITE_UNIQUE
+SoftwareTrigger
+---------------
+
+.. py:class:: SoftwareTrigger
+
+    .. py:attribute:: SoftwareTrigger.START
+
+
+
+    .. py:attribute:: SoftwareTrigger.CONDITIONAL_JUMP
+
+
+
+SourceDataMapping
+-----------------
+
+.. py:class:: SourceDataMapping
+
+    .. py:attribute:: SourceDataMapping.BROADCAST
+
+
+
+    .. py:attribute:: SourceDataMapping.SITE_UNIQUE
 
 
 
@@ -343,40 +356,40 @@ TerminationMode
 
 
 
-TimeSetEdge
------------
+TimeSetEdgeType
+---------------
 
-.. py:class:: TimeSetEdge
+.. py:class:: TimeSetEdgeType
 
-    .. py:attribute:: TimeSetEdge.DRIVE_ON
-
-
-
-    .. py:attribute:: TimeSetEdge.DRIVE_DATA
+    .. py:attribute:: TimeSetEdgeType.DRIVE_ON
 
 
 
-    .. py:attribute:: TimeSetEdge.DRIVE_RETURN
+    .. py:attribute:: TimeSetEdgeType.DRIVE_DATA
 
 
 
-    .. py:attribute:: TimeSetEdge.DRIVE_OFF
+    .. py:attribute:: TimeSetEdgeType.DRIVE_RETURN
 
 
 
-    .. py:attribute:: TimeSetEdge.COMPARE_STROBE
+    .. py:attribute:: TimeSetEdgeType.DRIVE_OFF
 
 
 
-    .. py:attribute:: TimeSetEdge.DRIVE_DATA2
+    .. py:attribute:: TimeSetEdgeType.COMPARE_STROBE
 
 
 
-    .. py:attribute:: TimeSetEdge.DRIVE_RETURN2
+    .. py:attribute:: TimeSetEdgeType.DRIVE_DATA2
 
 
 
-    .. py:attribute:: TimeSetEdge.COMPARE_STROBE2
+    .. py:attribute:: TimeSetEdgeType.DRIVE_RETURN2
+
+
+
+    .. py:attribute:: TimeSetEdgeType.COMPARE_STROBE2
 
 
 
@@ -394,6 +407,23 @@ TriggerType
 
 
     .. py:attribute:: TriggerType.SOFTWARE
+
+
+
+WriteStaticPinState
+-------------------
+
+.. py:class:: WriteStaticPinState
+
+    .. py:attribute:: WriteStaticPinState.ZERO
+
+
+
+    .. py:attribute:: WriteStaticPinState.ONE
+
+
+
+    .. py:attribute:: WriteStaticPinState.X
 
 
 

--- a/generated/nidigital/nidigital/enums.py
+++ b/generated/nidigital/nidigital/enums.py
@@ -4,10 +4,6 @@
 from enum import Enum
 
 
-class ApertureTimeUnits(Enum):
-    SECONDS = 2100
-
-
 class BitOrder(Enum):
     MSB = 2500
     LSB = 2501
@@ -18,21 +14,7 @@ class DigitalEdge(Enum):
     FALLING = 1801
 
 
-class DigitalState(Enum):
-    ZERO = 0
-    ONE = 1
-    L = 3
-    H = 4
-    X = 5
-    M = 6
-    V = 7
-    D = 8
-    E = 9
-    NOT_A_PIN_STATE = 254
-    PIN_STATE_NOT_ACQUIRED = 255
-
-
-class DriveEdgeSetFormat(Enum):
+class DriveFormat(Enum):
     NR = 1500
     RL = 1501
     RH = 1502
@@ -50,6 +32,10 @@ class HistoryRAMTriggerType(Enum):
     PATTERN_LABEL = 2202
 
 
+class PPMUApertureTimeUnits(Enum):
+    SECONDS = 2100
+
+
 class PPMUCurrentLimitBehavior(Enum):
     REGULATE = 3100
 
@@ -62,6 +48,20 @@ class PPMUMeasurementType(Enum):
 class PPMUOutputFunction(Enum):
     VOLTAGE = 1300
     CURRENT = 1301
+
+
+class PinState(Enum):
+    ZERO = 0
+    ONE = 1
+    L = 3
+    H = 4
+    X = 5
+    M = 6
+    V = 7
+    D = 8
+    E = 9
+    NOT_A_PIN_STATE = 254
+    PIN_STATE_NOT_ACQUIRED = 255
 
 
 class SelectedFunction(Enum):
@@ -97,12 +97,17 @@ class SequencerRegister(Enum):
     REGISTER15 = 'reg15'
 
 
-class SiteResult(Enum):
+class SiteResultType(Enum):
     PASS_FAIL = 3300
     CAPTURE_WAVEFORM = 3301
 
 
-class SourceMemoryDataMapping(Enum):
+class SoftwareTrigger(Enum):
+    START = 2000
+    CONDITIONAL_JUMP = 2001
+
+
+class SourceDataMapping(Enum):
     BROADCAST = 2600
     SITE_UNIQUE = 2601
 
@@ -118,7 +123,7 @@ class TerminationMode(Enum):
     HIGH_Z = 1202
 
 
-class TimeSetEdge(Enum):
+class TimeSetEdgeType(Enum):
     DRIVE_ON = 2800
     DRIVE_DATA = 2801
     DRIVE_RETURN = 2802
@@ -133,3 +138,9 @@ class TriggerType(Enum):
     NONE = 1700
     DIGITAL_EDGE = 1701
     SOFTWARE = 1702
+
+
+class WriteStaticPinState(Enum):
+    ZERO = 0
+    ONE = 1
+    X = 5

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -299,8 +299,8 @@ class _SessionBase(object):
     You can specify a subset of repeated capabilities using the Python index notation on an
     nidigital.Session repeated capabilities container, and calling set/get value on the result.
     '''
-    ppmu_aperture_time_units = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.ApertureTimeUnits, 1150038)
-    '''Type: enums.ApertureTimeUnits
+    ppmu_aperture_time_units = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.PPMUApertureTimeUnits, 1150038)
+    '''Type: enums.PPMUApertureTimeUnits
 
     Tip:
     This property can use repeated capabilities. If set or get directly on the
@@ -825,7 +825,7 @@ class _SessionBase(object):
         Args:
             time_set (str):
 
-            format (enums.DriveEdgeSetFormat):
+            format (enums.DriveFormat):
 
             drive_on_edge (float in seconds or datetime.timedelta):
 
@@ -836,8 +836,8 @@ class _SessionBase(object):
             drive_off_edge (float in seconds or datetime.timedelta):
 
         '''
-        if type(format) is not enums.DriveEdgeSetFormat:
-            raise TypeError('Parameter format must be of type ' + str(enums.DriveEdgeSetFormat))
+        if type(format) is not enums.DriveFormat:
+            raise TypeError('Parameter format must be of type ' + str(enums.DriveFormat))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         pin_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         time_set_ctype = ctypes.create_string_buffer(time_set.encode(self._encoding))  # case C020
@@ -865,7 +865,7 @@ class _SessionBase(object):
         Args:
             time_set (str):
 
-            format (enums.DriveEdgeSetFormat):
+            format (enums.DriveFormat):
 
             drive_on_edge (float in seconds or datetime.timedelta):
 
@@ -880,8 +880,8 @@ class _SessionBase(object):
             drive_return2_edge (float in seconds or datetime.timedelta):
 
         '''
-        if type(format) is not enums.DriveEdgeSetFormat:
-            raise TypeError('Parameter format must be of type ' + str(enums.DriveEdgeSetFormat))
+        if type(format) is not enums.DriveFormat:
+            raise TypeError('Parameter format must be of type ' + str(enums.DriveFormat))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         pin_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         time_set_ctype = ctypes.create_string_buffer(time_set.encode(self._encoding))  # case C020
@@ -911,11 +911,11 @@ class _SessionBase(object):
         Args:
             time_set (str):
 
-            drive_format (enums.DriveEdgeSetFormat):
+            drive_format (enums.DriveFormat):
 
         '''
-        if type(drive_format) is not enums.DriveEdgeSetFormat:
-            raise TypeError('Parameter drive_format must be of type ' + str(enums.DriveEdgeSetFormat))
+        if type(drive_format) is not enums.DriveFormat:
+            raise TypeError('Parameter drive_format must be of type ' + str(enums.DriveFormat))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         pin_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         time_set_ctype = ctypes.create_string_buffer(time_set.encode(self._encoding))  # case C020
@@ -939,13 +939,13 @@ class _SessionBase(object):
         Args:
             time_set (str):
 
-            edge (enums.TimeSetEdge):
+            edge (enums.TimeSetEdgeType):
 
             time (float in seconds or datetime.timedelta):
 
         '''
-        if type(edge) is not enums.TimeSetEdge:
-            raise TypeError('Parameter edge must be of type ' + str(enums.TimeSetEdge))
+        if type(edge) is not enums.TimeSetEdgeType:
+            raise TypeError('Parameter edge must be of type ' + str(enums.TimeSetEdgeType))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         pin_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         time_set_ctype = ctypes.create_string_buffer(time_set.encode(self._encoding))  # case C020
@@ -1085,11 +1085,11 @@ class _SessionBase(object):
         Args:
             waveform_name (str):
 
-            data_mapping (enums.SourceMemoryDataMapping):
+            data_mapping (enums.SourceDataMapping):
 
         '''
-        if type(data_mapping) is not enums.SourceMemoryDataMapping:
-            raise TypeError('Parameter data_mapping must be of type ' + str(enums.SourceMemoryDataMapping))
+        if type(data_mapping) is not enums.SourceDataMapping:
+            raise TypeError('Parameter data_mapping must be of type ' + str(enums.SourceDataMapping))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         pin_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         waveform_name_ctype = ctypes.create_string_buffer(waveform_name.encode(self._encoding))  # case C020
@@ -1113,15 +1113,15 @@ class _SessionBase(object):
         Args:
             waveform_name (str):
 
-            data_mapping (enums.SourceMemoryDataMapping):
+            data_mapping (enums.SourceDataMapping):
 
             sample_width (int):
 
             bit_order (enums.BitOrder):
 
         '''
-        if type(data_mapping) is not enums.SourceMemoryDataMapping:
-            raise TypeError('Parameter data_mapping must be of type ' + str(enums.SourceMemoryDataMapping))
+        if type(data_mapping) is not enums.SourceDataMapping:
+            raise TypeError('Parameter data_mapping must be of type ' + str(enums.SourceDataMapping))
         if type(bit_order) is not enums.BitOrder:
             raise TypeError('Parameter bit_order must be of type ' + str(enums.BitOrder))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -1222,7 +1222,7 @@ class _SessionBase(object):
         data, actual_num_waveforms, actual_samples_per_waveform = self._fetch_capture_waveform(waveform_name, samples_to_read, timeout)
 
         # Get the site list
-        site_list = self.get_site_results_site_numbers(enums.SiteResult.CAPTURE_WAVEFORM)
+        site_list = self.get_site_results_site_numbers(enums.SiteResultType.CAPTURE_WAVEFORM)
         assert len(site_list) == actual_num_waveforms
 
         waveforms = {}
@@ -1244,7 +1244,7 @@ class _SessionBase(object):
 
         If the pattern is using the edge multiplier feature, cycle numbers represent tester cycles, each of which may
         consist of multiple DUT cycles. When using pins with mixed edge multipliers, pins may return
-        DigitalState.PIN_STATE_NOT_ACQUIRED for DUT cycles where those pins do not have edges defined.
+        PinState.PIN_STATE_NOT_ACQUIRED for DUT cycles where those pins do not have edges defined.
 
         If pins are not specified, pin list from the pattern containing the start label is used. Call
         get_pattern_pin_names with the start label to retrieve the pins
@@ -1278,14 +1278,14 @@ class _SessionBase(object):
                 -  **scan_cycle_number** (int) Scan cycle number acquired by this History RAM sample. Scan cycle numbers
                    start at 0 from the first cycle of the scan vector. Scan cycle numbers are -1 for cycles that do not
                    have a scan opcode.
-                -  **expected_pin_states** (list of list of enums.DigitalState) Pin states as expected by the loaded
+                -  **expected_pin_states** (list of list of enums.PinState) Pin states as expected by the loaded
                    pattern in the order specified in the pin list. Pins without defined edges in the specified DUT cycle
-                   will have a value of DigitalState.PIN_STATE_NOT_ACQUIRED.
+                   will have a value of PinState.PIN_STATE_NOT_ACQUIRED.
                    Length of the outer list will be equal to the value of edge multiplier for the given vector.
                    Length of the inner list will be equal to the number of pins requested.
-                -  **actual_pin_states** (list of list of enums.DigitalState) Pin states acquired by History RAM in the
+                -  **actual_pin_states** (list of list of enums.PinState) Pin states acquired by History RAM in the
                    order specified in the pin list. Pins without defined edges in the specified DUT cycle will have a
-                   value of DigitalState.PIN_STATE_NOT_ACQUIRED.
+                   value of PinState.PIN_STATE_NOT_ACQUIRED.
                    Length of the outer list will be equal to the value of edge multiplier for the given vector.
                    Length of the inner list will be equal to the number of pins requested.
                 -  **per_pin_pass_fail** (list of list of bool) Pass fail information for pins in the order specified in
@@ -1410,7 +1410,7 @@ class _SessionBase(object):
         '''
         # For site_list, we just use the repeated capability
         result_list = self._get_site_pass_fail()
-        site_list = self.get_site_results_site_numbers(enums.SiteResult.PASS_FAIL)
+        site_list = self.get_site_results_site_numbers(enums.SiteResultType.PASS_FAIL)
         assert len(site_list) == len(result_list)
 
         return dict(zip(site_list, result_list))
@@ -1436,9 +1436,9 @@ class _SessionBase(object):
 
 
         Returns:
-            expected_pin_states (list of enums.DigitalState):
+            expected_pin_states (list of enums.PinState):
 
-            actual_pin_states (list of enums.DigitalState):
+            actual_pin_states (list of enums.PinState):
 
             per_pin_pass_fail (list of bool):
 
@@ -1464,7 +1464,7 @@ class _SessionBase(object):
         per_pin_pass_fail_ctype = get_ctypes_pointer_for_buffer(library_type=_visatype.ViBoolean, size=per_pin_pass_fail_size)  # case B620
         error_code = self._library.niDigital_FetchHistoryRAMCyclePinData(vi_ctype, site_ctype, pin_list_ctype, sample_index_ctype, dut_cycle_index_ctype, pin_data_buffer_size_ctype, expected_pin_states_ctype, actual_pin_states_ctype, per_pin_pass_fail_ctype, None if actual_num_pin_data_ctype is None else (ctypes.pointer(actual_num_pin_data_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return [enums.DigitalState(expected_pin_states_ctype[i]) for i in range(pin_data_buffer_size_ctype.value)], [enums.DigitalState(actual_pin_states_ctype[i]) for i in range(pin_data_buffer_size_ctype.value)], [bool(per_pin_pass_fail_ctype[i]) for i in range(pin_data_buffer_size_ctype.value)]
+        return [enums.PinState(expected_pin_states_ctype[i]) for i in range(pin_data_buffer_size_ctype.value)], [enums.PinState(actual_pin_states_ctype[i]) for i in range(pin_data_buffer_size_ctype.value)], [bool(per_pin_pass_fail_ctype[i]) for i in range(pin_data_buffer_size_ctype.value)]
 
     @ivi_synchronized
     def frequency_counter_measure_frequency(self):
@@ -1829,15 +1829,15 @@ class _SessionBase(object):
         nidigital.Session repeated capabilities container, and calling this method on the result.
 
         Args:
-            site_result_type (enums.SiteResult):
+            site_result_type (enums.SiteResultType):
 
 
         Returns:
             site_numbers (list of int):
 
         '''
-        if type(site_result_type) is not enums.SiteResult:
-            raise TypeError('Parameter site_result_type must be of type ' + str(enums.SiteResult))
+        if type(site_result_type) is not enums.SiteResultType:
+            raise TypeError('Parameter site_result_type must be of type ' + str(enums.SiteResultType))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         site_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         site_result_type_ctype = _visatype.ViInt32(site_result_type.value)  # case S130
@@ -1870,7 +1870,7 @@ class _SessionBase(object):
 
 
         Returns:
-            format (enums.DriveEdgeSetFormat):
+            format (enums.DriveFormat):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -1879,7 +1879,7 @@ class _SessionBase(object):
         format_ctype = _visatype.ViInt32()  # case S220
         error_code = self._library.niDigital_GetTimeSetDriveFormat(vi_ctype, pin_ctype, time_set_ctype, None if format_ctype is None else (ctypes.pointer(format_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return enums.DriveEdgeSetFormat(format_ctype.value)
+        return enums.DriveFormat(format_ctype.value)
 
     @ivi_synchronized
     def get_time_set_edge(self, time_set, edge):
@@ -1896,15 +1896,15 @@ class _SessionBase(object):
         Args:
             time_set (str):
 
-            edge (enums.TimeSetEdge):
+            edge (enums.TimeSetEdgeType):
 
 
         Returns:
             time (float):
 
         '''
-        if type(edge) is not enums.TimeSetEdge:
-            raise TypeError('Parameter edge must be of type ' + str(enums.TimeSetEdge))
+        if type(edge) is not enums.TimeSetEdgeType:
+            raise TypeError('Parameter edge must be of type ' + str(enums.TimeSetEdgeType))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         pin_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         time_set_ctype = ctypes.create_string_buffer(time_set.encode(self._encoding))  # case C020
@@ -2055,7 +2055,7 @@ class _SessionBase(object):
         nidigital.Session repeated capabilities container, and calling this method on the result.
 
         Returns:
-            data (list of enums.DigitalState):
+            data (list of enums.PinState):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -2070,7 +2070,7 @@ class _SessionBase(object):
         data_ctype = get_ctypes_pointer_for_buffer(library_type=_visatype.ViUInt8, size=data_size)  # case B620
         error_code = self._library.niDigital_ReadStatic(vi_ctype, channel_list_ctype, buffer_size_ctype, data_ctype, None if actual_num_read_ctype is None else (ctypes.pointer(actual_num_read_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return [enums.DigitalState(data_ctype[i]) for i in range(buffer_size_ctype.value)]
+        return [enums.PinState(data_ctype[i]) for i in range(buffer_size_ctype.value)]
 
     @ivi_synchronized
     def reset_attribute(self, attribute_id):
@@ -2318,11 +2318,11 @@ class _SessionBase(object):
         nidigital.Session repeated capabilities container, and calling this method on the result.
 
         Args:
-            state (enums.DigitalState):
+            state (enums.WriteStaticPinState):
 
         '''
-        if type(state) is not enums.DigitalState:
-            raise TypeError('Parameter state must be of type ' + str(enums.DigitalState))
+        if type(state) is not enums.WriteStaticPinState:
+            raise TypeError('Parameter state must be of type ' + str(enums.WriteStaticPinState))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         channel_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         state_ctype = _visatype.ViUInt8(state.value)  # case S130
@@ -3095,13 +3095,15 @@ class Session(_SessionBase):
         TBD
 
         Args:
-            trigger (int):
+            trigger (enums.SoftwareTrigger):
 
             trigger_identifier (str):
 
         '''
+        if type(trigger) is not enums.SoftwareTrigger:
+            raise TypeError('Parameter trigger must be of type ' + str(enums.SoftwareTrigger))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        trigger_ctype = _visatype.ViInt32(trigger)  # case S150
+        trigger_ctype = _visatype.ViInt32(trigger.value)  # case S130
         trigger_identifier_ctype = ctypes.create_string_buffer(trigger_identifier.encode(self._encoding))  # case C020
         error_code = self._library.niDigital_SendSoftwareEdgeTrigger(vi_ctype, trigger_ctype, trigger_identifier_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)

--- a/src/nidigital/metadata/attributes.py
+++ b/src/nidigital/metadata/attributes.py
@@ -356,7 +356,7 @@ attributes = {
     1150038: {
         'access': 'read-write',
         'channel_based': True,
-        'enum': 'ApertureTimeUnits',
+        'enum': 'PPMUApertureTimeUnits',
         'name': 'PPMU_APERTURE_TIME_UNITS',
         'resettable': True,
         'type': 'ViInt32'

--- a/src/nidigital/metadata/enums.py
+++ b/src/nidigital/metadata/enums.py
@@ -1,14 +1,6 @@
 # -*- coding: utf-8 -*-
 # This file is generated from NI-Digital Pattern Driver API metadata version 19.5.0d7
 enums = {
-    'ApertureTimeUnits': {
-        'values': [
-            {
-                'name': 'NIDIGITAL_VAL_SECONDS',
-                'value': 2100
-            }
-        ]
-    },
     'BitOrder': {
         'values': [
             {
@@ -21,7 +13,7 @@ enums = {
             }
         ]
     },
-    'ConditionalJumpTrigger': {
+    'ConditionalJumpTriggerId': {
         'values': [
             {
                 'name': 'NIDIGITAL_VAL_CONDITIONAL_JUMP_TRIGGER0',
@@ -57,57 +49,7 @@ enums = {
             }
         ]
     },
-    'DigitalState': {
-        'values': [
-            {
-                'name': 'NIDIGITAL_VAL_0',
-                'python_name': 'ZERO',
-                'value': 0
-            },
-            {
-                'name': 'NIDIGITAL_VAL_1',
-                'python_name': 'ONE',
-                'value': 1
-            },
-            {
-                'name': 'NIDIGITAL_VAL_L',
-                'value': 3
-            },
-            {
-                'name': 'NIDIGITAL_VAL_H',
-                'value': 4
-            },
-            {
-                'name': 'NIDIGITAL_VAL_X',
-                'value': 5
-            },
-            {
-                'name': 'NIDIGITAL_VAL_M',
-                'value': 6
-            },
-            {
-                'name': 'NIDIGITAL_VAL_V',
-                'value': 7
-            },
-            {
-                'name': 'NIDIGITAL_VAL_D',
-                'value': 8
-            },
-            {
-                'name': 'NIDIGITAL_VAL_E',
-                'value': 9
-            },
-            {
-                'name': 'NIDIGITAL_VAL_NOT_A_PIN_STATE',
-                'value': 254
-            },
-            {
-                'name': 'NIDIGITAL_VAL_PIN_STATE_NOT_ACQUIRED',
-                'value': 255
-            }
-        ]
-    },
-    'DriveEdgeSetFormat': {
+    'DriveFormat': {
         'values': [
             {
                 'name': 'NIDIGITAL_VAL_NR',
@@ -124,6 +66,26 @@ enums = {
             {
                 'name': 'NIDIGITAL_VAL_SBC',
                 'value': 1503
+            }
+        ]
+    },
+    'ExportSignal': {
+        'values': [
+            {
+                'name': 'NIDIGITAL_VAL_START_TRIGGER',
+                'value': 2000
+            },
+            {
+                'name': 'NIDIGITAL_VAL_CONDITIONAL_JUMP_TRIGGER',
+                'value': 2001
+            },
+            {
+                'name': 'NIDIGITAL_VAL_PATTERN_OPCODE_EVENT',
+                'value': 2002
+            },
+            {
+                'name': 'NIDIGITAL_VAL_REF_CLOCK',
+                'value': 2003
             }
         ]
     },
@@ -164,6 +126,14 @@ enums = {
             {
                 'name': 'NIDIGITAL_VAL_PARALLEL',
                 'value': 3701
+            }
+        ]
+    },
+    'PPMUApertureTimeUnits': {
+        'values': [
+            {
+                'name': 'NIDIGITAL_VAL_SECONDS',
+                'value': 2100
             }
         ]
     },
@@ -216,6 +186,56 @@ enums = {
             {
                 'name': 'NIDIGITAL_VAL_PATTERN_OPCODE_EVENT3',
                 'value': 'patternOpcodeEvent3'
+            }
+        ]
+    },
+    'PinState': {
+        'values': [
+            {
+                'name': 'NIDIGITAL_VAL_0',
+                'python_name': 'ZERO',
+                'value': 0
+            },
+            {
+                'name': 'NIDIGITAL_VAL_1',
+                'python_name': 'ONE',
+                'value': 1
+            },
+            {
+                'name': 'NIDIGITAL_VAL_L',
+                'value': 3
+            },
+            {
+                'name': 'NIDIGITAL_VAL_H',
+                'value': 4
+            },
+            {
+                'name': 'NIDIGITAL_VAL_X',
+                'value': 5
+            },
+            {
+                'name': 'NIDIGITAL_VAL_M',
+                'value': 6
+            },
+            {
+                'name': 'NIDIGITAL_VAL_V',
+                'value': 7
+            },
+            {
+                'name': 'NIDIGITAL_VAL_D',
+                'value': 8
+            },
+            {
+                'name': 'NIDIGITAL_VAL_E',
+                'value': 9
+            },
+            {
+                'name': 'NIDIGITAL_VAL_NOT_A_PIN_STATE',
+                'value': 254
+            },
+            {
+                'name': 'NIDIGITAL_VAL_PIN_STATE_NOT_ACQUIRED',
+                'value': 255
             }
         ]
     },
@@ -327,47 +347,7 @@ enums = {
             }
         ]
     },
-    'SessionState': {
-        'values': [
-            {
-                'name': 'NIDIGITAL_VAL_IDLE',
-                'value': 1
-            },
-            {
-                'name': 'NIDIGITAL_VAL_VERIFIED',
-                'value': 2
-            },
-            {
-                'name': 'NIDIGITAL_VAL_COMMITTED',
-                'value': 4
-            },
-            {
-                'name': 'NIDIGITAL_VAL_RUNNING',
-                'value': 8
-            }
-        ]
-    },
-    'Signal': {
-        'values': [
-            {
-                'name': 'NIDIGITAL_VAL_START_TRIGGER',
-                'value': 2000
-            },
-            {
-                'name': 'NIDIGITAL_VAL_CONDITIONAL_JUMP_TRIGGER',
-                'value': 2001
-            },
-            {
-                'name': 'NIDIGITAL_VAL_PATTERN_OPCODE_EVENT',
-                'value': 2002
-            },
-            {
-                'name': 'NIDIGITAL_VAL_REF_CLOCK',
-                'value': 2003
-            }
-        ]
-    },
-    'SiteResult': {
+    'SiteResultType': {
         'values': [
             {
                 'name': 'NIDIGITAL_VAL_PASS_FAIL',
@@ -379,7 +359,19 @@ enums = {
             }
         ]
     },
-    'SourceMemoryDataMapping': {
+    'SoftwareTrigger': {
+        'values': [
+            {
+                'name': 'NIDIGITAL_VAL_START_TRIGGER',
+                'value': 2000
+            },
+            {
+                'name': 'NIDIGITAL_VAL_CONDITIONAL_JUMP_TRIGGER',
+                'value': 2001
+            }
+        ]
+    },
+    'SourceDataMapping': {
         'values': [
             {
                 'name': 'NIDIGITAL_VAL_BROADCAST',
@@ -403,7 +395,59 @@ enums = {
             }
         ]
     },
-    'Terminal': {
+    'TerminationMode': {
+        'values': [
+            {
+                'name': 'NIDIGITAL_VAL_ACTIVE_LOAD',
+                'value': 1200
+            },
+            {
+                'name': 'NIDIGITAL_VAL_VTERM',
+                'value': 1201
+            },
+            {
+                'name': 'NIDIGITAL_VAL_HIGH_Z',
+                'value': 1202
+            }
+        ]
+    },
+    'TimeSetEdgeType': {
+        'values': [
+            {
+                'name': 'NIDIGITAL_VAL_DRIVE_ON',
+                'value': 2800
+            },
+            {
+                'name': 'NIDIGITAL_VAL_DRIVE_DATA',
+                'value': 2801
+            },
+            {
+                'name': 'NIDIGITAL_VAL_DRIVE_RETURN',
+                'value': 2802
+            },
+            {
+                'name': 'NIDIGITAL_VAL_DRIVE_OFF',
+                'value': 2803
+            },
+            {
+                'name': 'NIDIGITAL_VAL_COMPARE_STROBE',
+                'value': 2804
+            },
+            {
+                'name': 'NIDIGITAL_VAL_DRIVE_DATA2',
+                'value': 2805
+            },
+            {
+                'name': 'NIDIGITAL_VAL_DRIVE_RETURN2',
+                'value': 2806
+            },
+            {
+                'name': 'NIDIGITAL_VAL_COMPARE_STROBE2',
+                'value': 2807
+            }
+        ]
+    },
+    'TriggerTerminal': {
         'values': [
             {
                 'name': 'NIDIGITAL_VAL_DO_NOT_EXPORT_STR',
@@ -443,58 +487,6 @@ enums = {
             }
         ]
     },
-    'TerminationMode': {
-        'values': [
-            {
-                'name': 'NIDIGITAL_VAL_ACTIVE_LOAD',
-                'value': 1200
-            },
-            {
-                'name': 'NIDIGITAL_VAL_VTERM',
-                'value': 1201
-            },
-            {
-                'name': 'NIDIGITAL_VAL_HIGH_Z',
-                'value': 1202
-            }
-        ]
-    },
-    'TimeSetEdge': {
-        'values': [
-            {
-                'name': 'NIDIGITAL_VAL_DRIVE_ON',
-                'value': 2800
-            },
-            {
-                'name': 'NIDIGITAL_VAL_DRIVE_DATA',
-                'value': 2801
-            },
-            {
-                'name': 'NIDIGITAL_VAL_DRIVE_RETURN',
-                'value': 2802
-            },
-            {
-                'name': 'NIDIGITAL_VAL_DRIVE_OFF',
-                'value': 2803
-            },
-            {
-                'name': 'NIDIGITAL_VAL_COMPARE_STROBE',
-                'value': 2804
-            },
-            {
-                'name': 'NIDIGITAL_VAL_DRIVE_DATA2',
-                'value': 2805
-            },
-            {
-                'name': 'NIDIGITAL_VAL_DRIVE_RETURN2',
-                'value': 2806
-            },
-            {
-                'name': 'NIDIGITAL_VAL_COMPARE_STROBE2',
-                'value': 2807
-            }
-        ]
-    },
     'TriggerType': {
         'values': [
             {
@@ -508,6 +500,24 @@ enums = {
             {
                 'name': 'NIDIGITAL_VAL_SOFTWARE',
                 'value': 1702
+            }
+        ]
+    },
+    'WriteStaticPinState': {
+        'values': [
+            {
+                'name': 'NIDIGITAL_VAL_0',
+                'python_name': 'ZERO',
+                'value': 0
+            },
+            {
+                'name': 'NIDIGITAL_VAL_1',
+                'python_name': 'ONE',
+                'value': 1
+            },
+            {
+                'name': 'NIDIGITAL_VAL_X',
+                'value': 5
             }
         ]
     }

--- a/src/nidigital/metadata/functions.py
+++ b/src/nidigital/metadata/functions.py
@@ -396,7 +396,7 @@ functions = {
             },
             {
                 'direction': 'in',
-                'enum': 'DriveEdgeSetFormat',
+                'enum': 'DriveFormat',
                 'name': 'format',
                 'type': 'ViInt32'
             },
@@ -455,7 +455,7 @@ functions = {
             },
             {
                 'direction': 'in',
-                'enum': 'DriveEdgeSetFormat',
+                'enum': 'DriveFormat',
                 'name': 'format',
                 'type': 'ViInt32'
             },
@@ -528,7 +528,7 @@ functions = {
             },
             {
                 'direction': 'in',
-                'enum': 'DriveEdgeSetFormat',
+                'enum': 'DriveFormat',
                 'name': 'driveFormat',
                 'type': 'ViInt32'
             }
@@ -559,7 +559,7 @@ functions = {
             },
             {
                 'direction': 'in',
-                'enum': 'TimeSetEdge',
+                'enum': 'TimeSetEdgeType',
                 'name': 'edge',
                 'type': 'ViInt32'
             },
@@ -808,7 +808,7 @@ functions = {
             },
             {
                 'direction': 'in',
-                'enum': 'SourceMemoryDataMapping',
+                'enum': 'SourceDataMapping',
                 'name': 'dataMapping',
                 'type': 'ViInt32'
             }
@@ -839,7 +839,7 @@ functions = {
             },
             {
                 'direction': 'in',
-                'enum': 'SourceMemoryDataMapping',
+                'enum': 'SourceDataMapping',
                 'name': 'dataMapping',
                 'type': 'ViInt32'
             },
@@ -1100,7 +1100,7 @@ functions = {
             },
             {
                 'direction': 'out',
-                'enum': 'DigitalState',
+                'enum': 'PinState',
                 'name': 'expectedPinStates',
                 'size': {
                     'mechanism': 'ivi-dance-with-a-twist',
@@ -1111,7 +1111,7 @@ functions = {
             },
             {
                 'direction': 'out',
-                'enum': 'DigitalState',
+                'enum': 'PinState',
                 'name': 'actualPinStates',
                 'size': {
                     'mechanism': 'ivi-dance-with-a-twist',
@@ -1555,47 +1555,7 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
-    'GetPatternPinIndexes': {
-        'codegen_method': 'no',
-        'documentation': {
-            'description': 'TBD'
-        },
-        'parameters': [
-            {
-                'direction': 'in',
-                'name': 'vi',
-                'type': 'ViSession'
-            },
-            {
-                'direction': 'in',
-                'name': 'startLabel',
-                'type': 'ViConstString'
-            },
-            {
-                'direction': 'in',
-                'name': 'pinIndexesBufferSize',
-                'type': 'ViInt32'
-            },
-            {
-                'direction': 'out',
-                'name': 'pinIndexes',
-                'size': {
-                    'mechanism': 'ivi-dance-with-a-twist',
-                    'value': 'pinIndexesBufferSize',
-                    'value_twist': 'actualNumPins'
-                },
-                'type': 'ViInt32[]'
-            },
-            {
-                'direction': 'out',
-                'name': 'actualNumPins',
-                'type': 'ViInt32'
-            }
-        ],
-        'returns': 'ViStatus'
-    },
     'GetPatternPinList': {
-        'python_name': 'get_pattern_pin_names',
         'documentation': {
             'description': 'TBD'
         },
@@ -1626,6 +1586,7 @@ functions = {
                 'type': 'ViChar[]'
             }
         ],
+        'python_name': 'get_pattern_pin_names',
         'returns': 'ViStatus'
     },
     'GetPinName': {
@@ -1781,7 +1742,7 @@ functions = {
             },
             {
                 'direction': 'in',
-                'enum': 'SiteResult',
+                'enum': 'SiteResultType',
                 'name': 'siteResultType',
                 'type': 'ViInt32'
             },
@@ -1832,7 +1793,7 @@ functions = {
             },
             {
                 'direction': 'out',
-                'enum': 'DriveEdgeSetFormat',
+                'enum': 'DriveFormat',
                 'name': 'format',
                 'type': 'ViInt32'
             }
@@ -1863,7 +1824,7 @@ functions = {
             },
             {
                 'direction': 'in',
-                'enum': 'TimeSetEdge',
+                'enum': 'TimeSetEdgeType',
                 'name': 'edge',
                 'type': 'ViInt32'
             },
@@ -2311,7 +2272,7 @@ functions = {
             },
             {
                 'direction': 'out',
-                'enum': 'DigitalState',
+                'enum': 'PinState',
                 'name': 'data',
                 'size': {
                     'mechanism': 'ivi-dance-with-a-twist',
@@ -2389,6 +2350,7 @@ functions = {
             },
             {
                 'direction': 'in',
+                'enum': 'SoftwareTrigger',
                 'name': 'trigger',
                 'type': 'ViInt32'
             },
@@ -2844,7 +2806,7 @@ functions = {
             },
             {
                 'direction': 'in',
-                'enum': 'DigitalState',
+                'enum': 'WriteStaticPinState',
                 'name': 'state',
                 'type': 'ViUInt8'
             }

--- a/src/nidigital/metadata/functions_addon.py
+++ b/src/nidigital/metadata/functions_addon.py
@@ -264,12 +264,12 @@ the following information about each pattern cycle:
 -  **scan_cycle_number** (int) Scan cycle number acquired by this History RAM sample. Scan cycle numbers
    start at 0 from the first cycle of the scan vector. Scan cycle numbers are -1 for cycles that do not
    have a scan opcode.
--  **expected_pin_states** (list of list of enums.DigitalState) Pin states as expected by the loaded
+-  **expected_pin_states** (list of list of enums.PinState) Pin states as expected by the loaded
    pattern in the order specified in the pin list. Pins without defined edges in the specified DUT cycle
    will have a value of NIDIGITAL_VAL_PIN_STATE_NOT_ACQUIRED.
    Length of the outer list will be equal to the value of edge multiplier for the given vector.
    Length of the inner list will be equal to the number of pins requested.
--  **actual_pin_states** (list of list of enums.DigitalState) Pin states acquired by History RAM in the
+-  **actual_pin_states** (list of list of enums.PinState) Pin states acquired by History RAM in the
    order specified in the pin list. Pins without defined edges in the specified DUT cycle will have a
    value of NIDIGITAL_VAL_PIN_STATE_NOT_ACQUIRED.
    Length of the outer list will be equal to the value of edge multiplier for the given vector.

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -7,7 +7,7 @@ import numpy
 import pytest
 
 import nidigital
-from nidigital.enums import DigitalState
+from nidigital.enums import PinState
 from nidigital.history_ram_cycle_information import HistoryRAMCycleInformation
 
 instruments = ['PXI1Slot2', 'PXI1Slot5']
@@ -37,9 +37,9 @@ def test_pins_rep_cap(multi_instrument_session):
     multi_instrument_session.create_time_set('t0')
     multi_instrument_session.pins['PinA', 'PinB'].configure_time_set_drive_format(
         time_set='t0',
-        drive_format=nidigital.DriveEdgeSetFormat.RL)
+        drive_format=nidigital.DriveFormat.RL)
     drive_format = multi_instrument_session.pins['PinA', 'PinB'].get_time_set_drive_format(time_set='t0')
-    assert drive_format == nidigital.DriveEdgeSetFormat.RL
+    assert drive_format == nidigital.DriveFormat.RL
 
 
 def test_instruments_rep_cap(multi_instrument_session):
@@ -117,7 +117,7 @@ def test_source_waveform_parallel_broadcast(multi_instrument_session):
 
     multi_instrument_session.pins['LowPins'].create_source_waveform_parallel(
         waveform_name='src_wfm',
-        data_mapping=nidigital.SourceMemoryDataMapping.BROADCAST)
+        data_mapping=nidigital.SourceDataMapping.BROADCAST)
 
     multi_instrument_session.write_source_waveform_broadcast(
         waveform_name='src_wfm',
@@ -158,7 +158,7 @@ def test_source_waveform_parallel_site_unique(multi_instrument_session, source_w
 
     multi_instrument_session.pins['LowPins'].create_source_waveform_parallel(
         waveform_name='src_wfm',
-        data_mapping=nidigital.SourceMemoryDataMapping.SITE_UNIQUE)
+        data_mapping=nidigital.SourceDataMapping.SITE_UNIQUE)
 
     if source_waveform_type == array.array:
         source_waveform = {
@@ -203,7 +203,7 @@ def test_fetch_capture_waveform(multi_instrument_session):
 
     multi_instrument_session.pins['LowPins'].create_source_waveform_parallel(
         waveform_name='src_wfm',
-        data_mapping=nidigital.SourceMemoryDataMapping.BROADCAST)
+        data_mapping=nidigital.SourceDataMapping.BROADCAST)
     source_waveform = [i for i in range(num_samples)]
     multi_instrument_session.write_source_waveform_broadcast(waveform_name='src_wfm', waveform_data=source_waveform)
 
@@ -258,14 +258,13 @@ def test_history_ram_cycle_information_representation():
         vector_number=42,
         cycle_number=999,
         scan_cycle_number=13,
-        expected_pin_states=[[DigitalState.D, DigitalState.D], [DigitalState.V, DigitalState.V]],
-        actual_pin_states=[[DigitalState.PIN_STATE_NOT_ACQUIRED, DigitalState.PIN_STATE_NOT_ACQUIRED], [DigitalState.NOT_A_PIN_STATE, DigitalState.NOT_A_PIN_STATE]],
+        expected_pin_states=[[PinState.D, PinState.D], [PinState.V, PinState.V]],
+        actual_pin_states=[[PinState.PIN_STATE_NOT_ACQUIRED, PinState.PIN_STATE_NOT_ACQUIRED], [PinState.NOT_A_PIN_STATE, PinState.NOT_A_PIN_STATE]],
         per_pin_pass_fail=[[True, True], [False, False]])
     recreated_cycle_info = eval(repr(cycle_info))
     assert str(recreated_cycle_info) == str(cycle_info)
 
 
-@pytest.mark.skip(reason="TODO(sbethur): Enable running on simulated session. GitHub issue #1273")
 def test_fetch_history_ram_cycle_information_position_negative(multi_instrument_session):
     configure_for_history_ram_test(multi_instrument_session)
 
@@ -290,7 +289,6 @@ def configure_for_history_ram_test(session):
     session.sites[1].burst_pattern(start_label='new_pattern')
 
 
-@pytest.mark.skip(reason="TODO(sbethur): Enable running on simulated session. GitHub issue #1273")
 def test_fetch_history_ram_cycle_information_position_out_of_bound(multi_instrument_session):
     configure_for_history_ram_test(multi_instrument_session)
 
@@ -301,7 +299,6 @@ def test_fetch_history_ram_cycle_information_position_out_of_bound(multi_instrum
             samples_to_read=-1)
 
 
-@pytest.mark.skip(reason="TODO(sbethur): Enable running on simulated session. GitHub issue #1273")
 def test_fetch_history_ram_cycle_information_position_last(multi_instrument_session):
     configure_for_history_ram_test(multi_instrument_session)
 
@@ -315,7 +312,6 @@ def test_fetch_history_ram_cycle_information_position_last(multi_instrument_sess
     assert history_ram_cycle_info[0].cycle_number == 11
 
 
-@pytest.mark.skip(reason="TODO(sbethur): Enable running on simulated session. GitHub issue #1273")
 def test_fetch_history_ram_cycle_information_is_finite_invalid(multi_instrument_session):
     configure_for_history_ram_test(multi_instrument_session)
     multi_instrument_session.history_ram_number_of_samples_is_finite = False
@@ -330,7 +326,6 @@ def test_fetch_history_ram_cycle_information_is_finite_invalid(multi_instrument_
             samples_to_read=-1)
 
 
-@pytest.mark.skip(reason="TODO(sbethur): Enable running on simulated session. GitHub issue #1273")
 def test_fetch_history_ram_cycle_information_samples_to_read_too_much(multi_instrument_session):
     configure_for_history_ram_test(multi_instrument_session)
 
@@ -361,7 +356,6 @@ def test_fetch_history_ram_cycle_information_samples_to_read_negative(multi_inst
             samples_to_read=-2)
 
 
-@pytest.mark.skip(reason="TODO(sbethur): Enable running on simulated session. GitHub issue #1273")
 def test_fetch_history_ram_cycle_information_samples_to_read_zero(multi_instrument_session):
     configure_for_history_ram_test(multi_instrument_session)
 
@@ -373,7 +367,6 @@ def test_fetch_history_ram_cycle_information_samples_to_read_zero(multi_instrume
     assert len(history_ram_cycle_info) == 0
 
 
-@pytest.mark.skip(reason="TODO(sbethur): Enable running on simulated session. GitHub issue #1273")
 def test_fetch_history_ram_cycle_information_samples_to_read_all(multi_instrument_session):
     configure_for_history_ram_test(multi_instrument_session)
 
@@ -402,32 +395,32 @@ def test_fetch_history_ram_cycle_information_samples_to_read_all(multi_instrumen
 
     expected_pin_states = [i.expected_pin_states for i in history_ram_cycle_info]
     assert expected_pin_states == [
-        [[DigitalState.ZERO, DigitalState.H, DigitalState.X, DigitalState.X, DigitalState.H, DigitalState.ZERO, DigitalState.X, DigitalState.X]],
-        [[DigitalState.X, DigitalState.X, DigitalState.ZERO, DigitalState.ONE, DigitalState.X, DigitalState.X, DigitalState.L, DigitalState.H]],
-        [[DigitalState.X, DigitalState.X, DigitalState.ONE, DigitalState.ZERO, DigitalState.X, DigitalState.X, DigitalState.H, DigitalState.L]],
-        [[DigitalState.ONE, DigitalState.ONE, DigitalState.X, DigitalState.X, DigitalState.H, DigitalState.H, DigitalState.X, DigitalState.X], [DigitalState.ZERO, DigitalState.ZERO, DigitalState.X, DigitalState.X, DigitalState.L, DigitalState.L, DigitalState.X, DigitalState.X]],
-        [[DigitalState.ONE, DigitalState.ONE, DigitalState.X, DigitalState.X, DigitalState.H, DigitalState.H, DigitalState.X, DigitalState.X], [DigitalState.ZERO, DigitalState.ZERO, DigitalState.X, DigitalState.X, DigitalState.L, DigitalState.L, DigitalState.X, DigitalState.X]],
-        [[DigitalState.ZERO, DigitalState.ONE, DigitalState.X, DigitalState.X, DigitalState.L, DigitalState.H, DigitalState.X, DigitalState.X], [DigitalState.ONE, DigitalState.ZERO, DigitalState.X, DigitalState.X, DigitalState.H, DigitalState.L, DigitalState.X, DigitalState.X]],
-        [[DigitalState.X, DigitalState.X, DigitalState.X, DigitalState.X, DigitalState.X, DigitalState.X, DigitalState.X, DigitalState.X]]
+        [[PinState.ZERO, PinState.H, PinState.X, PinState.X, PinState.H, PinState.ZERO, PinState.X, PinState.X]],
+        [[PinState.X, PinState.X, PinState.ZERO, PinState.ONE, PinState.X, PinState.X, PinState.L, PinState.H]],
+        [[PinState.X, PinState.X, PinState.ONE, PinState.ZERO, PinState.X, PinState.X, PinState.H, PinState.L]],
+        [[PinState.ONE, PinState.ONE, PinState.X, PinState.X, PinState.H, PinState.H, PinState.X, PinState.X], [PinState.ZERO, PinState.ZERO, PinState.X, PinState.X, PinState.L, PinState.L, PinState.X, PinState.X]],
+        [[PinState.ONE, PinState.ONE, PinState.X, PinState.X, PinState.H, PinState.H, PinState.X, PinState.X], [PinState.ZERO, PinState.ZERO, PinState.X, PinState.X, PinState.L, PinState.L, PinState.X, PinState.X]],
+        [[PinState.ZERO, PinState.ONE, PinState.X, PinState.X, PinState.L, PinState.H, PinState.X, PinState.X], [PinState.ONE, PinState.ZERO, PinState.X, PinState.X, PinState.H, PinState.L, PinState.X, PinState.X]],
+        [[PinState.X, PinState.X, PinState.X, PinState.X, PinState.X, PinState.X, PinState.X, PinState.X]]
     ]
 
     # If test expects actual pin state to be 'X', then value returned by the returned can be anything.
     # So, need to skip those pin states while comparing.
     actual_pin_states = [i.actual_pin_states for i in history_ram_cycle_info]
     actual_pin_states_expected_by_test = [
-        [[DigitalState.L, DigitalState.L, DigitalState.X, DigitalState.X, DigitalState.L, DigitalState.L, DigitalState.X, DigitalState.X]],
-        [[DigitalState.X, DigitalState.X, DigitalState.L, DigitalState.H, DigitalState.X, DigitalState.X, DigitalState.L, DigitalState.H]],
-        [[DigitalState.X, DigitalState.X, DigitalState.H, DigitalState.L, DigitalState.X, DigitalState.X, DigitalState.H, DigitalState.L]],
-        [[DigitalState.H, DigitalState.H, DigitalState.X, DigitalState.X, DigitalState.H, DigitalState.H, DigitalState.X, DigitalState.X], [DigitalState.L, DigitalState.L, DigitalState.X, DigitalState.X, DigitalState.L, DigitalState.L, DigitalState.X, DigitalState.X]],
-        [[DigitalState.H, DigitalState.H, DigitalState.X, DigitalState.X, DigitalState.H, DigitalState.H, DigitalState.X, DigitalState.X], [DigitalState.L, DigitalState.L, DigitalState.X, DigitalState.X, DigitalState.L, DigitalState.L, DigitalState.X, DigitalState.X]],
-        [[DigitalState.L, DigitalState.H, DigitalState.X, DigitalState.X, DigitalState.L, DigitalState.H, DigitalState.X, DigitalState.X], [DigitalState.H, DigitalState.L, DigitalState.X, DigitalState.X, DigitalState.H, DigitalState.L, DigitalState.X, DigitalState.X]],
-        [[DigitalState.X, DigitalState.X, DigitalState.X, DigitalState.X, DigitalState.X, DigitalState.X, DigitalState.X, DigitalState.X]]
+        [[PinState.L, PinState.L, PinState.X, PinState.X, PinState.L, PinState.L, PinState.X, PinState.X]],
+        [[PinState.X, PinState.X, PinState.L, PinState.H, PinState.X, PinState.X, PinState.L, PinState.H]],
+        [[PinState.X, PinState.X, PinState.H, PinState.L, PinState.X, PinState.X, PinState.H, PinState.L]],
+        [[PinState.H, PinState.H, PinState.X, PinState.X, PinState.H, PinState.H, PinState.X, PinState.X], [PinState.L, PinState.L, PinState.X, PinState.X, PinState.L, PinState.L, PinState.X, PinState.X]],
+        [[PinState.H, PinState.H, PinState.X, PinState.X, PinState.H, PinState.H, PinState.X, PinState.X], [PinState.L, PinState.L, PinState.X, PinState.X, PinState.L, PinState.L, PinState.X, PinState.X]],
+        [[PinState.L, PinState.H, PinState.X, PinState.X, PinState.L, PinState.H, PinState.X, PinState.X], [PinState.H, PinState.L, PinState.X, PinState.X, PinState.H, PinState.L, PinState.X, PinState.X]],
+        [[PinState.X, PinState.X, PinState.X, PinState.X, PinState.X, PinState.X, PinState.X, PinState.X]]
     ]
     assert len(actual_pin_states) == len(actual_pin_states_expected_by_test)
     for vector_pin_states, vector_pin_states_expected_by_test in zip(actual_pin_states, actual_pin_states_expected_by_test):
         for cycle_pin_states, cycle_pin_states_expected_by_test in zip(vector_pin_states, vector_pin_states_expected_by_test):
             for pin_state, pin_state_expected_by_test in zip(cycle_pin_states, cycle_pin_states_expected_by_test):
-                if pin_state_expected_by_test is not DigitalState.X:
+                if pin_state_expected_by_test is not PinState.X:
                     assert pin_state == pin_state_expected_by_test
 
     # Only the first cycle returned is expected to have failures

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -265,6 +265,7 @@ def test_history_ram_cycle_information_representation():
     assert str(recreated_cycle_info) == str(cycle_info)
 
 
+@pytest.mark.skip(reason="TODO(sbethur): Enable running on simulated session. GitHub issue #1273")
 def test_fetch_history_ram_cycle_information_position_negative(multi_instrument_session):
     configure_for_history_ram_test(multi_instrument_session)
 
@@ -289,6 +290,7 @@ def configure_for_history_ram_test(session):
     session.sites[1].burst_pattern(start_label='new_pattern')
 
 
+@pytest.mark.skip(reason="TODO(sbethur): Enable running on simulated session. GitHub issue #1273")
 def test_fetch_history_ram_cycle_information_position_out_of_bound(multi_instrument_session):
     configure_for_history_ram_test(multi_instrument_session)
 
@@ -299,6 +301,7 @@ def test_fetch_history_ram_cycle_information_position_out_of_bound(multi_instrum
             samples_to_read=-1)
 
 
+@pytest.mark.skip(reason="TODO(sbethur): Enable running on simulated session. GitHub issue #1273")
 def test_fetch_history_ram_cycle_information_position_last(multi_instrument_session):
     configure_for_history_ram_test(multi_instrument_session)
 
@@ -312,6 +315,7 @@ def test_fetch_history_ram_cycle_information_position_last(multi_instrument_sess
     assert history_ram_cycle_info[0].cycle_number == 11
 
 
+@pytest.mark.skip(reason="TODO(sbethur): Enable running on simulated session. GitHub issue #1273")
 def test_fetch_history_ram_cycle_information_is_finite_invalid(multi_instrument_session):
     configure_for_history_ram_test(multi_instrument_session)
     multi_instrument_session.history_ram_number_of_samples_is_finite = False
@@ -326,6 +330,7 @@ def test_fetch_history_ram_cycle_information_is_finite_invalid(multi_instrument_
             samples_to_read=-1)
 
 
+@pytest.mark.skip(reason="TODO(sbethur): Enable running on simulated session. GitHub issue #1273")
 def test_fetch_history_ram_cycle_information_samples_to_read_too_much(multi_instrument_session):
     configure_for_history_ram_test(multi_instrument_session)
 
@@ -356,6 +361,7 @@ def test_fetch_history_ram_cycle_information_samples_to_read_negative(multi_inst
             samples_to_read=-2)
 
 
+@pytest.mark.skip(reason="TODO(sbethur): Enable running on simulated session. GitHub issue #1273")
 def test_fetch_history_ram_cycle_information_samples_to_read_zero(multi_instrument_session):
     configure_for_history_ram_test(multi_instrument_session)
 
@@ -367,6 +373,7 @@ def test_fetch_history_ram_cycle_information_samples_to_read_zero(multi_instrume
     assert len(history_ram_cycle_info) == 0
 
 
+@pytest.mark.skip(reason="TODO(sbethur): Enable running on simulated session. GitHub issue #1273")
 def test_fetch_history_ram_cycle_information_samples_to_read_all(multi_instrument_session):
     configure_for_history_ram_test(multi_instrument_session)
 

--- a/src/nidigital/templates/session.py/fancy_fetch_capture_waveform.py.mako
+++ b/src/nidigital/templates/session.py/fancy_fetch_capture_waveform.py.mako
@@ -36,7 +36,7 @@
         data, actual_num_waveforms, actual_samples_per_waveform = self._fetch_capture_waveform(waveform_name, samples_to_read, timeout)
 
         # Get the site list
-        site_list = self.get_site_results_site_numbers(enums.SiteResult.CAPTURE_WAVEFORM)
+        site_list = self.get_site_results_site_numbers(enums.SiteResultType.CAPTURE_WAVEFORM)
         assert len(site_list) == actual_num_waveforms
 
         waveforms = {}

--- a/src/nidigital/templates/session.py/fancy_get_site_pass_fail.py.mako
+++ b/src/nidigital/templates/session.py/fancy_get_site_pass_fail.py.mako
@@ -11,7 +11,7 @@
         '''
         # For site_list, we just use the repeated capability
         result_list = self._get_site_pass_fail()
-        site_list = self.get_site_results_site_numbers(enums.SiteResult.PASS_FAIL)
+        site_list = self.get_site_results_site_numbers(enums.SiteResultType.PASS_FAIL)
         assert len(site_list) == len(result_list)
 
         return dict(zip(site_list, result_list))


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

- [x] I've added tests applicable for this pull request.

### What does this Pull Request accomplish?

Update enum types in nidigital to match the API in other ADEs:
- Update the names of many enum types.
- Added `WriteStaticPinState` enum type and changed the parameter type of `write_static` method to the newly added enum.
- Added `SoftwareTrigger` enum type and changed the parameter type of `send_software_edge_trigger` method to the newly added enum.
- Removed `SessionState` enum type from metadata.

Note: Internal metadata is being updated in an internal changelist.

### List issues fixed by this Pull Request below, if any.

* Fix #1330 

### What testing has been done?

Updated API methods in system tests to use the updated enum types and ran system tests successfully.