### PR TITLE
Remove reset_attribute() from nidigital API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to this project will be documented in this file.
     * #### Removed
         * `get_pattern_pin_list`, `get_pattern_pin_indexes` and `get_pin_name` - [#1292](https://github.com/ni/nimi-python/issues/1292)
         * `get_site_results_site_numbers` method and `SiteResultType` enum - [#1298](https://github.com/ni/nimi-python/issues/1298) 
+        * `reset_attribute` - [#1364](https://github.com/ni/nimi-python/issues/1364) 
 * ### NI-DMM
     * #### Added
     * #### Changed

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -2016,32 +2016,6 @@ reset
 
 
 
-reset_attribute
----------------
-
-    .. py:currentmodule:: nidigital.Session
-
-    .. py:method:: reset_attribute(attribute_id)
-
-            TBD
-
-            
-
-
-            .. tip:: This method requires repeated capabilities. If called directly on the
-                nidigital.Session object, then the method will use all repeated capabilities in the session.
-                You can specify a subset of repeated capabilities using the Python index notation on an
-                nidigital.Session repeated capabilities container, and calling this method on the result.
-
-
-            :param attribute_id:
-
-
-                
-
-
-            :type attribute_id: int
-
 reset_device
 ------------
 

--- a/generated/nidigital/nidigital/_library.py
+++ b/generated/nidigital/nidigital/_library.py
@@ -92,7 +92,6 @@ class Library(object):
         self.niDigital_ReadSequencerFlag_cfunc = None
         self.niDigital_ReadSequencerRegister_cfunc = None
         self.niDigital_ReadStatic_cfunc = None
-        self.niDigital_ResetAttribute_cfunc = None
         self.niDigital_ResetDevice_cfunc = None
         self.niDigital_SelfCalibrate_cfunc = None
         self.niDigital_SendSoftwareEdgeTrigger_cfunc = None
@@ -692,14 +691,6 @@ class Library(object):
                 self.niDigital_ReadStatic_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViUInt8), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_ReadStatic_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ReadStatic_cfunc(vi, channel_list, buffer_size, data, actual_num_read)
-
-    def niDigital_ResetAttribute(self, vi, channel_name, attribute_id):  # noqa: N802
-        with self._func_lock:
-            if self.niDigital_ResetAttribute_cfunc is None:
-                self.niDigital_ResetAttribute_cfunc = self._library.niDigital_ResetAttribute
-                self.niDigital_ResetAttribute_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr]  # noqa: F405
-                self.niDigital_ResetAttribute_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDigital_ResetAttribute_cfunc(vi, channel_name, attribute_id)
 
     def niDigital_ResetDevice(self, vi):  # noqa: N802
         with self._func_lock:

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -2316,29 +2316,6 @@ class _SessionBase(object):
         return [enums.PinState(data_ctype[i]) for i in range(buffer_size_ctype.value)]
 
     @ivi_synchronized
-    def reset_attribute(self, attribute_id):
-        r'''reset_attribute
-
-        TBD
-
-        Tip:
-        This method requires repeated capabilities. If called directly on the
-        nidigital.Session object, then the method will use all repeated capabilities in the session.
-        You can specify a subset of repeated capabilities using the Python index notation on an
-        nidigital.Session repeated capabilities container, and calling this method on the result.
-
-        Args:
-            attribute_id (int):
-
-        '''
-        vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        channel_name_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
-        attribute_id_ctype = _visatype.ViAttr(attribute_id)  # case S150
-        error_code = self._library.niDigital_ResetAttribute(vi_ctype, channel_name_ctype, attribute_id_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return
-
-    @ivi_synchronized
     def _set_attribute_vi_boolean(self, attribute, value):
         r'''_set_attribute_vi_boolean
 

--- a/generated/nidigital/nidigital/unit_tests/_mock_helper.py
+++ b/generated/nidigital/nidigital/unit_tests/_mock_helper.py
@@ -208,8 +208,6 @@ class SideEffectsHelper(object):
         self._defaults['ReadStatic']['return'] = 0
         self._defaults['ReadStatic']['actualNumRead'] = None
         self._defaults['ReadStatic']['data'] = None
-        self._defaults['ResetAttribute'] = {}
-        self._defaults['ResetAttribute']['return'] = 0
         self._defaults['ResetDevice'] = {}
         self._defaults['ResetDevice']['return'] = 0
         self._defaults['SelfCalibrate'] = {}
@@ -934,11 +932,6 @@ class SideEffectsHelper(object):
             data_ref[i] = self._defaults['ReadStatic']['data'][i]
         return self._defaults['ReadStatic']['return']
 
-    def niDigital_ResetAttribute(self, vi, channel_name, attribute_id):  # noqa: N802
-        if self._defaults['ResetAttribute']['return'] != 0:
-            return self._defaults['ResetAttribute']['return']
-        return self._defaults['ResetAttribute']['return']
-
     def niDigital_ResetDevice(self, vi):  # noqa: N802
         if self._defaults['ResetDevice']['return'] != 0:
             return self._defaults['ResetDevice']['return']
@@ -1241,8 +1234,6 @@ class SideEffectsHelper(object):
         mock_library.niDigital_ReadSequencerRegister.return_value = 0
         mock_library.niDigital_ReadStatic.side_effect = MockFunctionCallError("niDigital_ReadStatic")
         mock_library.niDigital_ReadStatic.return_value = 0
-        mock_library.niDigital_ResetAttribute.side_effect = MockFunctionCallError("niDigital_ResetAttribute")
-        mock_library.niDigital_ResetAttribute.return_value = 0
         mock_library.niDigital_ResetDevice.side_effect = MockFunctionCallError("niDigital_ResetDevice")
         mock_library.niDigital_ResetDevice.return_value = 0
         mock_library.niDigital_SelfCalibrate.side_effect = MockFunctionCallError("niDigital_SelfCalibrate")

--- a/src/nidigital/metadata/functions.py
+++ b/src/nidigital/metadata/functions.py
@@ -2298,6 +2298,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'ResetAttribute': {
+        'codegen_method': 'no',
         'documentation': {
             'description': 'TBD'
         },


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Remove `reset_attribute()` from nidigital API.

### List issues fixed by this Pull Request below, if any.

* Fix #1364 

### What testing has been done?

Ran existing unit and system tests