### PR TITLE
Adding tests for configuring levels

### DIFF
--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -558,6 +558,32 @@ def test_ppmu_source(multi_instrument_session):
     multi_instrument_session.pins['site0/LO0', 'site1/HI0'].ppmu_source()
 
 
+def test_configure_voltage_levels(multi_instrument_session):
+    assert round(multi_instrument_session.vil) == 0
+    assert round(multi_instrument_session.vih) == 3
+    assert round(multi_instrument_session.vol) == 2
+    assert round(multi_instrument_session.voh) == 2
+    assert round(multi_instrument_session.vterm) == 2
+    multi_instrument_session.load_pin_map(os.path.join(test_files_base_dir, "pin_map.pinmap"))
+    multi_instrument_session.pins['site0/PinA', 'site1/PinC'].configure_voltage_levels(1, 2, 3, 4, 5)
+    assert round(multi_instrument_session.pins['site0/PinA', 'site1/PinC'].vil) == 1
+    assert round(multi_instrument_session.pins['site0/PinA', 'site1/PinC'].vih) == 2
+    assert round(multi_instrument_session.pins['site0/PinA', 'site1/PinC'].vol) == 3
+    assert round(multi_instrument_session.pins['site0/PinA', 'site1/PinC'].voh) == 4
+    assert round(multi_instrument_session.pins['site0/PinA', 'site1/PinC'].vterm) == 5
+
+
+def test_configure_active_load_levels(multi_instrument_session):
+    assert round(multi_instrument_session.active_load_iol, 4) == 0.0015
+    assert round(multi_instrument_session.active_load_ioh, 4) == -0.0015
+    assert round(multi_instrument_session.active_load_vcom) == 2
+    multi_instrument_session.load_pin_map(os.path.join(test_files_base_dir, "pin_map.pinmap"))
+    multi_instrument_session.pins['site0/PinA', 'site1/PinC'].configure_active_load_levels(.024, -0.024, 3)
+    assert round(multi_instrument_session.pins['site0/PinA', 'site1/PinC'].active_load_iol, 3) == 0.024
+    assert round(multi_instrument_session.pins['site0/PinA', 'site1/PinC'].active_load_ioh, 3) == -0.024
+    assert round(multi_instrument_session.pins['site0/PinA', 'site1/PinC'].active_load_vcom) == 3
+
+
 def test_specifications_levels_and_timing_single(multi_instrument_session):
     pinmap = get_test_file_path('specifications_levels_and_timing_single', 'pin_map.pinmap')
     specs = get_test_file_path('specifications_levels_and_timing_single', 'specs.specs')

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -565,7 +565,12 @@ def test_configure_voltage_levels(multi_instrument_session):
     assert multi_instrument_session.voh == pytest.approx(1.7, rel=1e-3)
     assert multi_instrument_session.vterm == pytest.approx(2.0, rel=1e-3)
     multi_instrument_session.load_pin_map(os.path.join(test_files_base_dir, "pin_map.pinmap"))
-    multi_instrument_session.pins['site0/PinA', 'site1/PinC'].configure_voltage_levels(1.0, 2.0, 3.0, 4.0, 5.0)
+    multi_instrument_session.pins['site0/PinA', 'site1/PinC'].configure_voltage_levels(
+        vil=1.0,
+        vih=2.0,
+        vol=3.0,
+        voh=4.0,
+        vterm=5.0)
     assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].vil == pytest.approx(1.0, rel=1e-3)
     assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].vih == pytest.approx(2.0, rel=1e-3)
     assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].vol == pytest.approx(3.0, rel=1e-3)
@@ -578,7 +583,10 @@ def test_configure_active_load_levels(multi_instrument_session):
     assert multi_instrument_session.active_load_ioh == pytest.approx(-0.0015, rel=1e-3)
     assert multi_instrument_session.active_load_vcom == pytest.approx(2.0, rel=1e-3)
     multi_instrument_session.load_pin_map(os.path.join(test_files_base_dir, "pin_map.pinmap"))
-    multi_instrument_session.pins['site0/PinA', 'site1/PinC'].configure_active_load_levels(0.024, -0.024, 3.0)
+    multi_instrument_session.pins['site0/PinA', 'site1/PinC'].configure_active_load_levels(
+        iol=0.024,
+        ioh=-0.024,
+        vcom=3.0)
     assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].active_load_iol == pytest.approx(0.024, rel=1e-3)
     assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].active_load_ioh == pytest.approx(-0.024, rel=1e-3)
     assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].active_load_vcom == pytest.approx(3.0, rel=1e-3)

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -559,29 +559,29 @@ def test_ppmu_source(multi_instrument_session):
 
 
 def test_configure_voltage_levels(multi_instrument_session):
