### PR TITLE
Make enum usage more consistent in nidigital tests

### DIFF
--- a/generated/nidigital/nidigital/unit_tests/test_nidigital.py
+++ b/generated/nidigital/nidigital/unit_tests/test_nidigital.py
@@ -44,28 +44,28 @@ class TestSession(object):
 
         # for niDigital_FetchHistoryRAMCyclePinData_looping
         self.expected_pin_states_looping = [
-            [[nidigital.enums.PinState.ZERO, nidigital.enums.PinState.H, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.H, nidigital.enums.PinState.ZERO, nidigital.enums.PinState.X, nidigital.enums.PinState.X]],
-            [[nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.ZERO, nidigital.enums.PinState.ONE, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.L, nidigital.enums.PinState.H]],
-            [[nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.ONE, nidigital.enums.PinState.ZERO, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.H, nidigital.enums.PinState.L]],
-            [[nidigital.enums.PinState.ONE, nidigital.enums.PinState.ONE, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.H, nidigital.enums.PinState.H, nidigital.enums.PinState.X, nidigital.enums.PinState.X],
-             [nidigital.enums.PinState.ZERO, nidigital.enums.PinState.ZERO, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.L, nidigital.enums.PinState.L, nidigital.enums.PinState.X, nidigital.enums.PinState.X]],
-            [[nidigital.enums.PinState.ONE, nidigital.enums.PinState.ONE, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.H, nidigital.enums.PinState.H, nidigital.enums.PinState.X, nidigital.enums.PinState.X],
-             [nidigital.enums.PinState.ZERO, nidigital.enums.PinState.ZERO, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.L, nidigital.enums.PinState.L, nidigital.enums.PinState.X, nidigital.enums.PinState.X]],
-            [[nidigital.enums.PinState.ZERO, nidigital.enums.PinState.ONE, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.L, nidigital.enums.PinState.H, nidigital.enums.PinState.X, nidigital.enums.PinState.X],
-             [nidigital.enums.PinState.ONE, nidigital.enums.PinState.ZERO, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.H, nidigital.enums.PinState.L, nidigital.enums.PinState.X, nidigital.enums.PinState.X]],
-            [[nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.X]]
+            [[nidigital.PinState.ZERO, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.ZERO, nidigital.PinState.X, nidigital.PinState.X]],
+            [[nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.ZERO, nidigital.PinState.ONE, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.H]],
+            [[nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.ONE, nidigital.PinState.ZERO, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.L]],
+            [[nidigital.PinState.ONE, nidigital.PinState.ONE, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X],
+             [nidigital.PinState.ZERO, nidigital.PinState.ZERO, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X]],
+            [[nidigital.PinState.ONE, nidigital.PinState.ONE, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X],
+             [nidigital.PinState.ZERO, nidigital.PinState.ZERO, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X]],
+            [[nidigital.PinState.ZERO, nidigital.PinState.ONE, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X],
+             [nidigital.PinState.ONE, nidigital.PinState.ZERO, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X]],
+            [[nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X]]
         ]
         self.actual_pin_states_looping = [
-            [[nidigital.enums.PinState.L, nidigital.enums.PinState.L, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.L, nidigital.enums.PinState.L, nidigital.enums.PinState.X, nidigital.enums.PinState.X]],
-            [[nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.L, nidigital.enums.PinState.H, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.L, nidigital.enums.PinState.H]],
-            [[nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.H, nidigital.enums.PinState.L, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.H, nidigital.enums.PinState.L]],
-            [[nidigital.enums.PinState.H, nidigital.enums.PinState.H, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.H, nidigital.enums.PinState.H, nidigital.enums.PinState.X, nidigital.enums.PinState.X],
-             [nidigital.enums.PinState.L, nidigital.enums.PinState.L, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.L, nidigital.enums.PinState.L, nidigital.enums.PinState.X, nidigital.enums.PinState.X]],
-            [[nidigital.enums.PinState.H, nidigital.enums.PinState.H, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.H, nidigital.enums.PinState.H, nidigital.enums.PinState.X, nidigital.enums.PinState.X],
-             [nidigital.enums.PinState.L, nidigital.enums.PinState.L, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.L, nidigital.enums.PinState.L, nidigital.enums.PinState.X, nidigital.enums.PinState.X]],
-            [[nidigital.enums.PinState.L, nidigital.enums.PinState.H, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.L, nidigital.enums.PinState.H, nidigital.enums.PinState.X, nidigital.enums.PinState.X],
-             [nidigital.enums.PinState.H, nidigital.enums.PinState.L, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.H, nidigital.enums.PinState.L, nidigital.enums.PinState.X, nidigital.enums.PinState.X]],
-            [[nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.X]]
+            [[nidigital.PinState.L, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X]],
+            [[nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.H]],
+            [[nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.L]],
+            [[nidigital.PinState.H, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X],
+             [nidigital.PinState.L, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X]],
+            [[nidigital.PinState.H, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X],
+             [nidigital.PinState.L, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X]],
+            [[nidigital.PinState.L, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X],
+             [nidigital.PinState.H, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X]],
+            [[nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X]]
         ]
         self.per_pin_pass_fail_looping = [
             [[True, False, True, True, False, True, True, True]],
@@ -79,8 +79,8 @@ class TestSession(object):
 
         # for niDigital_FetchHistoryRAMCyclePinData_check_pins_looping
         self.expected_pin_list_check_pins_looping = None
-        self.expected_pin_states_check_pins_looping = [[[nidigital.enums.PinState.ZERO, nidigital.enums.PinState.H]]]
-        self.actual_pin_states_check_pins_looping = [[[nidigital.enums.PinState.L, nidigital.enums.PinState.L]]]
+        self.expected_pin_states_check_pins_looping = [[[nidigital.PinState.ZERO, nidigital.PinState.H]]]
+        self.actual_pin_states_check_pins_looping = [[[nidigital.PinState.L, nidigital.PinState.L]]]
         self.per_pin_pass_fail_check_pins_looping = [[[True, False]]]
 
         # for niDigital_GetHistoryRAMSampleCount_check_site_looping
@@ -125,8 +125,8 @@ class TestSession(object):
         self.side_effects_helper['FetchHistoryRAMScanCycleNumber']['scanCycleNumber'] = -1
         self.patched_library.niDigital_FetchHistoryRAMCyclePinData.side_effect = self.side_effects_helper.niDigital_FetchHistoryRAMCyclePinData
         self.side_effects_helper['FetchHistoryRAMCyclePinData']['actualNumPinData'] = 8
-        self.side_effects_helper['FetchHistoryRAMCyclePinData']['expectedPinStates'] = [nidigital.enums.PinState.X.value] * 8
-        self.side_effects_helper['FetchHistoryRAMCyclePinData']['actualPinStates'] = [nidigital.enums.PinState.NOT_A_PIN_STATE.value] * 8
+        self.side_effects_helper['FetchHistoryRAMCyclePinData']['expectedPinStates'] = [nidigital.PinState.X.value] * 8
+        self.side_effects_helper['FetchHistoryRAMCyclePinData']['actualPinStates'] = [nidigital.PinState.NOT_A_PIN_STATE.value] * 8
         self.side_effects_helper['FetchHistoryRAMCyclePinData']['perPinPassFail'] = [True] * 8
         with nidigital.Session('') as session:
             history_ram_cycle_info = session.sites[1].fetch_history_ram_cycle_information(
@@ -254,7 +254,7 @@ class TestSession(object):
         for vector_pin_states, vector_pin_states_expected_by_test in zip(actual_pin_states, self.actual_pin_states_looping):
             for cycle_pin_states, cycle_pin_states_expected_by_test in zip(vector_pin_states, vector_pin_states_expected_by_test):
                 for pin_state, pin_state_expected_by_test in zip(cycle_pin_states, cycle_pin_states_expected_by_test):
-                    if pin_state_expected_by_test is not nidigital.enums.PinState.X:
+                    if pin_state_expected_by_test is not nidigital.PinState.X:
                         assert pin_state == pin_state_expected_by_test
 
         # Only the first cycle returned is expected to have failures

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -309,6 +309,8 @@ def test_get_pin_results_pin_information(multi_instrument_session):
     assert channels == fully_qualified_channels
 
 
+# TODO(jfitzger): make enum and HistoryRAMCycleInformation access consistent with the rest of the tests
+# and remove unnecessary imports.  Blocked by GitHub issue# 1426.
 def test_history_ram_cycle_information_representation():
     cycle_info = HistoryRAMCycleInformation(
         pattern_name='pat',
@@ -324,14 +326,14 @@ def test_history_ram_cycle_information_representation():
 
 
 def test_history_ram_cycle_information_string():
-    cycle_info = HistoryRAMCycleInformation(
+    cycle_info = nidigital.HistoryRAMCycleInformation(
         pattern_name='pat',
         time_set_name='t0',
         vector_number=42,
         cycle_number=999,
         scan_cycle_number=13,
-        expected_pin_states=[[PinState.D, PinState.V], [PinState.V, PinState.D]],
-        actual_pin_states=[[PinState.PIN_STATE_NOT_ACQUIRED, PinState.PIN_STATE_NOT_ACQUIRED], [PinState.ZERO, PinState.ONE]],
+        expected_pin_states=[[nidigital.PinState.D, nidigital.PinState.V], [nidigital.PinState.V, nidigital.PinState.D]],
+        actual_pin_states=[[nidigital.PinState.PIN_STATE_NOT_ACQUIRED, nidigital.PinState.PIN_STATE_NOT_ACQUIRED], [nidigital.PinState.ZERO, nidigital.PinState.ONE]],
         per_pin_pass_fail=[[True, True], [False, False]])
     print(cycle_info)
     expected_string = '''Pattern Name        : pat
@@ -465,32 +467,32 @@ def test_fetch_history_ram_cycle_information_samples_to_read_all(multi_instrumen
 
     expected_pin_states = [i.expected_pin_states for i in history_ram_cycle_info]
     assert expected_pin_states == [
-        [[PinState.ZERO, PinState.H, PinState.X, PinState.X, PinState.H, PinState.ZERO, PinState.X, PinState.X]],
-        [[PinState.X, PinState.X, PinState.ZERO, PinState.ONE, PinState.X, PinState.X, PinState.L, PinState.H]],
-        [[PinState.X, PinState.X, PinState.ONE, PinState.ZERO, PinState.X, PinState.X, PinState.H, PinState.L]],
-        [[PinState.ONE, PinState.ONE, PinState.X, PinState.X, PinState.H, PinState.H, PinState.X, PinState.X], [PinState.ZERO, PinState.ZERO, PinState.X, PinState.X, PinState.L, PinState.L, PinState.X, PinState.X]],
-        [[PinState.ONE, PinState.ONE, PinState.X, PinState.X, PinState.H, PinState.H, PinState.X, PinState.X], [PinState.ZERO, PinState.ZERO, PinState.X, PinState.X, PinState.L, PinState.L, PinState.X, PinState.X]],
-        [[PinState.ZERO, PinState.ONE, PinState.X, PinState.X, PinState.L, PinState.H, PinState.X, PinState.X], [PinState.ONE, PinState.ZERO, PinState.X, PinState.X, PinState.H, PinState.L, PinState.X, PinState.X]],
-        [[PinState.X, PinState.X, PinState.X, PinState.X, PinState.X, PinState.X, PinState.X, PinState.X]]
+        [[nidigital.PinState.ZERO, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.ZERO, nidigital.PinState.X, nidigital.PinState.X]],
+        [[nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.ZERO, nidigital.PinState.ONE, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.H]],
+        [[nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.ONE, nidigital.PinState.ZERO, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.L]],
+        [[nidigital.PinState.ONE, nidigital.PinState.ONE, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X], [nidigital.PinState.ZERO, nidigital.PinState.ZERO, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X]],
+        [[nidigital.PinState.ONE, nidigital.PinState.ONE, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X], [nidigital.PinState.ZERO, nidigital.PinState.ZERO, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X]],
+        [[nidigital.PinState.ZERO, nidigital.PinState.ONE, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X], [nidigital.PinState.ONE, nidigital.PinState.ZERO, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X]],
+        [[nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X]]
     ]
 
     # If test expects actual pin state to be 'X', then value returned by the returned can be anything.
     # So, need to skip those pin states while comparing.
     actual_pin_states = [i.actual_pin_states for i in history_ram_cycle_info]
     actual_pin_states_expected_by_test = [
-        [[PinState.L, PinState.L, PinState.X, PinState.X, PinState.L, PinState.L, PinState.X, PinState.X]],
-        [[PinState.X, PinState.X, PinState.L, PinState.H, PinState.X, PinState.X, PinState.L, PinState.H]],
-        [[PinState.X, PinState.X, PinState.H, PinState.L, PinState.X, PinState.X, PinState.H, PinState.L]],
-        [[PinState.H, PinState.H, PinState.X, PinState.X, PinState.H, PinState.H, PinState.X, PinState.X], [PinState.L, PinState.L, PinState.X, PinState.X, PinState.L, PinState.L, PinState.X, PinState.X]],
-        [[PinState.H, PinState.H, PinState.X, PinState.X, PinState.H, PinState.H, PinState.X, PinState.X], [PinState.L, PinState.L, PinState.X, PinState.X, PinState.L, PinState.L, PinState.X, PinState.X]],
-        [[PinState.L, PinState.H, PinState.X, PinState.X, PinState.L, PinState.H, PinState.X, PinState.X], [PinState.H, PinState.L, PinState.X, PinState.X, PinState.H, PinState.L, PinState.X, PinState.X]],
-        [[PinState.X, PinState.X, PinState.X, PinState.X, PinState.X, PinState.X, PinState.X, PinState.X]]
+        [[nidigital.PinState.L, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X]],
+        [[nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.H]],
+        [[nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.L]],
+        [[nidigital.PinState.H, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X], [nidigital.PinState.L, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X]],
+        [[nidigital.PinState.H, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X], [nidigital.PinState.L, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X]],
+        [[nidigital.PinState.L, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X], [nidigital.PinState.H, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X]],
+        [[nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X]]
     ]
     assert len(actual_pin_states) == len(actual_pin_states_expected_by_test)
     for vector_pin_states, vector_pin_states_expected_by_test in zip(actual_pin_states, actual_pin_states_expected_by_test):
         for cycle_pin_states, cycle_pin_states_expected_by_test in zip(vector_pin_states, vector_pin_states_expected_by_test):
             for pin_state, pin_state_expected_by_test in zip(cycle_pin_states, cycle_pin_states_expected_by_test):
-                if pin_state_expected_by_test is not PinState.X:
+                if pin_state_expected_by_test is not nidigital.PinState.X:
                     assert pin_state == pin_state_expected_by_test
 
     # Only the first cycle returned is expected to have failures
@@ -554,7 +556,7 @@ def test_ppmu_measure(multi_instrument_session):
     configure_session(multi_instrument_session, test_name)
 
     voltage_measurements = multi_instrument_session.pins['site0/LO0', 'site1/HI0'].ppmu_measure(
-        nidigital.enums.PPMUMeasurementType.VOLTAGE)
+        nidigital.PPMUMeasurementType.VOLTAGE)
 
     assert len(voltage_measurements) == 2
 

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -7,8 +7,6 @@ import numpy
 import pytest
 
 import nidigital
-from nidigital.enums import PinState
-from nidigital.history_ram_cycle_information import HistoryRAMCycleInformation
 
 instruments = ['PXI1Slot2', 'PXI1Slot5']
 test_files_base_dir = os.path.join(os.path.dirname(__file__), 'test_files')
@@ -312,6 +310,8 @@ def test_get_pin_results_pin_information(multi_instrument_session):
 # TODO(jfitzger): make enum and HistoryRAMCycleInformation access consistent with the rest of the tests
 # and remove unnecessary imports.  Blocked by GitHub issue# 1426.
 def test_history_ram_cycle_information_representation():
+    from nidigital.enums import PinState
+    from nidigital.history_ram_cycle_information import HistoryRAMCycleInformation
     cycle_info = HistoryRAMCycleInformation(
         pattern_name='pat',
         time_set_name='t0',

--- a/src/nidigital/unit_tests/test_nidigital.py
+++ b/src/nidigital/unit_tests/test_nidigital.py
@@ -44,28 +44,28 @@ class TestSession(object):
 
         # for niDigital_FetchHistoryRAMCyclePinData_looping
         self.expected_pin_states_looping = [
-            [[nidigital.enums.PinState.ZERO, nidigital.enums.PinState.H, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.H, nidigital.enums.PinState.ZERO, nidigital.enums.PinState.X, nidigital.enums.PinState.X]],
-            [[nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.ZERO, nidigital.enums.PinState.ONE, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.L, nidigital.enums.PinState.H]],
-            [[nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.ONE, nidigital.enums.PinState.ZERO, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.H, nidigital.enums.PinState.L]],
-            [[nidigital.enums.PinState.ONE, nidigital.enums.PinState.ONE, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.H, nidigital.enums.PinState.H, nidigital.enums.PinState.X, nidigital.enums.PinState.X],
-             [nidigital.enums.PinState.ZERO, nidigital.enums.PinState.ZERO, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.L, nidigital.enums.PinState.L, nidigital.enums.PinState.X, nidigital.enums.PinState.X]],
-            [[nidigital.enums.PinState.ONE, nidigital.enums.PinState.ONE, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.H, nidigital.enums.PinState.H, nidigital.enums.PinState.X, nidigital.enums.PinState.X],
-             [nidigital.enums.PinState.ZERO, nidigital.enums.PinState.ZERO, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.L, nidigital.enums.PinState.L, nidigital.enums.PinState.X, nidigital.enums.PinState.X]],
-            [[nidigital.enums.PinState.ZERO, nidigital.enums.PinState.ONE, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.L, nidigital.enums.PinState.H, nidigital.enums.PinState.X, nidigital.enums.PinState.X],
-             [nidigital.enums.PinState.ONE, nidigital.enums.PinState.ZERO, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.H, nidigital.enums.PinState.L, nidigital.enums.PinState.X, nidigital.enums.PinState.X]],
-            [[nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.X]]
+            [[nidigital.PinState.ZERO, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.ZERO, nidigital.PinState.X, nidigital.PinState.X]],
+            [[nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.ZERO, nidigital.PinState.ONE, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.H]],
+            [[nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.ONE, nidigital.PinState.ZERO, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.L]],
+            [[nidigital.PinState.ONE, nidigital.PinState.ONE, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X],
+             [nidigital.PinState.ZERO, nidigital.PinState.ZERO, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X]],
+            [[nidigital.PinState.ONE, nidigital.PinState.ONE, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X],
+             [nidigital.PinState.ZERO, nidigital.PinState.ZERO, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X]],
+            [[nidigital.PinState.ZERO, nidigital.PinState.ONE, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X],
+             [nidigital.PinState.ONE, nidigital.PinState.ZERO, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X]],
+            [[nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X]]
         ]
         self.actual_pin_states_looping = [
-            [[nidigital.enums.PinState.L, nidigital.enums.PinState.L, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.L, nidigital.enums.PinState.L, nidigital.enums.PinState.X, nidigital.enums.PinState.X]],
-            [[nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.L, nidigital.enums.PinState.H, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.L, nidigital.enums.PinState.H]],
-            [[nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.H, nidigital.enums.PinState.L, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.H, nidigital.enums.PinState.L]],
-            [[nidigital.enums.PinState.H, nidigital.enums.PinState.H, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.H, nidigital.enums.PinState.H, nidigital.enums.PinState.X, nidigital.enums.PinState.X],
-             [nidigital.enums.PinState.L, nidigital.enums.PinState.L, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.L, nidigital.enums.PinState.L, nidigital.enums.PinState.X, nidigital.enums.PinState.X]],
-            [[nidigital.enums.PinState.H, nidigital.enums.PinState.H, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.H, nidigital.enums.PinState.H, nidigital.enums.PinState.X, nidigital.enums.PinState.X],
-             [nidigital.enums.PinState.L, nidigital.enums.PinState.L, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.L, nidigital.enums.PinState.L, nidigital.enums.PinState.X, nidigital.enums.PinState.X]],
-            [[nidigital.enums.PinState.L, nidigital.enums.PinState.H, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.L, nidigital.enums.PinState.H, nidigital.enums.PinState.X, nidigital.enums.PinState.X],
-             [nidigital.enums.PinState.H, nidigital.enums.PinState.L, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.H, nidigital.enums.PinState.L, nidigital.enums.PinState.X, nidigital.enums.PinState.X]],
-            [[nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.X, nidigital.enums.PinState.X]]
+            [[nidigital.PinState.L, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X]],
+            [[nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.H]],
+            [[nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.L]],
+            [[nidigital.PinState.H, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X],
+             [nidigital.PinState.L, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X]],
+            [[nidigital.PinState.H, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X],
+             [nidigital.PinState.L, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X]],
+            [[nidigital.PinState.L, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.L, nidigital.PinState.H, nidigital.PinState.X, nidigital.PinState.X],
+             [nidigital.PinState.H, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.H, nidigital.PinState.L, nidigital.PinState.X, nidigital.PinState.X]],
+            [[nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X, nidigital.PinState.X]]
         ]
         self.per_pin_pass_fail_looping = [
             [[True, False, True, True, False, True, True, True]],
@@ -79,8 +79,8 @@ class TestSession(object):
 
         # for niDigital_FetchHistoryRAMCyclePinData_check_pins_looping
         self.expected_pin_list_check_pins_looping = None
-        self.expected_pin_states_check_pins_looping = [[[nidigital.enums.PinState.ZERO, nidigital.enums.PinState.H]]]
-        self.actual_pin_states_check_pins_looping = [[[nidigital.enums.PinState.L, nidigital.enums.PinState.L]]]
+        self.expected_pin_states_check_pins_looping = [[[nidigital.PinState.ZERO, nidigital.PinState.H]]]
+        self.actual_pin_states_check_pins_looping = [[[nidigital.PinState.L, nidigital.PinState.L]]]
         self.per_pin_pass_fail_check_pins_looping = [[[True, False]]]
 
         # for niDigital_GetHistoryRAMSampleCount_check_site_looping
@@ -125,8 +125,8 @@ class TestSession(object):
         self.side_effects_helper['FetchHistoryRAMScanCycleNumber']['scanCycleNumber'] = -1
         self.patched_library.niDigital_FetchHistoryRAMCyclePinData.side_effect = self.side_effects_helper.niDigital_FetchHistoryRAMCyclePinData
         self.side_effects_helper['FetchHistoryRAMCyclePinData']['actualNumPinData'] = 8
-        self.side_effects_helper['FetchHistoryRAMCyclePinData']['expectedPinStates'] = [nidigital.enums.PinState.X.value] * 8
-        self.side_effects_helper['FetchHistoryRAMCyclePinData']['actualPinStates'] = [nidigital.enums.PinState.NOT_A_PIN_STATE.value] * 8
+        self.side_effects_helper['FetchHistoryRAMCyclePinData']['expectedPinStates'] = [nidigital.PinState.X.value] * 8
+        self.side_effects_helper['FetchHistoryRAMCyclePinData']['actualPinStates'] = [nidigital.PinState.NOT_A_PIN_STATE.value] * 8
         self.side_effects_helper['FetchHistoryRAMCyclePinData']['perPinPassFail'] = [True] * 8
         with nidigital.Session('') as session:
             history_ram_cycle_info = session.sites[1].fetch_history_ram_cycle_information(
@@ -254,7 +254,7 @@ class TestSession(object):
         for vector_pin_states, vector_pin_states_expected_by_test in zip(actual_pin_states, self.actual_pin_states_looping):
             for cycle_pin_states, cycle_pin_states_expected_by_test in zip(vector_pin_states, vector_pin_states_expected_by_test):
                 for pin_state, pin_state_expected_by_test in zip(cycle_pin_states, cycle_pin_states_expected_by_test):
-                    if pin_state_expected_by_test is not nidigital.enums.PinState.X:
+                    if pin_state_expected_by_test is not nidigital.PinState.X:
                         assert pin_state == pin_state_expected_by_test
 
         # Only the first cycle returned is expected to have failures


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] ~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

* Updates all nidigital tests except for one to use nidigital.<enum_name> to access enums.
  - Update of the other test was blocked by #1426.  A TODO was created to update it, when possible.

### List issues fixed by this Pull Request below, if any.

### What testing has been done?

* Ran unit tests.
* Ran the system tests on a system with nidigital 19.0.1 installed.