### PR TITLE
Change return type of `get_time_set_period` and `get_time_set_edge` to `datetime.timedelta`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
     * #### Changed
         * Changed initial_state parameters in `apply_levels_and_timing` to basic sequence types - [#1391](https://github.com/ni/nimi-python/issues/1391) 
         * Changed HistoryRAMCycleInformation.__repr__ to include `__module__` - [#1426](https://github.com/ni/nimi-python/issues/1426) 
+        * Changed return type of `get_time_set_period` and `get_time_set_edge` to `datetime.timedelta` - [#1397](https://github.com/ni/nimi-python/issues/1397) 
     * #### Removed
 * ### NI-DMM
     * #### Added

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -1561,7 +1561,7 @@ get_time_set_edge
 
             :type edge: :py:data:`nidigital.TimeSetEdgeType`
 
-            :rtype: float
+            :rtype: datetime.timedelta
             :return:
 
 
@@ -1653,7 +1653,7 @@ get_time_set_period
 
             :type time_set_name: str
 
-            :rtype: float
+            :rtype: datetime.timedelta
             :return:
 
 

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -2139,7 +2139,7 @@ class _SessionBase(object):
 
 
         Returns:
-            time (float):
+            time (datetime.timedelta):
 
         '''
         if type(edge) is not enums.TimeSetEdgeType:
@@ -2151,7 +2151,7 @@ class _SessionBase(object):
         time_ctype = _visatype.ViReal64()  # case S220
         error_code = self._library.niDigital_GetTimeSetEdge(vi_ctype, pin_ctype, time_set_name_ctype, edge_ctype, None if time_ctype is None else (ctypes.pointer(time_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return float(time_ctype.value)
+        return _converters.convert_seconds_real64_to_timedelta(float(time_ctype.value))
 
     @ivi_synchronized
     def get_time_set_edge_multiplier(self, time_set_name):
@@ -2989,7 +2989,7 @@ class Session(_SessionBase):
 
 
         Returns:
-            period (float):
+            period (datetime.timedelta):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -2997,7 +2997,7 @@ class Session(_SessionBase):
         period_ctype = _visatype.ViReal64()  # case S220
         error_code = self._library.niDigital_GetTimeSetPeriod(vi_ctype, time_set_name_ctype, None if period_ctype is None else (ctypes.pointer(period_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return float(period_ctype.value)
+        return _converters.convert_seconds_real64_to_timedelta(float(period_ctype.value))
 
     def _init_with_options(self, resource_name, id_query=False, reset_device=False, option_string=""):
         r'''_init_with_options

--- a/src/nidigital/metadata/functions.py
+++ b/src/nidigital/metadata/functions.py
@@ -1908,7 +1908,9 @@ the trigger conditions are met.
             {
                 'direction': 'out',
                 'name': 'time',
-                'type': 'ViReal64'
+                'python_api_converter_name': 'convert_seconds_real64_to_timedelta',
+                'type': 'ViReal64',
+                'type_in_documentation': 'datetime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -1994,7 +1996,9 @@ the trigger conditions are met.
             {
                 'direction': 'out',
                 'name': 'period',
-                'type': 'ViReal64'
+                'python_api_converter_name': 'convert_seconds_real64_to_timedelta',
+                'type': 'ViReal64',
+                'type_in_documentation': 'datetime.timedelta'
             }
         ],
         'returns': 'ViStatus'

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -709,9 +709,9 @@ def test_configure_get_time_set_period(multi_instrument_session):
     multi_instrument_session.load_pin_map(os.path.join(test_files_base_dir, "pin_map.pinmap"))
 
     multi_instrument_session.create_time_set(time_set_name)
-    assert multi_instrument_session.get_time_set_period(time_set_name) == 1e-6
+    assert multi_instrument_session.get_time_set_period(time_set_name) == datetime.timedelta(microseconds=1)
     multi_instrument_session.configure_time_set_period(time_set_name, time_set_period)
-    assert multi_instrument_session.get_time_set_period(time_set_name) == time_set_period.total_seconds()
+    assert multi_instrument_session.get_time_set_period(time_set_name) == time_set_period
 
 
 def test_configure_get_time_set_drive_format(multi_instrument_session):
@@ -743,9 +743,16 @@ def test_configure_get_time_set_edge(multi_instrument_session):
 
     multi_instrument_session.create_time_set(time_set_name)
     multi_instrument_session.configure_time_set_period(time_set_name, time_set_period)
-    assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].get_time_set_edge(time_set_name, nidigital.TimeSetEdgeType.DRIVE_ON) == 0
-    multi_instrument_session.pins['site0/PinA', 'site1/PinC'].configure_time_set_edge(time_set_name, nidigital.TimeSetEdgeType.DRIVE_ON, time_set_drive_on)
-    assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].get_time_set_edge(time_set_name, nidigital.TimeSetEdgeType.DRIVE_ON) == time_set_drive_on.total_seconds()
+    assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].get_time_set_edge(
+        time_set_name,
+        nidigital.TimeSetEdgeType.DRIVE_ON) == datetime.timedelta(seconds=0)
+    multi_instrument_session.pins['site0/PinA', 'site1/PinC'].configure_time_set_edge(
+        time_set_name,
+        nidigital.TimeSetEdgeType.DRIVE_ON,
+        time_set_drive_on)
+    assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].get_time_set_edge(
+        time_set_name,
+        nidigital.TimeSetEdgeType.DRIVE_ON) == time_set_drive_on
 
 
 def test_configure_time_set_drive_edges(multi_instrument_session):
