### PR TITLE
Undo changes for adding hightime to nidigital installer

### DIFF
--- a/build/helper/metadata_add_all.py
+++ b/build/helper/metadata_add_all.py
@@ -583,9 +583,6 @@ def add_all_config_metadata(config):
     if 'uses_nitclk' not in config:
         config['uses_nitclk'] = False
 
-    if 'uses_hightime' not in config:
-        config['uses_hightime'] = False
-
     return config
 
 
@@ -1281,7 +1278,6 @@ config_expected = {
         'metadata.enums_addon': {}
     },
     'uses_nitclk': False,
-    'uses_hightime': False,
 }
 
 

--- a/build/templates/setup.py.mako
+++ b/build/templates/setup.py.mako
@@ -53,9 +53,6 @@ setup(
         % if config['uses_nitclk']:
         'nitclk',
         % endif
-        % if config['uses_hightime']:
-        'hightime',
-        % endif
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/nidigital/setup.py
+++ b/generated/nidigital/setup.py
@@ -46,7 +46,6 @@ setup(
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
         'nitclk',
-        'hightime',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/src/nidigital/metadata/config.py
+++ b/src/nidigital/metadata/config.py
@@ -68,5 +68,4 @@ config = {
     'session_class_description': 'An NI-Digital Pattern Driver session',
     'session_handle_parameter_name': 'vi',
     'uses_nitclk': True,
-    'uses_hightime': True,
 }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

- `datetime` will be replaced by `hightime` across all nimi-python modules in a separate PR.
- Undo changes of #1438 

### List issues fixed by this Pull Request below, if any.

None

### What testing has been done?

CI will run tests.