### PR TITLE
Remove "PinState" from string representation of HistoryRAMCycleInformation

### DIFF
--- a/generated/nidigital/nidigital/history_ram_cycle_information.py
+++ b/generated/nidigital/nidigital/history_ram_cycle_information.py
@@ -34,8 +34,8 @@ class HistoryRAMCycleInformation(object):
         string_representation += row_format_d.format('Vector Number', self.vector_number)
         string_representation += row_format_d.format('Cycle Number', self.cycle_number)
         string_representation += row_format_d.format('Scan Cycle Number', self.scan_cycle_number)
-        string_representation += row_format_s.format('Expected Pin States', self._digital_states_representation(self.expected_pin_states))
-        string_representation += row_format_s.format('Actual Pin States', self._digital_states_representation(self.actual_pin_states))
+        string_representation += row_format_s.format('Expected Pin States', self._digital_states_string(self.expected_pin_states))
+        string_representation += row_format_s.format('Actual Pin States', self._digital_states_string(self.actual_pin_states))
         string_representation += row_format_s.format('Per Pin Pass Fail', self.per_pin_pass_fail)
 
         return string_representation
@@ -44,4 +44,9 @@ class HistoryRAMCycleInformation(object):
     def _digital_states_representation(states):
         states_representation = [['{0}.{1}'.format(i.__class__.__name__, i.name) for i in j] for j in states]
         return '[{}]'.format(', '.join(['[{}]'.format(', '.join(i)) for i in states_representation]))
+
+    @staticmethod
+    def _digital_states_string(states):
+        states_string = [['{0}'.format(i.name) for i in j] for j in states]
+        return '[{}]'.format(', '.join(['[{}]'.format(', '.join(i)) for i in states_string]))
 

--- a/src/nidigital/custom_types/history_ram_cycle_information.py
+++ b/src/nidigital/custom_types/history_ram_cycle_information.py
@@ -34,8 +34,8 @@ class HistoryRAMCycleInformation(object):
         string_representation += row_format_d.format('Vector Number', self.vector_number)
         string_representation += row_format_d.format('Cycle Number', self.cycle_number)
         string_representation += row_format_d.format('Scan Cycle Number', self.scan_cycle_number)
-        string_representation += row_format_s.format('Expected Pin States', self._digital_states_representation(self.expected_pin_states))
-        string_representation += row_format_s.format('Actual Pin States', self._digital_states_representation(self.actual_pin_states))
+        string_representation += row_format_s.format('Expected Pin States', self._digital_states_string(self.expected_pin_states))
+        string_representation += row_format_s.format('Actual Pin States', self._digital_states_string(self.actual_pin_states))
         string_representation += row_format_s.format('Per Pin Pass Fail', self.per_pin_pass_fail)
 
         return string_representation
@@ -44,4 +44,9 @@ class HistoryRAMCycleInformation(object):
     def _digital_states_representation(states):
         states_representation = [['{0}.{1}'.format(i.__class__.__name__, i.name) for i in j] for j in states]
         return '[{}]'.format(', '.join(['[{}]'.format(', '.join(i)) for i in states_representation]))
+
+    @staticmethod
+    def _digital_states_string(states):
+        states_string = [['{0}'.format(i.name) for i in j] for j in states]
+        return '[{}]'.format(', '.join(['[{}]'.format(', '.join(i)) for i in states_string]))
 

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -314,6 +314,29 @@ def test_history_ram_cycle_information_representation():
     assert str(recreated_cycle_info) == str(cycle_info)
 
 
+def test_history_ram_cycle_information_string():
+    cycle_info = HistoryRAMCycleInformation(
+        pattern_name='pat',
+        time_set_name='t0',
+        vector_number=42,
+        cycle_number=999,
+        scan_cycle_number=13,
+        expected_pin_states=[[PinState.D, PinState.V], [PinState.V, PinState.D]],
+        actual_pin_states=[[PinState.PIN_STATE_NOT_ACQUIRED, PinState.PIN_STATE_NOT_ACQUIRED], [PinState.ZERO, PinState.ONE]],
+        per_pin_pass_fail=[[True, True], [False, False]])
+    print(cycle_info)
+    expected_string = '''Pattern Name        : pat
+Time Set Name       : t0
+Vector Number       : 42
+Cycle Number        : 999
+Scan Cycle Number   : 13
+Expected Pin States : [[D, V], [V, D]]
+Actual Pin States   : [[PIN_STATE_NOT_ACQUIRED, PIN_STATE_NOT_ACQUIRED], [ZERO, ONE]]
+Per Pin Pass Fail   : [[True, True], [False, False]]
+'''
+    assert str(cycle_info) == expected_string
+
+
 def test_fetch_history_ram_cycle_information_without_site(multi_instrument_session):
     configure_for_history_ram_test(multi_instrument_session)
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

Remove "PinState" from string representation of HistoryRAMCycleInformation

### List issues fixed by this Pull Request below, if any.

* Fix #1379

### What testing has been done?

Added and executed new system test. Executed existing unit and system tests.