### PR TITLE
Add a note to docstring of History RAM methods

### DIFF
--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -1132,6 +1132,30 @@ fetch_history_ram_cycle_information
 
             
 
+            .. note:: Before bursting a pattern, you must configure the History RAM trigger and specify which cycles to acquire.
+
+                :py:attr:`nidigital.Session.history_ram_trigger_type` should be used to specify the trigger condition on which History RAM
+                starts acquiring pattern information.
+
+                If History RAM trigger is configured as :py:data:`~nidigital.HistoryRAMTriggerType.CYCLE_NUMBER`,
+                :py:attr:`nidigital.Session.cycle_number_history_ram_trigger_cycle_number` should be used to specify the cycle number on which
+                History RAM starts acquiring pattern information.
+
+                If History RAM trigger is configured as :py:data:`~nidigital.HistoryRAMTriggerType.PATTERN_LABEL`,
+                :py:attr:`nidigital.Session.pattern_label_history_ram_trigger_label` should be used to specify the pattern label from which to
+                start acquiring pattern information.
+                :py:attr:`nidigital.Session.pattern_label_history_ram_trigger_vector_offset` should be used to specify the number of vectors
+                following the specified pattern label from which to start acquiring pattern information.
+                :py:attr:`nidigital.Session.pattern_label_history_ram_trigger_cycle_offset` should be used to specify the number of cycles
+                following the specified pattern label and vector offset from which to start acquiring pattern information.
+
+                For all History RAM trigger conditions, :py:attr:`nidigital.Session.history_ram_pretrigger_samples` should be used to specify
+                the number of samples to acquire before the trigger conditions are met. If you configure History RAM to only
+                acquire failed cycles, you must set :py:attr:`nidigital.Session.history_ram_pretrigger_samples` to 0.
+
+                :py:attr:`nidigital.Session.history_ram_cycles_to_acquire` should be used to specify which cycles History RAM acquires after
+                the trigger conditions are met.
+
 
             .. tip:: This method requires repeated capabilities. If called directly on the
                 nidigital.Session object, then the method will use all repeated capabilities in the session.
@@ -1310,9 +1334,33 @@ get_history_ram_sample_count
 
     .. py:method:: get_history_ram_sample_count()
 
-            TBD
+            Returns the number of samples History RAM acquired on the last pattern burst.
 
             
+
+            .. note:: Before bursting a pattern, you must configure the History RAM trigger and specify which cycles to acquire.
+
+                :py:attr:`nidigital.Session.history_ram_trigger_type` should be used to specify the trigger condition on which History RAM
+                starts acquiring pattern information.
+
+                If History RAM trigger is configured as :py:data:`~nidigital.HistoryRAMTriggerType.CYCLE_NUMBER`,
+                :py:attr:`nidigital.Session.cycle_number_history_ram_trigger_cycle_number` should be used to specify the cycle number on which
+                History RAM starts acquiring pattern information.
+
+                If History RAM trigger is configured as :py:data:`~nidigital.HistoryRAMTriggerType.PATTERN_LABEL`,
+                :py:attr:`nidigital.Session.pattern_label_history_ram_trigger_label` should be used to specify the pattern label from which to
+                start acquiring pattern information.
+                :py:attr:`nidigital.Session.pattern_label_history_ram_trigger_vector_offset` should be used to specify the number of vectors
+                following the specified pattern label from which to start acquiring pattern information.
+                :py:attr:`nidigital.Session.pattern_label_history_ram_trigger_cycle_offset` should be used to specify the number of cycles
+                following the specified pattern label and vector offset from which to start acquiring pattern information.
+
+                For all History RAM trigger conditions, :py:attr:`nidigital.Session.history_ram_pretrigger_samples` should be used to specify
+                the number of samples to acquire before the trigger conditions are met. If you configure History RAM to only
+                acquire failed cycles, you must set :py:attr:`nidigital.Session.history_ram_pretrigger_samples` to 0.
+
+                :py:attr:`nidigital.Session.history_ram_cycles_to_acquire` should be used to specify which cycles History RAM acquires after
+                the trigger conditions are met.
 
 
             .. tip:: This method requires repeated capabilities. If called directly on the

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -1290,6 +1290,31 @@ class _SessionBase(object):
 
          session.sites[0].pins['PinA', 'PinB'].fetch_history_ram_cycle_information(0, -1)
 
