### PR TITLE
Improve usability of loading specifications, levels, and timing files and unloading specifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
     * #### Added
         * `get_pattern_pin_names` - [#1292](https://github.com/ni/nimi-python/issues/1292)
         * Support for `instruments` repeated capability in the following properties - `instrument_firmware_revision`, `serial_number`, and `timing_absolute_delay` -  [#1228](https://github.com/ni/nimi-python/issues/1228) 
+        * `load_specifications_levels_and_timing` that allows loading of multiple specs, levels, and/or timing files in a single call - [#1392](https://github.com/ni/nimi-python/issues/1392)
     * #### Changed
         * Change the type of applicable method parameters and properties to enums - [#1066](https://github.com/ni/nimi-python/issues/1066)
         * `get_site_pass_fail` returns dictionary where each key is a site number and value is a bool indicating pass/fail - [#1297](https://github.com/ni/nimi-python/issues/1297)
@@ -49,12 +50,14 @@ All notable changes to this project will be documented in this file.
             * Added `WriteStaticPinState` enum type and changed the parameter type of `write_static` method to the newly added enum.
             * Added `SoftwareTrigger` enum type and changed the parameter type of `send_software_edge_trigger` method to the newly added enum.
         * Update `fetch_history_ram_cycle_information`, `get_history_ram_sample_count`, and `is_site_enabled` to use `sites` repeated capability - [#1337](https://github.com/ni/nimi-python/issues/1337)
+        * Modified `unload_specifications` to allow unloading of one or more specs files in a single call - [#1392](https://github.com/ni/nimi-python/issues/1392) 
     * #### Removed
         * `get_pattern_pin_list`, `get_pattern_pin_indexes` and `get_pin_name` - [#1292](https://github.com/ni/nimi-python/issues/1292)
         * `get_site_results_site_numbers` method and `SiteResultType` enum - [#1298](https://github.com/ni/nimi-python/issues/1298) 
         * `reset_attribute` - [#1364](https://github.com/ni/nimi-python/issues/1364) 
         * `clear_error` - [#1366](https://github.com/ni/nimi-python/issues/1366) 
         * `clock_generator_initiate` - [#1370](https://github.com/ni/nimi-python/issues/1370) 
+        * `load_specifications`, `load_levels`, and `load_timing` - [#1392](https://github.com/ni/nimi-python/issues/1392) 
 * ### NI-DMM
     * #### Added
     * #### Changed

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -2118,13 +2118,11 @@ unload_specifications
             Unloads the given specifications sheets present in the previously loaded
             specifications files that you select.
 
-            You must call :py:meth:`nidigital.Session.LoadSpecificationsLevelsAndTiming` to reload the files with updated
+            You must call :py:meth:`nidigital.Session.load_specifications_levels_and_timing` to reload the files with updated
             specifications values. You must then call :py:meth:`nidigital.Session.apply_levels_and_timing` in order to apply
             the levels and timing values that reference the updated specifications values.
 
             
-
-            .. note:: One or more of the referenced methods are not in the Python API for this driver.
 
 
 

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -1682,27 +1682,6 @@ is_site_enabled
 
 
 
-load_levels
------------
-
-    .. py:currentmodule:: nidigital.Session
-
-    .. py:method:: load_levels(levels_file_path)
-
-            TBD
-
-            
-
-
-
-            :param levels_file_path:
-
-
-                
-
-
-            :type levels_file_path: str
-
 load_pattern
 ------------
 
@@ -1745,47 +1724,51 @@ load_pin_map
 
             :type pin_map_file_path: str
 
-load_specifications
--------------------
+load_specifications_levels_and_timing
+-------------------------------------
 
     .. py:currentmodule:: nidigital.Session
 
-    .. py:method:: load_specifications(specifications_file_path)
+    .. py:method:: load_specifications_levels_and_timing(specifications_file_paths=None, levels_file_paths=None, timing_file_paths=None)
 
-            TBD
+            Loads settings in specifications, levels, and timing sheets. These settings are not
+            applied to the digital pattern instrument until :py:meth:`nidigital.Session.apply_levels_and_timing` is called.
+
+            If the levels and timing sheets contains formulas, they are evaluated at load time.
+            If the formulas refer to variables, the specifications sheets that define those
+            variables must be loaded either first, or at the same time as the levels and timing sheets.
 
             
 
 
 
-            :param specifications_file_path:
+            :param specifications_file_paths:
 
 
-                
-
-
-            :type specifications_file_path: str
-
-load_timing
------------
-
-    .. py:currentmodule:: nidigital.Session
-
-    .. py:method:: load_timing(timing_file_path)
-
-            TBD
-
-            
-
-
-
-            :param timing_file_path:
-
+                Absolute file path of one or more specifications files.
 
                 
 
 
-            :type timing_file_path: str
+            :type specifications_file_paths: str or iterable of str
+            :param levels_file_paths:
+
+
+                Absolute file path of one or more levels sheet files.
+
+                
+
+
+            :type levels_file_paths: str or iterable of str
+            :param timing_file_paths:
+
+
+                Absolute file path of one or more timing sheet files.
+
+                
+
+
+            :type timing_file_paths: str or iterable of str
 
 lock
 ----
@@ -2124,27 +2107,6 @@ unload_all_patterns
 
 
             :type unload_keep_alive_pattern: bool
-
-unload_specifications
----------------------
-
-    .. py:currentmodule:: nidigital.Session
-
-    .. py:method:: unload_specifications(specifications_file_path)
-
-            TBD
-
-            
-
-
-
-            :param specifications_file_path:
-
-
-                
-
-
-            :type specifications_file_path: str
 
 unlock
 ------

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -2108,6 +2108,36 @@ unload_all_patterns
 
             :type unload_keep_alive_pattern: bool
 
+unload_specifications
+---------------------
+
+    .. py:currentmodule:: nidigital.Session
+
+    .. py:method:: unload_specifications(file_paths)
+
+            Unloads the given specifications sheets present in the previously loaded
+            specifications files that you select.
+
+            You must call :py:meth:`nidigital.Session.LoadSpecificationsLevelsAndTiming` to reload the files with updated
+            specifications values. You must then call :py:meth:`nidigital.Session.apply_levels_and_timing` in order to apply
+            the levels and timing values that reference the updated specifications values.
+
+            
+
+            .. note:: One or more of the referenced methods are not in the Python API for this driver.
+
+
+
+            :param file_paths:
+
+
+                Absolute file path of one or more loaded specifications files.
+
+                
+
+
+            :type file_paths: str or iterable of str
+
 unlock
 ------
 

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -2775,11 +2775,11 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def _load_files(self, loader, files):
+    def _file_helper(self, action, files):
         if isinstance(files, str):
             files = [files]
         for f in files:
-            loader(f)
+            action(f)
 
     def load_specifications_levels_and_timing(self, specifications_file_paths=None, levels_file_paths=None, timing_file_paths=None):
         '''load_specifications_levels_and_timing
@@ -2800,11 +2800,11 @@ class Session(_SessionBase):
 
         '''
         if specifications_file_paths is not None:
-            self._load_files(self._load_specifications, specifications_file_paths)
+            self._file_helper(self._load_specifications, specifications_file_paths)
         if levels_file_paths is not None:
-            self._load_files(self._load_levels, levels_file_paths)
+            self._file_helper(self._load_levels, levels_file_paths)
         if timing_file_paths is not None:
-            self._load_files(self._load_timing, timing_file_paths)
+            self._file_helper(self._load_timing, timing_file_paths)
 
     @ivi_synchronized
     def self_test(self):
@@ -2816,6 +2816,26 @@ class Session(_SessionBase):
         if code:
             raise errors.SelfTestError(code, msg)
         return None
+
+    @ivi_synchronized
+    def unload_specifications(self, file_paths):
+        '''unload_specifications
+
+        Unloads the given specifications sheets present in the previously loaded
+        specifications files that you select.
+
+        You must call LoadSpecificationsLevelsAndTiming to reload the files with updated
+        specifications values. You must then call apply_levels_and_timing in order to apply
+        the levels and timing values that reference the updated specifications values.
+
+        Note:
+        One or more of the referenced methods are not in the Python API for this driver.
+
+        Args:
+            file_paths (str or iterable of str): Absolute file path of one or more loaded specifications files.
+
+        '''
+        self._file_helper(self._unload_specifications, file_paths)
 
     @ivi_synchronized
     def write_source_waveform_site_unique(self, waveform_name, waveform_data):

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -2825,11 +2825,13 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def _file_helper(self, action, files):
+    def _call_method_with_iterable(self, method, files):
+        if files is None:
+            return
         if isinstance(files, str):
             files = [files]
         for f in files:
-            action(f)
+            method(f)
 
     def load_specifications_levels_and_timing(self, specifications_file_paths=None, levels_file_paths=None, timing_file_paths=None):
         '''load_specifications_levels_and_timing
@@ -2849,12 +2851,9 @@ class Session(_SessionBase):
             timing_file_paths (str or iterable of str): Absolute file path of one or more timing sheet files.
 
         '''
-        if specifications_file_paths is not None:
-            self._file_helper(self._load_specifications, specifications_file_paths)
-        if levels_file_paths is not None:
-            self._file_helper(self._load_levels, levels_file_paths)
-        if timing_file_paths is not None:
-            self._file_helper(self._load_timing, timing_file_paths)
+        self._call_method_with_iterable(self._load_specifications, specifications_file_paths)
+        self._call_method_with_iterable(self._load_levels, levels_file_paths)
+        self._call_method_with_iterable(self._load_timing, timing_file_paths)
 
     @ivi_synchronized
     def self_test(self):
@@ -2882,7 +2881,7 @@ class Session(_SessionBase):
             file_paths (str or iterable of str): Absolute file path of one or more loaded specifications files.
 
         '''
-        self._file_helper(self._unload_specifications, file_paths)
+        self._call_method_with_iterable(self._unload_specifications, file_paths)
 
     @ivi_synchronized
     def write_source_waveform_site_unique(self, waveform_name, waveform_data):

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -2824,12 +2824,9 @@ class Session(_SessionBase):
         Unloads the given specifications sheets present in the previously loaded
         specifications files that you select.
 
-        You must call LoadSpecificationsLevelsAndTiming to reload the files with updated
+        You must call load_specifications_levels_and_timing to reload the files with updated
         specifications values. You must then call apply_levels_and_timing in order to apply
         the levels and timing values that reference the updated specifications values.
-
-        Note:
-        One or more of the referenced methods are not in the Python API for this driver.
 
         Args:
             file_paths (str or iterable of str): Absolute file path of one or more loaded specifications files.

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -2775,6 +2775,38 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
+    def _load_files(self, loader, files):
+        if isinstance(files, str):
+            files = [files]
+        for f in files:
+            loader(f)
+
+    def load_specifications_levels_and_timing(self, specifications_file_paths=None, levels_file_paths=None, timing_file_paths=None):
+        '''load_specifications_levels_and_timing
+
+        Loads settings in specifications, levels, and timing sheets. These settings are not
+        applied to the digital pattern instrument until apply_levels_and_timing is called.
+
+        If the levels and timing sheets contains formulas, they are evaluated at load time.
+        If the formulas refer to variables, the specifications sheets that define those
+        variables must be loaded either first, or at the same time as the levels and timing sheets.
+
+        Args:
+            specifications_file_paths (str or iterable of str): Absolute file path of one or more specifications files.
+
+            levels_file_paths (str or iterable of str): Absolute file path of one or more levels sheet files.
+
+            timing_file_paths (str or iterable of str): Absolute file path of one or more timing sheet files.
+
+        '''
+        if specifications_file_paths is not None:
+            self._load_files(self._load_specifications, specifications_file_paths)
+        if levels_file_paths is not None:
+            self._load_files(self._load_levels, levels_file_paths)
+        if timing_file_paths is not None:
+            self._load_files(self._load_timing, timing_file_paths)
+
+    @ivi_synchronized
     def self_test(self):
         '''self_test
 
@@ -2970,8 +3002,8 @@ class Session(_SessionBase):
         return bool(done_ctype.value)
 
     @ivi_synchronized
-    def load_levels(self, levels_file_path):
-        r'''load_levels
+    def _load_levels(self, levels_file_path):
+        r'''_load_levels
 
         TBD
 
@@ -3018,8 +3050,8 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def load_specifications(self, specifications_file_path):
-        r'''load_specifications
+    def _load_specifications(self, specifications_file_path):
+        r'''_load_specifications
 
         TBD
 
@@ -3034,8 +3066,8 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def load_timing(self, timing_file_path):
-        r'''load_timing
+    def _load_timing(self, timing_file_path):
+        r'''_load_timing
 
         TBD
 
@@ -3173,8 +3205,8 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def unload_specifications(self, specifications_file_path):
-        r'''unload_specifications
+    def _unload_specifications(self, specifications_file_path):
+        r'''_unload_specifications
 
         TBD
 

--- a/src/nidigital/metadata/functions.py
+++ b/src/nidigital/metadata/functions.py
@@ -2031,6 +2031,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'LoadLevels': {
+        'codegen_method': 'private',
         'documentation': {
             'description': 'TBD'
         },
@@ -2085,6 +2086,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'LoadSpecifications': {
+        'codegen_method': 'private',
         'documentation': {
             'description': 'TBD'
         },
@@ -2103,6 +2105,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'LoadTiming': {
+        'codegen_method': 'private',
         'documentation': {
             'description': 'TBD'
         },
@@ -2610,6 +2613,7 @@ conditionalJumpTrigger1, conditionalJumpTrigger2, and conditionalJumpTrigger3.
         'returns': 'ViStatus'
     },
     'UnloadSpecifications': {
+        'codegen_method': 'private',
         'documentation': {
             'description': 'TBD'
         },

--- a/src/nidigital/metadata/functions_addon.py
+++ b/src/nidigital/metadata/functions_addon.py
@@ -455,7 +455,7 @@ functions_additional_unload_specifications = {
             'description': """\nUnloads the given specifications sheets present in the previously loaded
 specifications files that you select.
 
-You must call niDigital_LoadSpecificationsLevelsAndTiming to reload the files with updated
+You must call niDigital_FancyLoadSpecificationsLevelsAndTiming to reload the files with updated
 specifications values. You must then call niDigital_ApplyLevelsAndTiming in order to apply
 the levels and timing values that reference the updated specifications values.
 

--- a/src/nidigital/metadata/functions_addon.py
+++ b/src/nidigital/metadata/functions_addon.py
@@ -378,3 +378,64 @@ the following information about each pattern cycle:
         ],
     },
 }
+
+functions_additional_load_specifications_levels_and_timing = {
+    'FancyLoadSpecificationsLevelsAndTiming': {
+        'python_name': 'load_specifications_levels_and_timing',
+        'codegen_method': 'python-only',
+        'method_templates': [
+            {
+                'documentation_filename': 'default_method',
+                'method_python_name_suffix': '',
+                'session_filename': 'fancy_load_specifications_levels_and_timing',
+            }
+        ],
+        'documentation': {
+            'description': """\nLoads settings in specifications, levels, and timing sheets. These settings are not
+applied to the digital pattern instrument until niDigital_ApplyLevelsAndTiming is called.
+
+If the levels and timing sheets contains formulas, they are evaluated at load time.
+If the formulas refer to variables, the specifications sheets that define those
+variables must be loaded either first, or at the same time as the levels and timing sheets.
+
+"""
+        },
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'default_value': None,
+                'direction': 'in',
+                'documentation': {
+                    'description': '\nAbsolute file path of one or more specifications files.\n'
+                },
+                'name': 'specificationsFilePaths',
+                'type': 'ViConstString[]',  # Value is unused, but required by code generator
+                'type_in_documentation': 'str or iterable of str',
+            },
+            {
+                'default_value': None,
+                'direction': 'in',
+                'documentation': {
+                    'description': '\nAbsolute file path of one or more levels sheet files.\n'
+                },
+                'name': 'levelsFilePaths',
+                'type': 'ViConstString[]',  # Value is unused, but required by code generator
+                'type_in_documentation': 'str or iterable of str',
+            },
+            {
+                'default_value': None,
+                'direction': 'in',
+                'documentation': {
+                    'description': '\nAbsolute file path of one or more timing sheet files.\n'
+                },
+                'name': 'timingFilePaths',
+                'type': 'ViConstString[]',  # Value is unused, but required by code generator
+                'type_in_documentation': 'str or iterable of str',
+            },
+        ],
+    },
+}

--- a/src/nidigital/metadata/functions_addon.py
+++ b/src/nidigital/metadata/functions_addon.py
@@ -439,3 +439,43 @@ variables must be loaded either first, or at the same time as the levels and tim
         ],
     },
 }
+
+functions_additional_unload_specifications = {
+    'FancyUnloadSpecifications': {
+        'python_name': 'unload_specifications',
+        'codegen_method': 'python-only',
+        'method_templates': [
+            {
+                'documentation_filename': 'default_method',
+                'method_python_name_suffix': '',
+                'session_filename': 'fancy_unload_specifications',
+            }
+        ],
+        'documentation': {
+            'description': """\nUnloads the given specifications sheets present in the previously loaded
+specifications files that you select.
+
+You must call niDigital_LoadSpecificationsLevelsAndTiming to reload the files with updated
+specifications values. You must then call niDigital_ApplyLevelsAndTiming in order to apply
+the levels and timing values that reference the updated specifications values.
+
+"""
+        },
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': '\nAbsolute file path of one or more loaded specifications files.\n'
+                },
+                'name': 'filePaths',
+                'type': 'ViConstString[]',  # Value is unused, but required by code generator
+                'type_in_documentation': 'str or iterable of str',
+            },
+        ],
+    },
+}

--- a/src/nidigital/system_tests/test_files/specifications_levels_and_timing_multiple/levels1.digilevels
+++ b/src/nidigital/system_tests/test_files/specifications_levels_and_timing_multiple/levels1.digilevels
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PinLevelsFile xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.0" xmlns="http://www.ni.com/Semiconductor/PinLevels">
+  <PinLevelsSheet>
+    <DigitalPinLevelSets>
+      <DigitalPinLevelSet pin="AllPins">
+        <Vil>1 V</Vil>
+        <Vih>3 V + DC.VCC + DC.Offset</Vih>
+        <Vol>2 V</Vol>
+        <Voh>4 V</Voh>
+        <TerminationMode>HighZ</TerminationMode>
+        <Comment>Depends on both specs files</Comment>
+      </DigitalPinLevelSet>
+    </DigitalPinLevelSets>
+  </PinLevelsSheet>
+</PinLevelsFile>

--- a/src/nidigital/system_tests/test_files/specifications_levels_and_timing_multiple/levels2.digilevels
+++ b/src/nidigital/system_tests/test_files/specifications_levels_and_timing_multiple/levels2.digilevels
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PinLevelsFile xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.0" xmlns="http://www.ni.com/Semiconductor/PinLevels">
+  <PinLevelsSheet>
+    <DigitalPinLevelSets>
+      <DigitalPinLevelSet pin="AllPins">
+        <Vil>1 V</Vil>
+        <Vih>2 V + DC.VCC + DC.Offset</Vih>
+        <Vol>2 V</Vol>
+        <Voh>4 V</Voh>
+        <TerminationMode>HighZ</TerminationMode>
+        <Comment>Depends on both specs files</Comment>
+      </DigitalPinLevelSet>
+    </DigitalPinLevelSets>
+  </PinLevelsSheet>
+</PinLevelsFile>

--- a/src/nidigital/system_tests/test_files/specifications_levels_and_timing_multiple/pin_map.pinmap
+++ b/src/nidigital/system_tests/test_files/specifications_levels_and_timing_multiple/pin_map.pinmap
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<PinMap xmlns="http://www.ni.com/TestStand/SemiconductorModule/PinMap.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.5">
+	<Instruments>
+		<NIDigitalPatternInstrument name="PXI1Slot2" numberOfChannels="32" group="Digital" />
+		<NIDigitalPatternInstrument name="PXI1Slot5" numberOfChannels="32" group="Digital" />
+	</Instruments>
+	<Pins>
+		<DUTPin name="LO0" />
+		<DUTPin name="LO1" />
+		<DUTPin name="LO2" />
+		<DUTPin name="LO3" />
+		<DUTPin name="HI0" />
+		<DUTPin name="HI1" />
+		<DUTPin name="HI2" />
+		<DUTPin name="HI3" />
+	</Pins>
+	<PinGroups>
+		<PinGroup name="AllPins">
+			<PinReference pin="LO0" />
+			<PinReference pin="LO1" />
+			<PinReference pin="LO2" />
+			<PinReference pin="LO3" />
+			<PinReference pin="HI0" />
+			<PinReference pin="HI1" />
+			<PinReference pin="HI2" />
+			<PinReference pin="HI3" />
+		</PinGroup>
+		<PinGroup name="LowPins">
+			<PinReference pin="LO0" />
+			<PinReference pin="LO1" />
+			<PinReference pin="LO2" />
+			<PinReference pin="LO3" />
+		</PinGroup>
+		<PinGroup name="HighPins">
+			<PinReference pin="HI0" />
+			<PinReference pin="HI1" />
+			<PinReference pin="HI2" />
+			<PinReference pin="HI3" />
+		</PinGroup>
+	</PinGroups>
+	<Sites>
+		<Site siteNumber="0" />
+		<Site siteNumber="1" />
+		<Site siteNumber="2" />
+		<Site siteNumber="3" />
+	</Sites>
+	<Connections>
+		<Connection pin="HI0" siteNumber="0" instrument="PXI1Slot2" channel="0" />
+		<Connection pin="HI0" siteNumber="1" instrument="PXI1Slot2" channel="1" />
+		<Connection pin="HI0" siteNumber="2" instrument="PXI1Slot2" channel="2" />
+		<Connection pin="HI0" siteNumber="3" instrument="PXI1Slot2" channel="3" />
+		<Connection pin="HI1" siteNumber="0" instrument="PXI1Slot2" channel="4" />
+		<Connection pin="HI1" siteNumber="1" instrument="PXI1Slot2" channel="5" />
+		<Connection pin="HI1" siteNumber="2" instrument="PXI1Slot2" channel="6" />
+		<Connection pin="HI1" siteNumber="3" instrument="PXI1Slot2" channel="7" />
+		<Connection pin="HI2" siteNumber="0" instrument="PXI1Slot2" channel="8" />
+		<Connection pin="HI2" siteNumber="1" instrument="PXI1Slot2" channel="9" />
+		<Connection pin="HI2" siteNumber="2" instrument="PXI1Slot2" channel="10" />
+		<Connection pin="HI2" siteNumber="3" instrument="PXI1Slot2" channel="11" />
+		<Connection pin="HI3" siteNumber="0" instrument="PXI1Slot2" channel="12" />
+		<Connection pin="HI3" siteNumber="1" instrument="PXI1Slot2" channel="13" />
+		<Connection pin="HI3" siteNumber="3" instrument="PXI1Slot2" channel="15" />
+		<Connection pin="HI3" siteNumber="2" instrument="PXI1Slot2" channel="14" />
+		<Connection pin="LO0" siteNumber="0" instrument="PXI1Slot5" channel="16" />
+		<Connection pin="LO0" siteNumber="1" instrument="PXI1Slot5" channel="17" />
+		<Connection pin="LO0" siteNumber="2" instrument="PXI1Slot5" channel="18" />
+		<Connection pin="LO0" siteNumber="3" instrument="PXI1Slot5" channel="19" />
+		<Connection pin="LO1" siteNumber="0" instrument="PXI1Slot5" channel="20" />
+		<Connection pin="LO1" siteNumber="1" instrument="PXI1Slot5" channel="21" />
+		<Connection pin="LO1" siteNumber="2" instrument="PXI1Slot5" channel="22" />
+		<Connection pin="LO1" siteNumber="3" instrument="PXI1Slot5" channel="23" />
+		<Connection pin="LO2" siteNumber="0" instrument="PXI1Slot5" channel="24" />
+		<Connection pin="LO2" siteNumber="1" instrument="PXI1Slot5" channel="25" />
+		<Connection pin="LO2" siteNumber="2" instrument="PXI1Slot5" channel="26" />
+		<Connection pin="LO2" siteNumber="3" instrument="PXI1Slot5" channel="27" />
+		<Connection pin="LO3" siteNumber="0" instrument="PXI1Slot5" channel="28" />
+		<Connection pin="LO3" siteNumber="1" instrument="PXI1Slot5" channel="29" />
+		<Connection pin="LO3" siteNumber="2" instrument="PXI1Slot5" channel="30" />
+		<Connection pin="LO3" siteNumber="3" instrument="PXI1Slot5" channel="31" />
+	</Connections>
+</PinMap>

--- a/src/nidigital/system_tests/test_files/specifications_levels_and_timing_multiple/specs1.specs
+++ b/src/nidigital/system_tests/test_files/specifications_levels_and_timing_multiple/specs1.specs
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Specifications xmlns:f="http://www.ni.com/schemas/Semiconductor/Formula.xsd" schemaVersion="1.0" xmlns="http://www.ni.com/schemas/Semiconductor/Specifications.xsd">
+  <Section name="AC">
+    <f:Formula symbol="Period">
+      <f:Definition>10 µ</f:Definition>
+    </f:Formula>
+  </Section>
+  <Section name="DC">
+    <f:Formula symbol="VCC">
+      <f:Definition>2 V</f:Definition>
+    </f:Formula>
+  </Section>
+</Specifications>

--- a/src/nidigital/system_tests/test_files/specifications_levels_and_timing_multiple/specs2.specs
+++ b/src/nidigital/system_tests/test_files/specifications_levels_and_timing_multiple/specs2.specs
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Specifications xmlns:f="http://www.ni.com/schemas/Semiconductor/Formula.xsd" schemaVersion="1.0" xmlns="http://www.ni.com/schemas/Semiconductor/Specifications.xsd">
+  <Section name="AC">
+    <f:Formula symbol="Frequency">
+      <f:Definition>1 / AC.Period</f:Definition>
+      <f:Comment>Depends on specs1.specs</f:Comment>
+    </f:Formula>
+  </Section>
+  <Section name="DC">
+    <f:Formula symbol="Offset">
+      <f:Definition>100 mV</f:Definition>
+    </f:Formula>
+  </Section>
+</Specifications>

--- a/src/nidigital/system_tests/test_files/specifications_levels_and_timing_multiple/test.digiproj
+++ b/src/nidigital/system_tests/test_files/specifications_levels_and_timing_multiple/test.digiproj
@@ -1,0 +1,40 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<SourceFile Checksum="4EB353DE0E5729B338D9BA13B1063297" xmlns="http://www.ni.com/PlatformFramework">
+	<SourceModelFeatureSet>
+		<ParsableNamespace AssemblyFileVersion="5.3.1.52024" FeatureSetName="Digital Pattern Editor" Name="http://www.ni.com/PatternBasedDigital" OldestCompatibleVersion="4.5.0.0" Version="4.6.0.49152" />
+		<ParsableNamespace AssemblyFileVersion="5.3.1.52024" FeatureSetName="Editor" Name="http://www.ni.com/PlatformFramework" OldestCompatibleVersion="5.2.0.49153" Version="5.2.0.49153" />
+		<ApplicationVersionInfo Build="5.3.1.52024" Name="Digital Pattern Editor" Version="19.0.0" />
+	</SourceModelFeatureSet>
+	<Project xmlns="http://www.ni.com/PlatformFramework">
+		<ProjectSettings Id="1" ModelDefinitionType="ProjectSettings" Name="ZProjectSettings" />
+		<EmbeddedDefinitionReference Id="2" ModelDefinitionType="NationalInstruments.ProjectExplorer.Modeling.ProjectDataManager" Name="ProjectExplorer">
+			<ProjectExplorer />
+		</EmbeddedDefinitionReference>
+		<NameScopingEnvoy Id="3" ModelDefinitionType="DefaultTarget" Name="DefaultTarget">
+			<DefaultTarget />
+			<EmbeddedDefinitionReference Id="8" ModelDefinitionType="{http://www.ni.com/PatternBasedDigital}CaptureResultsDefinition" Name="CaptureResults">
+				<CaptureResultsDefinition xmlns="http://www.ni.com/PatternBasedDigital" />
+			</EmbeddedDefinitionReference>
+			<EmbeddedDefinitionReference Id="10" ModelDefinitionType="{http://www.ni.com/PatternBasedDigital}BurstResultsDefinition" Name="BurstResults">
+				<BurstResultsDefinition xmlns="http://www.ni.com/PatternBasedDigital" />
+			</EmbeddedDefinitionReference>
+			<EmbeddedDefinitionReference Id="12" ModelDefinitionType="{http://www.ni.com/PatternBasedDigital}SystemInfoDefinition" Name="SystemInfo">
+				<SystemInfoDefinition xmlns="http://www.ni.com/PatternBasedDigital" />
+			</EmbeddedDefinitionReference>
+			<EmbeddedDefinitionReference Id="13" ModelDefinitionType="{http://www.ni.com/PatternBasedDigital}DigitalScopeDefinition" Name="DigitalScope">
+				<DigitalScopeDefinition xmlns="http://www.ni.com/PatternBasedDigital" />
+			</EmbeddedDefinitionReference>
+			<FileReference Id="16" ModelDefinitionType="PinMap" Name="pin_map\.pinmap" StoragePath="pin_map.pinmap" p4:IsActive="True" xmlns:p4="http://www.ni.com/PatternBasedDigital" />
+			<FileReference Id="17" ModelDefinitionType="SpecificationsDefinition" Name="specs1\.specs" StoragePath="specs1.specs" />
+			<FileReference Id="18" ModelDefinitionType="PinLevelsDefinition" Name="levels1\.digilevels" StoragePath="levels1.digilevels" p4:IsActive="True" xmlns:p4="http://www.ni.com/PatternBasedDigital" />
+			<FileReference Id="19" ModelDefinitionType="TimingDefinition" Name="timing1\.digitiming" StoragePath="timing1.digitiming" p4:IsActive="True" xmlns:p4="http://www.ni.com/PatternBasedDigital" />
+			<FileReference Id="23" ModelDefinitionType="SpecificationsDefinition" Name="specs2\.specs" StoragePath="specs2.specs" />
+			<FileReference Id="24" ModelDefinitionType="PinLevelsDefinition" Name="levels2\.digilevels" StoragePath="levels2.digilevels" />
+			<FileReference Id="25" ModelDefinitionType="TimingDefinition" Name="timing2\.digitiming" StoragePath="timing2.digitiming" />
+		</NameScopingEnvoy>
+		<EmbeddedDefinitionReference Id="7" ModelDefinitionType="DigitalPatternEditor.ProjectPropertiesDefinition" Name="ProjectProperties">
+			<ProjectPropertiesDefinition xmlns="http://www.ni.com/PatternBasedDigital" />
+		</EmbeddedDefinitionReference>
+	</Project>
+	<ProjectInformation xmlns="http://www.ni.com/PlatformFramework" />
+</SourceFile>

--- a/src/nidigital/system_tests/test_files/specifications_levels_and_timing_multiple/timing1.digitiming
+++ b/src/nidigital/system_tests/test_files/specifications_levels_and_timing_multiple/timing1.digitiming
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TimingFile xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.0" xmlns="http://www.ni.com/Semiconductor/Timing">
+  <TimingSheet>
+    <TimeSets>
+      <TimeSet name="t0">
+        <Period>AC.Period + (1 / AC.Frequency) * 0.1</Period>
+        <PinEdges>
+          <PinEdge pin="AllPins">
+            <ReturnToLow>
+              <On>AC.Period * 0.1</On>
+              <Data>AC.Period * 0.2</Data>
+              <Return>AC.Period * 0.8</Return>
+              <Off>AC.Period * 0.9</Off>
+            </ReturnToLow>
+            <CompareStrobe>
+              <Strobe>AC.Period * 0.5</Strobe>
+            </CompareStrobe>
+            <DataSource>Pattern</DataSource>
+            <Comment>Depends on both specs files</Comment>
+          </PinEdge>
+        </PinEdges>
+      </TimeSet>
+    </TimeSets>
+  </TimingSheet>
+</TimingFile>

--- a/src/nidigital/system_tests/test_files/specifications_levels_and_timing_multiple/timing2.digitiming
+++ b/src/nidigital/system_tests/test_files/specifications_levels_and_timing_multiple/timing2.digitiming
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TimingFile xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.0" xmlns="http://www.ni.com/Semiconductor/Timing">
+  <TimingSheet>
+    <TimeSets>
+      <TimeSet name="t0">
+        <Period>AC.Period + (1 / AC.Frequency) * 0.2</Period>
+        <PinEdges>
+          <PinEdge pin="AllPins">
+            <ReturnToLow>
+              <On>AC.Period * 0.1</On>
+              <Data>AC.Period * 0.2</Data>
+              <Return>AC.Period * 0.8</Return>
+              <Off>AC.Period * 0.9</Off>
+            </ReturnToLow>
+            <CompareStrobe>
+              <Strobe>AC.Period * 0.5</Strobe>
+            </CompareStrobe>
+            <DataSource>Pattern</DataSource>
+            <Comment>Depends on both specs files</Comment>
+          </PinEdge>
+        </PinEdges>
+      </TimeSet>
+    </TimeSets>
+  </TimingSheet>
+</TimingFile>

--- a/src/nidigital/system_tests/test_files/specifications_levels_and_timing_single/levels.digilevels
+++ b/src/nidigital/system_tests/test_files/specifications_levels_and_timing_single/levels.digilevels
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PinLevelsFile xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.0" xmlns="http://www.ni.com/Semiconductor/PinLevels">
+  <PinLevelsSheet>
+    <DigitalPinLevelSets>
+      <DigitalPinLevelSet pin="AllPins">
+        <Vil>1 V</Vil>
+        <Vih>3 V + DC.VCC</Vih>
+        <Vol>2 V</Vol>
+        <Voh>4 V</Voh>
+        <TerminationMode>HighZ</TerminationMode>
+        <Comment>Depends on both specs files</Comment>
+      </DigitalPinLevelSet>
+    </DigitalPinLevelSets>
+  </PinLevelsSheet>
+</PinLevelsFile>

--- a/src/nidigital/system_tests/test_files/specifications_levels_and_timing_single/pin_map.pinmap
+++ b/src/nidigital/system_tests/test_files/specifications_levels_and_timing_single/pin_map.pinmap
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<PinMap xmlns="http://www.ni.com/TestStand/SemiconductorModule/PinMap.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.5">
+	<Instruments>
+		<NIDigitalPatternInstrument name="PXI1Slot2" numberOfChannels="32" group="Digital" />
+		<NIDigitalPatternInstrument name="PXI1Slot5" numberOfChannels="32" group="Digital" />
+	</Instruments>
+	<Pins>
+		<DUTPin name="LO0" />
+		<DUTPin name="LO1" />
+		<DUTPin name="LO2" />
+		<DUTPin name="LO3" />
+		<DUTPin name="HI0" />
+		<DUTPin name="HI1" />
+		<DUTPin name="HI2" />
+		<DUTPin name="HI3" />
+	</Pins>
+	<PinGroups>
+		<PinGroup name="AllPins">
+			<PinReference pin="LO0" />
+			<PinReference pin="LO1" />
+			<PinReference pin="LO2" />
+			<PinReference pin="LO3" />
+			<PinReference pin="HI0" />
+			<PinReference pin="HI1" />
+			<PinReference pin="HI2" />
+			<PinReference pin="HI3" />
+		</PinGroup>
+		<PinGroup name="LowPins">
+			<PinReference pin="LO0" />
+			<PinReference pin="LO1" />
+			<PinReference pin="LO2" />
+			<PinReference pin="LO3" />
+		</PinGroup>
+		<PinGroup name="HighPins">
+			<PinReference pin="HI0" />
+			<PinReference pin="HI1" />
+			<PinReference pin="HI2" />
+			<PinReference pin="HI3" />
+		</PinGroup>
+	</PinGroups>
+	<Sites>
+		<Site siteNumber="0" />
+		<Site siteNumber="1" />
+		<Site siteNumber="2" />
+		<Site siteNumber="3" />
+	</Sites>
+	<Connections>
+		<Connection pin="HI0" siteNumber="0" instrument="PXI1Slot2" channel="0" />
+		<Connection pin="HI0" siteNumber="1" instrument="PXI1Slot2" channel="1" />
+		<Connection pin="HI0" siteNumber="2" instrument="PXI1Slot2" channel="2" />
+		<Connection pin="HI0" siteNumber="3" instrument="PXI1Slot2" channel="3" />
+		<Connection pin="HI1" siteNumber="0" instrument="PXI1Slot2" channel="4" />
+		<Connection pin="HI1" siteNumber="1" instrument="PXI1Slot2" channel="5" />
+		<Connection pin="HI1" siteNumber="2" instrument="PXI1Slot2" channel="6" />
+		<Connection pin="HI1" siteNumber="3" instrument="PXI1Slot2" channel="7" />
+		<Connection pin="HI2" siteNumber="0" instrument="PXI1Slot2" channel="8" />
+		<Connection pin="HI2" siteNumber="1" instrument="PXI1Slot2" channel="9" />
+		<Connection pin="HI2" siteNumber="2" instrument="PXI1Slot2" channel="10" />
+		<Connection pin="HI2" siteNumber="3" instrument="PXI1Slot2" channel="11" />
+		<Connection pin="HI3" siteNumber="0" instrument="PXI1Slot2" channel="12" />
+		<Connection pin="HI3" siteNumber="1" instrument="PXI1Slot2" channel="13" />
+		<Connection pin="HI3" siteNumber="3" instrument="PXI1Slot2" channel="15" />
+		<Connection pin="HI3" siteNumber="2" instrument="PXI1Slot2" channel="14" />
+		<Connection pin="LO0" siteNumber="0" instrument="PXI1Slot5" channel="16" />
+		<Connection pin="LO0" siteNumber="1" instrument="PXI1Slot5" channel="17" />
+		<Connection pin="LO0" siteNumber="2" instrument="PXI1Slot5" channel="18" />
+		<Connection pin="LO0" siteNumber="3" instrument="PXI1Slot5" channel="19" />
+		<Connection pin="LO1" siteNumber="0" instrument="PXI1Slot5" channel="20" />
+		<Connection pin="LO1" siteNumber="1" instrument="PXI1Slot5" channel="21" />
+		<Connection pin="LO1" siteNumber="2" instrument="PXI1Slot5" channel="22" />
+		<Connection pin="LO1" siteNumber="3" instrument="PXI1Slot5" channel="23" />
+		<Connection pin="LO2" siteNumber="0" instrument="PXI1Slot5" channel="24" />
+		<Connection pin="LO2" siteNumber="1" instrument="PXI1Slot5" channel="25" />
+		<Connection pin="LO2" siteNumber="2" instrument="PXI1Slot5" channel="26" />
+		<Connection pin="LO2" siteNumber="3" instrument="PXI1Slot5" channel="27" />
+		<Connection pin="LO3" siteNumber="0" instrument="PXI1Slot5" channel="28" />
+		<Connection pin="LO3" siteNumber="1" instrument="PXI1Slot5" channel="29" />
+		<Connection pin="LO3" siteNumber="2" instrument="PXI1Slot5" channel="30" />
+		<Connection pin="LO3" siteNumber="3" instrument="PXI1Slot5" channel="31" />
+	</Connections>
+</PinMap>

--- a/src/nidigital/system_tests/test_files/specifications_levels_and_timing_single/specs.specs
+++ b/src/nidigital/system_tests/test_files/specifications_levels_and_timing_single/specs.specs
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Specifications xmlns:f="http://www.ni.com/schemas/Semiconductor/Formula.xsd" schemaVersion="1.0" xmlns="http://www.ni.com/schemas/Semiconductor/Specifications.xsd">
+  <Section name="AC">
+    <f:Formula symbol="Period">
+      <f:Definition>10 µ</f:Definition>
+    </f:Formula>
+  </Section>
+  <Section name="DC">
+    <f:Formula symbol="VCC">
+      <f:Definition>2 V</f:Definition>
+    </f:Formula>
+  </Section>
+</Specifications>

--- a/src/nidigital/system_tests/test_files/specifications_levels_and_timing_single/test.digiproj
+++ b/src/nidigital/system_tests/test_files/specifications_levels_and_timing_single/test.digiproj
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<SourceFile Checksum="041CFD3898DCA61BFAE728BF3559B76A" xmlns="http://www.ni.com/PlatformFramework">
+	<SourceModelFeatureSet>
+		<ParsableNamespace AssemblyFileVersion="5.3.1.52024" FeatureSetName="Digital Pattern Editor" Name="http://www.ni.com/PatternBasedDigital" OldestCompatibleVersion="4.5.0.0" Version="4.6.0.49152" />
+		<ParsableNamespace AssemblyFileVersion="5.3.1.52024" FeatureSetName="Editor" Name="http://www.ni.com/PlatformFramework" OldestCompatibleVersion="5.2.0.49153" Version="5.2.0.49153" />
+		<ApplicationVersionInfo Build="5.3.1.52024" Name="Digital Pattern Editor" Version="19.0.0" />
+	</SourceModelFeatureSet>
+	<Project xmlns="http://www.ni.com/PlatformFramework">
+		<ProjectSettings Id="1" ModelDefinitionType="ProjectSettings" Name="ZProjectSettings" />
+		<EmbeddedDefinitionReference Id="2" ModelDefinitionType="NationalInstruments.ProjectExplorer.Modeling.ProjectDataManager" Name="ProjectExplorer">
+			<ProjectExplorer />
+		</EmbeddedDefinitionReference>
+		<NameScopingEnvoy Id="3" ModelDefinitionType="DefaultTarget" Name="DefaultTarget">
+			<DefaultTarget />
+			<EmbeddedDefinitionReference Id="8" ModelDefinitionType="{http://www.ni.com/PatternBasedDigital}CaptureResultsDefinition" Name="CaptureResults">
+				<CaptureResultsDefinition xmlns="http://www.ni.com/PatternBasedDigital" />
+			</EmbeddedDefinitionReference>
+			<EmbeddedDefinitionReference Id="10" ModelDefinitionType="{http://www.ni.com/PatternBasedDigital}BurstResultsDefinition" Name="BurstResults">
+				<BurstResultsDefinition xmlns="http://www.ni.com/PatternBasedDigital" />
+			</EmbeddedDefinitionReference>
+			<EmbeddedDefinitionReference Id="12" ModelDefinitionType="{http://www.ni.com/PatternBasedDigital}SystemInfoDefinition" Name="SystemInfo">
+				<SystemInfoDefinition xmlns="http://www.ni.com/PatternBasedDigital" />
+			</EmbeddedDefinitionReference>
+			<EmbeddedDefinitionReference Id="13" ModelDefinitionType="{http://www.ni.com/PatternBasedDigital}DigitalScopeDefinition" Name="DigitalScope">
+				<DigitalScopeDefinition xmlns="http://www.ni.com/PatternBasedDigital" />
+			</EmbeddedDefinitionReference>
+			<FileReference Id="16" ModelDefinitionType="PinMap" Name="pin_map\.pinmap" StoragePath="pin_map.pinmap" p4:IsActive="True" xmlns:p4="http://www.ni.com/PatternBasedDigital" />
+			<FileReference Id="17" ModelDefinitionType="SpecificationsDefinition" Name="specs\.specs" StoragePath="specs.specs" />
+			<FileReference Id="18" ModelDefinitionType="PinLevelsDefinition" Name="levels\.digilevels" StoragePath="levels.digilevels" p4:IsActive="True" xmlns:p4="http://www.ni.com/PatternBasedDigital" />
+			<FileReference Id="19" ModelDefinitionType="TimingDefinition" Name="timing\.digitiming" StoragePath="timing.digitiming" p4:IsActive="True" xmlns:p4="http://www.ni.com/PatternBasedDigital" />
+		</NameScopingEnvoy>
+		<EmbeddedDefinitionReference Id="7" ModelDefinitionType="DigitalPatternEditor.ProjectPropertiesDefinition" Name="ProjectProperties">
+			<ProjectPropertiesDefinition xmlns="http://www.ni.com/PatternBasedDigital" />
+		</EmbeddedDefinitionReference>
+	</Project>
+	<ProjectInformation xmlns="http://www.ni.com/PlatformFramework" />
+</SourceFile>

--- a/src/nidigital/system_tests/test_files/specifications_levels_and_timing_single/timing.digitiming
+++ b/src/nidigital/system_tests/test_files/specifications_levels_and_timing_single/timing.digitiming
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TimingFile xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.0" xmlns="http://www.ni.com/Semiconductor/Timing">
+  <TimingSheet>
+    <TimeSets>
+      <TimeSet name="t0">
+        <Period>AC.Period</Period>
+        <PinEdges>
+          <PinEdge pin="AllPins">
+            <ReturnToLow>
+              <On>AC.Period * 0.1</On>
+              <Data>AC.Period * 0.2</Data>
+              <Return>AC.Period * 0.8</Return>
+              <Off>AC.Period * 0.9</Off>
+            </ReturnToLow>
+            <CompareStrobe>
+              <Strobe>AC.Period * 0.5</Strobe>
+            </CompareStrobe>
+            <DataSource>Pattern</DataSource>
+            <Comment>Depends on both specs files</Comment>
+          </PinEdge>
+        </PinEdges>
+      </TimeSet>
+    </TimeSets>
+  </TimingSheet>
+</TimingFile>

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -541,7 +541,7 @@ def test_get_site_pass_fail(multi_instrument_session):
     assert pass_fail == {3: True, 0: True}
 
 
-def test_load_specifications_levels_and_timing_single(multi_instrument_session):
+def test_specifications_levels_and_timing_single(multi_instrument_session):
     pinmap = get_test_file_path('specifications_levels_and_timing_single', 'pin_map.pinmap')
     specs = get_test_file_path('specifications_levels_and_timing_single', 'specs.specs')
     # Levels and timing files contain references to variables in specs1
@@ -557,8 +557,18 @@ def test_load_specifications_levels_and_timing_single(multi_instrument_session):
     # Verify the loaded levels and timing sheets can be applied to hardware
     multi_instrument_session.apply_levels_and_timing(levels_sheet='levels', timing_sheet='timing')
 
+    multi_instrument_session.unload_specifications(file_paths=specs)
 
-def test_load_specifications_levels_and_timing_multiple(multi_instrument_session):
+    # Verify reapplying the loaded levels and timing sheets throws
+    try:
+        multi_instrument_session.apply_levels_and_timing(levels_sheet='levels', timing_sheet='timing')
+        assert False
+    except nidigital.Error as e:
+        assert e.code == -1074118494
+        assert e.description.find('An error occurred while getting values from a levels sheet.') != -1
+
+
+def test_specifications_levels_and_timing_multiple(multi_instrument_session):
     pinmap = get_test_file_path('specifications_levels_and_timing_multiple', 'pin_map.pinmap')
 
     specs1 = get_test_file_path('specifications_levels_and_timing_multiple', 'specs1.specs')
@@ -581,8 +591,18 @@ def test_load_specifications_levels_and_timing_multiple(multi_instrument_session
     multi_instrument_session.apply_levels_and_timing(levels_sheet='levels1', timing_sheet='timing2')
     multi_instrument_session.apply_levels_and_timing(levels_sheet='levels2', timing_sheet='timing1')
 
+    multi_instrument_session.unload_specifications(file_paths=[specs1, specs2])
 
-def test_load_specifications_levels_and_timing_load_sequentially(multi_instrument_session):
+    # Verify reapplying the loaded levels and timing sheets throws
+    try:
+        multi_instrument_session.apply_levels_and_timing(levels_sheet='levels1', timing_sheet='timing2')
+        assert False
+    except nidigital.Error as e:
+        assert e.code == -1074118494
+        assert e.description.find('An error occurred while getting values from a levels sheet.') != -1
+
+
+def test_specifications_levels_and_timing_load_sequentially(multi_instrument_session):
     pinmap = get_test_file_path('specifications_levels_and_timing_multiple', 'pin_map.pinmap')
 
     specs1 = get_test_file_path('specifications_levels_and_timing_multiple', 'specs1.specs')
@@ -599,7 +619,7 @@ def test_load_specifications_levels_and_timing_load_sequentially(multi_instrumen
 
     # Load just the specs files first, in two separate calls
     multi_instrument_session.load_specifications_levels_and_timing(specifications_file_paths=specs1)
-    multi_instrument_session.load_specifications_levels_and_timing(specifications_file_paths=specs2)
+    multi_instrument_session.load_specifications_levels_and_timing(specifications_file_paths=[specs2])
 
     # Then load both the levels together
     multi_instrument_session.load_specifications_levels_and_timing(levels_file_paths=[levels2, levels1])
@@ -612,5 +632,14 @@ def test_load_specifications_levels_and_timing_load_sequentially(multi_instrumen
     multi_instrument_session.apply_levels_and_timing(levels_sheet='levels1', timing_sheet='timing2')
     multi_instrument_session.apply_levels_and_timing(levels_sheet='levels2', timing_sheet='timing1')
 
-    # TODO: Verify unload specs
+    multi_instrument_session.unload_specifications(file_paths=specs1)
+    multi_instrument_session.unload_specifications(file_paths=(specs2))
+
+    # Verify reapplying the loaded levels and timing sheets throws
+    try:
+        multi_instrument_session.apply_levels_and_timing(levels_sheet='levels1', timing_sheet='timing2')
+        assert False
+    except nidigital.Error as e:
+        assert e.code == -1074118494
+        assert e.description.find('An error occurred while getting values from a levels sheet.') != -1
 

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -47,8 +47,8 @@ def test_get_error(multi_instrument_session):
         assert e.description.find('Attribute is read-only.') != -1
 
 
-def test_self_calibrate(multi_instrument_session):
-    multi_instrument_session.self_calibrate()
+# def test_self_calibrate(multi_instrument_session):
+#     multi_instrument_session.self_calibrate()
 
 
 def test_pins_rep_cap(multi_instrument_session):
@@ -181,9 +181,10 @@ def test_source_waveform_parallel_broadcast(multi_instrument_session):
 def configure_session(session, test_name):
     session.load_pin_map(get_test_file_path(test_name, 'pin_map.pinmap'))
 
-    session.load_specifications(get_test_file_path(test_name, 'specifications.specs'))
-    session.load_levels(get_test_file_path(test_name, 'pin_levels.digilevels'))
-    session.load_timing(get_test_file_path(test_name, 'timing.digitiming'))
+    session.load_specifications_levels_and_timing(
+        specifications_file_paths=get_test_file_path(test_name, 'specifications.specs'),
+        levels_file_paths=get_test_file_path(test_name, 'pin_levels.digilevels'),
+        timing_file_paths=get_test_file_path(test_name, 'timing.digitiming'))
     session.apply_levels_and_timing(levels_sheet='pin_levels', timing_sheet='timing')
 
 

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -47,8 +47,8 @@ def test_get_error(multi_instrument_session):
         assert e.description.find('Attribute is read-only.') != -1
 
 
-# def test_self_calibrate(multi_instrument_session):
-#     multi_instrument_session.self_calibrate()
+def test_self_calibrate(multi_instrument_session):
+    multi_instrument_session.self_calibrate()
 
 
 def test_pins_rep_cap(multi_instrument_session):
@@ -539,4 +539,78 @@ def test_get_site_pass_fail(multi_instrument_session):
 
     pass_fail = multi_instrument_session.sites[3, 0].get_site_pass_fail()
     assert pass_fail == {3: True, 0: True}
+
+
+def test_load_specifications_levels_and_timing_single(multi_instrument_session):
+    pinmap = get_test_file_path('specifications_levels_and_timing_single', 'pin_map.pinmap')
+    specs = get_test_file_path('specifications_levels_and_timing_single', 'specs.specs')
+    # Levels and timing files contain references to variables in specs1
+    levels = get_test_file_path('specifications_levels_and_timing_single', 'levels.digilevels')
+    timing = get_test_file_path('specifications_levels_and_timing_single', 'timing.digitiming')
+
+    multi_instrument_session.load_pin_map(pin_map_file_path=pinmap)
+    multi_instrument_session.load_specifications_levels_and_timing(
+        specifications_file_paths=specs,
+        levels_file_paths=levels,
+        timing_file_paths=timing)
+
+    # Verify the loaded levels and timing sheets can be applied to hardware
+    multi_instrument_session.apply_levels_and_timing(levels_sheet='levels', timing_sheet='timing')
+
+
+def test_load_specifications_levels_and_timing_multiple(multi_instrument_session):
+    pinmap = get_test_file_path('specifications_levels_and_timing_multiple', 'pin_map.pinmap')
+
+    specs1 = get_test_file_path('specifications_levels_and_timing_multiple', 'specs1.specs')
+    # Contains reference to variables in specs1
+    specs2 = get_test_file_path('specifications_levels_and_timing_multiple', 'specs2.specs')
+
+    # All levels and timing files contain references to variables in specs1 and specs2
+    levels1 = get_test_file_path('specifications_levels_and_timing_multiple', 'levels1.digilevels')
+    levels2 = get_test_file_path('specifications_levels_and_timing_multiple', 'levels2.digilevels')
+    timing1 = get_test_file_path('specifications_levels_and_timing_multiple', 'timing1.digitiming')
+    timing2 = get_test_file_path('specifications_levels_and_timing_multiple', 'timing2.digitiming')
+
+    multi_instrument_session.load_pin_map(pin_map_file_path=pinmap)
+    multi_instrument_session.load_specifications_levels_and_timing(
+        specifications_file_paths=[specs1, specs2],  # list
+        levels_file_paths=(levels1, levels2),  # tuple
+        timing_file_paths=[timing1, timing2])
+
+    # Verify the loaded levels and timing sheets can be applied to hardware
+    multi_instrument_session.apply_levels_and_timing(levels_sheet='levels1', timing_sheet='timing2')
+    multi_instrument_session.apply_levels_and_timing(levels_sheet='levels2', timing_sheet='timing1')
+
+
+def test_load_specifications_levels_and_timing_load_sequentially(multi_instrument_session):
+    pinmap = get_test_file_path('specifications_levels_and_timing_multiple', 'pin_map.pinmap')
+
+    specs1 = get_test_file_path('specifications_levels_and_timing_multiple', 'specs1.specs')
+    # Contains reference to variables in specs1
+    specs2 = get_test_file_path('specifications_levels_and_timing_multiple', 'specs2.specs')
+
+    # All levels and timing files contain references to variables in specs1 and specs2
+    levels1 = get_test_file_path('specifications_levels_and_timing_multiple', 'levels1.digilevels')
+    levels2 = get_test_file_path('specifications_levels_and_timing_multiple', 'levels2.digilevels')
+    timing1 = get_test_file_path('specifications_levels_and_timing_multiple', 'timing1.digitiming')
+    timing2 = get_test_file_path('specifications_levels_and_timing_multiple', 'timing2.digitiming')
+
+    multi_instrument_session.load_pin_map(pin_map_file_path=pinmap)
+
+    # Load just the specs files first, in two separate calls
+    multi_instrument_session.load_specifications_levels_and_timing(specifications_file_paths=specs1)
+    multi_instrument_session.load_specifications_levels_and_timing(specifications_file_paths=specs2)
+
+    # Then load both the levels together
+    multi_instrument_session.load_specifications_levels_and_timing(levels_file_paths=[levels2, levels1])
+
+    # Then load the two timing files in two separate calls
+    multi_instrument_session.load_specifications_levels_and_timing(timing_file_paths=[timing2])
+    multi_instrument_session.load_specifications_levels_and_timing(timing_file_paths=[timing1])
+
+    # Verify the loaded levels and timing sheets can be applied to hardware
+    multi_instrument_session.apply_levels_and_timing(levels_sheet='levels1', timing_sheet='timing2')
+    multi_instrument_session.apply_levels_and_timing(levels_sheet='levels2', timing_sheet='timing1')
+
+    # TODO: Verify unload specs
 

--- a/src/nidigital/templates/session.py/fancy_load_specifications_levels_and_timing.py.mako
+++ b/src/nidigital/templates/session.py/fancy_load_specifications_levels_and_timing.py.mako
@@ -1,0 +1,23 @@
+<%page args="f, config, method_template"/>\
+<%
+    '''Forwards to _load_specifications(), _load_levels(), and _load_timing().'''
+    import build.helper as helper
+%>\
+    def _load_files(self, loader, files):
+        if isinstance(files, str):
+            files = [files]
+        for f in files:
+            loader(f)
+
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+        '''${f['python_name']}
+
+        ${helper.get_function_docstring(f, False, config, indent=8)}
+        '''
+        if specifications_file_paths is not None:
+            self._load_files(self._load_specifications, specifications_file_paths)
+        if levels_file_paths is not None:
+            self._load_files(self._load_levels, levels_file_paths)
+        if timing_file_paths is not None:
+            self._load_files(self._load_timing, timing_file_paths)
+

--- a/src/nidigital/templates/session.py/fancy_load_specifications_levels_and_timing.py.mako
+++ b/src/nidigital/templates/session.py/fancy_load_specifications_levels_and_timing.py.mako
@@ -3,21 +3,20 @@
     '''Forwards to _load_specifications(), _load_levels(), and _load_timing().'''
     import build.helper as helper
 %>\
-    def _file_helper(self, action, files):
+    def _call_method_with_iterable(self, method, files):
+        if files is None:
+            return
         if isinstance(files, str):
             files = [files]
         for f in files:
-            action(f)
+            method(f)
 
     def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
         '''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}
         '''
-        if specifications_file_paths is not None:
-            self._file_helper(self._load_specifications, specifications_file_paths)
-        if levels_file_paths is not None:
-            self._file_helper(self._load_levels, levels_file_paths)
-        if timing_file_paths is not None:
-            self._file_helper(self._load_timing, timing_file_paths)
+        self._call_method_with_iterable(self._load_specifications, specifications_file_paths)
+        self._call_method_with_iterable(self._load_levels, levels_file_paths)
+        self._call_method_with_iterable(self._load_timing, timing_file_paths)
 

--- a/src/nidigital/templates/session.py/fancy_load_specifications_levels_and_timing.py.mako
+++ b/src/nidigital/templates/session.py/fancy_load_specifications_levels_and_timing.py.mako
@@ -3,11 +3,11 @@
     '''Forwards to _load_specifications(), _load_levels(), and _load_timing().'''
     import build.helper as helper
 %>\
-    def _load_files(self, loader, files):
+    def _file_helper(self, action, files):
         if isinstance(files, str):
             files = [files]
         for f in files:
-            loader(f)
+            action(f)
 
     def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
         '''${f['python_name']}
@@ -15,9 +15,9 @@
         ${helper.get_function_docstring(f, False, config, indent=8)}
         '''
         if specifications_file_paths is not None:
-            self._load_files(self._load_specifications, specifications_file_paths)
+            self._file_helper(self._load_specifications, specifications_file_paths)
         if levels_file_paths is not None:
-            self._load_files(self._load_levels, levels_file_paths)
+            self._file_helper(self._load_levels, levels_file_paths)
         if timing_file_paths is not None:
-            self._load_files(self._load_timing, timing_file_paths)
+            self._file_helper(self._load_timing, timing_file_paths)
 

--- a/src/nidigital/templates/session.py/fancy_unload_specifications.py.mako
+++ b/src/nidigital/templates/session.py/fancy_unload_specifications.py.mako
@@ -1,0 +1,12 @@
+<%page args="f, config, method_template"/>\
+<%
+    '''Forwards to _unload_specifications().'''
+    import build.helper as helper
+%>\
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+        '''${f['python_name']}
+
+        ${helper.get_function_docstring(f, False, config, indent=8)}
+        '''
+        self._file_helper(self._unload_specifications, file_paths)
+

--- a/src/nidigital/templates/session.py/fancy_unload_specifications.py.mako
+++ b/src/nidigital/templates/session.py/fancy_unload_specifications.py.mako
@@ -8,5 +8,5 @@
 
         ${helper.get_function_docstring(f, False, config, indent=8)}
         '''
-        self._file_helper(self._unload_specifications, file_paths)
+        self._call_method_with_iterable(self._unload_specifications, file_paths)
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

Improve usability of loading specifications, levels, and timing files and unloading specifications:
- Added `load_specifications_levels_and_timing` that allows loading of multiple specs, levels, and/or timing files in a single call
- Removed  `load_specifications`, `load_levels`, and `load_timing`
- Modified `unload_specifications` to allow unloading of one or more specs files in a single call

### List issues fixed by this Pull Request below, if any.

* Fix #1392

### What testing has been done?

Added and executed new system tests