### PR TITLE
Add codegen support for basic sequence of strings type properties

### DIFF
--- a/build/templates/_attributes.py.mako
+++ b/build/templates/_attributes.py.mako
@@ -70,6 +70,15 @@ class AttributeViString(Attribute):
         session._set_attribute_vi_string(self._attribute_id, value)
 
 
+class AttributeViStringSequence(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_comma_separated_string_to_list(session._get_attribute_vi_string(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
 class AttributeViBoolean(Attribute):
 
     def __get__(self, session, session_type):

--- a/generated/nidcpower/nidcpower/_attributes.py
+++ b/generated/nidcpower/nidcpower/_attributes.py
@@ -66,6 +66,15 @@ class AttributeViString(Attribute):
         session._set_attribute_vi_string(self._attribute_id, value)
 
 
+class AttributeViStringSequence(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_comma_separated_string_to_list(session._get_attribute_vi_string(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
 class AttributeViBoolean(Attribute):
 
     def __get__(self, session, session_type):

--- a/generated/nidigital/nidigital/_attributes.py
+++ b/generated/nidigital/nidigital/_attributes.py
@@ -66,6 +66,15 @@ class AttributeViString(Attribute):
         session._set_attribute_vi_string(self._attribute_id, value)
 
 
+class AttributeViStringSequence(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_comma_separated_string_to_list(session._get_attribute_vi_string(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
 class AttributeViBoolean(Attribute):
 
     def __get__(self, session, session_type):

--- a/generated/nidmm/nidmm/_attributes.py
+++ b/generated/nidmm/nidmm/_attributes.py
@@ -66,6 +66,15 @@ class AttributeViString(Attribute):
         session._set_attribute_vi_string(self._attribute_id, value)
 
 
+class AttributeViStringSequence(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_comma_separated_string_to_list(session._get_attribute_vi_string(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
 class AttributeViBoolean(Attribute):
 
     def __get__(self, session, session_type):

--- a/generated/nifake/nifake/_attributes.py
+++ b/generated/nifake/nifake/_attributes.py
@@ -66,6 +66,15 @@ class AttributeViString(Attribute):
         session._set_attribute_vi_string(self._attribute_id, value)
 
 
+class AttributeViStringSequence(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_comma_separated_string_to_list(session._get_attribute_vi_string(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
 class AttributeViBoolean(Attribute):
 
     def __get__(self, session, session_type):

--- a/generated/nifake/nifake/session.py
+++ b/generated/nifake/nifake/session.py
@@ -142,6 +142,11 @@ class _SessionBase(object):
 
     A property of type Color with read/write access.
     '''
+    read_write_comma_delimited_string = _attributes.AttributeViStringSequence(1000010)
+    '''Type: basic sequence or str
+
+    Comma-delimited string with read/write access.
+    '''
     read_write_double = _attributes.AttributeViReal64(1000001)
     '''Type: float
 

--- a/generated/nifake/nifake/unit_tests/test_session.py
+++ b/generated/nifake/nifake/unit_tests/test_session.py
@@ -965,6 +965,29 @@ class TestSession(object):
             session.read_write_string = attrib_string
             self.patched_library.niFake_SetAttributeViString.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViStringMatcher('This is test string'))
 
+    def test_get_attribute_comma_delimited_string(self):
+        self.patched_library.niFake_GetAttributeViString.side_effect = self.side_effects_helper.niFake_GetAttributeViString
+        attribute_id = 1000010
+        test_string = 'PinA, PinB'
+        self.side_effects_helper['GetAttributeViString']['attributeValue'] = test_string
+        with nifake.Session('dev1') as session:
+            attr_string_sequence = session.read_write_comma_delimited_string
+            assert ['PinA', 'PinB'] == attr_string_sequence
+            from mock import call
+            calls = [
+                call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt32Matcher(0), None),
+                call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt32Matcher(10), _matchers.ViCharBufferMatcher(len(test_string)))]
+            self.patched_library.niFake_GetAttributeViString.assert_has_calls(calls)
+            assert self.patched_library.niFake_GetAttributeViString.call_count == 2
+
+    def test_set_attribute_comma_delimited_string(self):
+        self.patched_library.niFake_SetAttributeViString.side_effect = self.side_effects_helper.niFake_SetAttributeViString
+        attribute_id = 1000010
+        test_string = ['PinA', 'PinB']
+        with nifake.Session('dev1') as session:
+            session.read_write_comma_delimited_string = test_string
+            self.patched_library.niFake_SetAttributeViString.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViStringMatcher('PinA,PinB'))
+
     def test_get_attribute_boolean(self):
         self.patched_library.niFake_GetAttributeViBoolean.side_effect = self.side_effects_helper.niFake_GetAttributeViBoolean
         self.side_effects_helper['GetAttributeViBoolean']['attributeValue'] = 1

--- a/generated/nifgen/nifgen/_attributes.py
+++ b/generated/nifgen/nifgen/_attributes.py
@@ -66,6 +66,15 @@ class AttributeViString(Attribute):
         session._set_attribute_vi_string(self._attribute_id, value)
 
 
+class AttributeViStringSequence(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_comma_separated_string_to_list(session._get_attribute_vi_string(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
 class AttributeViBoolean(Attribute):
 
     def __get__(self, session, session_type):

--- a/generated/niscope/niscope/_attributes.py
+++ b/generated/niscope/niscope/_attributes.py
@@ -66,6 +66,15 @@ class AttributeViString(Attribute):
         session._set_attribute_vi_string(self._attribute_id, value)
 
 
+class AttributeViStringSequence(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_comma_separated_string_to_list(session._get_attribute_vi_string(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
 class AttributeViBoolean(Attribute):
 
     def __get__(self, session, session_type):

--- a/generated/niswitch/niswitch/_attributes.py
+++ b/generated/niswitch/niswitch/_attributes.py
@@ -66,6 +66,15 @@ class AttributeViString(Attribute):
         session._set_attribute_vi_string(self._attribute_id, value)
 
 
+class AttributeViStringSequence(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_comma_separated_string_to_list(session._get_attribute_vi_string(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
 class AttributeViBoolean(Attribute):
 
     def __get__(self, session, session_type):

--- a/generated/nitclk/nitclk/_attributes.py
+++ b/generated/nitclk/nitclk/_attributes.py
@@ -66,6 +66,15 @@ class AttributeViString(Attribute):
         session._set_attribute_vi_string(self._attribute_id, value)
 
 
+class AttributeViStringSequence(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_comma_separated_string_to_list(session._get_attribute_vi_string(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
 class AttributeViBoolean(Attribute):
 
     def __get__(self, session, session_type):

--- a/src/nifake/metadata/attributes.py
+++ b/src/nifake/metadata/attributes.py
@@ -112,5 +112,17 @@ attributes = {
         'name': 'READ_WRITE_DOUBLE_WITH_REPEATED_CAPABILITY',
         'resettable': False,
         'type': 'ViReal64'
-    }
+    },
+    1000010: {
+        'access': 'read-write',
+        'attribute_class': 'AttributeViStringSequence',
+        'channel_based': False,
+        'documentation': {
+            'description': 'Comma-delimited string with read/write access.'
+        },
+        'name': 'READ_WRITE_COMMA_DELIMITED_STRING',
+        'resettable': False,
+        'type': 'ViString',
+        'type_in_documentation': 'basic sequence or str',
+    },
 }

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -965,6 +965,29 @@ class TestSession(object):
             session.read_write_string = attrib_string
             self.patched_library.niFake_SetAttributeViString.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViStringMatcher('This is test string'))
 
+    def test_get_attribute_comma_delimited_string(self):
+        self.patched_library.niFake_GetAttributeViString.side_effect = self.side_effects_helper.niFake_GetAttributeViString
+        attribute_id = 1000010
+        test_string = 'PinA, PinB'
+        self.side_effects_helper['GetAttributeViString']['attributeValue'] = test_string
+        with nifake.Session('dev1') as session:
+            attr_string_sequence = session.read_write_comma_delimited_string
+            assert ['PinA', 'PinB'] == attr_string_sequence
+            from mock import call
+            calls = [
+                call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt32Matcher(0), None),
+                call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt32Matcher(10), _matchers.ViCharBufferMatcher(len(test_string)))]
+            self.patched_library.niFake_GetAttributeViString.assert_has_calls(calls)
+            assert self.patched_library.niFake_GetAttributeViString.call_count == 2
+
+    def test_set_attribute_comma_delimited_string(self):
+        self.patched_library.niFake_SetAttributeViString.side_effect = self.side_effects_helper.niFake_SetAttributeViString
+        attribute_id = 1000010
+        test_string = ['PinA', 'PinB']
+        with nifake.Session('dev1') as session:
+            session.read_write_comma_delimited_string = test_string
+            self.patched_library.niFake_SetAttributeViString.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViStringMatcher('PinA,PinB'))
+
     def test_get_attribute_boolean(self):
         self.patched_library.niFake_GetAttributeViBoolean.side_effect = self.side_effects_helper.niFake_GetAttributeViBoolean
         self.side_effects_helper['GetAttributeViBoolean']['attributeValue'] = 1


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

~Add codegen support for basic sequence of strings type properties~
Add the ability to have attributes that return a list of strings when the runtime returns a comma-separated string and vice-versa.

### List issues fixed by this Pull Request below, if any.

* Fix #1419

### What testing has been done?

Added new nifake unit tests. All tests will be run by CI.