### PR TITLE
Improve documentation related to types in applicable nidigital methods

### DIFF
--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -179,7 +179,7 @@ apply_tdr_offsets
                 
 
 
-            :type offsets: list of float in seconds or datetime.timedelta
+            :type offsets: basic sequence of float in seconds or datetime.timedelta
 
 burst_pattern
 -------------
@@ -1063,7 +1063,7 @@ fetch_capture_waveform
 
     .. py:method:: fetch_capture_waveform(waveform_name, samples_to_read, timeout=datetime.timedelta(seconds=10.0))
 
-            Returns dictionary where each key is the site number and the value is array.array of unsigned int
+            Returns dictionary where each key is a site number and value is a collection of digital states representing capture waveform data
 
             
 
@@ -1096,11 +1096,11 @@ fetch_capture_waveform
 
             :type timeout: float or datetime.timedelta
 
-            :rtype: { site: data, site: data, ... }
+            :rtype: { int: memoryview of array.array of unsigned int, int: memoryview of array.array of unsigned int, ... }
             :return:
 
 
-                    Dictionary where each key is the site number and the value is array.array of unsigned int
+                    Dictionary where each key is a site number and value is a collection of digital states representing capture waveform data
 
                     
 
@@ -1785,7 +1785,7 @@ load_specifications_levels_and_timing
                 
 
 
-            :type specifications_file_paths: str or iterable of str
+            :type specifications_file_paths: str or basic sequence of str
             :param levels_file_paths:
 
 
@@ -1794,7 +1794,7 @@ load_specifications_levels_and_timing
                 
 
 
-            :type levels_file_paths: str or iterable of str
+            :type levels_file_paths: str or basic sequence of str
             :param timing_file_paths:
 
 
@@ -1803,7 +1803,7 @@ load_specifications_levels_and_timing
                 
 
 
-            :type timing_file_paths: str or iterable of str
+            :type timing_file_paths: str or basic sequence of str
 
 lock
 ----
@@ -2169,7 +2169,7 @@ unload_specifications
                 
 
 
-            :type file_paths: str or iterable of str
+            :type file_paths: str or basic sequence of str
 
 unlock
 ------
@@ -2340,12 +2340,12 @@ write_source_waveform_site_unique
             :param waveform_data:
 
 
-                Dictionary where each key is the site number and the value is array.array of unsigned int
+                Dictionary where each key is a site number and value is a collection of samples to use as source data
 
                 
 
 
-            :type waveform_data: { site: data, site: data, ... }
+            :type waveform_data: { int: basic sequence of unsigned int, int: basic sequence of unsigned int, ... }
 
 write_static
 ------------

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -616,7 +616,7 @@ class _SessionBase(object):
         nidigital.Session repeated capabilities container, and calling this method on the result.
 
         Args:
-            offsets (list of float in seconds or datetime.timedelta):
+            offsets (basic sequence of float in seconds or datetime.timedelta):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -1232,7 +1232,7 @@ class _SessionBase(object):
     def fetch_capture_waveform(self, waveform_name, samples_to_read, timeout=datetime.timedelta(seconds=10.0)):
         '''fetch_capture_waveform
 
-        Returns dictionary where each key is the site number and the value is array.array of unsigned int
+        Returns dictionary where each key is a site number and value is a collection of digital states representing capture waveform data
 
         Tip:
         This method requires repeated capabilities. If called directly on the
@@ -1249,7 +1249,7 @@ class _SessionBase(object):
 
 
         Returns:
-            waveform ({ site: data, site: data, ... }): Dictionary where each key is the site number and the value is array.array of unsigned int
+            waveform ({ int: memoryview of array.array of unsigned int, int: memoryview of array.array of unsigned int, ... }): Dictionary where each key is a site number and value is a collection of digital states representing capture waveform data
 
         '''
         data, actual_num_waveforms, actual_samples_per_waveform = self._fetch_capture_waveform(waveform_name, samples_to_read, timeout)
@@ -2857,11 +2857,11 @@ class Session(_SessionBase):
         variables must be loaded either first, or at the same time as the levels and timing sheets.
 
         Args:
-            specifications_file_paths (str or iterable of str): Absolute file path of one or more specifications files.
+            specifications_file_paths (str or basic sequence of str): Absolute file path of one or more specifications files.
 
-            levels_file_paths (str or iterable of str): Absolute file path of one or more levels sheet files.
+            levels_file_paths (str or basic sequence of str): Absolute file path of one or more levels sheet files.
 
-            timing_file_paths (str or iterable of str): Absolute file path of one or more timing sheet files.
+            timing_file_paths (str or basic sequence of str): Absolute file path of one or more timing sheet files.
 
         '''
         self._call_method_with_iterable(self._load_specifications, specifications_file_paths)
@@ -2891,7 +2891,7 @@ class Session(_SessionBase):
         the levels and timing values that reference the updated specifications values.
 
         Args:
-            file_paths (str or iterable of str): Absolute file path of one or more loaded specifications files.
+            file_paths (str or basic sequence of str): Absolute file path of one or more loaded specifications files.
 
         '''
         self._call_method_with_iterable(self._unload_specifications, file_paths)
