### PR TITLE
Add a converter for converting seconds in float to timedelta

### DIFF
--- a/build/templates/_converters.py.mako
+++ b/build/templates/_converters.py.mako
@@ -175,8 +175,12 @@ def convert_timedeltas_to_seconds_real64(values):
     return [convert_timedelta_to_seconds_real64(i) for i in values]
 
 
-def convert_seconds_real64_to_timedeltas(seconds):
-    return [datetime.timedelta(seconds=i) for i in seconds]
+def convert_seconds_real64_to_timedelta(value):
+    return datetime.timedelta(seconds=value)
+
+
+def convert_seconds_real64_to_timedeltas(values):
+    return [convert_seconds_real64_to_timedelta(i) for i in values]
 
 
 def convert_month_to_timedelta(months):
@@ -368,6 +372,12 @@ def test_convert_timedeltas_to_seconds_real64():
     test_result = convert_timedeltas_to_seconds_real64(timedeltas)
     assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
+
+
+def test_convert_seconds_real64_to_timedelta():
+    time_value = 10.5
+    timedelta = convert_seconds_real64_to_timedelta(time_value)
+    assert timedelta.total_seconds() == time_value
 
 
 def test_convert_seconds_real64_to_timedeltas():

--- a/generated/nidcpower/nidcpower/_converters.py
+++ b/generated/nidcpower/nidcpower/_converters.py
@@ -170,8 +170,12 @@ def convert_timedeltas_to_seconds_real64(values):
     return [convert_timedelta_to_seconds_real64(i) for i in values]
 
 
-def convert_seconds_real64_to_timedeltas(seconds):
-    return [datetime.timedelta(seconds=i) for i in seconds]
+def convert_seconds_real64_to_timedelta(value):
+    return datetime.timedelta(seconds=value)
+
+
+def convert_seconds_real64_to_timedeltas(values):
+    return [convert_seconds_real64_to_timedelta(i) for i in values]
 
 
 def convert_month_to_timedelta(months):
@@ -319,6 +323,12 @@ def test_convert_timedeltas_to_seconds_real64():
     test_result = convert_timedeltas_to_seconds_real64(timedeltas)
     assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
+
+
+def test_convert_seconds_real64_to_timedelta():
+    time_value = 10.5
+    timedelta = convert_seconds_real64_to_timedelta(time_value)
+    assert timedelta.total_seconds() == time_value
 
 
 def test_convert_seconds_real64_to_timedeltas():

--- a/generated/nidigital/nidigital/_converters.py
+++ b/generated/nidigital/nidigital/_converters.py
@@ -170,8 +170,12 @@ def convert_timedeltas_to_seconds_real64(values):
     return [convert_timedelta_to_seconds_real64(i) for i in values]
 
 
-def convert_seconds_real64_to_timedeltas(seconds):
-    return [datetime.timedelta(seconds=i) for i in seconds]
+def convert_seconds_real64_to_timedelta(value):
+    return datetime.timedelta(seconds=value)
+
+
+def convert_seconds_real64_to_timedeltas(values):
+    return [convert_seconds_real64_to_timedelta(i) for i in values]
 
 
 def convert_month_to_timedelta(months):
@@ -319,6 +323,12 @@ def test_convert_timedeltas_to_seconds_real64():
     test_result = convert_timedeltas_to_seconds_real64(timedeltas)
     assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
+
+
+def test_convert_seconds_real64_to_timedelta():
+    time_value = 10.5
+    timedelta = convert_seconds_real64_to_timedelta(time_value)
+    assert timedelta.total_seconds() == time_value
 
 
 def test_convert_seconds_real64_to_timedeltas():

--- a/generated/nidmm/nidmm/_converters.py
+++ b/generated/nidmm/nidmm/_converters.py
@@ -170,8 +170,12 @@ def convert_timedeltas_to_seconds_real64(values):
     return [convert_timedelta_to_seconds_real64(i) for i in values]
 
 
-def convert_seconds_real64_to_timedeltas(seconds):
-    return [datetime.timedelta(seconds=i) for i in seconds]
+def convert_seconds_real64_to_timedelta(value):
+    return datetime.timedelta(seconds=value)
+
+
+def convert_seconds_real64_to_timedeltas(values):
+    return [convert_seconds_real64_to_timedelta(i) for i in values]
 
 
 def convert_month_to_timedelta(months):
