### PR TITLE
Add nidigital clock generator and frequency counter system tests

### DIFF
--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -558,6 +558,18 @@ def test_ppmu_source(multi_instrument_session):
     multi_instrument_session.pins['site0/LO0', 'site1/HI0'].ppmu_source()
 
 
+def test_clock_generator_abort(multi_instrument_session):
+    multi_instrument_session.load_pin_map(os.path.join(test_files_base_dir, "pin_map.pinmap"))
+    multi_instrument_session.pins['site0/PinA', 'site1/PinC'].clock_generator_abort()
+
+
+def test_clock_generator_generate_clock(multi_instrument_session):
+    multi_instrument_session.load_pin_map(os.path.join(test_files_base_dir, "pin_map.pinmap"))
+    multi_instrument_session.pins['site0/PinA', 'site1/PinC'].clock_generator_generate_clock(
+        1e6,
+        True)
+
+
 def test_specifications_levels_and_timing_single(multi_instrument_session):
     pinmap = get_test_file_path('specifications_levels_and_timing_single', 'pin_map.pinmap')
     specs = get_test_file_path('specifications_levels_and_timing_single', 'specs.specs')

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -571,10 +571,9 @@ def test_clock_generator_generate_clock(multi_instrument_session):
 
 
 def test_frequency_counter_measure_frequency(multi_instrument_session):
-    measurement_time = datetime.timedelta(milliseconds=5)
     multi_instrument_session.load_pin_map(os.path.join(test_files_base_dir, "pin_map.pinmap"))
     multi_instrument_session.pins['site0/PinA', 'site1/PinC'].selected_function = nidigital.SelectedFunction.DIGITAL
-    multi_instrument_session.pins['site0/PinA', 'site1/PinC'].frequency_counter_measurement_time = measurement_time
+    multi_instrument_session.pins['site0/PinA', 'site1/PinC'].frequency_counter_measurement_time = datetime.timedelta(milliseconds=5)
     frequencies = multi_instrument_session.pins['site0/PinA', 'site1/PinC'].frequency_counter_measure_frequency()
     assert frequencies == [0] * 2
 

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -573,7 +573,7 @@ def test_clock_generator_generate_clock(multi_instrument_session):
 def test_frequency_counter_measure_frequency(multi_instrument_session):
     measurement_time = datetime.timedelta(milliseconds=5)
     multi_instrument_session.load_pin_map(os.path.join(test_files_base_dir, "pin_map.pinmap"))
-    multi_instrument_session.pins['site0/PinA', 'site1/PinC'].selected_function = nidigital.enums.SelectedFunction.DIGITAL
+    multi_instrument_session.pins['site0/PinA', 'site1/PinC'].selected_function = nidigital.SelectedFunction.DIGITAL
     multi_instrument_session.pins['site0/PinA', 'site1/PinC'].frequency_counter_measurement_time = measurement_time
     frequencies = multi_instrument_session.pins['site0/PinA', 'site1/PinC'].frequency_counter_measure_frequency()
     assert frequencies == [0] * 2

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -570,6 +570,15 @@ def test_clock_generator_generate_clock(multi_instrument_session):
         True)
 
 
+def test_frequency_counter_measure_frequency(multi_instrument_session):
+    measurement_time = datetime.timedelta(milliseconds=5)
+    multi_instrument_session.load_pin_map(os.path.join(test_files_base_dir, "pin_map.pinmap"))
+    multi_instrument_session.pins['site0/PinA', 'site1/PinC'].selected_function = nidigital.enums.SelectedFunction.DIGITAL
+    multi_instrument_session.pins['site0/PinA', 'site1/PinC'].frequency_counter_measurement_time = measurement_time
+    frequencies = multi_instrument_session.pins['site0/PinA', 'site1/PinC'].frequency_counter_measure_frequency()
+    assert frequencies == [0] * 2
+
+
 def test_specifications_levels_and_timing_single(multi_instrument_session):
     pinmap = get_test_file_path('specifications_levels_and_timing_single', 'pin_map.pinmap')
     specs = get_test_file_path('specifications_levels_and_timing_single', 'specs.specs')


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

* Adds nidigital system test `test_clock_generator_abort`
* Adds nidigital system test `test_clock_generator_generate_clock`
* Adds nidigital system test `test_frequency_counter_measure_frequency`

### List issues fixed by this Pull Request below, if any.

### What testing has been done?

Ran the new system tests on a system with nidigital 19.0.1 installed.
