### PR TITLE
Fix a bug in test_reset_with_default() in nidcpower

### DIFF
--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -92,7 +92,7 @@ def test_reset_device(session):
 def test_reset_with_default(session):
     channel = session.channels['0']
     assert channel.aperture_time_units == nidcpower.ApertureTimeUnits.SECONDS
-    channel.aperture_time_units == nidcpower.ApertureTimeUnits.POWER_LINE_CYCLES
+    channel.aperture_time_units = nidcpower.ApertureTimeUnits.POWER_LINE_CYCLES
     session.reset_with_defaults()
     assert channel.aperture_time_units == nidcpower.ApertureTimeUnits.SECONDS
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Fix a bug in `test_reset_with_default()` in nidcpower.

### List issues fixed by this Pull Request below, if any.

None

### What testing has been done?

Ran the fixed test