@@ -319,6 +323,12 @@ def test_convert_timedeltas_to_seconds_real64():
     test_result = convert_timedeltas_to_seconds_real64(timedeltas)
     assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
+
+
+def test_convert_seconds_real64_to_timedelta():
+    time_value = 10.5
+    timedelta = convert_seconds_real64_to_timedelta(time_value)
+    assert timedelta.total_seconds() == time_value
 
 
 def test_convert_seconds_real64_to_timedeltas():

--- a/generated/nifake/nifake/_converters.py
+++ b/generated/nifake/nifake/_converters.py
@@ -170,8 +170,12 @@ def convert_timedeltas_to_seconds_real64(values):
     return [convert_timedelta_to_seconds_real64(i) for i in values]
 
 
-def convert_seconds_real64_to_timedeltas(seconds):
-    return [datetime.timedelta(seconds=i) for i in seconds]
+def convert_seconds_real64_to_timedelta(value):
+    return datetime.timedelta(seconds=value)
+
+
+def convert_seconds_real64_to_timedeltas(values):
+    return [convert_seconds_real64_to_timedelta(i) for i in values]
 
 
 def convert_month_to_timedelta(months):
@@ -324,6 +328,12 @@ def test_convert_timedeltas_to_seconds_real64():
     test_result = convert_timedeltas_to_seconds_real64(timedeltas)
     assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
+
+
+def test_convert_seconds_real64_to_timedelta():
+    time_value = 10.5
+    timedelta = convert_seconds_real64_to_timedelta(time_value)
+    assert timedelta.total_seconds() == time_value
 
 
 def test_convert_seconds_real64_to_timedeltas():

--- a/generated/nifake/nifake/_library.py
+++ b/generated/nifake/nifake/_library.py
@@ -61,6 +61,7 @@ class Library(object):
         self.niFake_Read_cfunc = None
         self.niFake_ReadFromChannel_cfunc = None
         self.niFake_ReturnANumberAndAString_cfunc = None
+        self.niFake_ReturnDurationInSeconds_cfunc = None
         self.niFake_ReturnListOfDurationsInSeconds_cfunc = None
         self.niFake_ReturnMultipleTypes_cfunc = None
         self.niFake_SetAttributeViBoolean_cfunc = None
@@ -406,6 +407,14 @@ class Library(object):
                 self.niFake_ReturnANumberAndAString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_ReturnANumberAndAString_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ReturnANumberAndAString_cfunc(vi, a_number, a_string)
+
+    def niFake_ReturnDurationInSeconds(self, vi, timedelta):  # noqa: N802
+        with self._func_lock:
+            if self.niFake_ReturnDurationInSeconds_cfunc is None:
+                self.niFake_ReturnDurationInSeconds_cfunc = self._library.niFake_ReturnDurationInSeconds
+                self.niFake_ReturnDurationInSeconds_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
+                self.niFake_ReturnDurationInSeconds_cfunc.restype = ViStatus  # noqa: F405
+        return self.niFake_ReturnDurationInSeconds_cfunc(vi, timedelta)
 
     def niFake_ReturnListOfDurationsInSeconds(self, vi, number_of_elements, timedeltas):  # noqa: N802
         with self._func_lock:

--- a/generated/nifake/nifake/session.py
+++ b/generated/nifake/nifake/session.py
@@ -1541,6 +1541,22 @@ class Session(_SessionBase):
         return int(a_number_ctype.value), a_string_ctype.value.decode(self._encoding)
 
     @ivi_synchronized
