### PR TITLE
Remove get_site_results_site_numbers() and SiteResultType enum from public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to this project will be documented in this file.
             * Added `SoftwareTrigger` enum type and changed the parameter type of `send_software_edge_trigger` method to the newly added enum.
     * #### Removed
         * `get_pattern_pin_list`, `get_pattern_pin_indexes` and `get_pin_name` - [#1292](https://github.com/ni/nimi-python/issues/1292)
+        * `get_site_results_site_numbers` method and `SiteResultType` enum - [#1298](https://github.com/ni/nimi-python/issues/1298) 
 * ### NI-DMM
     * #### Added
     * #### Changed

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -1490,40 +1490,6 @@ get_site_pass_fail
 
 
 
-get_site_results_site_numbers
------------------------------
-
-    .. py:currentmodule:: nidigital.Session
-
-    .. py:method:: get_site_results_site_numbers(site_result_type)
-
-            TBD
-
-            
-
-
-            .. tip:: This method requires repeated capabilities. If called directly on the
-                nidigital.Session object, then the method will use all repeated capabilities in the session.
-                You can specify a subset of repeated capabilities using the Python index notation on an
-                nidigital.Session repeated capabilities container, and calling this method on the result.
-
-
-            :param site_result_type:
-
-
-                
-
-
-            :type site_result_type: :py:data:`nidigital.SiteResultType`
-
-            :rtype: list of int
-            :return:
-
-
-                    
-
-
-
 get_time_set_drive_format
 -------------------------
 

--- a/docs/nidigital/enums.rst
+++ b/docs/nidigital/enums.rst
@@ -287,19 +287,6 @@ SequencerRegister
 
 
 
-SiteResultType
---------------
-
-.. py:class:: SiteResultType
-
-    .. py:attribute:: SiteResultType.PASS_FAIL
-
-
-
-    .. py:attribute:: SiteResultType.CAPTURE_WAVEFORM
-
-
-
 SoftwareTrigger
 ---------------
 

--- a/generated/nidigital/nidigital/enums.py
+++ b/generated/nidigital/nidigital/enums.py
@@ -97,7 +97,7 @@ class SequencerRegister(Enum):
     REGISTER15 = 'reg15'
 
 
-class SiteResultType(Enum):
+class _SiteResultType(Enum):
     PASS_FAIL = 3300
     CAPTURE_WAVEFORM = 3301
 

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -1260,7 +1260,7 @@ class _SessionBase(object):
         data, actual_num_waveforms, actual_samples_per_waveform = self._fetch_capture_waveform(waveform_name, samples_to_read, timeout)
 
         # Get the site list
-        site_list = self.get_site_results_site_numbers(enums.SiteResultType.CAPTURE_WAVEFORM)
+        site_list = self._get_site_results_site_numbers(enums._SiteResultType.CAPTURE_WAVEFORM)
         assert len(site_list) == actual_num_waveforms
 
         waveforms = {}
@@ -1454,7 +1454,7 @@ class _SessionBase(object):
         '''
         # For site_list, we just use the repeated capability
         result_list = self._get_site_pass_fail()
-        site_list = self.get_site_results_site_numbers(enums.SiteResultType.PASS_FAIL)
+        site_list = self._get_site_results_site_numbers(enums._SiteResultType.PASS_FAIL)
         assert len(site_list) == len(result_list)
 
         return dict(zip(site_list, result_list))
@@ -1861,8 +1861,8 @@ class _SessionBase(object):
         return [bool(pass_fail_ctype[i]) for i in range(pass_fail_buffer_size_ctype.value)]
 
     @ivi_synchronized
-    def get_site_results_site_numbers(self, site_result_type):
-        r'''get_site_results_site_numbers
+    def _get_site_results_site_numbers(self, site_result_type):
+        r'''_get_site_results_site_numbers
 
         TBD
 
@@ -1880,8 +1880,8 @@ class _SessionBase(object):
             site_numbers (list of int):
 
         '''
-        if type(site_result_type) is not enums.SiteResultType:
-            raise TypeError('Parameter site_result_type must be of type ' + str(enums.SiteResultType))
+        if type(site_result_type) is not enums._SiteResultType:
+            raise TypeError('Parameter site_result_type must be of type ' + str(enums._SiteResultType))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         site_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         site_result_type_ctype = _visatype.ViInt32(site_result_type.value)  # case S130

--- a/src/nidigital/metadata/functions.py
+++ b/src/nidigital/metadata/functions.py
@@ -1725,6 +1725,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'GetSiteResultsSiteNumbers': {
+        'codegen_method': 'private',
         'documentation': {
             'description': 'TBD'
         },

--- a/src/nidigital/templates/session.py/fancy_fetch_capture_waveform.py.mako
+++ b/src/nidigital/templates/session.py/fancy_fetch_capture_waveform.py.mako
@@ -36,7 +36,7 @@
         data, actual_num_waveforms, actual_samples_per_waveform = self._fetch_capture_waveform(waveform_name, samples_to_read, timeout)
 
         # Get the site list
-        site_list = self.get_site_results_site_numbers(enums.SiteResultType.CAPTURE_WAVEFORM)
+        site_list = self._get_site_results_site_numbers(enums._SiteResultType.CAPTURE_WAVEFORM)
         assert len(site_list) == actual_num_waveforms
 
         waveforms = {}

--- a/src/nidigital/templates/session.py/fancy_get_site_pass_fail.py.mako
+++ b/src/nidigital/templates/session.py/fancy_get_site_pass_fail.py.mako
@@ -11,7 +11,7 @@
         '''
         # For site_list, we just use the repeated capability
         result_list = self._get_site_pass_fail()
-        site_list = self.get_site_results_site_numbers(enums.SiteResultType.PASS_FAIL)
+        site_list = self._get_site_results_site_numbers(enums._SiteResultType.PASS_FAIL)
         assert len(site_list) == len(result_list)
 
         return dict(zip(site_list, result_list))


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

Remove get_site_results_site_numbers() and SiteResultType enum from public API. Users do not need to use this method since site numbers are included in the data returned by get_site_pass_fail() and fetch_capture_waveform().

### List issues fixed by this Pull Request below, if any.

* Fix #1298 

### What testing has been done?

Ran system tests that indirectly call removed method and enum.