### PR TITLE
Update HistoryRAMCycleInformation.__repr__ to use `__module__` and `__qualname__`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to this project will be documented in this file.
     * #### Added
     * #### Changed
         * Changed initial_state parameters in `apply_levels_and_timing` to basic sequence types - [#1391](https://github.com/ni/nimi-python/issues/1391) 
+        * Changed HistoryRAMCycleInformation.__repr__ to include `__module__` - [#1426](https://github.com/ni/nimi-python/issues/1426) 
     * #### Removed
 * ### NI-DMM
     * #### Added

--- a/generated/nidigital/nidigital/history_ram_cycle_information.py
+++ b/generated/nidigital/nidigital/history_ram_cycle_information.py
@@ -21,7 +21,7 @@ class HistoryRAMCycleInformation(object):
             'per_pin_pass_fail={}'.format(self.per_pin_pass_fail),
         ]
 
-        return '{0}({1})'.format(self.__class__.__name__, ', '.join(parameter_list))
+        return '{0}.{1}({2})'.format(self.__class__.__module__, self.__class__.__qualname__, ', '.join(parameter_list))
 
     def __str__(self):
         # different format lines
@@ -42,7 +42,7 @@ class HistoryRAMCycleInformation(object):
 
     @staticmethod
     def _digital_states_representation(states):
-        states_representation = [['{0}.{1}'.format(i.__class__.__name__, i.name) for i in j] for j in states]
+        states_representation = [['{0}.{1}.{2}'.format(i.__class__.__module__, i.__class__.__qualname__, i.name) for i in j] for j in states]
         return '[{}]'.format(', '.join(['[{}]'.format(', '.join(i)) for i in states_representation]))
 
     @staticmethod

--- a/src/nidigital/custom_types/history_ram_cycle_information.py
+++ b/src/nidigital/custom_types/history_ram_cycle_information.py
@@ -21,7 +21,7 @@ class HistoryRAMCycleInformation(object):
             'per_pin_pass_fail={}'.format(self.per_pin_pass_fail),
         ]
 
-        return '{0}({1})'.format(self.__class__.__name__, ', '.join(parameter_list))
+        return '{0}.{1}({2})'.format(self.__class__.__module__, self.__class__.__qualname__, ', '.join(parameter_list))
 
     def __str__(self):
         # different format lines
@@ -42,7 +42,7 @@ class HistoryRAMCycleInformation(object):
 
     @staticmethod
     def _digital_states_representation(states):
-        states_representation = [['{0}.{1}'.format(i.__class__.__name__, i.name) for i in j] for j in states]
+        states_representation = [['{0}.{1}.{2}'.format(i.__class__.__module__, i.__class__.__qualname__, i.name) for i in j] for j in states]
         return '[{}]'.format(', '.join(['[{}]'.format(', '.join(i)) for i in states_representation]))
 
     @staticmethod

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -323,19 +323,16 @@ def test_get_pin_results_pin_information(multi_instrument_session):
     assert channels == fully_qualified_channels
 
 
-# TODO(jfitzger): make enum and HistoryRAMCycleInformation access consistent with the rest of the tests
-# and remove unnecessary imports.  Blocked by GitHub issue# 1426.
 def test_history_ram_cycle_information_representation():
-    from nidigital.enums import PinState
-    from nidigital.history_ram_cycle_information import HistoryRAMCycleInformation
-    cycle_info = HistoryRAMCycleInformation(
+    cycle_info = nidigital.HistoryRAMCycleInformation(
         pattern_name='pat',
         time_set_name='t0',
         vector_number=42,
         cycle_number=999,
         scan_cycle_number=13,
-        expected_pin_states=[[PinState.D, PinState.D], [PinState.V, PinState.V]],
-        actual_pin_states=[[PinState.PIN_STATE_NOT_ACQUIRED, PinState.PIN_STATE_NOT_ACQUIRED], [PinState.NOT_A_PIN_STATE, PinState.NOT_A_PIN_STATE]],
+        expected_pin_states=[[nidigital.PinState.D, nidigital.PinState.D], [nidigital.PinState.V, nidigital.PinState.V]],
+        actual_pin_states=[[nidigital.PinState.PIN_STATE_NOT_ACQUIRED, nidigital.PinState.PIN_STATE_NOT_ACQUIRED],
+                           [nidigital.PinState.NOT_A_PIN_STATE, nidigital.PinState.NOT_A_PIN_STATE]],
         per_pin_pass_fail=[[True, True], [False, False]])
     recreated_cycle_info = eval(repr(cycle_info))
     assert str(recreated_cycle_info) == str(cycle_info)


### PR DESCRIPTION

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

Update HistoryRAMCycleInformation.__repr__ to use `__module__` and `__qualname__`.

Best practice for implementing `__repr__` for custom types is to use
`__module__` and `__qualname__`.

By including `__module__` in `__repr__`, `eval(repr(HistoryRAMCycleInformation()))`
can be called by importing nidigital as `import nidigital`; which is
consistent with recommended import style of nimi-python.

If this change is accepted, `__repr__` for private and internal types
(including nifake) will be changed in a separate PR. `__repr__` for public
types in other modules will be done in 2.0 Source Breakers milestone.


### List issues fixed by this Pull Request below, if any.

* Fix #1426

### What testing has been done?

Updated existing `__repr__` test. CI will run all tests.