+    def return_duration_in_seconds(self):
+        r'''return_duration_in_seconds
+
+        Returns a datetime.timedelta instance.
+
+        Returns:
+            timedelta (datetime.timedelta): Duration in seconds.
+
+        '''
+        vi_ctype = _visatype.ViSession(self._vi)  # case S110
+        timedelta_ctype = _visatype.ViReal64()  # case S220
+        error_code = self._library.niFake_ReturnDurationInSeconds(vi_ctype, None if timedelta_ctype is None else (ctypes.pointer(timedelta_ctype)))
+        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
+        return _converters.convert_seconds_real64_to_timedelta(float(timedelta_ctype.value))
+
+    @ivi_synchronized
     def return_list_of_durations_in_seconds(self, number_of_elements):
         r'''return_list_of_durations_in_seconds
 

--- a/generated/nifake/nifake/unit_tests/_mock_helper.py
+++ b/generated/nifake/nifake/unit_tests/_mock_helper.py
@@ -139,6 +139,9 @@ class SideEffectsHelper(object):
         self._defaults['ReturnANumberAndAString']['return'] = 0
         self._defaults['ReturnANumberAndAString']['aNumber'] = None
         self._defaults['ReturnANumberAndAString']['aString'] = None
+        self._defaults['ReturnDurationInSeconds'] = {}
+        self._defaults['ReturnDurationInSeconds']['return'] = 0
+        self._defaults['ReturnDurationInSeconds']['timedelta'] = None
         self._defaults['ReturnListOfDurationsInSeconds'] = {}
         self._defaults['ReturnListOfDurationsInSeconds']['return'] = 0
         self._defaults['ReturnListOfDurationsInSeconds']['timedeltas'] = None
@@ -675,6 +678,16 @@ class SideEffectsHelper(object):
             a_string[i] = test_value[i]
         return self._defaults['ReturnANumberAndAString']['return']
 
+    def niFake_ReturnDurationInSeconds(self, vi, timedelta):  # noqa: N802
+        if self._defaults['ReturnDurationInSeconds']['return'] != 0:
+            return self._defaults['ReturnDurationInSeconds']['return']
+        # timedelta
+        if self._defaults['ReturnDurationInSeconds']['timedelta'] is None:
+            raise MockFunctionCallError("niFake_ReturnDurationInSeconds", param='timedelta')
+        if timedelta is not None:
+            timedelta.contents.value = self._defaults['ReturnDurationInSeconds']['timedelta']
+        return self._defaults['ReturnDurationInSeconds']['return']
+
     def niFake_ReturnListOfDurationsInSeconds(self, vi, number_of_elements, timedeltas):  # noqa: N802
         if self._defaults['ReturnListOfDurationsInSeconds']['return'] != 0:
             return self._defaults['ReturnListOfDurationsInSeconds']['return']
@@ -934,6 +947,8 @@ class SideEffectsHelper(object):
         mock_library.niFake_ReadFromChannel.return_value = 0
         mock_library.niFake_ReturnANumberAndAString.side_effect = MockFunctionCallError("niFake_ReturnANumberAndAString")
         mock_library.niFake_ReturnANumberAndAString.return_value = 0
+        mock_library.niFake_ReturnDurationInSeconds.side_effect = MockFunctionCallError("niFake_ReturnDurationInSeconds")
+        mock_library.niFake_ReturnDurationInSeconds.return_value = 0
         mock_library.niFake_ReturnListOfDurationsInSeconds.side_effect = MockFunctionCallError("niFake_ReturnListOfDurationsInSeconds")
         mock_library.niFake_ReturnListOfDurationsInSeconds.return_value = 0
         mock_library.niFake_ReturnMultipleTypes.side_effect = MockFunctionCallError("niFake_ReturnMultipleTypes")

--- a/generated/nifake/nifake/unit_tests/test_session.py
+++ b/generated/nifake/nifake/unit_tests/test_session.py
@@ -1463,6 +1463,19 @@ class TestSession(object):
                 _matchers.ViReal64BufferMatcher(time_values)
             )
 
+    def test_return_timedelta(self):
+        self.patched_library.niFake_ReturnDurationInSeconds.side_effect = self.side_effects_helper.niFake_ReturnDurationInSeconds
+        time_value = -1.5
+        expected_timedelta = datetime.timedelta(seconds=time_value)
+        self.side_effects_helper['ReturnDurationInSeconds']['timedelta'] = time_value
+        with nifake.Session('dev1') as session:
+            returned_timedelta = session.return_duration_in_seconds()
+            assert returned_timedelta == expected_timedelta
+            self.patched_library.niFake_ReturnDurationInSeconds.assert_called_once_with(
+                _matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST),
+                _matchers.ViReal64PointerMatcher()
+            )
+
     def test_return_timedeltas(self):
         self.patched_library.niFake_ReturnListOfDurationsInSeconds.side_effect = self.side_effects_helper.niFake_ReturnListOfDurationsInSeconds
         time_values = [-1.5, 2.0]

--- a/generated/nifgen/nifgen/_converters.py
+++ b/generated/nifgen/nifgen/_converters.py
@@ -170,8 +170,12 @@ def convert_timedeltas_to_seconds_real64(values):
     return [convert_timedelta_to_seconds_real64(i) for i in values]
 
 
-def convert_seconds_real64_to_timedeltas(seconds):
-    return [datetime.timedelta(seconds=i) for i in seconds]
+def convert_seconds_real64_to_timedelta(value):
+    return datetime.timedelta(seconds=value)
+
+
+def convert_seconds_real64_to_timedeltas(values):
+    return [convert_seconds_real64_to_timedelta(i) for i in values]
 
 
 def convert_month_to_timedelta(months):
@@ -319,6 +323,12 @@ def test_convert_timedeltas_to_seconds_real64():
     test_result = convert_timedeltas_to_seconds_real64(timedeltas)
     assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
+
+
+def test_convert_seconds_real64_to_timedelta():
+    time_value = 10.5
+    timedelta = convert_seconds_real64_to_timedelta(time_value)
+    assert timedelta.total_seconds() == time_value
 
 
 def test_convert_seconds_real64_to_timedeltas():

--- a/generated/nimodinst/nimodinst/_converters.py
+++ b/generated/nimodinst/nimodinst/_converters.py
@@ -170,8 +170,12 @@ def convert_timedeltas_to_seconds_real64(values):
     return [convert_timedelta_to_seconds_real64(i) for i in values]
 
 
-def convert_seconds_real64_to_timedeltas(seconds):
-    return [datetime.timedelta(seconds=i) for i in seconds]
+def convert_seconds_real64_to_timedelta(value):
+    return datetime.timedelta(seconds=value)
+
+
+def convert_seconds_real64_to_timedeltas(values):
+    return [convert_seconds_real64_to_timedelta(i) for i in values]
 
 
 def convert_month_to_timedelta(months):
@@ -319,6 +323,12 @@ def test_convert_timedeltas_to_seconds_real64():
     test_result = convert_timedeltas_to_seconds_real64(timedeltas)
     assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
+
+
+def test_convert_seconds_real64_to_timedelta():
+    time_value = 10.5
+    timedelta = convert_seconds_real64_to_timedelta(time_value)
+    assert timedelta.total_seconds() == time_value
 
 
 def test_convert_seconds_real64_to_timedeltas():

--- a/generated/niscope/niscope/_converters.py
+++ b/generated/niscope/niscope/_converters.py
@@ -170,8 +170,12 @@ def convert_timedeltas_to_seconds_real64(values):
     return [convert_timedelta_to_seconds_real64(i) for i in values]
 
 
-def convert_seconds_real64_to_timedeltas(seconds):
-    return [datetime.timedelta(seconds=i) for i in seconds]
+def convert_seconds_real64_to_timedelta(value):
+    return datetime.timedelta(seconds=value)
+
+
+def convert_seconds_real64_to_timedeltas(values):
+    return [convert_seconds_real64_to_timedelta(i) for i in values]
 
 
 def convert_month_to_timedelta(months):
@@ -319,6 +323,12 @@ def test_convert_timedeltas_to_seconds_real64():
     test_result = convert_timedeltas_to_seconds_real64(timedeltas)
     assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
+
+
+def test_convert_seconds_real64_to_timedelta():
+    time_value = 10.5
+    timedelta = convert_seconds_real64_to_timedelta(time_value)
+    assert timedelta.total_seconds() == time_value
 
 
 def test_convert_seconds_real64_to_timedeltas():

--- a/generated/nise/nise/_converters.py
+++ b/generated/nise/nise/_converters.py
@@ -170,8 +170,12 @@ def convert_timedeltas_to_seconds_real64(values):
     return [convert_timedelta_to_seconds_real64(i) for i in values]
 
 
-def convert_seconds_real64_to_timedeltas(seconds):
-    return [datetime.timedelta(seconds=i) for i in seconds]
+def convert_seconds_real64_to_timedelta(value):
+    return datetime.timedelta(seconds=value)
+
+
+def convert_seconds_real64_to_timedeltas(values):
+    return [convert_seconds_real64_to_timedelta(i) for i in values]
 
 
 def convert_month_to_timedelta(months):
@@ -319,6 +323,12 @@ def test_convert_timedeltas_to_seconds_real64():
     test_result = convert_timedeltas_to_seconds_real64(timedeltas)
     assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
+
+
+def test_convert_seconds_real64_to_timedelta():
+    time_value = 10.5
+    timedelta = convert_seconds_real64_to_timedelta(time_value)
+    assert timedelta.total_seconds() == time_value
 
 
 def test_convert_seconds_real64_to_timedeltas():

--- a/generated/niswitch/niswitch/_converters.py
+++ b/generated/niswitch/niswitch/_converters.py
@@ -170,8 +170,12 @@ def convert_timedeltas_to_seconds_real64(values):
     return [convert_timedelta_to_seconds_real64(i) for i in values]
 
 
-def convert_seconds_real64_to_timedeltas(seconds):
-    return [datetime.timedelta(seconds=i) for i in seconds]
+def convert_seconds_real64_to_timedelta(value):
+    return datetime.timedelta(seconds=value)
+
+
+def convert_seconds_real64_to_timedeltas(values):
+    return [convert_seconds_real64_to_timedelta(i) for i in values]
 
 
 def convert_month_to_timedelta(months):
@@ -319,6 +323,12 @@ def test_convert_timedeltas_to_seconds_real64():
     test_result = convert_timedeltas_to_seconds_real64(timedeltas)
     assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
+
+
+def test_convert_seconds_real64_to_timedelta():
+    time_value = 10.5
+    timedelta = convert_seconds_real64_to_timedelta(time_value)
+    assert timedelta.total_seconds() == time_value
 
 
 def test_convert_seconds_real64_to_timedeltas():

--- a/generated/nitclk/nitclk/_converters.py
+++ b/generated/nitclk/nitclk/_converters.py
@@ -170,8 +170,12 @@ def convert_timedeltas_to_seconds_real64(values):
     return [convert_timedelta_to_seconds_real64(i) for i in values]
 
 
-def convert_seconds_real64_to_timedeltas(seconds):
-    return [datetime.timedelta(seconds=i) for i in seconds]
+def convert_seconds_real64_to_timedelta(value):
+    return datetime.timedelta(seconds=value)
+
+
+def convert_seconds_real64_to_timedeltas(values):
+    return [convert_seconds_real64_to_timedelta(i) for i in values]
 
 
 def convert_month_to_timedelta(months):
@@ -345,6 +349,12 @@ def test_convert_timedeltas_to_seconds_real64():
     test_result = convert_timedeltas_to_seconds_real64(timedeltas)
     assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
+
+
+def test_convert_seconds_real64_to_timedelta():
+    time_value = 10.5
+    timedelta = convert_seconds_real64_to_timedelta(time_value)
+    assert timedelta.total_seconds() == time_value
 
 
 def test_convert_seconds_real64_to_timedeltas():

--- a/src/nifake/metadata/functions.py
+++ b/src/nifake/metadata/functions.py
@@ -1731,6 +1731,33 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
+    'ReturnDurationInSeconds': {
+        'codegen_method': 'public',
+        'documentation': {
+            'description': 'Returns a datetime.timedelta instance.'
+        },
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Identifies a particular instrument session.'
+                },
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'out',
+                'documentation': {
+                    'description': 'Duration in seconds.'
+                },
+                'name': 'timedelta',
+                'python_api_converter_name': 'convert_seconds_real64_to_timedelta',
+                'type': 'ViReal64',
+                'type_in_documentation': 'datetime.timedelta'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
     'ReturnListOfDurationsInSeconds': {
         'codegen_method': 'public',
         'documentation': {

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -1463,6 +1463,19 @@ class TestSession(object):
                 _matchers.ViReal64BufferMatcher(time_values)
             )
 
+    def test_return_timedelta(self):
+        self.patched_library.niFake_ReturnDurationInSeconds.side_effect = self.side_effects_helper.niFake_ReturnDurationInSeconds
+        time_value = -1.5
+        expected_timedelta = datetime.timedelta(seconds=time_value)
+        self.side_effects_helper['ReturnDurationInSeconds']['timedelta'] = time_value
+        with nifake.Session('dev1') as session:
+            returned_timedelta = session.return_duration_in_seconds()
+            assert returned_timedelta == expected_timedelta
+            self.patched_library.niFake_ReturnDurationInSeconds.assert_called_once_with(
+                _matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST),
+                _matchers.ViReal64PointerMatcher()
+            )
+
     def test_return_timedeltas(self):
         self.patched_library.niFake_ReturnListOfDurationsInSeconds.side_effect = self.side_effects_helper.niFake_ReturnListOfDurationsInSeconds
         time_values = [-1.5, 2.0]


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

Add a converter for converting seconds in float to timedelta.

### List issues fixed by this Pull Request below, if any.

Required for fixing #1397 

### What testing has been done?

Added new unit tests. Tests will be run by CI.