### PR TITLE
Fix/cleanup invocation of coverage tool in tox scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ generated/*/coverage.xml
 .eggs/
 .tox/
 .coverage
+nidigitalunittest.xml
 nifakeunittest.xml
 nimodinstunittest.xml
 nitclkunittest.xml

--- a/tox-travis.ini
+++ b/tox-travis.ini
@@ -36,31 +36,39 @@ changedir =
     flake8: .
     pkg: .
 
-# We touch .coverage first to ensure the files exists, then remove it.
 commands =
     build_test: python --version
     build_test: python -c "import platform; print(platform.architecture())"
     build_test: python -m pip install --disable-pip-version-check --upgrade pip
     build_test: python -m pip list
     build_test: coverage run --rcfile=tools/coverage_unit_tests.rc --source build.helper -m py.test --pyargs build.helper
-    build_test: coverage report --rcfile=tools/coverage_unit_tests.rc
+    # Display the report on console
+    build_test: coverage report
     # Create the report to upload
-    build_test: coverage xml -i --rcfile=tools/coverage_system_tests.rc -o codegen.xml
+    build_test: coverage xml -o codegen.xml
+    # Save the report
+    build_test: coverage html --directory=generated/htmlcov/unit_tests/codegen
     build_test: flake8 --config=./tox.ini build/
     test: python --version
     test: python -c "import platform; print(platform.architecture())"
     test: python -m pip install --disable-pip-version-check --upgrade pip
     test: python tools/install_local_wheel.py --driver nitclk
     test: coverage run --rcfile=tools/coverage_unit_tests.rc --source nifake -m py.test generated/nifake/nifake {posargs} -s
-    test: coverage xml -i --rcfile=tools/coverage_system_tests.rc -o nifakeunittest.xml
-    test: coverage run --rcfile=tools/coverage_unit_tests.rc --append --source nidigital -m py.test generated/nidigital/nidigital {posargs} -s
-    test: coverage xml -i --rcfile=tools/coverage_system_tests.rc -o nidigitalunittest.xml
-    test: coverage run --rcfile=tools/coverage_unit_tests.rc --append --source nimodinst -m py.test generated/nimodinst/nimodinst {posargs} -s
-    test: coverage xml -i --rcfile=tools/coverage_system_tests.rc -o nimodinstunittest.xml
-    test: coverage run --rcfile=tools/coverage_unit_tests.rc --append --source nitclk -m py.test generated/nitclk/nitclk {posargs} -s
-    test: coverage xml -i --rcfile=tools/coverage_system_tests.rc -o nitclkunittest.xml
-    test: coverage report --rcfile=tools/coverage_unit_tests.rc
-    test: coverage html --rcfile=tools/coverage_unit_tests.rc  --directory=generated/htmlcov/unit_tests
+    test: coverage report
+    test: coverage xml -o nifakeunittest.xml
+    test: coverage html --directory=generated/htmlcov/unit_tests/nifake
+    test: coverage run --rcfile=tools/coverage_unit_tests.rc --source nidigital -m py.test generated/nidigital/nidigital {posargs} -s
+    test: coverage report
+    test: coverage xml -o nidigitalunittest.xml
+    test: coverage html --directory=generated/htmlcov/unit_tests/nidigital
+    test: coverage run --rcfile=tools/coverage_unit_tests.rc --source nimodinst -m py.test generated/nimodinst/nimodinst {posargs} -s
+    test: coverage report
+    test: coverage xml -o nimodinstunittest.xml
+    test: coverage html --directory=generated/htmlcov/unit_tests/nimodinst
+    test: coverage run --rcfile=tools/coverage_unit_tests.rc --source nitclk -m py.test generated/nitclk/nitclk {posargs} -s
+    test: coverage report
+    test: coverage xml -o nitclkunittest.xml
+    test: coverage html --directory=generated/htmlcov/unit_tests/nitclk
     clean: python --version
     clean: python -c "import platform; print(platform.architecture())"
     clean: make clean {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -36,31 +36,39 @@ changedir =
     flake8: .
     pkg: .
 
-# We touch .coverage first to ensure the files exists, then remove it.
 commands =
     build_test: python --version
     build_test: python -c "import platform; print(platform.architecture())"
     build_test: python -m pip install --disable-pip-version-check --upgrade pip
     build_test: python -m pip list
     build_test: coverage run --rcfile=tools/coverage_unit_tests.rc --source build.helper -m py.test --pyargs build.helper
-    build_test: coverage report --rcfile=tools/coverage_unit_tests.rc
+    # Display the report on console
+    build_test: coverage report
     # Create the report to upload
-    build_test: coverage xml -i --rcfile=tools/coverage_system_tests.rc -o codegen.xml
+    build_test: coverage xml -o codegen.xml
+    # Save the report
+    build_test: coverage html --directory=generated/htmlcov/unit_tests/codegen
     build_test: flake8 --config=./tox.ini build/
     test: python --version
     test: python -c "import platform; print(platform.architecture())"
     test: python -m pip install --disable-pip-version-check --upgrade pip
     test: python tools/install_local_wheel.py --driver nitclk
     test: coverage run --rcfile=tools/coverage_unit_tests.rc --source nifake -m py.test generated/nifake/nifake {posargs} -s
-    test: coverage xml -i --rcfile=tools/coverage_system_tests.rc -o nifakeunittest.xml
-    test: coverage run --rcfile=tools/coverage_unit_tests.rc --append --source nidigital -m py.test generated/nidigital/nidigital {posargs} -s
-    test: coverage xml -i --rcfile=tools/coverage_system_tests.rc -o nidigitalunittest.xml
-    test: coverage run --rcfile=tools/coverage_unit_tests.rc --append --source nimodinst -m py.test generated/nimodinst/nimodinst {posargs} -s
-    test: coverage xml -i --rcfile=tools/coverage_system_tests.rc -o nimodinstunittest.xml
-    test: coverage run --rcfile=tools/coverage_unit_tests.rc --append --source nitclk -m py.test generated/nitclk/nitclk {posargs} -s
-    test: coverage xml -i --rcfile=tools/coverage_system_tests.rc -o nitclkunittest.xml
-    test: coverage report --rcfile=tools/coverage_unit_tests.rc
-    test: coverage html --rcfile=tools/coverage_unit_tests.rc  --directory=generated/htmlcov/unit_tests
+    test: coverage report
+    test: coverage xml -o nifakeunittest.xml
+    test: coverage html --directory=generated/htmlcov/unit_tests/nifake
+    test: coverage run --rcfile=tools/coverage_unit_tests.rc --source nidigital -m py.test generated/nidigital/nidigital {posargs} -s
+    test: coverage report
+    test: coverage xml -o nidigitalunittest.xml
+    test: coverage html --directory=generated/htmlcov/unit_tests/nidigital
+    test: coverage run --rcfile=tools/coverage_unit_tests.rc --source nimodinst -m py.test generated/nimodinst/nimodinst {posargs} -s
+    test: coverage report
+    test: coverage xml -o nimodinstunittest.xml
+    test: coverage html --directory=generated/htmlcov/unit_tests/nimodinst
+    test: coverage run --rcfile=tools/coverage_unit_tests.rc --source nitclk -m py.test generated/nitclk/nitclk {posargs} -s
+    test: coverage report
+    test: coverage xml -o nitclkunittest.xml
+    test: coverage html --directory=generated/htmlcov/unit_tests/nitclk
     clean: python --version
     clean: python -c "import platform; print(platform.architecture())"
     clean: make clean {posargs}


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

- Remove --append flag for "coverage run" since the flag was causing coverage to be double/triple counted.
- Create separate HTML coverage reports for different unit tests. Needed to separate since --append flag was removed.
- Remove --rcfile flag from "report", "xml", and "html" commands since it is not used.
- Remove -i (ignore errors) flag for "coverage xml" since there are no errors.
- Delete outdated comments and add useful comments.

### List issues fixed by this Pull Request below, if any.

* Fix #1355 

### What testing has been done?

Visual inspection of generated coverage report files