### PR TITLE
Remove clock_generator_initiate() from nidigital API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to this project will be documented in this file.
         * `get_pattern_pin_list`, `get_pattern_pin_indexes` and `get_pin_name` - [#1292](https://github.com/ni/nimi-python/issues/1292)
         * `get_site_results_site_numbers` method and `SiteResultType` enum - [#1298](https://github.com/ni/nimi-python/issues/1298) 
         * `reset_attribute` - [#1364](https://github.com/ni/nimi-python/issues/1364) 
+        * `clock_generator_initiate` - [#1370](https://github.com/ni/nimi-python/issues/1370) 
 * ### NI-DMM
     * #### Added
     * #### Changed

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -307,24 +307,6 @@ clock_generator_generate_clock
 
             :type select_digital_function: bool
 
-clock_generator_initiate
-------------------------
-
-    .. py:currentmodule:: nidigital.Session
-
-    .. py:method:: clock_generator_initiate()
-
-            TBD
-
-            
-
-
-            .. tip:: This method requires repeated capabilities. If called directly on the
-                nidigital.Session object, then the method will use all repeated capabilities in the session.
-                You can specify a subset of repeated capabilities using the Python index notation on an
-                nidigital.Session repeated capabilities container, and calling this method on the result.
-
-
 close
 -----
 

--- a/generated/nidigital/nidigital/_library.py
+++ b/generated/nidigital/nidigital/_library.py
@@ -28,7 +28,6 @@ class Library(object):
         self.niDigital_ClearError_cfunc = None
         self.niDigital_ClockGenerator_Abort_cfunc = None
         self.niDigital_ClockGenerator_GenerateClock_cfunc = None
-        self.niDigital_ClockGenerator_Initiate_cfunc = None
         self.niDigital_Commit_cfunc = None
         self.niDigital_ConfigureActiveLoadLevels_cfunc = None
         self.niDigital_ConfigurePatternBurstSites_cfunc = None
@@ -179,14 +178,6 @@ class Library(object):
                 self.niDigital_ClockGenerator_GenerateClock_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViBoolean]  # noqa: F405
                 self.niDigital_ClockGenerator_GenerateClock_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ClockGenerator_GenerateClock_cfunc(vi, channel_list, frequency, select_digital_function)
-
-    def niDigital_ClockGenerator_Initiate(self, vi, channel_list):  # noqa: N802
-        with self._func_lock:
-            if self.niDigital_ClockGenerator_Initiate_cfunc is None:
-                self.niDigital_ClockGenerator_Initiate_cfunc = self._library.niDigital_ClockGenerator_Initiate
-                self.niDigital_ClockGenerator_Initiate_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
-                self.niDigital_ClockGenerator_Initiate_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDigital_ClockGenerator_Initiate_cfunc(vi, channel_list)
 
     def niDigital_Commit(self, vi):  # noqa: N802
         with self._func_lock:

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -704,24 +704,6 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def clock_generator_initiate(self):
-        r'''clock_generator_initiate
-
-        TBD
-
-        Tip:
-        This method requires repeated capabilities. If called directly on the
-        nidigital.Session object, then the method will use all repeated capabilities in the session.
-        You can specify a subset of repeated capabilities using the Python index notation on an
-        nidigital.Session repeated capabilities container, and calling this method on the result.
-        '''
-        vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        channel_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
-        error_code = self._library.niDigital_ClockGenerator_Initiate(vi_ctype, channel_list_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return
-
-    @ivi_synchronized
     def configure_active_load_levels(self, iol, ioh, vcom):
         r'''configure_active_load_levels
 

--- a/generated/nidigital/nidigital/unit_tests/_mock_helper.py
+++ b/generated/nidigital/nidigital/unit_tests/_mock_helper.py
@@ -32,8 +32,6 @@ class SideEffectsHelper(object):
         self._defaults['ClockGenerator_Abort']['return'] = 0
         self._defaults['ClockGenerator_GenerateClock'] = {}
         self._defaults['ClockGenerator_GenerateClock']['return'] = 0
-        self._defaults['ClockGenerator_Initiate'] = {}
-        self._defaults['ClockGenerator_Initiate']['return'] = 0
         self._defaults['Commit'] = {}
         self._defaults['Commit']['return'] = 0
         self._defaults['ConfigureActiveLoadLevels'] = {}
@@ -306,11 +304,6 @@ class SideEffectsHelper(object):
         if self._defaults['ClockGenerator_GenerateClock']['return'] != 0:
             return self._defaults['ClockGenerator_GenerateClock']['return']
         return self._defaults['ClockGenerator_GenerateClock']['return']
-
-    def niDigital_ClockGenerator_Initiate(self, vi, channel_list):  # noqa: N802
-        if self._defaults['ClockGenerator_Initiate']['return'] != 0:
-            return self._defaults['ClockGenerator_Initiate']['return']
-        return self._defaults['ClockGenerator_Initiate']['return']
 
     def niDigital_Commit(self, vi):  # noqa: N802
         if self._defaults['Commit']['return'] != 0:
@@ -1108,8 +1101,6 @@ class SideEffectsHelper(object):
         mock_library.niDigital_ClockGenerator_Abort.return_value = 0
         mock_library.niDigital_ClockGenerator_GenerateClock.side_effect = MockFunctionCallError("niDigital_ClockGenerator_GenerateClock")
         mock_library.niDigital_ClockGenerator_GenerateClock.return_value = 0
-        mock_library.niDigital_ClockGenerator_Initiate.side_effect = MockFunctionCallError("niDigital_ClockGenerator_Initiate")
-        mock_library.niDigital_ClockGenerator_Initiate.return_value = 0
         mock_library.niDigital_Commit.side_effect = MockFunctionCallError("niDigital_Commit")
         mock_library.niDigital_Commit.return_value = 0
         mock_library.niDigital_ConfigureActiveLoadLevels.side_effect = MockFunctionCallError("niDigital_ConfigureActiveLoadLevels")

--- a/src/nidigital/metadata/functions.py
+++ b/src/nidigital/metadata/functions.py
@@ -218,6 +218,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'ClockGenerator_Initiate': {
+        'codegen_method': 'no',
         'documentation': {
             'description': 'TBD'
         },


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Remove clock_generator_initiate() from nidigital API

### List issues fixed by this Pull Request below, if any.

* Fix #1370 

### What testing has been done?

Ran existing unit and system tests