@@ -771,16 +778,16 @@ def test_configure_time_set_drive_edges(multi_instrument_session):
     assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].get_time_set_drive_format(time_set_name) == time_set_drive_format
     assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].get_time_set_edge(
         time_set_name,
-        nidigital.TimeSetEdgeType.DRIVE_ON) == time_set_drive_on.total_seconds()
+        nidigital.TimeSetEdgeType.DRIVE_ON) == time_set_drive_on
     assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].get_time_set_edge(
         time_set_name,
-        nidigital.TimeSetEdgeType.DRIVE_DATA) == time_set_drive_data.total_seconds()
+        nidigital.TimeSetEdgeType.DRIVE_DATA) == time_set_drive_data
     assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].get_time_set_edge(
         time_set_name,
-        nidigital.TimeSetEdgeType.DRIVE_RETURN) == time_set_drive_return.total_seconds()
+        nidigital.TimeSetEdgeType.DRIVE_RETURN) == time_set_drive_return
     assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].get_time_set_edge(
         time_set_name,
-        nidigital.TimeSetEdgeType.DRIVE_OFF) == time_set_drive_off.total_seconds()
+        nidigital.TimeSetEdgeType.DRIVE_OFF) == time_set_drive_off
 
 
 def test_configure_time_set_compare_edges_strobe(multi_instrument_session):
@@ -797,7 +804,7 @@ def test_configure_time_set_compare_edges_strobe(multi_instrument_session):
         time_set_strobe)
     assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].get_time_set_edge(
         time_set_name,
-        nidigital.TimeSetEdgeType.COMPARE_STROBE) == time_set_strobe.total_seconds()
+        nidigital.TimeSetEdgeType.COMPARE_STROBE) == time_set_strobe
 
 
 def test_configure_get_time_set_edge_multiplier(multi_instrument_session):
@@ -847,22 +854,22 @@ def test_configure_time_set_drive_edges2x(multi_instrument_session):
     assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].get_time_set_drive_format(time_set_name) == time_set_drive_format
     assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].get_time_set_edge(
         time_set_name,
-        nidigital.TimeSetEdgeType.DRIVE_ON) == time_set_drive_on.total_seconds()
+        nidigital.TimeSetEdgeType.DRIVE_ON) == time_set_drive_on
     assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].get_time_set_edge(
         time_set_name,
-        nidigital.TimeSetEdgeType.DRIVE_DATA) == time_set_drive_data.total_seconds()
+        nidigital.TimeSetEdgeType.DRIVE_DATA) == time_set_drive_data
     assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].get_time_set_edge(
         time_set_name,
-        nidigital.TimeSetEdgeType.DRIVE_RETURN) == time_set_drive_return.total_seconds()
+        nidigital.TimeSetEdgeType.DRIVE_RETURN) == time_set_drive_return
     assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].get_time_set_edge(
         time_set_name,
-        nidigital.TimeSetEdgeType.DRIVE_OFF) == time_set_drive_off.total_seconds()
+        nidigital.TimeSetEdgeType.DRIVE_OFF) == time_set_drive_off
     assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].get_time_set_edge(
         time_set_name,
-        nidigital.TimeSetEdgeType.DRIVE_DATA2) == time_set_drive_data2.total_seconds()
+        nidigital.TimeSetEdgeType.DRIVE_DATA2) == time_set_drive_data2
     assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].get_time_set_edge(
         time_set_name,
-        nidigital.TimeSetEdgeType.DRIVE_RETURN2) == time_set_drive_return2.total_seconds()
+        nidigital.TimeSetEdgeType.DRIVE_RETURN2) == time_set_drive_return2
 
 
 def test_configure_time_set_compare_edges_strobe2x(multi_instrument_session):
@@ -882,10 +889,10 @@ def test_configure_time_set_compare_edges_strobe2x(multi_instrument_session):
         time_set_strobe2)
     assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].get_time_set_edge(
         time_set_name,
-        nidigital.TimeSetEdgeType.COMPARE_STROBE) == time_set_strobe.total_seconds()
+        nidigital.TimeSetEdgeType.COMPARE_STROBE) == time_set_strobe
     assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].get_time_set_edge(
         time_set_name,
-        nidigital.TimeSetEdgeType.COMPARE_STROBE2) == time_set_strobe2.total_seconds()
+        nidigital.TimeSetEdgeType.COMPARE_STROBE2) == time_set_strobe2
 
 
 def test_enable_disable_sites_single(multi_instrument_session):


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

Change return type of `get_time_set_period` and `get_time_set_edge` to `datetime.timedelta`.

### List issues fixed by this Pull Request below, if any.

Partial fix for Issue 1397

### What testing has been done?

Tests have been updated as required. CI will run the tests.