### PR TITLE
Change metadata key `supports_nitclk` to `uses_nitclk`

### DIFF
--- a/build/helper/metadata_add_all.py
+++ b/build/helper/metadata_add_all.py
@@ -580,8 +580,8 @@ def add_all_config_metadata(config):
     if 'use_locking' not in config:
         config['use_locking'] = True
 
-    if 'supports_nitclk' not in config:
-        config['supports_nitclk'] = False
+    if 'uses_nitclk' not in config:
+        config['uses_nitclk'] = False
 
     return config
 
@@ -1277,7 +1277,7 @@ config_expected = {
     'modules': {
         'metadata.enums_addon': {}
     },
-    'supports_nitclk': False
+    'uses_nitclk': False,
 }
 
 

--- a/build/templates/class.rst.mako
+++ b/build/templates/class.rst.mako
@@ -102,7 +102,7 @@ desc = helper.get_documentation_for_node_rst(a, config, indent=0)
 % endfor
 % endif
 
-% if config['supports_nitclk']:
+% if config['uses_nitclk']:
 ${helper.get_rst_header_snippet('NI-TClk Support', '=')}
 
     .. py:attribute:: tclk

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -41,7 +41,7 @@ import ${module_name}.errors as errors
 import ${module_name}.${c['file_name']} as ${c['file_name']}  # noqa: F401
 % endfor
 
-% if config['supports_nitclk']:
+% if config['uses_nitclk']:
 import nitclk
 % endif
 
@@ -272,7 +272,7 @@ class Session(_SessionBase):
         self._${config['session_handle_parameter_name']} = 0  # This must be set before calling ${init_function['python_name']}().
         self._${config['session_handle_parameter_name']} = self.${init_function['python_name']}(${init_call_params})
 
-% if config['supports_nitclk']:
+% if config['uses_nitclk']:
         self.tclk = nitclk.SessionReference(self._${config['session_handle_parameter_name']})
 
 % endif

--- a/build/templates/setup.py.mako
+++ b/build/templates/setup.py.mako
@@ -50,7 +50,7 @@ setup(
     install_requires=[
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
-        % if config['supports_nitclk']:
+        % if config['uses_nitclk']:
         'nitclk',
         % endif
     ],

--- a/build/templates/tox-system_tests.ini.mako
+++ b/build/templates/tox-system_tests.ini.mako
@@ -4,7 +4,7 @@
     config = template_parameters['metadata'].config
     module_name = config['module_name']
     driver_name = config['driver_name']
-    if config['supports_nitclk'] or module_name == 'nitclk':
+    if config['uses_nitclk'] or module_name == 'nitclk':
         wheel_env_no_py = '{}-wheel_dep'.format(module_name)
         wheel_env = 'py38-' + wheel_env_no_py + ','
         uses_other_wheel = True

--- a/src/nidcpower/metadata/config.py
+++ b/src/nidcpower/metadata/config.py
@@ -45,5 +45,5 @@ config = {
     ],
     'session_class_description': 'An NI-DCPower session to a National Instruments Programmable Power Supply or Source Measure Unit.',
     'session_handle_parameter_name': 'vi',
-    'supports_nitclk': False
+    'uses_nitclk': False,
 }

--- a/src/nidigital/metadata/config.py
+++ b/src/nidigital/metadata/config.py
@@ -67,5 +67,5 @@ config = {
     ],
     'session_class_description': 'An NI-Digital Pattern Driver session',
     'session_handle_parameter_name': 'vi',
-    'supports_nitclk': True
+    'uses_nitclk': True,
 }

--- a/src/nifake/metadata/config.py
+++ b/src/nifake/metadata/config.py
@@ -57,5 +57,5 @@ config = {
     ],
     'session_class_description': 'An NI-FAKE session to a fake MI driver whose sole purpose is to test nimi-python code generation',
     'session_handle_parameter_name': 'vi',
-    'supports_nitclk': True
+    'uses_nitclk': True,
 }

--- a/src/nifgen/metadata/config.py
+++ b/src/nifgen/metadata/config.py
@@ -53,5 +53,5 @@ config = {
     ],
     'session_class_description': 'An NI-FGEN session to a National Instruments Signal Generator.',
     'session_handle_parameter_name': 'vi',
-    'supports_nitclk': True
+    'uses_nitclk': True,
 }

--- a/src/niscope/metadata/config.py
+++ b/src/niscope/metadata/config.py
@@ -50,5 +50,5 @@ config = {
     ],
     'session_class_description': 'An NI-SCOPE session to a National Instruments Digitizer.',
     'session_handle_parameter_name': 'vi',
-    'supports_nitclk': True
+    'uses_nitclk': True,
 }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Change metadata key `supports_nitclk` to `uses_nitclk`.

A new metadata key called `uses_hightime` will be added for #1368. This change will make the key names consistent.

### List issues fixed by this Pull Request below, if any.

None

### What testing has been done?

No new tests added. CI will run the tests.