### PR TITLE
Use 54x3 in get_hardware_state test

### DIFF
--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -185,7 +185,7 @@ def test_get_ext_cal_recommended_interval(session):
 
 
 def test_get_hardware_state(session):
-    assert session_5421.get_hardware_state() == nifgen.HardwareState.IDLE
+    assert session.get_hardware_state() == nifgen.HardwareState.IDLE
 
 
 def test_get_self_cal_last_temp(session):

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -184,7 +184,7 @@ def test_get_ext_cal_recommended_interval(session):
     assert interval.days == 730  # recommended external cal interval is 24 months
 
 
-def test_get_hardware_state(session_5421):
+def test_get_hardware_state(session):
     assert session_5421.get_hardware_state() == nifgen.HardwareState.IDLE
 
 


### PR DESCRIPTION
Use this device which is a lot faster to simulate and doesn't require synchronization.

- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [ ] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~

- [X] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

Uses 54x3 instead of 5421 in `test_get_hardware_state`. Support was added in NI-FGEN 17.8.
Using 54x3 is preferrable because simulated sessions open much faster, and because we don't need to synchronize opening/closing those sessions in order to workaround driver bugs.

### List issues fixed by this Pull Request below, if any.

None

### What testing has been done?

Let nimi-bot run the system test.