@@ -2905,7 +2905,7 @@ class Session(_SessionBase):
         Args:
             waveform_name (str):
 
-            waveform_data ({ site: data, site: data, ... }): Dictionary where each key is the site number and the value is array.array of unsigned int
+            waveform_data ({ int: basic sequence of unsigned int, int: basic sequence of unsigned int, ... }): Dictionary where each key is a site number and value is a collection of samples to use as source data
 
         '''
         site_list = []

--- a/src/nidigital/metadata/functions.py
+++ b/src/nidigital/metadata/functions.py
@@ -104,7 +104,7 @@ functions = {
                     'value': 'numOffsets'
                 },
                 'type': 'ViReal64[]',
-                'type_in_documentation': 'list of float in seconds or datetime.timedelta'
+                'type_in_documentation': 'basic sequence of float in seconds or datetime.timedelta'
             }
         ],
         'returns': 'ViStatus'

--- a/src/nidigital/metadata/functions_addon.py
+++ b/src/nidigital/metadata/functions_addon.py
@@ -107,11 +107,11 @@ functions_additional_write_source_waveform_site_unique = {
             {
                 'direction': 'in',
                 'documentation': {
-                    'description': '\nDictionary where each key is the site number and the value is array.array of unsigned int\n'
+                    'description': '\nDictionary where each key is a site number and value is a collection of samples to use as source data\n'
                 },
                 'name': 'waveform_data',
                 'type': 'ViUInt32',  # This type is ignored since this function isn't code generated
-                'type_in_documentation': '{ site: data, site: data, ... }',
+                'type_in_documentation': '{ int: basic sequence of unsigned int, int: basic sequence of unsigned int, ... }',
             },
         ],
     },
@@ -215,7 +215,7 @@ functions_additional_fetch_capture_waveform = {
             }
         ],
        'documentation': {
-            'description': '\nReturns dictionary where each key is the site number and the value is array.array of unsigned int\n\n',
+            'description': '\nReturns dictionary where each key is a site number and value is a collection of digital states representing capture waveform data\n\n',
         },
         'parameters': [
             {
@@ -251,7 +251,7 @@ functions_additional_fetch_capture_waveform = {
             {
                 'direction': 'out',
                 'documentation': {
-                    'description': '\nDictionary where each key is the site number and the value is array.array of unsigned int\n'
+                    'description': '\nDictionary where each key is a site number and value is a collection of digital states representing capture waveform data\n'
                 },
                 'name': 'waveform',
                 'size': {
@@ -259,7 +259,7 @@ functions_additional_fetch_capture_waveform = {
                     'value': None
                 },
                 'type': 'ViUInt32',
-                'type_in_documentation': '{ site: data, site: data, ... }',
+                'type_in_documentation': '{ int: memoryview of array.array of unsigned int, int: memoryview of array.array of unsigned int, ... }',
             },
         ],
     },
@@ -438,7 +438,7 @@ variables must be loaded either first, or at the same time as the levels and tim
                 },
                 'name': 'specificationsFilePaths',
                 'type': 'ViConstString[]',  # Value is unused, but required by code generator
-                'type_in_documentation': 'str or iterable of str',
+                'type_in_documentation': 'str or basic sequence of str',
             },
             {
                 'default_value': None,
@@ -448,7 +448,7 @@ variables must be loaded either first, or at the same time as the levels and tim
                 },
                 'name': 'levelsFilePaths',
                 'type': 'ViConstString[]',  # Value is unused, but required by code generator
-                'type_in_documentation': 'str or iterable of str',
+                'type_in_documentation': 'str or basic sequence of str',
             },
             {
                 'default_value': None,
@@ -458,7 +458,7 @@ variables must be loaded either first, or at the same time as the levels and tim
                 },
                 'name': 'timingFilePaths',
                 'type': 'ViConstString[]',  # Value is unused, but required by code generator
-                'type_in_documentation': 'str or iterable of str',
+                'type_in_documentation': 'str or basic sequence of str',
             },
         ],
     },
@@ -498,7 +498,7 @@ the levels and timing values that reference the updated specifications values.
                 },
                 'name': 'filePaths',
                 'type': 'ViConstString[]',  # Value is unused, but required by code generator
-                'type_in_documentation': 'str or iterable of str',
+                'type_in_documentation': 'str or basic sequence of str',
             },
         ],
     },


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Improve documentation related to types in applicable nidigital methods:
- Change "list" to "basic sequence types"
- Fix info related to types and "represented objects" in some parameter docstrings. The format used in nimi-python is `param_name (type): Info about the object that this parameter represents`. In certain places, the type and represented object was flipped.

### List issues fixed by this Pull Request below, if any.

None

### What testing has been done?

Visual inspection of the generated filed. CI will run tests.