+        Note:
+        Before bursting a pattern, you must configure the History RAM trigger and specify which cycles to acquire.
+
+        history_ram_trigger_type should be used to specify the trigger condition on which History RAM
+        starts acquiring pattern information.
+
+        If History RAM trigger is configured as HistoryRAMTriggerType.CYCLE_NUMBER,
+        cycle_number_history_ram_trigger_cycle_number should be used to specify the cycle number on which
+        History RAM starts acquiring pattern information.
+
+        If History RAM trigger is configured as HistoryRAMTriggerType.PATTERN_LABEL,
+        pattern_label_history_ram_trigger_label should be used to specify the pattern label from which to
+        start acquiring pattern information.
+        pattern_label_history_ram_trigger_vector_offset should be used to specify the number of vectors
+        following the specified pattern label from which to start acquiring pattern information.
+        pattern_label_history_ram_trigger_cycle_offset should be used to specify the number of cycles
+        following the specified pattern label and vector offset from which to start acquiring pattern information.
+
+        For all History RAM trigger conditions, history_ram_pretrigger_samples should be used to specify
+        the number of samples to acquire before the trigger conditions are met. If you configure History RAM to only
+        acquire failed cycles, you must set history_ram_pretrigger_samples to 0.
+
+        history_ram_cycles_to_acquire should be used to specify which cycles History RAM acquires after
+        the trigger conditions are met.
+
         Tip:
         This method requires repeated capabilities. If called directly on the
         nidigital.Session object, then the method will use all repeated capabilities in the session.
