### PR TITLE
In nidigital, remove unnecessary prefix for file_path parameter in methods that load and unload files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to this project will be documented in this file.
         * Update `fetch_history_ram_cycle_information`, `get_history_ram_sample_count`, and `is_site_enabled` to use `sites` repeated capability - [#1337](https://github.com/ni/nimi-python/issues/1337)
         * Rename parameter `time_set` to `time_set_name` in applicable time set methods - [#1396](https://github.com/ni/nimi-python/issues/1396)
         * Modified `unload_specifications` to allow unloading of one or more specs files in a single call - [#1392](https://github.com/ni/nimi-python/issues/1392) 
+        * In `load_pin_map`, changed parameter name `pin_map_file_path` to `file_path` - [#1393](https://github.com/ni/nimi-python/issues/1393) 
     * #### Removed
         * `get_pattern_pin_list`, `get_pattern_pin_indexes` and `get_pin_name` - [#1292](https://github.com/ni/nimi-python/issues/1292)
         * `get_site_results_site_numbers` method and `SiteResultType` enum - [#1298](https://github.com/ni/nimi-python/issues/1298) 

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -1756,7 +1756,7 @@ load_pin_map
 
     .. py:currentmodule:: nidigital.Session
 
-    .. py:method:: load_pin_map(pin_map_file_path)
+    .. py:method:: load_pin_map(file_path)
 
             TBD
 
@@ -1764,13 +1764,13 @@ load_pin_map
 
 
 
-            :param pin_map_file_path:
+            :param file_path:
 
 
                 
 
 
-            :type pin_map_file_path: str
+            :type file_path: str
 
 load_specifications_levels_and_timing
 -------------------------------------

--- a/generated/nidigital/nidigital/_library.py
+++ b/generated/nidigital/nidigital/_library.py
@@ -586,13 +586,13 @@ class Library(object):
                 self.niDigital_IsSiteEnabled_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_IsSiteEnabled_cfunc(vi, site, enable)
 
-    def niDigital_LoadLevels(self, vi, levels_file_path):  # noqa: N802
+    def niDigital_LoadLevels(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDigital_LoadLevels_cfunc is None:
                 self.niDigital_LoadLevels_cfunc = self._library.niDigital_LoadLevels
                 self.niDigital_LoadLevels_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_LoadLevels_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDigital_LoadLevels_cfunc(vi, levels_file_path)
+        return self.niDigital_LoadLevels_cfunc(vi, file_path)
 
     def niDigital_LoadPattern(self, vi, file_path):  # noqa: N802
         with self._func_lock:
@@ -602,29 +602,29 @@ class Library(object):
                 self.niDigital_LoadPattern_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_LoadPattern_cfunc(vi, file_path)
 
-    def niDigital_LoadPinMap(self, vi, pin_map_file_path):  # noqa: N802
+    def niDigital_LoadPinMap(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDigital_LoadPinMap_cfunc is None:
                 self.niDigital_LoadPinMap_cfunc = self._library.niDigital_LoadPinMap
                 self.niDigital_LoadPinMap_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_LoadPinMap_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDigital_LoadPinMap_cfunc(vi, pin_map_file_path)
+        return self.niDigital_LoadPinMap_cfunc(vi, file_path)
 
-    def niDigital_LoadSpecifications(self, vi, specifications_file_path):  # noqa: N802
+    def niDigital_LoadSpecifications(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDigital_LoadSpecifications_cfunc is None:
                 self.niDigital_LoadSpecifications_cfunc = self._library.niDigital_LoadSpecifications
                 self.niDigital_LoadSpecifications_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_LoadSpecifications_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDigital_LoadSpecifications_cfunc(vi, specifications_file_path)
+        return self.niDigital_LoadSpecifications_cfunc(vi, file_path)
 
-    def niDigital_LoadTiming(self, vi, timing_file_path):  # noqa: N802
+    def niDigital_LoadTiming(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDigital_LoadTiming_cfunc is None:
                 self.niDigital_LoadTiming_cfunc = self._library.niDigital_LoadTiming
                 self.niDigital_LoadTiming_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_LoadTiming_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDigital_LoadTiming_cfunc(vi, timing_file_path)
+        return self.niDigital_LoadTiming_cfunc(vi, file_path)
 
     def niDigital_LockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
@@ -754,13 +754,13 @@ class Library(object):
                 self.niDigital_UnloadAllPatterns_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_UnloadAllPatterns_cfunc(vi, unload_keep_alive_pattern)
 
-    def niDigital_UnloadSpecifications(self, vi, specifications_file_path):  # noqa: N802
+    def niDigital_UnloadSpecifications(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDigital_UnloadSpecifications_cfunc is None:
                 self.niDigital_UnloadSpecifications_cfunc = self._library.niDigital_UnloadSpecifications
                 self.niDigital_UnloadSpecifications_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_UnloadSpecifications_cfunc.restype = ViStatus  # noqa: F405
-        return self.niDigital_UnloadSpecifications_cfunc(vi, specifications_file_path)
+        return self.niDigital_UnloadSpecifications_cfunc(vi, file_path)
 
     def niDigital_UnlockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -3068,18 +3068,18 @@ class Session(_SessionBase):
         return bool(done_ctype.value)
 
     @ivi_synchronized
-    def _load_levels(self, levels_file_path):
+    def _load_levels(self, file_path):
         r'''_load_levels
 
         TBD
 
         Args:
-            levels_file_path (str):
+            file_path (str):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        levels_file_path_ctype = ctypes.create_string_buffer(levels_file_path.encode(self._encoding))  # case C020
-        error_code = self._library.niDigital_LoadLevels(vi_ctype, levels_file_path_ctype)
+        file_path_ctype = ctypes.create_string_buffer(file_path.encode(self._encoding))  # case C020
+        error_code = self._library.niDigital_LoadLevels(vi_ctype, file_path_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -3100,50 +3100,50 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def load_pin_map(self, pin_map_file_path):
+    def load_pin_map(self, file_path):
         r'''load_pin_map
 
         TBD
 
         Args:
-            pin_map_file_path (str):
+            file_path (str):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        pin_map_file_path_ctype = ctypes.create_string_buffer(pin_map_file_path.encode(self._encoding))  # case C020
-        error_code = self._library.niDigital_LoadPinMap(vi_ctype, pin_map_file_path_ctype)
+        file_path_ctype = ctypes.create_string_buffer(file_path.encode(self._encoding))  # case C020
+        error_code = self._library.niDigital_LoadPinMap(vi_ctype, file_path_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
     @ivi_synchronized
-    def _load_specifications(self, specifications_file_path):
+    def _load_specifications(self, file_path):
         r'''_load_specifications
 
         TBD
 
         Args:
-            specifications_file_path (str):
+            file_path (str):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        specifications_file_path_ctype = ctypes.create_string_buffer(specifications_file_path.encode(self._encoding))  # case C020
-        error_code = self._library.niDigital_LoadSpecifications(vi_ctype, specifications_file_path_ctype)
+        file_path_ctype = ctypes.create_string_buffer(file_path.encode(self._encoding))  # case C020
+        error_code = self._library.niDigital_LoadSpecifications(vi_ctype, file_path_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
     @ivi_synchronized
-    def _load_timing(self, timing_file_path):
+    def _load_timing(self, file_path):
         r'''_load_timing
 
         TBD
 
         Args:
-            timing_file_path (str):
+            file_path (str):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        timing_file_path_ctype = ctypes.create_string_buffer(timing_file_path.encode(self._encoding))  # case C020
-        error_code = self._library.niDigital_LoadTiming(vi_ctype, timing_file_path_ctype)
+        file_path_ctype = ctypes.create_string_buffer(file_path.encode(self._encoding))  # case C020
+        error_code = self._library.niDigital_LoadTiming(vi_ctype, file_path_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -3271,18 +3271,18 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def _unload_specifications(self, specifications_file_path):
+    def _unload_specifications(self, file_path):
         r'''_unload_specifications
 
         TBD
 
         Args:
-            specifications_file_path (str):
+            file_path (str):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        specifications_file_path_ctype = ctypes.create_string_buffer(specifications_file_path.encode(self._encoding))  # case C020
-        error_code = self._library.niDigital_UnloadSpecifications(vi_ctype, specifications_file_path_ctype)
+        file_path_ctype = ctypes.create_string_buffer(file_path.encode(self._encoding))  # case C020
+        error_code = self._library.niDigital_UnloadSpecifications(vi_ctype, file_path_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 

--- a/generated/nidigital/nidigital/unit_tests/_mock_helper.py
+++ b/generated/nidigital/nidigital/unit_tests/_mock_helper.py
@@ -818,7 +818,7 @@ class SideEffectsHelper(object):
             enable.contents.value = self._defaults['IsSiteEnabled']['enable']
         return self._defaults['IsSiteEnabled']['return']
 
-    def niDigital_LoadLevels(self, vi, levels_file_path):  # noqa: N802
+    def niDigital_LoadLevels(self, vi, file_path):  # noqa: N802
         if self._defaults['LoadLevels']['return'] != 0:
             return self._defaults['LoadLevels']['return']
         return self._defaults['LoadLevels']['return']
@@ -828,17 +828,17 @@ class SideEffectsHelper(object):
             return self._defaults['LoadPattern']['return']
         return self._defaults['LoadPattern']['return']
 
-    def niDigital_LoadPinMap(self, vi, pin_map_file_path):  # noqa: N802
+    def niDigital_LoadPinMap(self, vi, file_path):  # noqa: N802
         if self._defaults['LoadPinMap']['return'] != 0:
             return self._defaults['LoadPinMap']['return']
         return self._defaults['LoadPinMap']['return']
 
-    def niDigital_LoadSpecifications(self, vi, specifications_file_path):  # noqa: N802
+    def niDigital_LoadSpecifications(self, vi, file_path):  # noqa: N802
         if self._defaults['LoadSpecifications']['return'] != 0:
             return self._defaults['LoadSpecifications']['return']
         return self._defaults['LoadSpecifications']['return']
 
-    def niDigital_LoadTiming(self, vi, timing_file_path):  # noqa: N802
+    def niDigital_LoadTiming(self, vi, file_path):  # noqa: N802
         if self._defaults['LoadTiming']['return'] != 0:
             return self._defaults['LoadTiming']['return']
         return self._defaults['LoadTiming']['return']
@@ -983,7 +983,7 @@ class SideEffectsHelper(object):
             return self._defaults['UnloadAllPatterns']['return']
         return self._defaults['UnloadAllPatterns']['return']
 
-    def niDigital_UnloadSpecifications(self, vi, specifications_file_path):  # noqa: N802
+    def niDigital_UnloadSpecifications(self, vi, file_path):  # noqa: N802
         if self._defaults['UnloadSpecifications']['return'] != 0:
             return self._defaults['UnloadSpecifications']['return']
         return self._defaults['UnloadSpecifications']['return']

--- a/src/nidigital/metadata/functions.py
+++ b/src/nidigital/metadata/functions.py
@@ -2068,7 +2068,7 @@ the trigger conditions are met.
             },
             {
                 'direction': 'in',
-                'name': 'levelsFilePath',
+                'name': 'filePath',
                 'type': 'ViConstString'
             }
         ],
@@ -2104,7 +2104,7 @@ the trigger conditions are met.
             },
             {
                 'direction': 'in',
-                'name': 'pinMapFilePath',
+                'name': 'filePath',
                 'type': 'ViConstString'
             }
         ],
@@ -2123,7 +2123,7 @@ the trigger conditions are met.
             },
             {
                 'direction': 'in',
-                'name': 'specificationsFilePath',
+                'name': 'filePath',
                 'type': 'ViConstString'
             }
         ],
@@ -2142,7 +2142,7 @@ the trigger conditions are met.
             },
             {
                 'direction': 'in',
-                'name': 'timingFilePath',
+                'name': 'filePath',
                 'type': 'ViConstString'
             }
         ],
@@ -2650,7 +2650,7 @@ conditionalJumpTrigger1, conditionalJumpTrigger2, and conditionalJumpTrigger3.
             },
             {
                 'direction': 'in',
-                'name': 'specificationsFilePath',
+                'name': 'filePath',
                 'type': 'ViConstString'
             }
         ],

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -565,7 +565,7 @@ def test_specifications_levels_and_timing_single(multi_instrument_session):
     levels = get_test_file_path('specifications_levels_and_timing_single', 'levels.digilevels')
     timing = get_test_file_path('specifications_levels_and_timing_single', 'timing.digitiming')
 
-    multi_instrument_session.load_pin_map(pin_map_file_path=pinmap)
+    multi_instrument_session.load_pin_map(file_path=pinmap)
     multi_instrument_session.load_specifications_levels_and_timing(
         specifications_file_paths=specs,
         levels_file_paths=levels,
@@ -598,7 +598,7 @@ def test_specifications_levels_and_timing_multiple(multi_instrument_session):
     timing1 = get_test_file_path('specifications_levels_and_timing_multiple', 'timing1.digitiming')
     timing2 = get_test_file_path('specifications_levels_and_timing_multiple', 'timing2.digitiming')
 
-    multi_instrument_session.load_pin_map(pin_map_file_path=pinmap)
+    multi_instrument_session.load_pin_map(file_path=pinmap)
     multi_instrument_session.load_specifications_levels_and_timing(
         specifications_file_paths=[specs1, specs2],  # list
         levels_file_paths=(levels1, levels2),  # tuple
@@ -632,7 +632,7 @@ def test_specifications_levels_and_timing_load_sequentially(multi_instrument_ses
     timing1 = get_test_file_path('specifications_levels_and_timing_multiple', 'timing1.digitiming')
     timing2 = get_test_file_path('specifications_levels_and_timing_multiple', 'timing2.digitiming')
 
-    multi_instrument_session.load_pin_map(pin_map_file_path=pinmap)
+    multi_instrument_session.load_pin_map(file_path=pinmap)
 
     # Load just the specs files first, in two separate calls
     multi_instrument_session.load_specifications_levels_and_timing(specifications_file_paths=specs1)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

In nidigital, remove unnecessary prefix for file_path parameter in methods that load and unload files:
- _load_levels()
- load_pin_map()
- _load_specifications()
- _load_timing()
- _unload_specifications()

### List issues fixed by this Pull Request below, if any.

* Fix #1393

### What testing has been done?

Updated impacted system tests and ran all nidigital system tests. Also ran unit tests. CI will run system tests for all modules.