-    assert round(multi_instrument_session.vil) == 0
-    assert round(multi_instrument_session.vih) == 3
-    assert round(multi_instrument_session.vol) == 2
-    assert round(multi_instrument_session.voh) == 2
-    assert round(multi_instrument_session.vterm) == 2
+    assert multi_instrument_session.vil == pytest.approx(0.0, abs=1e-4)
+    assert multi_instrument_session.vih == pytest.approx(3.3, rel=1e-3)
+    assert multi_instrument_session.vol == pytest.approx(1.6, rel=1e-3)
+    assert multi_instrument_session.voh == pytest.approx(1.7, rel=1e-3)
+    assert multi_instrument_session.vterm == pytest.approx(2.0, rel=1e-3)
     multi_instrument_session.load_pin_map(os.path.join(test_files_base_dir, "pin_map.pinmap"))
-    multi_instrument_session.pins['site0/PinA', 'site1/PinC'].configure_voltage_levels(1, 2, 3, 4, 5)
-    assert round(multi_instrument_session.pins['site0/PinA', 'site1/PinC'].vil) == 1
-    assert round(multi_instrument_session.pins['site0/PinA', 'site1/PinC'].vih) == 2
-    assert round(multi_instrument_session.pins['site0/PinA', 'site1/PinC'].vol) == 3
-    assert round(multi_instrument_session.pins['site0/PinA', 'site1/PinC'].voh) == 4
-    assert round(multi_instrument_session.pins['site0/PinA', 'site1/PinC'].vterm) == 5
+    multi_instrument_session.pins['site0/PinA', 'site1/PinC'].configure_voltage_levels(1.0, 2.0, 3.0, 4.0, 5.0)
+    assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].vil == pytest.approx(1.0, rel=1e-3)
+    assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].vih == pytest.approx(2.0, rel=1e-3)
+    assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].vol == pytest.approx(3.0, rel=1e-3)
+    assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].voh == pytest.approx(4.0, rel=1e-3)
+    assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].vterm == pytest.approx(5.0, rel=1e-3)
 
 
 def test_configure_active_load_levels(multi_instrument_session):
-    assert round(multi_instrument_session.active_load_iol, 4) == 0.0015
-    assert round(multi_instrument_session.active_load_ioh, 4) == -0.0015
-    assert round(multi_instrument_session.active_load_vcom) == 2
+    assert multi_instrument_session.active_load_iol == pytest.approx(0.0015, rel=1e-3)
+    assert multi_instrument_session.active_load_ioh == pytest.approx(-0.0015, rel=1e-3)
+    assert multi_instrument_session.active_load_vcom == pytest.approx(2.0, rel=1e-3)
     multi_instrument_session.load_pin_map(os.path.join(test_files_base_dir, "pin_map.pinmap"))
-    multi_instrument_session.pins['site0/PinA', 'site1/PinC'].configure_active_load_levels(.024, -0.024, 3)
-    assert round(multi_instrument_session.pins['site0/PinA', 'site1/PinC'].active_load_iol, 3) == 0.024
-    assert round(multi_instrument_session.pins['site0/PinA', 'site1/PinC'].active_load_ioh, 3) == -0.024
-    assert round(multi_instrument_session.pins['site0/PinA', 'site1/PinC'].active_load_vcom) == 3
+    multi_instrument_session.pins['site0/PinA', 'site1/PinC'].configure_active_load_levels(0.024, -0.024, 3.0)
+    assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].active_load_iol == pytest.approx(0.024, rel=1e-3)
+    assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].active_load_ioh == pytest.approx(-0.024, rel=1e-3)
+    assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].active_load_vcom == pytest.approx(3.0, rel=1e-3)
 
 
 def test_specifications_levels_and_timing_single(multi_instrument_session):


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

* Adds nidigital system test `test_configure_voltage_levels`
* Adds nidigital system test `test_configure_active_load_levels`

### List issues fixed by this Pull Request below, if any.

### What testing has been done?

Ran the new system tests on a system with nidigital 19.0.1 installed.