@@ -1851,7 +1876,32 @@ class _SessionBase(object):
     def get_history_ram_sample_count(self):
         r'''get_history_ram_sample_count
 
-        TBD
+        Returns the number of samples History RAM acquired on the last pattern burst.
+
+        Note:
+        Before bursting a pattern, you must configure the History RAM trigger and specify which cycles to acquire.
+
+        history_ram_trigger_type should be used to specify the trigger condition on which History RAM
+        starts acquiring pattern information.
+
+        If History RAM trigger is configured as HistoryRAMTriggerType.CYCLE_NUMBER,
+        cycle_number_history_ram_trigger_cycle_number should be used to specify the cycle number on which
+        History RAM starts acquiring pattern information.
+
+        If History RAM trigger is configured as HistoryRAMTriggerType.PATTERN_LABEL,
+        pattern_label_history_ram_trigger_label should be used to specify the pattern label from which to
+        start acquiring pattern information.
+        pattern_label_history_ram_trigger_vector_offset should be used to specify the number of vectors
+        following the specified pattern label from which to start acquiring pattern information.
+        pattern_label_history_ram_trigger_cycle_offset should be used to specify the number of cycles
+        following the specified pattern label and vector offset from which to start acquiring pattern information.
+
+        For all History RAM trigger conditions, history_ram_pretrigger_samples should be used to specify
+        the number of samples to acquire before the trigger conditions are met. If you configure History RAM to only
+        acquire failed cycles, you must set history_ram_pretrigger_samples to 0.
+
+        history_ram_cycles_to_acquire should be used to specify which cycles History RAM acquires after
+        the trigger conditions are met.
 
         Tip:
         This method requires repeated capabilities. If called directly on the

--- a/src/nidigital/metadata/functions.py
+++ b/src/nidigital/metadata/functions.py
@@ -1507,7 +1507,32 @@ functions = {
     },
     'GetHistoryRAMSampleCount': {
         'documentation': {
-            'description': 'TBD'
+            'description': """\nReturns the number of samples History RAM acquired on the last pattern burst.
+""",
+            'note': """\nBefore bursting a pattern, you must configure the History RAM trigger and specify which cycles to acquire. 
+
+NIDIGITAL_ATTR_HISTORY_RAM_TRIGGER_TYPE should be used to specify the trigger condition on which History RAM
+starts acquiring pattern information.
+
+If History RAM trigger is configured as NIDIGITAL_VAL_CYCLE_NUMBER,
+NIDIGITAL_ATTR_CYCLE_NUMBER_HISTORY_RAM_TRIGGER_CYCLE_NUMBER should be used to specify the cycle number on which
+History RAM starts acquiring pattern information.
+
+If History RAM trigger is configured as NIDIGITAL_VAL_PATTERN_LABEL,
+NIDIGITAL_ATTR_PATTERN_LABEL_HISTORY_RAM_TRIGGER_LABEL should be used to specify the pattern label from which to
+start acquiring pattern information. 
+NIDIGITAL_ATTR_PATTERN_LABEL_HISTORY_RAM_TRIGGER_VECTOR_OFFSET should be used to specify the number of vectors
+following the specified pattern label from which to start acquiring pattern information. 
+NIDIGITAL_ATTR_PATTERN_LABEL_HISTORY_RAM_TRIGGER_CYCLE_OFFSET should be used to specify the number of cycles
+following the specified pattern label and vector offset from which to start acquiring pattern information.
+
+For all History RAM trigger conditions, NIDIGITAL_ATTR_HISTORY_RAM_PRETRIGGER_SAMPLES should be used to specify
+the number of samples to acquire before the trigger conditions are met. If you configure History RAM to only
+acquire failed cycles, you must set NIDIGITAL_ATTR_HISTORY_RAM_PRETRIGGER_SAMPLES to 0. 
+
+NIDIGITAL_ATTR_HISTORY_RAM_CYCLES_TO_ACQUIRE should be used to specify which cycles History RAM acquires after
+the trigger conditions are met.
+""",
         },
         'parameters': [
             {

--- a/src/nidigital/metadata/functions_addon.py
+++ b/src/nidigital/metadata/functions_addon.py
@@ -293,7 +293,31 @@ niDigital_GetPatternPinList with the start label to retrieve the pins associated
 .. code:: python
 
  session.sites[0].pins['PinA', 'PinB'].fetch_history_ram_cycle_information(0, -1)
-"""
+""",
+            'note': """\nBefore bursting a pattern, you must configure the History RAM trigger and specify which cycles to acquire. 
+
+NIDIGITAL_ATTR_HISTORY_RAM_TRIGGER_TYPE should be used to specify the trigger condition on which History RAM
+starts acquiring pattern information.
+
+If History RAM trigger is configured as NIDIGITAL_VAL_CYCLE_NUMBER,
+NIDIGITAL_ATTR_CYCLE_NUMBER_HISTORY_RAM_TRIGGER_CYCLE_NUMBER should be used to specify the cycle number on which
+History RAM starts acquiring pattern information.
+
+If History RAM trigger is configured as NIDIGITAL_VAL_PATTERN_LABEL,
+NIDIGITAL_ATTR_PATTERN_LABEL_HISTORY_RAM_TRIGGER_LABEL should be used to specify the pattern label from which to
+start acquiring pattern information. 
+NIDIGITAL_ATTR_PATTERN_LABEL_HISTORY_RAM_TRIGGER_VECTOR_OFFSET should be used to specify the number of vectors
+following the specified pattern label from which to start acquiring pattern information. 
+NIDIGITAL_ATTR_PATTERN_LABEL_HISTORY_RAM_TRIGGER_CYCLE_OFFSET should be used to specify the number of cycles
+following the specified pattern label and vector offset from which to start acquiring pattern information.
+
+For all History RAM trigger conditions, NIDIGITAL_ATTR_HISTORY_RAM_PRETRIGGER_SAMPLES should be used to specify
+the number of samples to acquire before the trigger conditions are met. If you configure History RAM to only
+acquire failed cycles, you must set NIDIGITAL_ATTR_HISTORY_RAM_PRETRIGGER_SAMPLES to 0. 
+
+NIDIGITAL_ATTR_HISTORY_RAM_CYCLES_TO_ACQUIRE should be used to specify which cycles History RAM acquires after
+the trigger conditions are met.
+""",
         },
         'parameters': [
             {


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

- Note added to `get_history_ram_sample_count` and `fetch_history_ram_cycle_information`
- The note mentions that History RAM configuration must be done before bursting a pattern

### List issues fixed by this Pull Request below, if any.

* Fix #1390

### What testing has been done?

Tests will be run by CI