### PR TITLE
Improve usability of getting channel names from channel indices in nidigital

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to this project will be documented in this file.
         * `get_pattern_pin_names` - [#1292](https://github.com/ni/nimi-python/issues/1292)
         * Support for `instruments` repeated capability in the following properties - `instrument_firmware_revision`, `serial_number`, and `timing_absolute_delay` -  [#1228](https://github.com/ni/nimi-python/issues/1228) 
         * `load_specifications_levels_and_timing` that allows loading of multiple specs, levels, and/or timing files in a single call - [#1392](https://github.com/ni/nimi-python/issues/1392)
+        * `get_channel_names` - [#1386](https://github.com/ni/nimi-python/issues/1386) 
     * #### Changed
         * Change the type of applicable method parameters and properties to enums - [#1066](https://github.com/ni/nimi-python/issues/1066)
         * `get_site_pass_fail` returns dictionary where each key is a site number and value is a bool indicating pass/fail - [#1297](https://github.com/ni/nimi-python/issues/1297)
@@ -59,6 +60,7 @@ All notable changes to this project will be documented in this file.
         * `clear_error` - [#1366](https://github.com/ni/nimi-python/issues/1366) 
         * `clock_generator_initiate` - [#1370](https://github.com/ni/nimi-python/issues/1370) 
         * `load_specifications`, `load_levels`, and `load_timing` - [#1392](https://github.com/ni/nimi-python/issues/1392) 
+        * `get_channel_name` and `get_channel_name_from_string` - [#1386](https://github.com/ni/nimi-python/issues/1386) 
 * ### NI-DMM
     * #### Added
     * #### Changed

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -1265,9 +1265,9 @@ get_channel_names
                 Specifies indices for the channels in the session.
                 Valid values are from zero to the total number of channels in the session minus one.
                 The following types and formats are supported:
-                  - int - for example, 0
-                  - Basic sequence types (list, tuple, range, slice) - for example, [0, range(2, 4)]
-                  - str - for example, "0, 2, 3, 1", "0-3", "0:3"
+                  - int - example: 0
+                  - Basic sequence - example: [0, range(2, 4)]
+                  - str - example: "0, 2, 3, 1", "0-3", "0:3"
 
                 The input can contain any combination of above types. Both out-of-order and repeated indices are
                 supported ([2,3,0], [1,2,2,3]). White space characters, including spaces, tabs, feeds, and

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -1252,6 +1252,9 @@ get_channel_names
 
             Returns a list of channel names for given channel indices.
 
+            This is useful in multi-instrument sessions, where channels are expected to be
+            referenced by their fully-qualified names, for example, PXI1Slot3/0.
+
             
 
 
@@ -1262,19 +1265,12 @@ get_channel_names
                 Specifies indices for the channels in the session.
                 Valid values are from zero to the total number of channels in the session minus one.
                 The following types and formats are supported:
-                  - Basic Sequence types
-                    - list - for example, [0, 2, 3, 1]
-                    - tuple - for example, (0, 2, 3, 1)
-                    - range - for example, range(0, 15, 2)
-                  - slice - for example, slice(0, 15, 2)
-                  - str
-                    - A comma-separated list - for example, "0,2,3,1"
-                    - A range using a hyphen - for example, "0-3"
-                    - A range using a colon - for example, "0:3"
                   - int - for example, 0
+                  - Basic sequence types (list, tuple, range, slice) - for example, [0, range(2, 4)]
+                  - str - for example, "0, 2, 3, 1", "0-3", "0:3"
 
                 The input can contain any combination of above types. Both out-of-order and repeated indices are
-                supported ("2,3,0", "1,2,2,3"). White space characters, including spaces, tabs, feeds, and
+                supported ([2,3,0], [1,2,2,3]). White space characters, including spaces, tabs, feeds, and
                 carriage returns, are allowed within strings. Ranges can be incrementing or decrementing.
 
                 

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -1243,59 +1243,50 @@ frequency_counter_measure_frequency
 
 
 
-get_channel_name
-----------------
+get_channel_names
+-----------------
 
     .. py:currentmodule:: nidigital.Session
 
-    .. py:method:: get_channel_name(index)
+    .. py:method:: get_channel_names(indices)
 
-            TBD
+            Returns a list of channel names for given channel indices.
 
             
 
 
 
-            :param index:
+            :param indices:
 
 
-                
+                Specifies indices for the channels in the session.
+                Valid values are from zero to the total number of channels in the session minus one.
+                The following types and formats are supported:
+                  - Basic Sequence types
+                    - list - for example, [0, 2, 3, 1]
+                    - tuple - for example, (0, 2, 3, 1)
+                    - range - for example, range(0, 15, 2)
+                  - slice - for example, slice(0, 15, 2)
+                  - str
+                    - A comma-separated list - for example, "0,2,3,1"
+                    - A range using a hyphen - for example, "0-3"
+                    - A range using a colon - for example, "0:3"
+                  - int - for example, 0
 
-
-            :type index: int
-
-            :rtype: str
-            :return:
-
-
-                    
-
-
-
-get_channel_name_from_string
-----------------------------
-
-    .. py:currentmodule:: nidigital.Session
-
-    .. py:method:: get_channel_name_from_string(index)
-
-            TBD
-
-            
-
-
-
-            :param index:
-
+                The input can contain any combination of above types. Both out-of-order and repeated indices are
+                supported ("2,3,0", "1,2,2,3"). White space characters, including spaces, tabs, feeds, and
+                carriage returns, are allowed within strings. Ranges can be incrementing or decrementing.
 
                 
 
 
-            :type index: str
+            :type indices: basic sequence types or str or int
 
-            :rtype: str
+            :rtype: list of str
             :return:
 
+
+                    Channel names
 
                     
 
@@ -1427,7 +1418,7 @@ get_pattern_pin_names
 
             :type start_label: str
 
-            :rtype: str
+            :rtype: list of str
             :return:
 
 

--- a/generated/nidigital/nidigital/_library.py
+++ b/generated/nidigital/nidigital/_library.py
@@ -59,7 +59,6 @@ class Library(object):
         self.niDigital_GetAttributeViInt64_cfunc = None
         self.niDigital_GetAttributeViReal64_cfunc = None
         self.niDigital_GetAttributeViString_cfunc = None
-        self.niDigital_GetChannelName_cfunc = None
         self.niDigital_GetChannelNameFromString_cfunc = None
         self.niDigital_GetError_cfunc = None
         self.niDigital_GetFailCount_cfunc = None
@@ -425,14 +424,6 @@ class Library(object):
                 self.niDigital_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetAttributeViString_cfunc(vi, channel_name, attribute, buffer_size, value)
-
-    def niDigital_GetChannelName(self, vi, index, name_buffer_size, name):  # noqa: N802
-        with self._func_lock:
-            if self.niDigital_GetChannelName_cfunc is None:
-                self.niDigital_GetChannelName_cfunc = self._library.niDigital_GetChannelName
-                self.niDigital_GetChannelName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
-                self.niDigital_GetChannelName_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDigital_GetChannelName_cfunc(vi, index, name_buffer_size, name)
 
     def niDigital_GetChannelNameFromString(self, vi, indices, name_buffer_size, names):  # noqa: N802
         with self._func_lock:

--- a/generated/nidigital/nidigital/_library.py
+++ b/generated/nidigital/nidigital/_library.py
@@ -434,13 +434,13 @@ class Library(object):
                 self.niDigital_GetChannelName_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetChannelName_cfunc(vi, index, name_buffer_size, name)
 
-    def niDigital_GetChannelNameFromString(self, vi, index, name_buffer_size, name):  # noqa: N802
+    def niDigital_GetChannelNameFromString(self, vi, indices, name_buffer_size, names):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetChannelNameFromString_cfunc is None:
                 self.niDigital_GetChannelNameFromString_cfunc = self._library.niDigital_GetChannelNameFromString
                 self.niDigital_GetChannelNameFromString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_GetChannelNameFromString_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDigital_GetChannelNameFromString_cfunc(vi, index, name_buffer_size, name)
+        return self.niDigital_GetChannelNameFromString_cfunc(vi, indices, name_buffer_size, names)
 
     def niDigital_GetError(self, vi, error_code, error_description_buffer_size, error_description):  # noqa: N802
         with self._func_lock:

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -1471,7 +1471,7 @@ class _SessionBase(object):
         pin_infos = []
         for i in range(len(pin_indexes)):
             pin_name = "" if pin_indexes[i] == -1 else self._get_pin_name(pin_indexes[i])
-            channel_name = self.get_channel_name(channel_indexes[i])
+            channel_name = self._get_channel_name(channel_indexes[i])
             pin_infos.append(PinInfo(pin_name=pin_name, site_number=site_numbers[i], channel_name=channel_name))
 
         return pin_infos
@@ -1794,8 +1794,8 @@ class _SessionBase(object):
         return value_ctype.value.decode(self._encoding)
 
     @ivi_synchronized
-    def get_channel_name(self, index):
-        r'''get_channel_name
+    def _get_channel_name(self, index):
+        r'''_get_channel_name
 
         TBD
 
@@ -2940,30 +2940,46 @@ class Session(_SessionBase):
         self.sites[site_list]._write_source_waveform_site_unique_u32(waveform_name, len(waveform_data), actual_samples_per_waveform, data)
 
     @ivi_synchronized
-    def get_channel_name_from_string(self, index):
-        r'''get_channel_name_from_string
+    def get_channel_names(self, indices):
+        r'''get_channel_names
 
-        TBD
+        Returns a list of channel names for given channel indices.
 
         Args:
-            index (str):
+            indices (basic sequence types or str or int): Specifies indices for the channels in the session.
+                Valid values are from zero to the total number of channels in the session minus one.
+                The following types and formats are supported:
+                  - Basic Sequence types
+                    - list - for example, [0, 2, 3, 1]
+                    - tuple - for example, (0, 2, 3, 1)
+                    - range - for example, range(0, 15, 2)
+                  - slice - for example, slice(0, 15, 2)
+                  - str
+                    - A comma-separated list - for example, "0,2,3,1"
+                    - A range using a hyphen - for example, "0-3"
+                    - A range using a colon - for example, "0:3"
+                  - int - for example, 0
+
+                The input can contain any combination of above types. Both out-of-order and repeated indices are
+                supported ("2,3,0", "1,2,2,3"). White space characters, including spaces, tabs, feeds, and
+                carriage returns, are allowed within strings. Ranges can be incrementing or decrementing.
 
 
         Returns:
-            name (str):
+            names (list of str): Channel names
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        index_ctype = ctypes.create_string_buffer(index.encode(self._encoding))  # case C020
+        indices_ctype = ctypes.create_string_buffer(_converters.convert_repeated_capabilities_without_prefix(indices).encode(self._encoding))  # case C040
         name_buffer_size_ctype = _visatype.ViInt32()  # case S170
-        name_ctype = None  # case C050
-        error_code = self._library.niDigital_GetChannelNameFromString(vi_ctype, index_ctype, name_buffer_size_ctype, name_ctype)
+        names_ctype = None  # case C050
+        error_code = self._library.niDigital_GetChannelNameFromString(vi_ctype, indices_ctype, name_buffer_size_ctype, names_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         name_buffer_size_ctype = _visatype.ViInt32(error_code)  # case S180
-        name_ctype = (_visatype.ViChar * name_buffer_size_ctype.value)()  # case C060
-        error_code = self._library.niDigital_GetChannelNameFromString(vi_ctype, index_ctype, name_buffer_size_ctype, name_ctype)
+        names_ctype = (_visatype.ViChar * name_buffer_size_ctype.value)()  # case C060
+        error_code = self._library.niDigital_GetChannelNameFromString(vi_ctype, indices_ctype, name_buffer_size_ctype, names_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return name_ctype.value.decode(self._encoding)
+        return _converters.convert_comma_separated_string_to_list(names_ctype.value.decode(self._encoding))
 
     @ivi_synchronized
     def get_pattern_pin_names(self, start_label):
@@ -2976,7 +2992,7 @@ class Session(_SessionBase):
 
 
         Returns:
-            pin_list (str):
+            pin_list (list of str):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -1807,9 +1807,9 @@ class _SessionBase(object):
             indices (basic sequence types or str or int): Specifies indices for the channels in the session.
                 Valid values are from zero to the total number of channels in the session minus one.
                 The following types and formats are supported:
-                  - int - for example, 0
-                  - Basic sequence types (list, tuple, range, slice) - for example, [0, range(2, 4)]
-                  - str - for example, "0, 2, 3, 1", "0-3", "0:3"
+                  - int - example: 0
+                  - Basic sequence - example: [0, range(2, 4)]
+                  - str - example: "0, 2, 3, 1", "0-3", "0:3"
 
                 The input can contain any combination of above types. Both out-of-order and repeated indices are
                 supported ([2,3,0], [1,2,2,3]). White space characters, including spaces, tabs, feeds, and

--- a/generated/nidigital/nidigital/unit_tests/_mock_helper.py
+++ b/generated/nidigital/nidigital/unit_tests/_mock_helper.py
@@ -114,7 +114,7 @@ class SideEffectsHelper(object):
         self._defaults['GetChannelName']['name'] = None
         self._defaults['GetChannelNameFromString'] = {}
         self._defaults['GetChannelNameFromString']['return'] = 0
-        self._defaults['GetChannelNameFromString']['name'] = None
+        self._defaults['GetChannelNameFromString']['names'] = None
         self._defaults['GetError'] = {}
         self._defaults['GetError']['return'] = 0
         self._defaults['GetError']['errorCode'] = None
@@ -568,14 +568,14 @@ class SideEffectsHelper(object):
         name.value = self._defaults['GetChannelName']['name'].encode('ascii')
         return self._defaults['GetChannelName']['return']
 
-    def niDigital_GetChannelNameFromString(self, vi, index, name_buffer_size, name):  # noqa: N802
+    def niDigital_GetChannelNameFromString(self, vi, indices, name_buffer_size, names):  # noqa: N802
         if self._defaults['GetChannelNameFromString']['return'] != 0:
             return self._defaults['GetChannelNameFromString']['return']
-        if self._defaults['GetChannelNameFromString']['name'] is None:
-            raise MockFunctionCallError("niDigital_GetChannelNameFromString", param='name')
+        if self._defaults['GetChannelNameFromString']['names'] is None:
+            raise MockFunctionCallError("niDigital_GetChannelNameFromString", param='names')
         if name_buffer_size.value == 0:
-            return len(self._defaults['GetChannelNameFromString']['name'])
-        name.value = self._defaults['GetChannelNameFromString']['name'].encode('ascii')
+            return len(self._defaults['GetChannelNameFromString']['names'])
+        names.value = self._defaults['GetChannelNameFromString']['names'].encode('ascii')
         return self._defaults['GetChannelNameFromString']['return']
 
     def niDigital_GetError(self, vi, error_code, error_description_buffer_size, error_description):  # noqa: N802

--- a/generated/nidigital/nidigital/unit_tests/_mock_helper.py
+++ b/generated/nidigital/nidigital/unit_tests/_mock_helper.py
@@ -109,9 +109,6 @@ class SideEffectsHelper(object):
         self._defaults['GetAttributeViString'] = {}
         self._defaults['GetAttributeViString']['return'] = 0
         self._defaults['GetAttributeViString']['value'] = None
-        self._defaults['GetChannelName'] = {}
-        self._defaults['GetChannelName']['return'] = 0
-        self._defaults['GetChannelName']['name'] = None
         self._defaults['GetChannelNameFromString'] = {}
         self._defaults['GetChannelNameFromString']['return'] = 0
         self._defaults['GetChannelNameFromString']['names'] = None
@@ -557,16 +554,6 @@ class SideEffectsHelper(object):
             return len(self._defaults['GetAttributeViString']['value'])
         value.value = self._defaults['GetAttributeViString']['value'].encode('ascii')
         return self._defaults['GetAttributeViString']['return']
-
-    def niDigital_GetChannelName(self, vi, index, name_buffer_size, name):  # noqa: N802
-        if self._defaults['GetChannelName']['return'] != 0:
-            return self._defaults['GetChannelName']['return']
-        if self._defaults['GetChannelName']['name'] is None:
-            raise MockFunctionCallError("niDigital_GetChannelName", param='name')
-        if name_buffer_size.value == 0:
-            return len(self._defaults['GetChannelName']['name'])
-        name.value = self._defaults['GetChannelName']['name'].encode('ascii')
-        return self._defaults['GetChannelName']['return']
 
     def niDigital_GetChannelNameFromString(self, vi, indices, name_buffer_size, names):  # noqa: N802
         if self._defaults['GetChannelNameFromString']['return'] != 0:
@@ -1154,8 +1141,6 @@ class SideEffectsHelper(object):
         mock_library.niDigital_GetAttributeViReal64.return_value = 0
         mock_library.niDigital_GetAttributeViString.side_effect = MockFunctionCallError("niDigital_GetAttributeViString")
         mock_library.niDigital_GetAttributeViString.return_value = 0
-        mock_library.niDigital_GetChannelName.side_effect = MockFunctionCallError("niDigital_GetChannelName")
-        mock_library.niDigital_GetChannelName.return_value = 0
         mock_library.niDigital_GetChannelNameFromString.side_effect = MockFunctionCallError("niDigital_GetChannelNameFromString")
         mock_library.niDigital_GetChannelNameFromString.return_value = 0
         mock_library.niDigital_GetError.side_effect = MockFunctionCallError("niDigital_GetError")

--- a/src/nidigital/metadata/functions.py
+++ b/src/nidigital/metadata/functions.py
@@ -1368,6 +1368,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'GetChannelName': {
+        'codegen_method': 'private',
         'documentation': {
             'description': 'TBD'
         },
@@ -1402,7 +1403,7 @@ functions = {
     },
     'GetChannelNameFromString': {
         'documentation': {
-            'description': 'TBD'
+            'description': '\nReturns a list of channel names for given channel indices.',
         },
         'parameters': [
             {
@@ -1412,8 +1413,31 @@ functions = {
             },
             {
                 'direction': 'in',
-                'name': 'index',
-                'type': 'ViConstString'
+                'documentation': {
+                    'description': """\nSpecifies indices for the channels in the session.
+Valid values are from zero to the total number of channels in the session minus one.
+The following types and formats are supported:
+  - Basic Sequence types
+    - list - for example, [0, 2, 3, 1]
+    - tuple - for example, (0, 2, 3, 1)
+    - range - for example, range(0, 15, 2)
+  - slice - for example, slice(0, 15, 2)
+  - str
+    - A comma-separated list - for example, "0,2,3,1"
+    - A range using a hyphen - for example, "0-3"
+    - A range using a colon - for example, "0:3"
+  - int - for example, 0
+    
+The input can contain any combination of above types. Both out-of-order and repeated indices are
+supported ("2,3,0", "1,2,2,3"). White space characters, including spaces, tabs, feeds, and
+carriage returns, are allowed within strings. Ranges can be incrementing or decrementing.
+
+"""
+                },
+                'name': 'indices',
+                'python_api_converter_name': 'convert_repeated_capabilities_without_prefix',
+                'type': 'ViConstString',
+                'type_in_documentation': 'basic sequence types or str or int',
             },
             {
                 'direction': 'in',
@@ -1422,14 +1446,20 @@ functions = {
             },
             {
                 'direction': 'out',
-                'name': 'name',
+                'documentation': {
+                    'description': '\nChannel names'
+                },
+                'name': 'names',
+                'python_api_converter_name': 'convert_comma_separated_string_to_list',
                 'size': {
                     'mechanism': 'ivi-dance',
                     'value': 'nameBufferSize'
                 },
-                'type': 'ViChar[]'
+                'type': 'ViChar[]',
+                'type_in_documentation': 'list of str',
             }
         ],
+        'python_name': 'get_channel_names',
         'returns': 'ViStatus'
     },
     'GetError': {
@@ -1616,7 +1646,8 @@ the trigger conditions are met.
                     'mechanism': 'ivi-dance',
                     'value': 'pinListBufferSize'
                 },
-                'type': 'ViChar[]'
+                'type': 'ViChar[]',
+                'type_in_documentation': 'list of str',
             }
         ],
         'python_name': 'get_pattern_pin_names',

--- a/src/nidigital/metadata/functions.py
+++ b/src/nidigital/metadata/functions.py
@@ -1420,9 +1420,9 @@ referenced by their fully-qualified names, for example, PXI1Slot3/0.
                     'description': """\nSpecifies indices for the channels in the session.
 Valid values are from zero to the total number of channels in the session minus one.
 The following types and formats are supported:
-  - int - for example, 0
-  - Basic sequence types (list, tuple, range, slice) - for example, [0, range(2, 4)]
-  - str - for example, "0, 2, 3, 1", "0-3", "0:3"
+  - int - example: 0
+  - Basic sequence - example: [0, range(2, 4)]
+  - str - example: "0, 2, 3, 1", "0-3", "0:3"
     
 The input can contain any combination of above types. Both out-of-order and repeated indices are
 supported ([2,3,0], [1,2,2,3]). White space characters, including spaces, tabs, feeds, and

--- a/src/nidigital/metadata/functions.py
+++ b/src/nidigital/metadata/functions.py
@@ -1368,7 +1368,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'GetChannelName': {
-        'codegen_method': 'private',
+        'codegen_method': 'no',
         'documentation': {
             'description': 'TBD'
         },
@@ -1398,12 +1398,15 @@ functions = {
                 'type': 'ViChar[]'
             }
         ],
-        'render_in_session_base': True,
         'returns': 'ViStatus'
     },
     'GetChannelNameFromString': {
         'documentation': {
-            'description': '\nReturns a list of channel names for given channel indices.',
+            'description': """\nReturns a list of channel names for given channel indices.
+ 
+This is useful in multi-instrument sessions, where channels are expected to be
+referenced by their fully-qualified names, for example, PXI1Slot3/0.
+"""
         },
         'parameters': [
             {
@@ -1417,19 +1420,12 @@ functions = {
                     'description': """\nSpecifies indices for the channels in the session.
 Valid values are from zero to the total number of channels in the session minus one.
 The following types and formats are supported:
-  - Basic Sequence types
-    - list - for example, [0, 2, 3, 1]
-    - tuple - for example, (0, 2, 3, 1)
-    - range - for example, range(0, 15, 2)
-  - slice - for example, slice(0, 15, 2)
-  - str
-    - A comma-separated list - for example, "0,2,3,1"
-    - A range using a hyphen - for example, "0-3"
-    - A range using a colon - for example, "0:3"
   - int - for example, 0
+  - Basic sequence types (list, tuple, range, slice) - for example, [0, range(2, 4)]
+  - str - for example, "0, 2, 3, 1", "0-3", "0:3"
     
 The input can contain any combination of above types. Both out-of-order and repeated indices are
-supported ("2,3,0", "1,2,2,3"). White space characters, including spaces, tabs, feeds, and
+supported ([2,3,0], [1,2,2,3]). White space characters, including spaces, tabs, feeds, and
 carriage returns, are allowed within strings. Ranges can be incrementing or decrementing.
 
 """
@@ -1460,6 +1456,7 @@ carriage returns, are allowed within strings. Ranges can be incrementing or decr
             }
         ],
         'python_name': 'get_channel_names',
+        'render_in_session_base': True,  # Used in FancyGetPinResultsPinInformation()
         'returns': 'ViStatus'
     },
     'GetError': {

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -90,13 +90,13 @@ def test_instruments_rep_cap(multi_instrument_session):
 
 
 def test_property_boolean(multi_instrument_session):
-    channel = multi_instrument_session.get_channel_name(index=42)
+    channel = multi_instrument_session.get_channel_names(indices=42)
     multi_instrument_session.channels[channel].ppmu_allow_extended_voltage_range = True
     assert multi_instrument_session.channels[channel].ppmu_allow_extended_voltage_range is True
 
 
 def test_property_int32(multi_instrument_session):
-    channel = multi_instrument_session.get_channel_name(index=42)
+    channel = multi_instrument_session.get_channel_names(indices=42)
     multi_instrument_session.channels[channel].termination_mode = nidigital.TerminationMode.HIGH_Z
     assert multi_instrument_session.channels[channel].termination_mode == nidigital.TerminationMode.HIGH_Z
 
@@ -107,7 +107,7 @@ def test_property_int64(multi_instrument_session):
 
 
 def test_property_real64(multi_instrument_session):
-    channel = multi_instrument_session.get_channel_name(index=42)
+    channel = multi_instrument_session.get_channel_names(indices=42)
     multi_instrument_session.channels[channel].ppmu_voltage_level = 4
     assert multi_instrument_session.channels[channel].ppmu_voltage_level == pytest.approx(4, rel=1e-3)
 
@@ -117,20 +117,28 @@ def test_property_string(multi_instrument_session):
     assert multi_instrument_session.start_label == 'foo'
 
 
+def test_get_channel_names(multi_instrument_session):
+    expected_string = ['{0}/{1}'.format(instruments[0], x) for x in range(12)]
+    # Sanity test few different types of input. No need for test to be exhaustive
+    # since all the various types are covered by converter unit tests.
+    channel_indices = ['0-1, 2, 3:4', 5, (6, 7), range(8, 10), slice(10, 12)]
+    assert multi_instrument_session.get_channel_names(indices=channel_indices) == expected_string
+
+
 def test_tdr_all_channels(multi_instrument_session):
     applied_offsets = multi_instrument_session.tdr(apply_offsets=False)
     assert len(applied_offsets) == multi_instrument_session.channel_count
 
     multi_instrument_session.apply_tdr_offsets(applied_offsets)
 
-    channels = [multi_instrument_session.get_channel_name(i) for i in
-                range(1, multi_instrument_session.channel_count + 1)]
+    channels = [multi_instrument_session.get_channel_names(i) for i in
+                range(0, multi_instrument_session.channel_count)]
     fetched_offsets = [multi_instrument_session.channels[i].tdr_offset for i in channels]
     assert fetched_offsets == applied_offsets
 
 
 def test_tdr_some_channels(multi_instrument_session):
-    channels = [multi_instrument_session.get_channel_name(i) for i in [64, 1, 50, 25]]
+    channels = [multi_instrument_session.get_channel_names(i) for i in [63, 0, 49, 24]]
     applied_offsets = multi_instrument_session.channels[channels].tdr(apply_offsets=False)
     assert len(applied_offsets) == len(channels)
 

--- a/src/nidigital/templates/session.py/fancy_get_pin_results_pin_information.py.mako
+++ b/src/nidigital/templates/session.py/fancy_get_pin_results_pin_information.py.mako
@@ -18,8 +18,9 @@
         pin_infos = []
         for i in range(len(pin_indexes)):
             pin_name = "" if pin_indexes[i] == -1 else self._get_pin_name(pin_indexes[i])
-            channel_name = self._get_channel_name(channel_indexes[i])
-            pin_infos.append(PinInfo(pin_name=pin_name, site_number=site_numbers[i], channel_name=channel_name))
+            channel_names = self.get_channel_names(channel_indexes[i] - 1)  # channel_indexes are 1-based
+            assert 1 == len(channel_names)
+            pin_infos.append(PinInfo(pin_name=pin_name, site_number=site_numbers[i], channel_name=channel_names[0]))
 
         return pin_infos
 

--- a/src/nidigital/templates/session.py/fancy_get_pin_results_pin_information.py.mako
+++ b/src/nidigital/templates/session.py/fancy_get_pin_results_pin_information.py.mako
@@ -18,7 +18,7 @@
         pin_infos = []
         for i in range(len(pin_indexes)):
             pin_name = "" if pin_indexes[i] == -1 else self._get_pin_name(pin_indexes[i])
-            channel_name = self.get_channel_name(channel_indexes[i])
+            channel_name = self._get_channel_name(channel_indexes[i])
             pin_infos.append(PinInfo(pin_name=pin_name, site_number=site_numbers[i], channel_name=channel_name))
 
         return pin_infos


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

- Add get_channel_names()
- Remove get_channel_name() and get_channel_name_from_string()

### List issues fixed by this Pull Request below, if any.

* Fix #1386

### What testing has been done?

Added new system test and ran all unit tests. System tests will be run by CI.