### PR TITLE
Add nidigital system tests for low level actions

### DIFF
--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -953,11 +953,11 @@ def test_configure_pattern_burst_sites(multi_instrument_session):
     multi_instrument_session.load_pattern(get_test_file_path(test_name, 'pattern_b.digipat'))
     multi_instrument_session.start_label = 'second_pattern'
     multi_instrument_session.selected_function = nidigital.SelectedFunction.DIGITAL
-    multi_instrument_session.wait_until_done(timeout=datetime.timedelta(seconds=5.0))
 
     multi_instrument_session.sites[0, 2, 3].configure_pattern_burst_sites()
 
     multi_instrument_session.initiate()
+    multi_instrument_session.wait_until_done(timeout=datetime.timedelta(seconds=5.0))
     result = multi_instrument_session.sites[0, 1, 3].get_site_pass_fail()
     assert result == {0: True, 3: True}
 

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -947,6 +947,7 @@ def test_load_get_unload_patterns(multi_instrument_session):
 
 
 def test_configure_pattern_burst_sites(multi_instrument_session):
+    # Also tests initiate
     test_name = 'multiple_patterns'
     configure_session(multi_instrument_session, test_name)
     multi_instrument_session.load_pattern(get_test_file_path(test_name, 'pattern_b.digipat'))
@@ -959,6 +960,53 @@ def test_configure_pattern_burst_sites(multi_instrument_session):
     multi_instrument_session.initiate()
     result = multi_instrument_session.sites[0, 1, 3].get_site_pass_fail()
     assert result == {0: True, 3: True}
+
+
+def test_commit(multi_instrument_session):
+    multi_instrument_session.cycle_number_history_ram_trigger_cycle_number = 42
+    multi_instrument_session.commit()
+    assert multi_instrument_session.cycle_number_history_ram_trigger_cycle_number == 42
+
+
+def test_initiate_context_manager_and_wait_until_done(multi_instrument_session):
+    '''Test initiate's context manager and pattern completion methods.
+
+    - with initiate
+    - wait_until_done
+    - is_done
+    '''
+    test_name = 'simple_pattern'
+    configure_session(multi_instrument_session, test_name)
+    multi_instrument_session.load_pattern(get_test_file_path(test_name, 'pattern.digipat'))
+    multi_instrument_session.start_label = 'new_pattern'
+    multi_instrument_session.selected_function = nidigital.SelectedFunction.DIGITAL
+
+    with multi_instrument_session.initiate():
+        # note that wait_until_done will return immediately with simulated hardware
+        multi_instrument_session.wait_until_done(timeout=datetime.timedelta(seconds=5.0))
+    assert multi_instrument_session.is_done()
+
+
+def test_abort(multi_instrument_session):
+    test_name = 'simple_pattern'
+    configure_session(multi_instrument_session, test_name)
+    multi_instrument_session.load_pattern(get_test_file_path(test_name, 'pattern.digipat'))
+    multi_instrument_session.start_label = 'new_pattern'
+    multi_instrument_session.selected_function = nidigital.SelectedFunction.DIGITAL
+    multi_instrument_session.initiate()
+
+    multi_instrument_session.abort()
+
+
+def test_abort_keep_alive(multi_instrument_session):
+    test_name = 'simple_pattern'
+    configure_session(multi_instrument_session, test_name)
+    multi_instrument_session.load_pattern(get_test_file_path(test_name, 'pattern.digipat'))
+    multi_instrument_session.start_label = 'new_pattern'
+    multi_instrument_session.selected_function = nidigital.SelectedFunction.DIGITAL
+    multi_instrument_session.initiate()
+
+    multi_instrument_session.abort_keep_alive()
 
 
 def test_specifications_levels_and_timing_single(multi_instrument_session):


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] ~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

* Documents coverage of `initiate` in `test_configure_pattern_burst_sites` and corrects api usage
* Adds test `test_commit`
* Adds test `test_initiate_context_manager_and_wait_until_done`
  - Covers context manager for `initiate`
  - Covers `wait_until_done`
  - Covers `is_done`
* Adds test `test_abort`
* Adds test `test_abort_keep_alive`

### List issues fixed by this Pull Request below, if any.

### What testing has been done?

Ran the system tests on a system with ni-digital 19.0.1 installed.