### PR TITLE
Replace usage of `datetime` library types with `hightime` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 * ### ALL
     * #### Added
     * #### Changed
+        * Change the type of applicable properties and method parameters from `datetime.timedelta` to `hightime.timedelta` and from `datetime.datetime` to `hightime.datetime`. - [#744](https://github.com/ni/nimi-python/issues/744), [#1368](https://github.com/ni/nimi-python/issues/1368), [#1382](https://github.com/ni/nimi-python/issues/1382), [#1397](https://github.com/ni/nimi-python/issues/1397)
     * #### Removed
 * ### NI-DCPower
     * #### Added

--- a/build/helper/codegen_helper.py
+++ b/build/helper/codegen_helper.py
@@ -856,7 +856,6 @@ parameters_for_testing = [
         'type': 'ViReal64',
         'use_in_python_api': True,
         'python_api_converter_name': 'timedelta_converter_seconds_real64',
-        'python_api_converter_type': 'datetime.timedelta',
     },
     {  # 15
         'ctypes_type': 'ViString',

--- a/build/helper/metadata_add_all.py
+++ b/build/helper/metadata_add_all.py
@@ -405,7 +405,7 @@ def _add_default_attribute_class(a, attributes):
     '''Set 'attribute_class' if not set.
 
     By default, the 'attribute_class' is only based on the 'type'.
-    It can be set in attributes_addon if we want to convert to/from a different datatype, such as datetime.timedelta
+    It can be set in attributes_addon if we want to convert to/from a different datatype, such as hightime.timedelta
     '''
     if 'attribute_class' not in attributes[a]:
         attributes[a]['attribute_class'] = 'Attribute' + attributes[a]['type']
@@ -582,9 +582,6 @@ def add_all_config_metadata(config):
 
     if 'uses_nitclk' not in config:
         config['uses_nitclk'] = False
-
-    if 'uses_hightime' not in config:
-        config['uses_hightime'] = False
 
     return config
 
@@ -1281,7 +1278,6 @@ config_expected = {
         'metadata.enums_addon': {}
     },
     'uses_nitclk': False,
-    'uses_hightime': False,
 }
 
 

--- a/build/templates/_attributes.py.mako
+++ b/build/templates/_attributes.py.mako
@@ -6,7 +6,7 @@ ${template_parameters['encoding_tag']}
 %>\
 import ${module_name}._converters as _converters
 
-import datetime
+import hightime
 
 
 class Attribute(object):
@@ -28,7 +28,7 @@ class AttributeViInt32(Attribute):
 class AttributeViInt32TimeDeltaMilliseconds(Attribute):
 
     def __get__(self, session, session_type):
-        return datetime.timedelta(milliseconds=session._get_attribute_vi_int32(self._attribute_id))
+        return hightime.timedelta(milliseconds=session._get_attribute_vi_int32(self._attribute_id))
 
     def __set__(self, session, value):
         session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_milliseconds_int32(value).value)
@@ -55,7 +55,7 @@ class AttributeViReal64(Attribute):
 class AttributeViReal64TimeDeltaSeconds(Attribute):
 
     def __get__(self, session, session_type):
-        return datetime.timedelta(seconds=session._get_attribute_vi_real64(self._attribute_id))
+        return hightime.timedelta(seconds=session._get_attribute_vi_real64(self._attribute_id))
 
     def __set__(self, session, value):
         session._set_attribute_vi_real64(self._attribute_id, _converters.convert_timedelta_to_seconds_real64(value).value)

--- a/build/templates/_converters.py.mako
+++ b/build/templates/_converters.py.mako
@@ -10,8 +10,9 @@ import ${module_name}.errors as errors
 
 import array
 import collections
-import datetime
+import hightime
 import numbers
+import pytest
 
 from functools import singledispatch
 
@@ -149,7 +150,7 @@ def convert_repeated_capabilities_without_prefix(repeated_capability):
 
 def _convert_timedelta(value, library_type, scaling):
     try:
-        # We first assume it is a datetime.timedelta object
+        # We first assume it is a timedelta object
         scaled_value = value.total_seconds() * scaling
     except AttributeError:
         # If that doesn't work, assume it is a value in seconds
@@ -176,7 +177,7 @@ def convert_timedeltas_to_seconds_real64(values):
 
 
 def convert_seconds_real64_to_timedelta(value):
-    return datetime.timedelta(seconds=value)
+    return hightime.timedelta(seconds=value)
 
 
 def convert_seconds_real64_to_timedeltas(values):
@@ -184,7 +185,7 @@ def convert_seconds_real64_to_timedeltas(values):
 
 
 def convert_month_to_timedelta(months):
-    return datetime.timedelta(days=(30.4167 * months))
+    return hightime.timedelta(days=(30.4167 * months))
 
 
 # This converter is not called from the normal codegen path for function. Instead it is
@@ -334,11 +335,11 @@ def test_convert_init_with_options_dictionary():
 
 # Tests - time
 def test_convert_timedelta_to_seconds_double():
-    test_result = convert_timedelta_to_seconds_real64(datetime.timedelta(seconds=10))
+    test_result = convert_timedelta_to_seconds_real64(hightime.timedelta(seconds=10))
     assert test_result.value == 10.0
     assert isinstance(test_result, _visatype.ViReal64)
-    test_result = convert_timedelta_to_seconds_real64(datetime.timedelta(seconds=-1))
-    assert test_result.value == -1
+    test_result = convert_timedelta_to_seconds_real64(hightime.timedelta(nanoseconds=-0.5))
+    assert test_result.value == pytest.approx(-5e-10)
     assert isinstance(test_result, _visatype.ViReal64)
     test_result = convert_timedelta_to_seconds_real64(10.5)
     assert test_result.value == 10.5
@@ -349,11 +350,11 @@ def test_convert_timedelta_to_seconds_double():
 
 
 def test_convert_timedelta_to_milliseconds_int32():
-    test_result = convert_timedelta_to_milliseconds_int32(datetime.timedelta(seconds=10))
+    test_result = convert_timedelta_to_milliseconds_int32(hightime.timedelta(seconds=10))
     assert test_result.value == 10000
     assert isinstance(test_result, _visatype.ViInt32)
-    test_result = convert_timedelta_to_milliseconds_int32(datetime.timedelta(seconds=-1))
-    assert test_result.value == -1000
+    test_result = convert_timedelta_to_milliseconds_int32(hightime.timedelta(seconds=-5))
+    assert test_result.value == -5000
     assert isinstance(test_result, _visatype.ViInt32)
     test_result = convert_timedelta_to_milliseconds_int32(10.5)
     assert test_result.value == 10500
@@ -364,26 +365,28 @@ def test_convert_timedelta_to_milliseconds_int32():
 
 
 def test_convert_timedeltas_to_seconds_real64():
-    time_values = [10.5, -1]
+    time_values = [10.5, -5e-10]
     test_result = convert_timedeltas_to_seconds_real64(time_values)
-    assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
+    assert all([actual.value == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
-    timedeltas = [datetime.timedelta(seconds=s, milliseconds=ms) for s, ms in zip([10, -1], [500, 0])]
-    test_result = convert_timedeltas_to_seconds_real64(timedeltas)
-    assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
+    test_input = [hightime.timedelta(seconds=10.5), hightime.timedelta(nanoseconds=-0.5)]
+    test_result = convert_timedeltas_to_seconds_real64(test_input)
+    assert all([actual.value == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
 
 
 def test_convert_seconds_real64_to_timedelta():
-    time_value = 10.5
-    timedelta = convert_seconds_real64_to_timedelta(time_value)
-    assert timedelta.total_seconds() == time_value
+    time_value = -5e-10
+    test_result = convert_seconds_real64_to_timedelta(time_value)
+    assert test_result.total_seconds() == pytest.approx(time_value)
+    assert isinstance(test_result, hightime.timedelta)
 
 
 def test_convert_seconds_real64_to_timedeltas():
-    time_values = [10.5, -1]
-    timedeltas = convert_seconds_real64_to_timedeltas(time_values)
-    assert all([actual.total_seconds() == expected for actual, expected in zip(timedeltas, time_values)])
+    time_values = [10.5, -5e-10]
+    test_result = convert_seconds_real64_to_timedeltas(time_values)
+    assert all([actual.total_seconds() == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
+    assert all([isinstance(x, hightime.timedelta) for x in test_result])
 
 
 <%

--- a/build/templates/conf.py.mako
+++ b/build/templates/conf.py.mako
@@ -1,6 +1,6 @@
 <%
-from datetime import datetime
-current_year = datetime.today().year
+import datetime
+current_year = datetime.datetime.today().year
 
 with open('./VERSION') as vf:
     global_version = vf.read().strip()

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -22,7 +22,6 @@ ${template_parameters['encoding_tag']}
 %>\
 import array  # noqa: F401
 import ctypes
-import datetime  # noqa: F401
 % if config['use_locking']:
 # Used by @ivi_synchronized
 from functools import wraps
@@ -41,6 +40,7 @@ import ${module_name}.errors as errors
 import ${module_name}.${c['file_name']} as ${c['file_name']}  # noqa: F401
 % endfor
 
+import hightime
 % if config['uses_nitclk']:
 import nitclk
 % endif

--- a/build/templates/session.py/datetime_wrappers.py.mako
+++ b/build/templates/session.py/datetime_wrappers.py.mako
@@ -19,5 +19,5 @@
         ${helper.get_function_docstring(f, False, config, indent=8)}
         '''
         ${output_params} = self.${called_function['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_CALL)})
-        return datetime.datetime(year, month, day, hour, minute)
+        return hightime.datetime(year, month, day, hour, minute)
 

--- a/build/templates/setup.py.mako
+++ b/build/templates/setup.py.mako
@@ -53,9 +53,7 @@ setup(
         % if config['uses_nitclk']:
         'nitclk',
         % endif
-        % if config['uses_hightime']:
         'hightime',
-        % endif
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/build/templates/setup.py.mako
+++ b/build/templates/setup.py.mako
@@ -50,10 +50,10 @@ setup(
     install_requires=[
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
+        'hightime',
         % if config['uses_nitclk']:
         'nitclk',
         % endif
-        'hightime',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/build/templates/tox-system_tests.ini.mako
+++ b/build/templates/tox-system_tests.ini.mako
@@ -74,6 +74,7 @@ deps =
     ${module_name}-system_tests: pytest
     ${module_name}-system_tests: coverage
     ${module_name}-system_tests: numpy
+    ${module_name}-system_tests: hightime
     ${module_name}-system_tests: scipy
     ${module_name}-system_tests: fasteners
     ${module_name}-system_tests: pytest-json

--- a/docs/nidcpower/class.rst
+++ b/docs/nidcpower/class.rst
@@ -739,7 +739,7 @@ fetch_multiple
                 .. note:: When setting the timeout interval, ensure you take into account any triggers so that the timeout interval is long enough for your application.
 
 
-            :type timeout: float in seconds or hightime.timedelta
+            :type timeout: hightime.timedelta, datetime.timedelta, or float in seconds
 
             :rtype: list of Measurement
             :return:
@@ -1785,7 +1785,7 @@ wait_for_event
                     application.
 
 
-            :type timeout: float in seconds or hightime.timedelta
+            :type timeout: hightime.timedelta, datetime.timedelta, or float in seconds
 
 
 Properties
@@ -3370,17 +3370,17 @@ measure_complete_event_delay
 
         The following table lists the characteristics of this property.
 
-            +----------------+----------------------------------------+
-            | Characteristic | Value                                  |
-            +================+========================================+
-            | Datatype       | float in seconds or hightime.timedelta |
-            +----------------+----------------------------------------+
-            | Permissions    | read-write                             |
-            +----------------+----------------------------------------+
-            | Channel Based  | Yes                                    |
-            +----------------+----------------------------------------+
-            | Resettable     | No                                     |
-            +----------------+----------------------------------------+
+            +----------------+-------------------------------------------------------------+
+            | Characteristic | Value                                                       |
+            +================+=============================================================+
+            | Datatype       | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +----------------+-------------------------------------------------------------+
+            | Permissions    | read-write                                                  |
+            +----------------+-------------------------------------------------------------+
+            | Channel Based  | Yes                                                         |
+            +----------------+-------------------------------------------------------------+
+            | Resettable     | No                                                          |
+            +----------------+-------------------------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -3529,17 +3529,17 @@ measure_record_delta_time
 
         The following table lists the characteristics of this property.
 
-            +----------------+----------------------------------------+
-            | Characteristic | Value                                  |
-            +================+========================================+
-            | Datatype       | float in seconds or hightime.timedelta |
-            +----------------+----------------------------------------+
-            | Permissions    | read only                              |
-            +----------------+----------------------------------------+
-            | Channel Based  | Yes                                    |
-            +----------------+----------------------------------------+
-            | Resettable     | No                                     |
-            +----------------+----------------------------------------+
+            +----------------+-------------------------------------------------------------+
+            | Characteristic | Value                                                       |
+            +================+=============================================================+
+            | Datatype       | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +----------------+-------------------------------------------------------------+
+            | Permissions    | read only                                                   |
+            +----------------+-------------------------------------------------------------+
+            | Channel Based  | Yes                                                         |
+            +----------------+-------------------------------------------------------------+
+            | Resettable     | No                                                          |
+            +----------------+-------------------------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -5019,17 +5019,17 @@ pulse_off_time
 
         The following table lists the characteristics of this property.
 
-            +----------------+----------------------------------------+
-            | Characteristic | Value                                  |
-            +================+========================================+
-            | Datatype       | float in seconds or hightime.timedelta |
-            +----------------+----------------------------------------+
-            | Permissions    | read-write                             |
-            +----------------+----------------------------------------+
-            | Channel Based  | Yes                                    |
-            +----------------+----------------------------------------+
-            | Resettable     | No                                     |
-            +----------------+----------------------------------------+
+            +----------------+-------------------------------------------------------------+
+            | Characteristic | Value                                                       |
+            +================+=============================================================+
+            | Datatype       | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +----------------+-------------------------------------------------------------+
+            | Permissions    | read-write                                                  |
+            +----------------+-------------------------------------------------------------+
+            | Channel Based  | Yes                                                         |
+            +----------------+-------------------------------------------------------------+
+            | Resettable     | No                                                          |
+            +----------------+-------------------------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -5058,17 +5058,17 @@ pulse_on_time
 
         The following table lists the characteristics of this property.
 
-            +----------------+----------------------------------------+
-            | Characteristic | Value                                  |
-            +================+========================================+
-            | Datatype       | float in seconds or hightime.timedelta |
-            +----------------+----------------------------------------+
-            | Permissions    | read-write                             |
-            +----------------+----------------------------------------+
-            | Channel Based  | Yes                                    |
-            +----------------+----------------------------------------+
-            | Resettable     | No                                     |
-            +----------------+----------------------------------------+
+            +----------------+-------------------------------------------------------------+
+            | Characteristic | Value                                                       |
+            +================+=============================================================+
+            | Datatype       | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +----------------+-------------------------------------------------------------+
+            | Permissions    | read-write                                                  |
+            +----------------+-------------------------------------------------------------+
+            | Channel Based  | Yes                                                         |
+            +----------------+-------------------------------------------------------------+
+            | Resettable     | No                                                          |
+            +----------------+-------------------------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -6293,17 +6293,17 @@ source_delay
 
         The following table lists the characteristics of this property.
 
-            +----------------+----------------------------------------+
-            | Characteristic | Value                                  |
-            +================+========================================+
-            | Datatype       | float in seconds or hightime.timedelta |
-            +----------------+----------------------------------------+
-            | Permissions    | read-write                             |
-            +----------------+----------------------------------------+
-            | Channel Based  | Yes                                    |
-            +----------------+----------------------------------------+
-            | Resettable     | No                                     |
-            +----------------+----------------------------------------+
+            +----------------+-------------------------------------------------------------+
+            | Characteristic | Value                                                       |
+            +================+=============================================================+
+            | Datatype       | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +----------------+-------------------------------------------------------------+
+            | Permissions    | read-write                                                  |
+            +----------------+-------------------------------------------------------------+
+            | Channel Based  | Yes                                                         |
+            +----------------+-------------------------------------------------------------+
+            | Resettable     | No                                                          |
+            +----------------+-------------------------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:

--- a/docs/nidcpower/class.rst
+++ b/docs/nidcpower/class.rst
@@ -695,7 +695,7 @@ fetch_multiple
 
     .. py:currentmodule:: nidcpower.Session
 
-    .. py:method:: fetch_multiple(count, timeout=datetime.timedelta(seconds=1.0))
+    .. py:method:: fetch_multiple(count, timeout=hightime.timedelta(seconds=1.0))
 
             Returns a list of named tuples (Measurement) that were
             previously taken and are stored in the NI-DCPower buffer. This method
@@ -739,7 +739,7 @@ fetch_multiple
                 .. note:: When setting the timeout interval, ensure you take into account any triggers so that the timeout interval is long enough for your application.
 
 
-            :type timeout: float in seconds or datetime.timedelta
+            :type timeout: float in seconds or hightime.timedelta
 
             :rtype: list of Measurement
             :return:
@@ -804,7 +804,7 @@ get_ext_cal_last_date_and_time
 
 
 
-            :rtype: datetime.datetime
+            :rtype: hightime.datetime
             :return:
 
 
@@ -853,7 +853,7 @@ get_ext_cal_recommended_interval
 
 
 
-            :rtype: datetime.timedelta
+            :rtype: hightime.timedelta
             :return:
 
 
@@ -879,7 +879,7 @@ get_self_cal_last_date_and_time
 
 
 
-            :rtype: datetime.datetime
+            :rtype: hightime.datetime
             :return:
 
 
@@ -1729,7 +1729,7 @@ wait_for_event
 
     .. py:currentmodule:: nidcpower.Session
 
-    .. py:method:: wait_for_event(event_id, timeout=datetime.timedelta(seconds=10.0))
+    .. py:method:: wait_for_event(event_id, timeout=hightime.timedelta(seconds=10.0))
 
             Waits until the device has generated the specified event.
 
@@ -1785,7 +1785,7 @@ wait_for_event
                     application.
 
 
-            :type timeout: float in seconds or datetime.timedelta
+            :type timeout: float in seconds or hightime.timedelta
 
 
 Properties
@@ -3373,7 +3373,7 @@ measure_complete_event_delay
             +----------------+----------------------------------------+
             | Characteristic | Value                                  |
             +================+========================================+
-            | Datatype       | float in seconds or datetime.timedelta |
+            | Datatype       | float in seconds or hightime.timedelta |
             +----------------+----------------------------------------+
             | Permissions    | read-write                             |
             +----------------+----------------------------------------+
@@ -3532,7 +3532,7 @@ measure_record_delta_time
             +----------------+----------------------------------------+
             | Characteristic | Value                                  |
             +================+========================================+
-            | Datatype       | float in seconds or datetime.timedelta |
+            | Datatype       | float in seconds or hightime.timedelta |
             +----------------+----------------------------------------+
             | Permissions    | read only                              |
             +----------------+----------------------------------------+
@@ -5022,7 +5022,7 @@ pulse_off_time
             +----------------+----------------------------------------+
             | Characteristic | Value                                  |
             +================+========================================+
-            | Datatype       | float in seconds or datetime.timedelta |
+            | Datatype       | float in seconds or hightime.timedelta |
             +----------------+----------------------------------------+
             | Permissions    | read-write                             |
             +----------------+----------------------------------------+
@@ -5061,7 +5061,7 @@ pulse_on_time
             +----------------+----------------------------------------+
             | Characteristic | Value                                  |
             +================+========================================+
-            | Datatype       | float in seconds or datetime.timedelta |
+            | Datatype       | float in seconds or hightime.timedelta |
             +----------------+----------------------------------------+
             | Permissions    | read-write                             |
             +----------------+----------------------------------------+
@@ -6296,7 +6296,7 @@ source_delay
             +----------------+----------------------------------------+
             | Characteristic | Value                                  |
             +================+========================================+
-            | Datatype       | float in seconds or datetime.timedelta |
+            | Datatype       | float in seconds or hightime.timedelta |
             +----------------+----------------------------------------+
             | Permissions    | read-write                             |
             +----------------+----------------------------------------+

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -185,7 +185,7 @@ apply_tdr_offsets
                 
 
 
-            :type offsets: basic sequence of float in seconds or hightime.timedelta
+            :type offsets: basic sequence of hightime.timedelta, datetime.timedelta, or float in seconds
 
 burst_pattern
 -------------
@@ -236,7 +236,7 @@ burst_pattern
                 
 
 
-            :type timeout: float in seconds or hightime.timedelta
+            :type timeout: hightime.timedelta, datetime.timedelta, or float in seconds
 
             :rtype: { int: bool, int: bool, ... }
             :return:
@@ -417,7 +417,7 @@ configure_time_set_compare_edges_strobe
                 
 
 
-            :type strobe_edge: float in seconds or hightime.timedelta
+            :type strobe_edge: hightime.timedelta, datetime.timedelta, or float in seconds
 
 configure_time_set_compare_edges_strobe2x
 -----------------------------------------
@@ -450,14 +450,14 @@ configure_time_set_compare_edges_strobe2x
                 
 
 
-            :type strobe_edge: float in seconds or hightime.timedelta
+            :type strobe_edge: hightime.timedelta, datetime.timedelta, or float in seconds
             :param strobe2_edge:
 
 
                 
 
 
-            :type strobe2_edge: float in seconds or hightime.timedelta
+            :type strobe2_edge: hightime.timedelta, datetime.timedelta, or float in seconds
 
 configure_time_set_drive_edges
 ------------------------------
@@ -497,28 +497,28 @@ configure_time_set_drive_edges
                 
 
 
-            :type drive_on_edge: float in seconds or hightime.timedelta
+            :type drive_on_edge: hightime.timedelta, datetime.timedelta, or float in seconds
             :param drive_data_edge:
 
 
                 
 
 
-            :type drive_data_edge: float in seconds or hightime.timedelta
+            :type drive_data_edge: hightime.timedelta, datetime.timedelta, or float in seconds
             :param drive_return_edge:
 
 
                 
 
 
-            :type drive_return_edge: float in seconds or hightime.timedelta
+            :type drive_return_edge: hightime.timedelta, datetime.timedelta, or float in seconds
             :param drive_off_edge:
 
 
                 
 
 
-            :type drive_off_edge: float in seconds or hightime.timedelta
+            :type drive_off_edge: hightime.timedelta, datetime.timedelta, or float in seconds
 
 configure_time_set_drive_edges2x
 --------------------------------
@@ -558,42 +558,42 @@ configure_time_set_drive_edges2x
                 
 
 
-            :type drive_on_edge: float in seconds or hightime.timedelta
+            :type drive_on_edge: hightime.timedelta, datetime.timedelta, or float in seconds
             :param drive_data_edge:
 
 
                 
 
 
-            :type drive_data_edge: float in seconds or hightime.timedelta
+            :type drive_data_edge: hightime.timedelta, datetime.timedelta, or float in seconds
             :param drive_return_edge:
 
 
                 
 
 
-            :type drive_return_edge: float in seconds or hightime.timedelta
+            :type drive_return_edge: hightime.timedelta, datetime.timedelta, or float in seconds
             :param drive_off_edge:
 
 
                 
 
 
-            :type drive_off_edge: float in seconds or hightime.timedelta
+            :type drive_off_edge: hightime.timedelta, datetime.timedelta, or float in seconds
             :param drive_data2_edge:
 
 
                 
 
 
-            :type drive_data2_edge: float in seconds or hightime.timedelta
+            :type drive_data2_edge: hightime.timedelta, datetime.timedelta, or float in seconds
             :param drive_return2_edge:
 
 
                 
 
 
-            :type drive_return2_edge: float in seconds or hightime.timedelta
+            :type drive_return2_edge: hightime.timedelta, datetime.timedelta, or float in seconds
 
 configure_time_set_drive_format
 -------------------------------
@@ -666,7 +666,7 @@ configure_time_set_edge
                 
 
 
-            :type time: float in seconds or hightime.timedelta
+            :type time: hightime.timedelta, datetime.timedelta, or float in seconds
 
 configure_time_set_edge_multiplier
 ----------------------------------
@@ -727,7 +727,7 @@ configure_time_set_period
                 
 
 
-            :type period: float in seconds or hightime.timedelta
+            :type period: hightime.timedelta, datetime.timedelta, or float in seconds
 
 configure_voltage_levels
 ------------------------
@@ -1100,7 +1100,7 @@ fetch_capture_waveform
                 
 
 
-            :type timeout: float in seconds or hightime.timedelta
+            :type timeout: hightime.timedelta, datetime.timedelta, or float in seconds
 
             :rtype: { int: memoryview of array.array of unsigned int, int: memoryview of array.array of unsigned int, ... }
             :return:
@@ -2209,7 +2209,7 @@ wait_until_done
                 
 
 
-            :type timeout: float in seconds or hightime.timedelta
+            :type timeout: hightime.timedelta, datetime.timedelta, or float in seconds
 
 write_sequencer_flag
 --------------------
@@ -2896,17 +2896,17 @@ frequency_counter_measurement_time
 
         The following table lists the characteristics of this property.
 
-            +----------------+----------------------------------------+
-            | Characteristic | Value                                  |
-            +================+========================================+
-            | Datatype       | float in seconds or hightime.timedelta |
-            +----------------+----------------------------------------+
-            | Permissions    | read-write                             |
-            +----------------+----------------------------------------+
-            | Channel Based  | Yes                                    |
-            +----------------+----------------------------------------+
-            | Resettable     | Yes                                    |
-            +----------------+----------------------------------------+
+            +----------------+-------------------------------------------------------------+
+            | Characteristic | Value                                                       |
+            +================+=============================================================+
+            | Datatype       | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +----------------+-------------------------------------------------------------+
+            | Permissions    | read-write                                                  |
+            +----------------+-------------------------------------------------------------+
+            | Channel Based  | Yes                                                         |
+            +----------------+-------------------------------------------------------------+
+            | Resettable     | Yes                                                         |
+            +----------------+-------------------------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -4305,17 +4305,17 @@ tdr_offset
 
         The following table lists the characteristics of this property.
 
-            +----------------+----------------------------------------+
-            | Characteristic | Value                                  |
-            +================+========================================+
-            | Datatype       | float in seconds or hightime.timedelta |
-            +----------------+----------------------------------------+
-            | Permissions    | read-write                             |
-            +----------------+----------------------------------------+
-            | Channel Based  | Yes                                    |
-            +----------------+----------------------------------------+
-            | Resettable     | Yes                                    |
-            +----------------+----------------------------------------+
+            +----------------+-------------------------------------------------------------+
+            | Characteristic | Value                                                       |
+            +================+=============================================================+
+            | Datatype       | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +----------------+-------------------------------------------------------------+
+            | Permissions    | read-write                                                  |
+            +----------------+-------------------------------------------------------------+
+            | Channel Based  | Yes                                                         |
+            +----------------+-------------------------------------------------------------+
+            | Resettable     | Yes                                                         |
+            +----------------+-------------------------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -4363,17 +4363,17 @@ timing_absolute_delay
 
         The following table lists the characteristics of this property.
 
-            +----------------+----------------------------------------+
-            | Characteristic | Value                                  |
-            +================+========================================+
-            | Datatype       | float in seconds or hightime.timedelta |
-            +----------------+----------------------------------------+
-            | Permissions    | read-write                             |
-            +----------------+----------------------------------------+
-            | Channel Based  | No                                     |
-            +----------------+----------------------------------------+
-            | Resettable     | Yes                                    |
-            +----------------+----------------------------------------+
+            +----------------+-------------------------------------------------------------+
+            | Characteristic | Value                                                       |
+            +================+=============================================================+
+            | Datatype       | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +----------------+-------------------------------------------------------------+
+            | Permissions    | read-write                                                  |
+            +----------------+-------------------------------------------------------------+
+            | Channel Based  | No                                                          |
+            +----------------+-------------------------------------------------------------+
+            | Resettable     | Yes                                                         |
+            +----------------+-------------------------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -185,14 +185,14 @@ apply_tdr_offsets
                 
 
 
-            :type offsets: basic sequence of float in seconds or datetime.timedelta
+            :type offsets: basic sequence of float in seconds or hightime.timedelta
 
 burst_pattern
 -------------
 
     .. py:currentmodule:: nidigital.Session
 
-    .. py:method:: burst_pattern(start_label, select_digital_function=True, wait_until_done=True, timeout=datetime.timedelta(seconds=10.0))
+    .. py:method:: burst_pattern(start_label, select_digital_function=True, wait_until_done=True, timeout=hightime.timedelta(seconds=10.0))
 
             Uses the start_label you specify to burst the pattern on the sites you specify. If you
             specify wait_until_done as True, waits for the burst to complete, and returns comparison results for each site.
@@ -236,7 +236,7 @@ burst_pattern
                 
 
 
-            :type timeout: float in seconds or datetime.timedelta
+            :type timeout: float in seconds or hightime.timedelta
 
             :rtype: { int: bool, int: bool, ... }
             :return:
@@ -417,7 +417,7 @@ configure_time_set_compare_edges_strobe
                 
 
 
-            :type strobe_edge: float in seconds or datetime.timedelta
+            :type strobe_edge: float in seconds or hightime.timedelta
 
 configure_time_set_compare_edges_strobe2x
 -----------------------------------------
@@ -450,14 +450,14 @@ configure_time_set_compare_edges_strobe2x
                 
 
 
-            :type strobe_edge: float in seconds or datetime.timedelta
+            :type strobe_edge: float in seconds or hightime.timedelta
             :param strobe2_edge:
 
 
                 
 
 
-            :type strobe2_edge: float in seconds or datetime.timedelta
+            :type strobe2_edge: float in seconds or hightime.timedelta
 
 configure_time_set_drive_edges
 ------------------------------
@@ -497,28 +497,28 @@ configure_time_set_drive_edges
                 
 
 
-            :type drive_on_edge: float in seconds or datetime.timedelta
+            :type drive_on_edge: float in seconds or hightime.timedelta
             :param drive_data_edge:
 
 
                 
 
 
-            :type drive_data_edge: float in seconds or datetime.timedelta
+            :type drive_data_edge: float in seconds or hightime.timedelta
             :param drive_return_edge:
 
 
                 
 
 
-            :type drive_return_edge: float in seconds or datetime.timedelta
+            :type drive_return_edge: float in seconds or hightime.timedelta
             :param drive_off_edge:
 
 
                 
 
 
-            :type drive_off_edge: float in seconds or datetime.timedelta
+            :type drive_off_edge: float in seconds or hightime.timedelta
 
 configure_time_set_drive_edges2x
 --------------------------------
@@ -558,42 +558,42 @@ configure_time_set_drive_edges2x
                 
 
 
-            :type drive_on_edge: float in seconds or datetime.timedelta
+            :type drive_on_edge: float in seconds or hightime.timedelta
             :param drive_data_edge:
 
 
                 
 
 
-            :type drive_data_edge: float in seconds or datetime.timedelta
+            :type drive_data_edge: float in seconds or hightime.timedelta
             :param drive_return_edge:
 
 
                 
 
 
-            :type drive_return_edge: float in seconds or datetime.timedelta
+            :type drive_return_edge: float in seconds or hightime.timedelta
             :param drive_off_edge:
 
 
                 
 
 
-            :type drive_off_edge: float in seconds or datetime.timedelta
+            :type drive_off_edge: float in seconds or hightime.timedelta
             :param drive_data2_edge:
 
 
                 
 
 
-            :type drive_data2_edge: float in seconds or datetime.timedelta
+            :type drive_data2_edge: float in seconds or hightime.timedelta
             :param drive_return2_edge:
 
 
                 
 
 
-            :type drive_return2_edge: float in seconds or datetime.timedelta
+            :type drive_return2_edge: float in seconds or hightime.timedelta
 
 configure_time_set_drive_format
 -------------------------------
@@ -666,7 +666,7 @@ configure_time_set_edge
                 
 
 
-            :type time: float in seconds or datetime.timedelta
+            :type time: float in seconds or hightime.timedelta
 
 configure_time_set_edge_multiplier
 ----------------------------------
@@ -727,7 +727,7 @@ configure_time_set_period
                 
 
 
-            :type period: float in seconds or datetime.timedelta
+            :type period: float in seconds or hightime.timedelta
 
 configure_voltage_levels
 ------------------------
@@ -1067,7 +1067,7 @@ fetch_capture_waveform
 
     .. py:currentmodule:: nidigital.Session
 
-    .. py:method:: fetch_capture_waveform(waveform_name, samples_to_read, timeout=datetime.timedelta(seconds=10.0))
+    .. py:method:: fetch_capture_waveform(waveform_name, samples_to_read, timeout=hightime.timedelta(seconds=10.0))
 
             Returns dictionary where each key is a site number and value is a collection of digital states representing capture waveform data
 
@@ -1100,7 +1100,7 @@ fetch_capture_waveform
                 
 
 
-            :type timeout: float or datetime.timedelta
+            :type timeout: float in seconds or hightime.timedelta
 
             :rtype: { int: memoryview of array.array of unsigned int, int: memoryview of array.array of unsigned int, ... }
             :return:
@@ -1561,7 +1561,7 @@ get_time_set_edge
 
             :type edge: :py:data:`nidigital.TimeSetEdgeType`
 
-            :rtype: datetime.timedelta
+            :rtype: hightime.timedelta
             :return:
 
 
@@ -1653,7 +1653,7 @@ get_time_set_period
 
             :type time_set_name: str
 
-            :rtype: datetime.timedelta
+            :rtype: hightime.timedelta
             :return:
 
 
@@ -2120,7 +2120,7 @@ tdr
 
             :type apply_offsets: bool
 
-            :rtype: list of datetime.timedelta
+            :rtype: list of hightime.timedelta
             :return:
 
 
@@ -2195,7 +2195,7 @@ wait_until_done
 
     .. py:currentmodule:: nidigital.Session
 
-    .. py:method:: wait_until_done(timeout=datetime.timedelta(seconds=10.0))
+    .. py:method:: wait_until_done(timeout=hightime.timedelta(seconds=10.0))
 
             TBD
 
@@ -2209,7 +2209,7 @@ wait_until_done
                 
 
 
-            :type timeout: float in seconds or datetime.timedelta
+            :type timeout: float in seconds or hightime.timedelta
 
 write_sequencer_flag
 --------------------
@@ -2899,7 +2899,7 @@ frequency_counter_measurement_time
             +----------------+----------------------------------------+
             | Characteristic | Value                                  |
             +================+========================================+
-            | Datatype       | float in seconds or datetime.timedelta |
+            | Datatype       | float in seconds or hightime.timedelta |
             +----------------+----------------------------------------+
             | Permissions    | read-write                             |
             +----------------+----------------------------------------+
@@ -4308,7 +4308,7 @@ tdr_offset
             +----------------+----------------------------------------+
             | Characteristic | Value                                  |
             +================+========================================+
-            | Datatype       | float in seconds or datetime.timedelta |
+            | Datatype       | float in seconds or hightime.timedelta |
             +----------------+----------------------------------------+
             | Permissions    | read-write                             |
             +----------------+----------------------------------------+
@@ -4366,7 +4366,7 @@ timing_absolute_delay
             +----------------+----------------------------------------+
             | Characteristic | Value                                  |
             +================+========================================+
-            | Datatype       | float in seconds or datetime.timedelta |
+            | Datatype       | float in seconds or hightime.timedelta |
             +----------------+----------------------------------------+
             | Permissions    | read-write                             |
             +----------------+----------------------------------------+

--- a/docs/nidmm/class.rst
+++ b/docs/nidmm/class.rst
@@ -321,7 +321,7 @@ configure_multi_point
 
     .. py:currentmodule:: nidmm.Session
 
-    .. py:method:: configure_multi_point(trigger_count, sample_count, sample_trigger=nidmm.SampleTrigger.IMMEDIATE, sample_interval=datetime.timedelta(seconds=-1))
+    .. py:method:: configure_multi_point(trigger_count, sample_count, sample_trigger=nidmm.SampleTrigger.IMMEDIATE, sample_interval=hightime.timedelta(seconds=-1))
 
             Configures the properties for multipoint measurements. These properties
             include :py:attr:`nidmm.Session.trigger_count`, :py:attr:`nidmm.Session.sample_count`,
@@ -396,7 +396,7 @@ configure_multi_point
                 .. note:: This property is not used on the NI 4080/4081/4082 and the NI 4050.
 
 
-            :type sample_interval: float in seconds or datetime.timedelta
+            :type sample_interval: float in seconds or hightime.timedelta
 
 configure_rtd_custom
 --------------------
@@ -612,7 +612,7 @@ configure_trigger
 
     .. py:currentmodule:: nidmm.Session
 
-    .. py:method:: configure_trigger(trigger_source, trigger_delay=datetime.timedelta(seconds=-1))
+    .. py:method:: configure_trigger(trigger_source, trigger_delay=hightime.timedelta(seconds=-1))
 
             Configures the DMM **Trigger_Source** and **Trigger_Delay**. Refer to
             `Triggering <REPLACE_DRIVER_SPECIFIC_URL_1(trigger)>`__ and `Using
@@ -659,7 +659,7 @@ configure_trigger
                 .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
 
-            :type trigger_delay: float in seconds or datetime.timedelta
+            :type trigger_delay: float in seconds or hightime.timedelta
 
 configure_waveform_acquisition
 ------------------------------
@@ -876,7 +876,7 @@ fetch
 
     .. py:currentmodule:: nidmm.Session
 
-    .. py:method:: fetch(maximum_time=datetime.timedelta(milliseconds=-1))
+    .. py:method:: fetch(maximum_time=hightime.timedelta(milliseconds=-1))
 
             Returns the value from a previously initiated measurement. You must call
             :py:meth:`nidmm.Session._initiate` before calling this method.
@@ -904,7 +904,7 @@ fetch
                 .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
 
-            :type maximum_time: int in milliseconds or datetime.timedelta
+            :type maximum_time: int in milliseconds or hightime.timedelta
 
             :rtype: float
             :return:
@@ -921,7 +921,7 @@ fetch_multi_point
 
     .. py:currentmodule:: nidmm.Session
 
-    .. py:method:: fetch_multi_point(array_size, maximum_time=datetime.timedelta(milliseconds=-1))
+    .. py:method:: fetch_multi_point(array_size, maximum_time=hightime.timedelta(milliseconds=-1))
 
             Returns an array of values from a previously initiated multipoint
             measurement. The number of measurements the DMM makes is determined by
@@ -967,7 +967,7 @@ fetch_multi_point
                 .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
 
-            :type maximum_time: int in milliseconds or datetime.timedelta
+            :type maximum_time: int in milliseconds or hightime.timedelta
 
             :rtype: tuple (reading_array, actual_number_of_points)
 
@@ -998,7 +998,7 @@ fetch_waveform
 
     .. py:currentmodule:: nidmm.Session
 
-    .. py:method:: fetch_waveform(array_size, maximum_time=datetime.timedelta(milliseconds=-1))
+    .. py:method:: fetch_waveform(array_size, maximum_time=hightime.timedelta(milliseconds=-1))
 
             For the NI 4080/4081/4082 and the NI 4070/4071/4072, returns an array of
             values from a previously initiated waveform acquisition. You must call
@@ -1039,7 +1039,7 @@ fetch_waveform
                 .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
 
-            :type maximum_time: int in milliseconds or datetime.timedelta
+            :type maximum_time: int in milliseconds or hightime.timedelta
 
             :rtype: tuple (waveform_array, actual_number_of_points)
 
@@ -1068,7 +1068,7 @@ fetch_waveform_into
 
     .. py:currentmodule:: nidmm.Session
 
-    .. py:method:: fetch_waveform_into(array_size, maximum_time=datetime.timedelta(milliseconds=-1))
+    .. py:method:: fetch_waveform_into(array_size, maximum_time=hightime.timedelta(milliseconds=-1))
 
             For the NI 4080/4081/4082 and the NI 4070/4071/4072, returns an array of
             values from a previously initiated waveform acquisition. You must call
@@ -1107,7 +1107,7 @@ fetch_waveform_into
                 .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
 
-            :type maximum_time: int in milliseconds or datetime.timedelta
+            :type maximum_time: int in milliseconds or hightime.timedelta
 
             :rtype: tuple (waveform_array, actual_number_of_points)
 
@@ -1164,7 +1164,7 @@ get_cal_date_and_time
 
             :type cal_type: int
 
-            :rtype: datetime.datetime
+            :rtype: hightime.datetime
             :return:
 
 
@@ -1225,7 +1225,7 @@ get_ext_cal_recommended_interval
 
 
 
-            :rtype: datetime.timedelta
+            :rtype: hightime.timedelta
             :return:
 
 
@@ -1583,7 +1583,7 @@ read
 
     .. py:currentmodule:: nidmm.Session
 
-    .. py:method:: read(maximum_time=datetime.timedelta(milliseconds=-1))
+    .. py:method:: read(maximum_time=hightime.timedelta(milliseconds=-1))
 
             Acquires a single measurement and returns the measured value.
 
@@ -1610,7 +1610,7 @@ read
                 .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
 
-            :type maximum_time: int in milliseconds or datetime.timedelta
+            :type maximum_time: int in milliseconds or hightime.timedelta
 
             :rtype: float
             :return:
@@ -1627,7 +1627,7 @@ read_multi_point
 
     .. py:currentmodule:: nidmm.Session
 
-    .. py:method:: read_multi_point(array_size, maximum_time=datetime.timedelta(milliseconds=-1))
+    .. py:method:: read_multi_point(array_size, maximum_time=hightime.timedelta(milliseconds=-1))
 
             Acquires multiple measurements and returns an array of measured values.
             The number of measurements the DMM makes is determined by the values you
@@ -1672,7 +1672,7 @@ read_multi_point
                 .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
 
-            :type maximum_time: int in milliseconds or datetime.timedelta
+            :type maximum_time: int in milliseconds or hightime.timedelta
 
             :rtype: tuple (reading_array, actual_number_of_points)
 
@@ -1760,7 +1760,7 @@ read_waveform
 
     .. py:currentmodule:: nidmm.Session
 
-    .. py:method:: read_waveform(array_size, maximum_time=datetime.timedelta(milliseconds=-1))
+    .. py:method:: read_waveform(array_size, maximum_time=hightime.timedelta(milliseconds=-1))
 
             For the NI 4080/4081/4082 and the NI 4070/4071/4072, acquires a waveform
             and returns data as an array of values or as a waveform data type. The
@@ -1803,7 +1803,7 @@ read_waveform
                 .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
 
-            :type maximum_time: int in milliseconds or datetime.timedelta
+            :type maximum_time: int in milliseconds or hightime.timedelta
 
             :rtype: tuple (waveform_array, actual_number_of_points)
 
@@ -3002,7 +3002,7 @@ sample_interval
             +----------------+----------------------------------------+
             | Characteristic | Value                                  |
             +================+========================================+
-            | Datatype       | float in seconds or datetime.timedelta |
+            | Datatype       | float in seconds or hightime.timedelta |
             +----------------+----------------------------------------+
             | Permissions    | read-write                             |
             +----------------+----------------------------------------+
@@ -3089,7 +3089,7 @@ settle_time
             +----------------+----------------------------------------+
             | Characteristic | Value                                  |
             +================+========================================+
-            | Datatype       | float in seconds or datetime.timedelta |
+            | Datatype       | float in seconds or hightime.timedelta |
             +----------------+----------------------------------------+
             | Permissions    | read-write                             |
             +----------------+----------------------------------------+
@@ -3764,7 +3764,7 @@ trigger_delay
             +----------------+----------------------------------------+
             | Characteristic | Value                                  |
             +================+========================================+
-            | Datatype       | float in seconds or datetime.timedelta |
+            | Datatype       | float in seconds or hightime.timedelta |
             +----------------+----------------------------------------+
             | Permissions    | read-write                             |
             +----------------+----------------------------------------+

--- a/docs/nidmm/class.rst
+++ b/docs/nidmm/class.rst
@@ -396,7 +396,7 @@ configure_multi_point
                 .. note:: This property is not used on the NI 4080/4081/4082 and the NI 4050.
 
 
-            :type sample_interval: float in seconds or hightime.timedelta
+            :type sample_interval: hightime.timedelta, datetime.timedelta, or float in seconds
 
 configure_rtd_custom
 --------------------
@@ -659,7 +659,7 @@ configure_trigger
                 .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
 
-            :type trigger_delay: float in seconds or hightime.timedelta
+            :type trigger_delay: hightime.timedelta, datetime.timedelta, or float in seconds
 
 configure_waveform_acquisition
 ------------------------------
@@ -904,7 +904,7 @@ fetch
                 .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
 
-            :type maximum_time: int in milliseconds or hightime.timedelta
+            :type maximum_time: hightime.timedelta, datetime.timedelta, or int in milliseconds
 
             :rtype: float
             :return:
@@ -967,7 +967,7 @@ fetch_multi_point
                 .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
 
-            :type maximum_time: int in milliseconds or hightime.timedelta
+            :type maximum_time: hightime.timedelta, datetime.timedelta, or int in milliseconds
 
             :rtype: tuple (reading_array, actual_number_of_points)
 
@@ -1039,7 +1039,7 @@ fetch_waveform
                 .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
 
-            :type maximum_time: int in milliseconds or hightime.timedelta
+            :type maximum_time: hightime.timedelta, datetime.timedelta, or int in milliseconds
 
             :rtype: tuple (waveform_array, actual_number_of_points)
 
@@ -1107,7 +1107,7 @@ fetch_waveform_into
                 .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
 
-            :type maximum_time: int in milliseconds or hightime.timedelta
+            :type maximum_time: hightime.timedelta, datetime.timedelta, or int in milliseconds
 
             :rtype: tuple (waveform_array, actual_number_of_points)
 
@@ -1610,7 +1610,7 @@ read
                 .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
 
-            :type maximum_time: int in milliseconds or hightime.timedelta
+            :type maximum_time: hightime.timedelta, datetime.timedelta, or int in milliseconds
 
             :rtype: float
             :return:
@@ -1672,7 +1672,7 @@ read_multi_point
                 .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
 
-            :type maximum_time: int in milliseconds or hightime.timedelta
+            :type maximum_time: hightime.timedelta, datetime.timedelta, or int in milliseconds
 
             :rtype: tuple (reading_array, actual_number_of_points)
 
@@ -1803,7 +1803,7 @@ read_waveform
                 .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
 
-            :type maximum_time: int in milliseconds or hightime.timedelta
+            :type maximum_time: hightime.timedelta, datetime.timedelta, or int in milliseconds
 
             :rtype: tuple (waveform_array, actual_number_of_points)
 
@@ -2999,17 +2999,17 @@ sample_interval
 
         The following table lists the characteristics of this property.
 
-            +----------------+----------------------------------------+
-            | Characteristic | Value                                  |
-            +================+========================================+
-            | Datatype       | float in seconds or hightime.timedelta |
-            +----------------+----------------------------------------+
-            | Permissions    | read-write                             |
-            +----------------+----------------------------------------+
-            | Channel Based  | No                                     |
-            +----------------+----------------------------------------+
-            | Resettable     | No                                     |
-            +----------------+----------------------------------------+
+            +----------------+-------------------------------------------------------------+
+            | Characteristic | Value                                                       |
+            +================+=============================================================+
+            | Datatype       | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +----------------+-------------------------------------------------------------+
+            | Permissions    | read-write                                                  |
+            +----------------+-------------------------------------------------------------+
+            | Channel Based  | No                                                          |
+            +----------------+-------------------------------------------------------------+
+            | Resettable     | No                                                          |
+            +----------------+-------------------------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -3086,17 +3086,17 @@ settle_time
 
         The following table lists the characteristics of this property.
 
-            +----------------+----------------------------------------+
-            | Characteristic | Value                                  |
-            +================+========================================+
-            | Datatype       | float in seconds or hightime.timedelta |
-            +----------------+----------------------------------------+
-            | Permissions    | read-write                             |
-            +----------------+----------------------------------------+
-            | Channel Based  | No                                     |
-            +----------------+----------------------------------------+
-            | Resettable     | No                                     |
-            +----------------+----------------------------------------+
+            +----------------+-------------------------------------------------------------+
+            | Characteristic | Value                                                       |
+            +================+=============================================================+
+            | Datatype       | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +----------------+-------------------------------------------------------------+
+            | Permissions    | read-write                                                  |
+            +----------------+-------------------------------------------------------------+
+            | Channel Based  | No                                                          |
+            +----------------+-------------------------------------------------------------+
+            | Resettable     | No                                                          |
+            +----------------+-------------------------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -3761,17 +3761,17 @@ trigger_delay
 
         The following table lists the characteristics of this property.
 
-            +----------------+----------------------------------------+
-            | Characteristic | Value                                  |
-            +================+========================================+
-            | Datatype       | float in seconds or hightime.timedelta |
-            +----------------+----------------------------------------+
-            | Permissions    | read-write                             |
-            +----------------+----------------------------------------+
-            | Channel Based  | No                                     |
-            +----------------+----------------------------------------+
-            | Resettable     | No                                     |
-            +----------------+----------------------------------------+
+            +----------------+-------------------------------------------------------------+
+            | Characteristic | Value                                                       |
+            +================+=============================================================+
+            | Datatype       | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +----------------+-------------------------------------------------------------+
+            | Permissions    | read-write                                                  |
+            +----------------+-------------------------------------------------------------+
+            | Channel Based  | No                                                          |
+            +----------------+-------------------------------------------------------------+
+            | Resettable     | No                                                          |
+            +----------------+-------------------------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:

--- a/docs/nifgen/class.rst
+++ b/docs/nifgen/class.rst
@@ -2415,7 +2415,7 @@ wait_until_done
                 
 
 
-            :type max_time: int in milliseconds or hightime.timedelta
+            :type max_time: hightime.timedelta, datetime.timedelta, or int in milliseconds
 
 write_script
 ------------
@@ -5767,17 +5767,17 @@ streaming_write_timeout
 
         The following table lists the characteristics of this property.
 
-            +----------------+----------------------------------------+
-            | Characteristic | Value                                  |
-            +================+========================================+
-            | Datatype       | float in seconds or hightime.timedelta |
-            +----------------+----------------------------------------+
-            | Permissions    | read-write                             |
-            +----------------+----------------------------------------+
-            | Channel Based  | No                                     |
-            +----------------+----------------------------------------+
-            | Resettable     | Yes                                    |
-            +----------------+----------------------------------------+
+            +----------------+-------------------------------------------------------------+
+            | Characteristic | Value                                                       |
+            +================+=============================================================+
+            | Datatype       | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +----------------+-------------------------------------------------------------+
+            | Permissions    | read-write                                                  |
+            +----------------+-------------------------------------------------------------+
+            | Channel Based  | No                                                          |
+            +----------------+-------------------------------------------------------------+
+            | Resettable     | Yes                                                         |
+            +----------------+-------------------------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:

--- a/docs/nifgen/class.rst
+++ b/docs/nifgen/class.rst
@@ -1597,7 +1597,7 @@ get_ext_cal_last_date_and_time
 
 
 
-            :rtype: datetime.datetime
+            :rtype: hightime.datetime
             :return:
 
 
@@ -1646,7 +1646,7 @@ get_ext_cal_recommended_interval
 
 
 
-            :rtype: datetime.timedelta
+            :rtype: hightime.timedelta
             :return:
 
 
@@ -1708,7 +1708,7 @@ get_self_cal_last_date_and_time
 
 
 
-            :rtype: datetime.datetime
+            :rtype: hightime.datetime
             :return:
 
 
@@ -2398,7 +2398,7 @@ wait_until_done
 
     .. py:currentmodule:: nifgen.Session
 
-    .. py:method:: wait_until_done(max_time=datetime.timedelta(seconds=10.0))
+    .. py:method:: wait_until_done(max_time=hightime.timedelta(seconds=10.0))
 
             Waits until the device is done generating or until the maximum time has
             expired.
@@ -2415,7 +2415,7 @@ wait_until_done
                 
 
 
-            :type max_time: int in milliseconds or datetime.timedelta
+            :type max_time: int in milliseconds or hightime.timedelta
 
 write_script
 ------------
@@ -5770,7 +5770,7 @@ streaming_write_timeout
             +----------------+----------------------------------------+
             | Characteristic | Value                                  |
             +================+========================================+
-            | Datatype       | float in seconds or datetime.timedelta |
+            | Datatype       | float in seconds or hightime.timedelta |
             +----------------+----------------------------------------+
             | Permissions    | read-write                             |
             +----------------+----------------------------------------+

--- a/docs/niscope/class.rst
+++ b/docs/niscope/class.rst
@@ -485,7 +485,7 @@ configure_trigger_digital
 
     .. py:currentmodule:: niscope.Session
 
-    .. py:method:: configure_trigger_digital(trigger_source, slope=niscope.TriggerSlope.POSITIVE, holdoff=datetime.timedelta(seconds=0.0), delay=datetime.timedelta(seconds=0.0))
+    .. py:method:: configure_trigger_digital(trigger_source, slope=niscope.TriggerSlope.POSITIVE, holdoff=hightime.timedelta(seconds=0.0), delay=hightime.timedelta(seconds=0.0))
 
             Configures the common properties of a digital trigger.
 
@@ -551,7 +551,7 @@ configure_trigger_digital
                 
 
 
-            :type holdoff: float in seconds or datetime.timedelta
+            :type holdoff: float in seconds or hightime.timedelta
             :param delay:
 
 
@@ -562,14 +562,14 @@ configure_trigger_digital
                 
 
 
-            :type delay: float in seconds or datetime.timedelta
+            :type delay: float in seconds or hightime.timedelta
 
 configure_trigger_edge
 ----------------------
 
     .. py:currentmodule:: niscope.Session
 
-    .. py:method:: configure_trigger_edge(trigger_source, level, trigger_coupling, slope=niscope.TriggerSlope.POSITIVE, holdoff=datetime.timedelta(seconds=0.0), delay=datetime.timedelta(seconds=0.0))
+    .. py:method:: configure_trigger_edge(trigger_source, level, trigger_coupling, slope=niscope.TriggerSlope.POSITIVE, holdoff=hightime.timedelta(seconds=0.0), delay=hightime.timedelta(seconds=0.0))
 
             Configures common properties for analog edge triggering.
 
@@ -645,7 +645,7 @@ configure_trigger_edge
                 
 
 
-            :type holdoff: float in seconds or datetime.timedelta
+            :type holdoff: float in seconds or hightime.timedelta
             :param delay:
 
 
@@ -656,14 +656,14 @@ configure_trigger_edge
                 
 
 
-            :type delay: float in seconds or datetime.timedelta
+            :type delay: float in seconds or hightime.timedelta
 
 configure_trigger_hysteresis
 ----------------------------
 
     .. py:currentmodule:: niscope.Session
 
-    .. py:method:: configure_trigger_hysteresis(trigger_source, level, hysteresis, trigger_coupling, slope=niscope.TriggerSlope.POSITIVE, holdoff=datetime.timedelta(seconds=0.0), delay=datetime.timedelta(seconds=0.0))
+    .. py:method:: configure_trigger_hysteresis(trigger_source, level, hysteresis, trigger_coupling, slope=niscope.TriggerSlope.POSITIVE, holdoff=hightime.timedelta(seconds=0.0), delay=hightime.timedelta(seconds=0.0))
 
             Configures common properties for analog hysteresis triggering. This kind
             of trigger specifies an additional value, specified in the
@@ -756,7 +756,7 @@ configure_trigger_hysteresis
                 
 
 
-            :type holdoff: float in seconds or datetime.timedelta
+            :type holdoff: float in seconds or hightime.timedelta
             :param delay:
 
 
@@ -767,7 +767,7 @@ configure_trigger_hysteresis
                 
 
 
-            :type delay: float in seconds or datetime.timedelta
+            :type delay: float in seconds or hightime.timedelta
 
 configure_trigger_immediate
 ---------------------------
@@ -792,7 +792,7 @@ configure_trigger_software
 
     .. py:currentmodule:: niscope.Session
 
-    .. py:method:: configure_trigger_software(holdoff=datetime.timedelta(seconds=0.0), delay=datetime.timedelta(seconds=0.0))
+    .. py:method:: configure_trigger_software(holdoff=hightime.timedelta(seconds=0.0), delay=hightime.timedelta(seconds=0.0))
 
             Configures common properties for software triggering.
 
@@ -829,7 +829,7 @@ configure_trigger_software
                 
 
 
-            :type holdoff: float in seconds or datetime.timedelta
+            :type holdoff: float in seconds or hightime.timedelta
             :param delay:
 
 
@@ -840,14 +840,14 @@ configure_trigger_software
                 
 
 
-            :type delay: float in seconds or datetime.timedelta
+            :type delay: float in seconds or hightime.timedelta
 
 configure_trigger_video
 -----------------------
 
     .. py:currentmodule:: niscope.Session
 
-    .. py:method:: configure_trigger_video(trigger_source, signal_format, event, polarity, trigger_coupling, enable_dc_restore=False, line_number=1, holdoff=datetime.timedelta(seconds=0.0), delay=datetime.timedelta(seconds=0.0))
+    .. py:method:: configure_trigger_video(trigger_source, signal_format, event, polarity, trigger_coupling, enable_dc_restore=False, line_number=1, holdoff=hightime.timedelta(seconds=0.0), delay=hightime.timedelta(seconds=0.0))
 
             Configures the common properties for video triggering, including the
             signal format, TV event, line number, polarity, and enable DC restore. A
@@ -961,7 +961,7 @@ configure_trigger_video
                 
 
 
-            :type holdoff: float in seconds or datetime.timedelta
+            :type holdoff: float in seconds or hightime.timedelta
             :param delay:
 
 
@@ -972,14 +972,14 @@ configure_trigger_video
                 
 
 
-            :type delay: float in seconds or datetime.timedelta
+            :type delay: float in seconds or hightime.timedelta
 
 configure_trigger_window
 ------------------------
 
     .. py:currentmodule:: niscope.Session
 
-    .. py:method:: configure_trigger_window(trigger_source, low_level, high_level, window_mode, trigger_coupling, holdoff=datetime.timedelta(seconds=0.0), delay=datetime.timedelta(seconds=0.0))
+    .. py:method:: configure_trigger_window(trigger_source, low_level, high_level, window_mode, trigger_coupling, holdoff=hightime.timedelta(seconds=0.0), delay=hightime.timedelta(seconds=0.0))
 
             Configures common properties for analog window triggering. A window
             trigger occurs when a signal enters or leaves a window you specify with
@@ -1065,7 +1065,7 @@ configure_trigger_window
                 
 
 
-            :type holdoff: float in seconds or datetime.timedelta
+            :type holdoff: float in seconds or hightime.timedelta
             :param delay:
 
 
@@ -1076,7 +1076,7 @@ configure_trigger_window
                 
 
 
-            :type delay: float in seconds or datetime.timedelta
+            :type delay: float in seconds or hightime.timedelta
 
 configure_vertical
 ------------------
@@ -1252,7 +1252,7 @@ fetch
 
     .. py:currentmodule:: niscope.Session
 
-    .. py:method:: fetch(num_samples=None, relative_to=niscope.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout=datetime.timedelta(seconds=5.0))
+    .. py:method:: fetch(num_samples=None, relative_to=niscope.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout=hightime.timedelta(seconds=5.0))
 
             Returns the waveform from a previously initiated acquisition that the
             digitizer acquires for the specified channel. This method returns
@@ -1325,7 +1325,7 @@ fetch
                 
 
 
-            :type timeout: float in seconds or datetime.timedelta
+            :type timeout: float in seconds or hightime.timedelta
 
             :rtype: list of WaveformInfo
             :return:
@@ -1361,7 +1361,7 @@ fetch_into
 
     .. py:currentmodule:: niscope.Session
 
-    .. py:method:: fetch_into(waveform, relative_to=niscope.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout=datetime.timedelta(seconds=5.0))
+    .. py:method:: fetch_into(waveform, relative_to=niscope.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout=hightime.timedelta(seconds=5.0))
 
             Returns the waveform from a previously initiated acquisition that the
             digitizer acquires for the specified channel. This method returns
@@ -1448,7 +1448,7 @@ fetch_into
                 
 
 
-            :type timeout: float in seconds or datetime.timedelta
+            :type timeout: float in seconds or hightime.timedelta
 
             :rtype: list of WaveformInfo
             :return:
@@ -1678,7 +1678,7 @@ read
 
     .. py:currentmodule:: niscope.Session
 
-    .. py:method:: read(num_samples=None, relative_to=niscope.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout=datetime.timedelta(seconds=5.0))
+    .. py:method:: read(num_samples=None, relative_to=niscope.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout=hightime.timedelta(seconds=5.0))
 
             Initiates an acquisition, waits for it to complete, and retrieves the
             data. The process is similar to calling :py:meth:`niscope.Session._initiate_acquisition`,
@@ -1754,7 +1754,7 @@ read
                 
 
 
-            :type timeout: float in seconds or datetime.timedelta
+            :type timeout: float in seconds or hightime.timedelta
 
             :rtype: list of WaveformInfo
             :return:
@@ -1982,7 +1982,7 @@ absolute_sample_clock_offset
             +----------------+----------------------------------------+
             | Characteristic | Value                                  |
             +================+========================================+
-            | Datatype       | float in seconds or datetime.timedelta |
+            | Datatype       | float in seconds or hightime.timedelta |
             +----------------+----------------------------------------+
             | Permissions    | read-write                             |
             +----------------+----------------------------------------+
@@ -2009,7 +2009,7 @@ acquisition_start_time
             +----------------+----------------------------------------+
             | Characteristic | Value                                  |
             +================+========================================+
-            | Datatype       | float in seconds or datetime.timedelta |
+            | Datatype       | float in seconds or hightime.timedelta |
             +----------------+----------------------------------------+
             | Permissions    | read-write                             |
             +----------------+----------------------------------------+
@@ -2775,7 +2775,7 @@ end_of_record_to_advance_trigger_holdoff
             +----------------+----------------------------------------+
             | Characteristic | Value                                  |
             +================+========================================+
-            | Datatype       | float in seconds or datetime.timedelta |
+            | Datatype       | float in seconds or hightime.timedelta |
             +----------------+----------------------------------------+
             | Permissions    | read-write                             |
             +----------------+----------------------------------------+
@@ -3311,7 +3311,7 @@ horz_time_per_record
             +----------------+----------------------------------------+
             | Characteristic | Value                                  |
             +================+========================================+
-            | Datatype       | float in seconds or datetime.timedelta |
+            | Datatype       | float in seconds or hightime.timedelta |
             +----------------+----------------------------------------+
             | Permissions    | read-write                             |
             +----------------+----------------------------------------+
@@ -4159,7 +4159,7 @@ ref_trigger_minimum_quiet_time
             +----------------+----------------------------------------+
             | Characteristic | Value                                  |
             +================+========================================+
-            | Datatype       | float in seconds or datetime.timedelta |
+            | Datatype       | float in seconds or hightime.timedelta |
             +----------------+----------------------------------------+
             | Permissions    | read-write                             |
             +----------------+----------------------------------------+
@@ -4862,7 +4862,7 @@ start_to_ref_trigger_holdoff
             +----------------+----------------------------------------+
             | Characteristic | Value                                  |
             +================+========================================+
-            | Datatype       | float in seconds or datetime.timedelta |
+            | Datatype       | float in seconds or hightime.timedelta |
             +----------------+----------------------------------------+
             | Permissions    | read-write                             |
             +----------------+----------------------------------------+
@@ -4971,7 +4971,7 @@ trigger_delay_time
             +----------------+----------------------------------------+
             | Characteristic | Value                                  |
             +================+========================================+
-            | Datatype       | float in seconds or datetime.timedelta |
+            | Datatype       | float in seconds or hightime.timedelta |
             +----------------+----------------------------------------+
             | Permissions    | read-write                             |
             +----------------+----------------------------------------+
@@ -4999,7 +4999,7 @@ trigger_holdoff
             +----------------+----------------------------------------+
             | Characteristic | Value                                  |
             +================+========================================+
-            | Datatype       | float in seconds or datetime.timedelta |
+            | Datatype       | float in seconds or hightime.timedelta |
             +----------------+----------------------------------------+
             | Permissions    | read-write                             |
             +----------------+----------------------------------------+

--- a/docs/niscope/class.rst
+++ b/docs/niscope/class.rst
@@ -551,7 +551,7 @@ configure_trigger_digital
                 
 
 
-            :type holdoff: float in seconds or hightime.timedelta
+            :type holdoff: hightime.timedelta, datetime.timedelta, or float in seconds
             :param delay:
 
 
@@ -562,7 +562,7 @@ configure_trigger_digital
                 
 
 
-            :type delay: float in seconds or hightime.timedelta
+            :type delay: hightime.timedelta, datetime.timedelta, or float in seconds
 
 configure_trigger_edge
 ----------------------
@@ -645,7 +645,7 @@ configure_trigger_edge
                 
 
 
-            :type holdoff: float in seconds or hightime.timedelta
+            :type holdoff: hightime.timedelta, datetime.timedelta, or float in seconds
             :param delay:
 
 
@@ -656,7 +656,7 @@ configure_trigger_edge
                 
 
 
-            :type delay: float in seconds or hightime.timedelta
+            :type delay: hightime.timedelta, datetime.timedelta, or float in seconds
 
 configure_trigger_hysteresis
 ----------------------------
@@ -756,7 +756,7 @@ configure_trigger_hysteresis
                 
 
 
-            :type holdoff: float in seconds or hightime.timedelta
+            :type holdoff: hightime.timedelta, datetime.timedelta, or float in seconds
             :param delay:
 
 
@@ -767,7 +767,7 @@ configure_trigger_hysteresis
                 
 
 
-            :type delay: float in seconds or hightime.timedelta
+            :type delay: hightime.timedelta, datetime.timedelta, or float in seconds
 
 configure_trigger_immediate
 ---------------------------
@@ -829,7 +829,7 @@ configure_trigger_software
                 
 
 
-            :type holdoff: float in seconds or hightime.timedelta
+            :type holdoff: hightime.timedelta, datetime.timedelta, or float in seconds
             :param delay:
 
 
@@ -840,7 +840,7 @@ configure_trigger_software
                 
 
 
-            :type delay: float in seconds or hightime.timedelta
+            :type delay: hightime.timedelta, datetime.timedelta, or float in seconds
 
 configure_trigger_video
 -----------------------
@@ -961,7 +961,7 @@ configure_trigger_video
                 
 
 
-            :type holdoff: float in seconds or hightime.timedelta
+            :type holdoff: hightime.timedelta, datetime.timedelta, or float in seconds
             :param delay:
 
 
@@ -972,7 +972,7 @@ configure_trigger_video
                 
 
 
-            :type delay: float in seconds or hightime.timedelta
+            :type delay: hightime.timedelta, datetime.timedelta, or float in seconds
 
 configure_trigger_window
 ------------------------
@@ -1065,7 +1065,7 @@ configure_trigger_window
                 
 
 
-            :type holdoff: float in seconds or hightime.timedelta
+            :type holdoff: hightime.timedelta, datetime.timedelta, or float in seconds
             :param delay:
 
 
@@ -1076,7 +1076,7 @@ configure_trigger_window
                 
 
 
-            :type delay: float in seconds or hightime.timedelta
+            :type delay: hightime.timedelta, datetime.timedelta, or float in seconds
 
 configure_vertical
 ------------------
@@ -1325,7 +1325,7 @@ fetch
                 
 
 
-            :type timeout: float in seconds or hightime.timedelta
+            :type timeout: hightime.timedelta, datetime.timedelta, or float in seconds
 
             :rtype: list of WaveformInfo
             :return:
@@ -1448,7 +1448,7 @@ fetch_into
                 
 
 
-            :type timeout: float in seconds or hightime.timedelta
+            :type timeout: hightime.timedelta, datetime.timedelta, or float in seconds
 
             :rtype: list of WaveformInfo
             :return:
@@ -1754,7 +1754,7 @@ read
                 
 
 
-            :type timeout: float in seconds or hightime.timedelta
+            :type timeout: hightime.timedelta, datetime.timedelta, or float in seconds
 
             :rtype: list of WaveformInfo
             :return:
@@ -1979,17 +1979,17 @@ absolute_sample_clock_offset
 
         The following table lists the characteristics of this property.
 
-            +----------------+----------------------------------------+
-            | Characteristic | Value                                  |
-            +================+========================================+
-            | Datatype       | float in seconds or hightime.timedelta |
-            +----------------+----------------------------------------+
-            | Permissions    | read-write                             |
-            +----------------+----------------------------------------+
-            | Channel Based  | No                                     |
-            +----------------+----------------------------------------+
-            | Resettable     | Yes                                    |
-            +----------------+----------------------------------------+
+            +----------------+-------------------------------------------------------------+
+            | Characteristic | Value                                                       |
+            +================+=============================================================+
+            | Datatype       | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +----------------+-------------------------------------------------------------+
+            | Permissions    | read-write                                                  |
+            +----------------+-------------------------------------------------------------+
+            | Channel Based  | No                                                          |
+            +----------------+-------------------------------------------------------------+
+            | Resettable     | Yes                                                         |
+            +----------------+-------------------------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -2006,17 +2006,17 @@ acquisition_start_time
 
         The following table lists the characteristics of this property.
 
-            +----------------+----------------------------------------+
-            | Characteristic | Value                                  |
-            +================+========================================+
-            | Datatype       | float in seconds or hightime.timedelta |
-            +----------------+----------------------------------------+
-            | Permissions    | read-write                             |
-            +----------------+----------------------------------------+
-            | Channel Based  | No                                     |
-            +----------------+----------------------------------------+
-            | Resettable     | Yes                                    |
-            +----------------+----------------------------------------+
+            +----------------+-------------------------------------------------------------+
+            | Characteristic | Value                                                       |
+            +================+=============================================================+
+            | Datatype       | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +----------------+-------------------------------------------------------------+
+            | Permissions    | read-write                                                  |
+            +----------------+-------------------------------------------------------------+
+            | Channel Based  | No                                                          |
+            +----------------+-------------------------------------------------------------+
+            | Resettable     | Yes                                                         |
+            +----------------+-------------------------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -2772,17 +2772,17 @@ end_of_record_to_advance_trigger_holdoff
 
         The following table lists the characteristics of this property.
 
-            +----------------+----------------------------------------+
-            | Characteristic | Value                                  |
-            +================+========================================+
-            | Datatype       | float in seconds or hightime.timedelta |
-            +----------------+----------------------------------------+
-            | Permissions    | read-write                             |
-            +----------------+----------------------------------------+
-            | Channel Based  | No                                     |
-            +----------------+----------------------------------------+
-            | Resettable     | Yes                                    |
-            +----------------+----------------------------------------+
+            +----------------+-------------------------------------------------------------+
+            | Characteristic | Value                                                       |
+            +================+=============================================================+
+            | Datatype       | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +----------------+-------------------------------------------------------------+
+            | Permissions    | read-write                                                  |
+            +----------------+-------------------------------------------------------------+
+            | Channel Based  | No                                                          |
+            +----------------+-------------------------------------------------------------+
+            | Resettable     | Yes                                                         |
+            +----------------+-------------------------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -3308,17 +3308,17 @@ horz_time_per_record
 
         The following table lists the characteristics of this property.
 
-            +----------------+----------------------------------------+
-            | Characteristic | Value                                  |
-            +================+========================================+
-            | Datatype       | float in seconds or hightime.timedelta |
-            +----------------+----------------------------------------+
-            | Permissions    | read-write                             |
-            +----------------+----------------------------------------+
-            | Channel Based  | No                                     |
-            +----------------+----------------------------------------+
-            | Resettable     | Yes                                    |
-            +----------------+----------------------------------------+
+            +----------------+-------------------------------------------------------------+
+            | Characteristic | Value                                                       |
+            +================+=============================================================+
+            | Datatype       | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +----------------+-------------------------------------------------------------+
+            | Permissions    | read-write                                                  |
+            +----------------+-------------------------------------------------------------+
+            | Channel Based  | No                                                          |
+            +----------------+-------------------------------------------------------------+
+            | Resettable     | Yes                                                         |
+            +----------------+-------------------------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -4156,17 +4156,17 @@ ref_trigger_minimum_quiet_time
 
         The following table lists the characteristics of this property.
 
-            +----------------+----------------------------------------+
-            | Characteristic | Value                                  |
-            +================+========================================+
-            | Datatype       | float in seconds or hightime.timedelta |
-            +----------------+----------------------------------------+
-            | Permissions    | read-write                             |
-            +----------------+----------------------------------------+
-            | Channel Based  | No                                     |
-            +----------------+----------------------------------------+
-            | Resettable     | Yes                                    |
-            +----------------+----------------------------------------+
+            +----------------+-------------------------------------------------------------+
+            | Characteristic | Value                                                       |
+            +================+=============================================================+
+            | Datatype       | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +----------------+-------------------------------------------------------------+
+            | Permissions    | read-write                                                  |
+            +----------------+-------------------------------------------------------------+
+            | Channel Based  | No                                                          |
+            +----------------+-------------------------------------------------------------+
+            | Resettable     | Yes                                                         |
+            +----------------+-------------------------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -4859,17 +4859,17 @@ start_to_ref_trigger_holdoff
 
         The following table lists the characteristics of this property.
 
-            +----------------+----------------------------------------+
-            | Characteristic | Value                                  |
-            +================+========================================+
-            | Datatype       | float in seconds or hightime.timedelta |
-            +----------------+----------------------------------------+
-            | Permissions    | read-write                             |
-            +----------------+----------------------------------------+
-            | Channel Based  | No                                     |
-            +----------------+----------------------------------------+
-            | Resettable     | Yes                                    |
-            +----------------+----------------------------------------+
+            +----------------+-------------------------------------------------------------+
+            | Characteristic | Value                                                       |
+            +================+=============================================================+
+            | Datatype       | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +----------------+-------------------------------------------------------------+
+            | Permissions    | read-write                                                  |
+            +----------------+-------------------------------------------------------------+
+            | Channel Based  | No                                                          |
+            +----------------+-------------------------------------------------------------+
+            | Resettable     | Yes                                                         |
+            +----------------+-------------------------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -4968,17 +4968,17 @@ trigger_delay_time
 
         The following table lists the characteristics of this property.
 
-            +----------------+----------------------------------------+
-            | Characteristic | Value                                  |
-            +================+========================================+
-            | Datatype       | float in seconds or hightime.timedelta |
-            +----------------+----------------------------------------+
-            | Permissions    | read-write                             |
-            +----------------+----------------------------------------+
-            | Channel Based  | No                                     |
-            +----------------+----------------------------------------+
-            | Resettable     | Yes                                    |
-            +----------------+----------------------------------------+
+            +----------------+-------------------------------------------------------------+
+            | Characteristic | Value                                                       |
+            +================+=============================================================+
+            | Datatype       | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +----------------+-------------------------------------------------------------+
+            | Permissions    | read-write                                                  |
+            +----------------+-------------------------------------------------------------+
+            | Channel Based  | No                                                          |
+            +----------------+-------------------------------------------------------------+
+            | Resettable     | Yes                                                         |
+            +----------------+-------------------------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -4996,17 +4996,17 @@ trigger_holdoff
 
         The following table lists the characteristics of this property.
 
-            +----------------+----------------------------------------+
-            | Characteristic | Value                                  |
-            +================+========================================+
-            | Datatype       | float in seconds or hightime.timedelta |
-            +----------------+----------------------------------------+
-            | Permissions    | read-write                             |
-            +----------------+----------------------------------------+
-            | Channel Based  | No                                     |
-            +----------------+----------------------------------------+
-            | Resettable     | Yes                                    |
-            +----------------+----------------------------------------+
+            +----------------+-------------------------------------------------------------+
+            | Characteristic | Value                                                       |
+            +================+=============================================================+
+            | Datatype       | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +----------------+-------------------------------------------------------------+
+            | Permissions    | read-write                                                  |
+            +----------------+-------------------------------------------------------------+
+            | Channel Based  | No                                                          |
+            +----------------+-------------------------------------------------------------+
+            | Resettable     | Yes                                                         |
+            +----------------+-------------------------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:

--- a/docs/nise/class.rst
+++ b/docs/nise/class.rst
@@ -682,7 +682,7 @@ wait_for_debounce
 
     .. py:currentmodule:: nise.Session
 
-    .. py:method:: wait_for_debounce(maximum_time_ms=datetime.timedelta(milliseconds=-1))
+    .. py:method:: wait_for_debounce(maximum_time_ms=hightime.timedelta(milliseconds=-1))
 
             Waits for all of the switches in the NI Switch Executive virtual device
             to debounce. This method does not return until either the switching
@@ -709,7 +709,7 @@ wait_for_debounce
                 
 
 
-            :type maximum_time_ms: int in milliseconds or datetime.timedelta
+            :type maximum_time_ms: int in milliseconds or hightime.timedelta
 
 
 

--- a/docs/nise/class.rst
+++ b/docs/nise/class.rst
@@ -709,7 +709,7 @@ wait_for_debounce
                 
 
 
-            :type maximum_time_ms: int in milliseconds or hightime.timedelta
+            :type maximum_time_ms: hightime.timedelta, datetime.timedelta, or int in milliseconds
 
 
 

--- a/docs/niswitch/class.rst
+++ b/docs/niswitch/class.rst
@@ -1163,7 +1163,7 @@ wait_for_debounce
 
     .. py:currentmodule:: niswitch.Session
 
-    .. py:method:: wait_for_debounce(maximum_time_ms=datetime.timedelta(milliseconds=5000))
+    .. py:method:: wait_for_debounce(maximum_time_ms=hightime.timedelta(milliseconds=5000))
 
             Pauses until all created paths have settled. If the time you specify
             with the Maximum Time (ms) parameter elapsed before the switch paths
@@ -1185,14 +1185,14 @@ wait_for_debounce
                 
 
 
-            :type maximum_time_ms: int in milliseconds or datetime.timedelta
+            :type maximum_time_ms: int in milliseconds or hightime.timedelta
 
 wait_for_scan_complete
 ----------------------
 
     .. py:currentmodule:: niswitch.Session
 
-    .. py:method:: wait_for_scan_complete(maximum_time_ms=datetime.timedelta(milliseconds=5000))
+    .. py:method:: wait_for_scan_complete(maximum_time_ms=hightime.timedelta(milliseconds=5000))
 
             Pauses until the switch module stops scanning or the maximum time has
             elapsed and returns a timeout error. If the time you specify with the
@@ -1215,7 +1215,7 @@ wait_for_scan_complete
                 
 
 
-            :type maximum_time_ms: int in milliseconds or datetime.timedelta
+            :type maximum_time_ms: int in milliseconds or hightime.timedelta
 
 
 Properties
@@ -2309,7 +2309,7 @@ scan_delay
             +----------------+----------------------------------------+
             | Characteristic | Value                                  |
             +================+========================================+
-            | Datatype       | float in seconds or datetime.timedelta |
+            | Datatype       | float in seconds or hightime.timedelta |
             +----------------+----------------------------------------+
             | Permissions    | read-write                             |
             +----------------+----------------------------------------+
@@ -2444,7 +2444,7 @@ settling_time
             +----------------+----------------------------------------+
             | Characteristic | Value                                  |
             +================+========================================+
-            | Datatype       | float in seconds or datetime.timedelta |
+            | Datatype       | float in seconds or hightime.timedelta |
             +----------------+----------------------------------------+
             | Permissions    | read-write                             |
             +----------------+----------------------------------------+

--- a/docs/niswitch/class.rst
+++ b/docs/niswitch/class.rst
@@ -1185,7 +1185,7 @@ wait_for_debounce
                 
 
 
-            :type maximum_time_ms: int in milliseconds or hightime.timedelta
+            :type maximum_time_ms: hightime.timedelta, datetime.timedelta, or int in milliseconds
 
 wait_for_scan_complete
 ----------------------
@@ -1215,7 +1215,7 @@ wait_for_scan_complete
                 
 
 
-            :type maximum_time_ms: int in milliseconds or hightime.timedelta
+            :type maximum_time_ms: hightime.timedelta, datetime.timedelta, or int in milliseconds
 
 
 Properties
@@ -2306,17 +2306,17 @@ scan_delay
 
         The following table lists the characteristics of this property.
 
-            +----------------+----------------------------------------+
-            | Characteristic | Value                                  |
-            +================+========================================+
-            | Datatype       | float in seconds or hightime.timedelta |
-            +----------------+----------------------------------------+
-            | Permissions    | read-write                             |
-            +----------------+----------------------------------------+
-            | Channel Based  | No                                     |
-            +----------------+----------------------------------------+
-            | Resettable     | No                                     |
-            +----------------+----------------------------------------+
+            +----------------+-------------------------------------------------------------+
+            | Characteristic | Value                                                       |
+            +================+=============================================================+
+            | Datatype       | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +----------------+-------------------------------------------------------------+
+            | Permissions    | read-write                                                  |
+            +----------------+-------------------------------------------------------------+
+            | Channel Based  | No                                                          |
+            +----------------+-------------------------------------------------------------+
+            | Resettable     | No                                                          |
+            +----------------+-------------------------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -2441,17 +2441,17 @@ settling_time
 
         The following table lists the characteristics of this property.
 
-            +----------------+----------------------------------------+
-            | Characteristic | Value                                  |
-            +================+========================================+
-            | Datatype       | float in seconds or hightime.timedelta |
-            +----------------+----------------------------------------+
-            | Permissions    | read-write                             |
-            +----------------+----------------------------------------+
-            | Channel Based  | Yes                                    |
-            +----------------+----------------------------------------+
-            | Resettable     | No                                     |
-            +----------------+----------------------------------------+
+            +----------------+-------------------------------------------------------------+
+            | Characteristic | Value                                                       |
+            +================+=============================================================+
+            | Datatype       | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +----------------+-------------------------------------------------------------+
+            | Permissions    | read-write                                                  |
+            +----------------+-------------------------------------------------------------+
+            | Channel Based  | Yes                                                         |
+            +----------------+-------------------------------------------------------------+
+            | Resettable     | No                                                          |
+            +----------------+-------------------------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:

--- a/docs/nitclk/class.rst
+++ b/docs/nitclk/class.rst
@@ -167,7 +167,7 @@ finish_sync_pulse_sender_synchronize
 
     .. py:currentmodule:: nitclk
 
-    .. py:function:: finish_sync_pulse_sender_synchronize(sessions, min_time=datetime.timedelta(seconds=0.0))
+    .. py:function:: finish_sync_pulse_sender_synchronize(sessions, min_time=hightime.timedelta(seconds=0.0))
 
         Finishes synchronizing the Sync Pulse Sender.
 
@@ -197,7 +197,7 @@ finish_sync_pulse_sender_synchronize
             
 
 
-        :type min_time: float in seconds or datetime.timedelta
+        :type min_time: float in seconds or hightime.timedelta
 
 initiate
 --------
@@ -267,7 +267,7 @@ setup_for_sync_pulse_sender_synchronize
 
     .. py:currentmodule:: nitclk
 
-    .. py:function:: setup_for_sync_pulse_sender_synchronize(sessions, min_time=datetime.timedelta(seconds=0.0))
+    .. py:function:: setup_for_sync_pulse_sender_synchronize(sessions, min_time=hightime.timedelta(seconds=0.0))
 
         Configures the TClks on all the devices and prepares the Sync Pulse Sender for synchronization
 
@@ -297,14 +297,14 @@ setup_for_sync_pulse_sender_synchronize
             
 
 
-        :type min_time: float in seconds or datetime.timedelta
+        :type min_time: float in seconds or hightime.timedelta
 
 synchronize
 -----------
 
     .. py:currentmodule:: nitclk
 
-    .. py:function:: synchronize(sessions, min_tclk_period=datetime.timedelta(seconds=0.0))
+    .. py:function:: synchronize(sessions, min_tclk_period=hightime.timedelta(seconds=0.0))
 
         Synchronizes the TClk signals on the given sessions. After
         :py:func:`nitclk.synchronize` executes, TClk signals from all sessions are
@@ -339,14 +339,14 @@ synchronize
             
 
 
-        :type min_tclk_period: float in seconds or datetime.timedelta
+        :type min_tclk_period: float in seconds or hightime.timedelta
 
 synchronize_to_sync_pulse_sender
 --------------------------------
 
     .. py:currentmodule:: nitclk
 
-    .. py:function:: synchronize_to_sync_pulse_sender(sessions, min_time=datetime.timedelta(seconds=0.0))
+    .. py:function:: synchronize_to_sync_pulse_sender(sessions, min_time=hightime.timedelta(seconds=0.0))
 
         Synchronizes the other devices to the Sync Pulse Sender.
 
@@ -376,14 +376,14 @@ synchronize_to_sync_pulse_sender
             
 
 
-        :type min_time: float in seconds or datetime.timedelta
+        :type min_time: float in seconds or hightime.timedelta
 
 wait_until_done
 ---------------
 
     .. py:currentmodule:: nitclk
 
-    .. py:function:: wait_until_done(sessions, timeout=datetime.timedelta(seconds=0.0))
+    .. py:function:: wait_until_done(sessions, timeout=hightime.timedelta(seconds=0.0))
 
         Call this method to pause execution of your program until the
         acquisitions and/or generations corresponding to sessions are done or
@@ -417,7 +417,7 @@ wait_until_done
             
 
 
-        :type timeout: float in seconds or datetime.timedelta
+        :type timeout: float in seconds or hightime.timedelta
 
 
 SessionReference
@@ -600,7 +600,7 @@ sample_clock_delay
             +----------------+----------------------------------------+
             | Characteristic | Value                                  |
             +================+========================================+
-            | Datatype       | float in seconds or datetime.timedelta |
+            | Datatype       | float in seconds or hightime.timedelta |
             +----------------+----------------------------------------+
             | Permissions    | read-write                             |
             +----------------+----------------------------------------+

--- a/docs/nitclk/class.rst
+++ b/docs/nitclk/class.rst
@@ -197,7 +197,7 @@ finish_sync_pulse_sender_synchronize
             
 
 
-        :type min_time: float in seconds or hightime.timedelta
+        :type min_time: hightime.timedelta, datetime.timedelta, or float in seconds
 
 initiate
 --------
@@ -297,7 +297,7 @@ setup_for_sync_pulse_sender_synchronize
             
 
 
-        :type min_time: float in seconds or hightime.timedelta
+        :type min_time: hightime.timedelta, datetime.timedelta, or float in seconds
 
 synchronize
 -----------
@@ -339,7 +339,7 @@ synchronize
             
 
 
-        :type min_tclk_period: float in seconds or hightime.timedelta
+        :type min_tclk_period: hightime.timedelta, datetime.timedelta, or float in seconds
 
 synchronize_to_sync_pulse_sender
 --------------------------------
@@ -376,7 +376,7 @@ synchronize_to_sync_pulse_sender
             
 
 
-        :type min_time: float in seconds or hightime.timedelta
+        :type min_time: hightime.timedelta, datetime.timedelta, or float in seconds
 
 wait_until_done
 ---------------
@@ -417,7 +417,7 @@ wait_until_done
             
 
 
-        :type timeout: float in seconds or hightime.timedelta
+        :type timeout: hightime.timedelta, datetime.timedelta, or float in seconds
 
 
 SessionReference
@@ -597,17 +597,17 @@ sample_clock_delay
 
         The following table lists the characteristics of this property.
 
-            +----------------+----------------------------------------+
-            | Characteristic | Value                                  |
-            +================+========================================+
-            | Datatype       | float in seconds or hightime.timedelta |
-            +----------------+----------------------------------------+
-            | Permissions    | read-write                             |
-            +----------------+----------------------------------------+
-            | Channel Based  | No                                     |
-            +----------------+----------------------------------------+
-            | Resettable     | No                                     |
-            +----------------+----------------------------------------+
+            +----------------+-------------------------------------------------------------+
+            | Characteristic | Value                                                       |
+            +================+=============================================================+
+            | Datatype       | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +----------------+-------------------------------------------------------------+
+            | Permissions    | read-write                                                  |
+            +----------------+-------------------------------------------------------------+
+            | Channel Based  | No                                                          |
+            +----------------+-------------------------------------------------------------+
+            | Resettable     | No                                                          |
+            +----------------+-------------------------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:

--- a/generated/nidcpower/nidcpower/_attributes.py
+++ b/generated/nidcpower/nidcpower/_attributes.py
@@ -2,7 +2,7 @@
 # This file was generated
 import nidcpower._converters as _converters
 
-import datetime
+import hightime
 
 
 class Attribute(object):
@@ -24,7 +24,7 @@ class AttributeViInt32(Attribute):
 class AttributeViInt32TimeDeltaMilliseconds(Attribute):
 
     def __get__(self, session, session_type):
-        return datetime.timedelta(milliseconds=session._get_attribute_vi_int32(self._attribute_id))
+        return hightime.timedelta(milliseconds=session._get_attribute_vi_int32(self._attribute_id))
 
     def __set__(self, session, value):
         session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_milliseconds_int32(value).value)
@@ -51,7 +51,7 @@ class AttributeViReal64(Attribute):
 class AttributeViReal64TimeDeltaSeconds(Attribute):
 
     def __get__(self, session, session_type):
-        return datetime.timedelta(seconds=session._get_attribute_vi_real64(self._attribute_id))
+        return hightime.timedelta(seconds=session._get_attribute_vi_real64(self._attribute_id))
 
     def __set__(self, session, value):
         session._set_attribute_vi_real64(self._attribute_id, _converters.convert_timedelta_to_seconds_real64(value).value)

--- a/generated/nidcpower/nidcpower/_converters.py
+++ b/generated/nidcpower/nidcpower/_converters.py
@@ -5,8 +5,9 @@ import nidcpower.errors as errors
 
 import array
 import collections
-import datetime
+import hightime
 import numbers
+import pytest
 
 from functools import singledispatch
 
@@ -144,7 +145,7 @@ def convert_repeated_capabilities_without_prefix(repeated_capability):
 
 def _convert_timedelta(value, library_type, scaling):
     try:
-        # We first assume it is a datetime.timedelta object
+        # We first assume it is a timedelta object
         scaled_value = value.total_seconds() * scaling
     except AttributeError:
         # If that doesn't work, assume it is a value in seconds
@@ -171,7 +172,7 @@ def convert_timedeltas_to_seconds_real64(values):
 
 
 def convert_seconds_real64_to_timedelta(value):
-    return datetime.timedelta(seconds=value)
+    return hightime.timedelta(seconds=value)
 
 
 def convert_seconds_real64_to_timedeltas(values):
@@ -179,7 +180,7 @@ def convert_seconds_real64_to_timedeltas(values):
 
 
 def convert_month_to_timedelta(months):
-    return datetime.timedelta(days=(30.4167 * months))
+    return hightime.timedelta(days=(30.4167 * months))
 
 
 # This converter is not called from the normal codegen path for function. Instead it is
@@ -285,11 +286,11 @@ def test_convert_init_with_options_dictionary():
 
 # Tests - time
 def test_convert_timedelta_to_seconds_double():
-    test_result = convert_timedelta_to_seconds_real64(datetime.timedelta(seconds=10))
+    test_result = convert_timedelta_to_seconds_real64(hightime.timedelta(seconds=10))
     assert test_result.value == 10.0
     assert isinstance(test_result, _visatype.ViReal64)
-    test_result = convert_timedelta_to_seconds_real64(datetime.timedelta(seconds=-1))
-    assert test_result.value == -1
+    test_result = convert_timedelta_to_seconds_real64(hightime.timedelta(nanoseconds=-0.5))
+    assert test_result.value == pytest.approx(-5e-10)
     assert isinstance(test_result, _visatype.ViReal64)
     test_result = convert_timedelta_to_seconds_real64(10.5)
     assert test_result.value == 10.5
@@ -300,11 +301,11 @@ def test_convert_timedelta_to_seconds_double():
 
 
 def test_convert_timedelta_to_milliseconds_int32():
-    test_result = convert_timedelta_to_milliseconds_int32(datetime.timedelta(seconds=10))
+    test_result = convert_timedelta_to_milliseconds_int32(hightime.timedelta(seconds=10))
     assert test_result.value == 10000
     assert isinstance(test_result, _visatype.ViInt32)
-    test_result = convert_timedelta_to_milliseconds_int32(datetime.timedelta(seconds=-1))
-    assert test_result.value == -1000
+    test_result = convert_timedelta_to_milliseconds_int32(hightime.timedelta(seconds=-5))
+    assert test_result.value == -5000
     assert isinstance(test_result, _visatype.ViInt32)
     test_result = convert_timedelta_to_milliseconds_int32(10.5)
     assert test_result.value == 10500
@@ -315,26 +316,28 @@ def test_convert_timedelta_to_milliseconds_int32():
 
 
 def test_convert_timedeltas_to_seconds_real64():
-    time_values = [10.5, -1]
+    time_values = [10.5, -5e-10]
     test_result = convert_timedeltas_to_seconds_real64(time_values)
-    assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
+    assert all([actual.value == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
-    timedeltas = [datetime.timedelta(seconds=s, milliseconds=ms) for s, ms in zip([10, -1], [500, 0])]
-    test_result = convert_timedeltas_to_seconds_real64(timedeltas)
-    assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
+    test_input = [hightime.timedelta(seconds=10.5), hightime.timedelta(nanoseconds=-0.5)]
+    test_result = convert_timedeltas_to_seconds_real64(test_input)
+    assert all([actual.value == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
 
 
 def test_convert_seconds_real64_to_timedelta():
-    time_value = 10.5
-    timedelta = convert_seconds_real64_to_timedelta(time_value)
-    assert timedelta.total_seconds() == time_value
+    time_value = -5e-10
+    test_result = convert_seconds_real64_to_timedelta(time_value)
+    assert test_result.total_seconds() == pytest.approx(time_value)
+    assert isinstance(test_result, hightime.timedelta)
 
 
 def test_convert_seconds_real64_to_timedeltas():
-    time_values = [10.5, -1]
-    timedeltas = convert_seconds_real64_to_timedeltas(time_values)
-    assert all([actual.total_seconds() == expected for actual, expected in zip(timedeltas, time_values)])
+    time_values = [10.5, -5e-10]
+    test_result = convert_seconds_real64_to_timedeltas(time_values)
+    assert all([actual.total_seconds() == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
+    assert all([isinstance(x, hightime.timedelta) for x in test_result])
 
 
 # Tests - repeated capabilities

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -741,7 +741,7 @@ class _SessionBase(object):
     nidcpower.Session repeated capabilities container, and calling set/get value on the result.
     '''
     measure_complete_event_delay = _attributes.AttributeViReal64TimeDeltaSeconds(1150046)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
     Specifies the amount of time to delay the generation of the Measure Complete event, in seconds.
     for information about supported devices.
@@ -805,7 +805,7 @@ class _SessionBase(object):
     nidcpower.Session repeated capabilities container, and calling set/get value on the result.
     '''
     measure_record_delta_time = _attributes.AttributeViReal64TimeDeltaSeconds(1150065)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
     Queries the amount of time, in seconds, between between the start of two consecutive measurements in a measure record.  Only query this property after the desired measurement settings are committed.
     for information about supported devices.
@@ -1494,7 +1494,7 @@ class _SessionBase(object):
     nidcpower.Session repeated capabilities container, and calling set/get value on the result.
     '''
     pulse_off_time = _attributes.AttributeViReal64TimeDeltaSeconds(1150094)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
     Determines the length, in seconds, of the off phase of a pulse.
     Valid Values: 10 microseconds to 167 seconds
@@ -1509,7 +1509,7 @@ class _SessionBase(object):
     nidcpower.Session repeated capabilities container, and calling set/get value on the result.
     '''
     pulse_on_time = _attributes.AttributeViReal64TimeDeltaSeconds(1150093)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
     Determines the length, in seconds, of the on phase of a pulse.
     Valid Values: 10 microseconds to 167 seconds
@@ -2015,7 +2015,7 @@ class _SessionBase(object):
     nidcpower.Session repeated capabilities container, and calling set/get value on the result.
     '''
     source_delay = _attributes.AttributeViReal64TimeDeltaSeconds(1150051)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
     Determines when, in seconds, the device generates the Source Complete event, potentially starting a measurement if the  measure_when property is set to MeasureWhen.AUTOMATICALLY_AFTER_SOURCE_COMPLETE.
     Refer to the Single Point Source Mode and Sequence Source Mode topics for more information.
@@ -2514,7 +2514,7 @@ class _SessionBase(object):
         Args:
             count (int): Specifies the number of measurements to fetch.
 
-            timeout (float in seconds or hightime.timedelta): Specifies the maximum time allowed for this method to complete. If the method does not complete within this time interval, NI-DCPower returns an error.
+            timeout (hightime.timedelta, datetime.timedelta, or float in seconds): Specifies the maximum time allowed for this method to complete. If the method does not complete within this time interval, NI-DCPower returns an error.
 
                 Note: When setting the timeout interval, ensure you take into account any triggers so that the timeout interval is long enough for your application.
 
@@ -2603,7 +2603,7 @@ class _SessionBase(object):
         nidcpower.Session repeated capabilities container, and calling this method on the result.
 
         Args:
-            timeout (float in seconds or hightime.timedelta): Specifies the maximum time allowed for this method to complete, in
+            timeout (hightime.timedelta, datetime.timedelta, or float in seconds): Specifies the maximum time allowed for this method to complete, in
                 seconds. If the method does not complete within this time interval,
                 NI-DCPower returns an error.
 
@@ -5019,7 +5019,7 @@ class Session(_SessionBase):
                 Note:
                 One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
-            timeout (float in seconds or hightime.timedelta): Specifies the maximum time allowed for this method to complete, in
+            timeout (hightime.timedelta, datetime.timedelta, or float in seconds): Specifies the maximum time allowed for this method to complete, in
                 seconds. If the method does not complete within this time interval,
                 NI-DCPower returns an error.
 

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -2,7 +2,6 @@
 # This file was generated
 import array  # noqa: F401
 import ctypes
-import datetime  # noqa: F401
 # Used by @ivi_synchronized
 from functools import wraps
 
@@ -13,6 +12,7 @@ import nidcpower._visatype as _visatype
 import nidcpower.enums as enums
 import nidcpower.errors as errors
 
+import hightime
 
 # Used for __repr__
 import pprint
@@ -741,7 +741,7 @@ class _SessionBase(object):
     nidcpower.Session repeated capabilities container, and calling set/get value on the result.
     '''
     measure_complete_event_delay = _attributes.AttributeViReal64TimeDeltaSeconds(1150046)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     Specifies the amount of time to delay the generation of the Measure Complete event, in seconds.
     for information about supported devices.
@@ -805,7 +805,7 @@ class _SessionBase(object):
     nidcpower.Session repeated capabilities container, and calling set/get value on the result.
     '''
     measure_record_delta_time = _attributes.AttributeViReal64TimeDeltaSeconds(1150065)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     Queries the amount of time, in seconds, between between the start of two consecutive measurements in a measure record.  Only query this property after the desired measurement settings are committed.
     for information about supported devices.
@@ -1494,7 +1494,7 @@ class _SessionBase(object):
     nidcpower.Session repeated capabilities container, and calling set/get value on the result.
     '''
     pulse_off_time = _attributes.AttributeViReal64TimeDeltaSeconds(1150094)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     Determines the length, in seconds, of the off phase of a pulse.
     Valid Values: 10 microseconds to 167 seconds
@@ -1509,7 +1509,7 @@ class _SessionBase(object):
     nidcpower.Session repeated capabilities container, and calling set/get value on the result.
     '''
     pulse_on_time = _attributes.AttributeViReal64TimeDeltaSeconds(1150093)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     Determines the length, in seconds, of the on phase of a pulse.
     Valid Values: 10 microseconds to 167 seconds
@@ -2015,7 +2015,7 @@ class _SessionBase(object):
     nidcpower.Session repeated capabilities container, and calling set/get value on the result.
     '''
     source_delay = _attributes.AttributeViReal64TimeDeltaSeconds(1150051)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     Determines when, in seconds, the device generates the Source Complete event, potentially starting a measurement if the  measure_when property is set to MeasureWhen.AUTOMATICALLY_AFTER_SOURCE_COMPLETE.
     Refer to the Single Point Source Mode and Sequence Source Mode topics for more information.
@@ -2488,7 +2488,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def fetch_multiple(self, count, timeout=datetime.timedelta(seconds=1.0)):
+    def fetch_multiple(self, count, timeout=hightime.timedelta(seconds=1.0)):
         '''fetch_multiple
 
         Returns a list of named tuples (Measurement) that were
@@ -2514,7 +2514,7 @@ class _SessionBase(object):
         Args:
             count (int): Specifies the number of measurements to fetch.
 
-            timeout (float in seconds or datetime.timedelta): Specifies the maximum time allowed for this method to complete. If the method does not complete within this time interval, NI-DCPower returns an error.
+            timeout (float in seconds or hightime.timedelta): Specifies the maximum time allowed for this method to complete. If the method does not complete within this time interval, NI-DCPower returns an error.
 
                 Note: When setting the timeout interval, ensure you take into account any triggers so that the timeout interval is long enough for your application.
 
@@ -2603,7 +2603,7 @@ class _SessionBase(object):
         nidcpower.Session repeated capabilities container, and calling this method on the result.
 
         Args:
-            timeout (float in seconds or datetime.timedelta): Specifies the maximum time allowed for this method to complete, in
+            timeout (float in seconds or hightime.timedelta): Specifies the maximum time allowed for this method to complete, in
                 seconds. If the method does not complete within this time interval,
                 NI-DCPower returns an error.
 
@@ -4550,7 +4550,7 @@ class Session(_SessionBase):
         external calibrations.
 
         Returns:
-            months (datetime.timedelta): Specifies the recommended maximum interval, in **months**, between
+            months (hightime.timedelta): Specifies the recommended maximum interval, in **months**, between
                 external calibrations.
 
         '''
@@ -4567,11 +4567,11 @@ class Session(_SessionBase):
         Returns the date and time of the last successful calibration.
 
         Returns:
-            month (datetime.datetime): Indicates date and time of the last calibration.
+            month (hightime.datetime): Indicates date and time of the last calibration.
 
         '''
         year, month, day, hour, minute = self._get_ext_cal_last_date_and_time()
-        return datetime.datetime(year, month, day, hour, minute)
+        return hightime.datetime(year, month, day, hour, minute)
 
     @ivi_synchronized
     def get_self_cal_last_date_and_time(self):
@@ -4582,11 +4582,11 @@ class Session(_SessionBase):
         Note: This method is not supported on all devices.
 
         Returns:
-            month (datetime.datetime): Returns the date and time the device was last calibrated.
+            month (hightime.datetime): Returns the date and time the device was last calibrated.
 
         '''
         year, month, day, hour, minute = self._get_self_cal_last_date_and_time()
-        return datetime.datetime(year, month, day, hour, minute)
+        return hightime.datetime(year, month, day, hour, minute)
 
     @ivi_synchronized
     def _get_self_cal_last_date_and_time(self):
@@ -4982,7 +4982,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def wait_for_event(self, event_id, timeout=datetime.timedelta(seconds=10.0)):
+    def wait_for_event(self, event_id, timeout=hightime.timedelta(seconds=10.0)):
         r'''wait_for_event
 
         Waits until the device has generated the specified event.
@@ -5019,7 +5019,7 @@ class Session(_SessionBase):
                 Note:
                 One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
-            timeout (float in seconds or datetime.timedelta): Specifies the maximum time allowed for this method to complete, in
+            timeout (float in seconds or hightime.timedelta): Specifies the maximum time allowed for this method to complete, in
                 seconds. If the method does not complete within this time interval,
                 NI-DCPower returns an error.
 

--- a/generated/nidcpower/setup.py
+++ b/generated/nidcpower/setup.py
@@ -45,6 +45,7 @@ setup(
     install_requires=[
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
+        'hightime',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/nidcpower/tox-system_tests.ini
+++ b/generated/nidcpower/tox-system_tests.ini
@@ -37,6 +37,7 @@ deps =
     nidcpower-system_tests: pytest
     nidcpower-system_tests: coverage
     nidcpower-system_tests: numpy
+    nidcpower-system_tests: hightime
     nidcpower-system_tests: scipy
     nidcpower-system_tests: fasteners
     nidcpower-system_tests: pytest-json

--- a/generated/nidigital/nidigital/_attributes.py
+++ b/generated/nidigital/nidigital/_attributes.py
@@ -2,7 +2,7 @@
 # This file was generated
 import nidigital._converters as _converters
 
-import datetime
+import hightime
 
 
 class Attribute(object):
@@ -24,7 +24,7 @@ class AttributeViInt32(Attribute):
 class AttributeViInt32TimeDeltaMilliseconds(Attribute):
 
     def __get__(self, session, session_type):
-        return datetime.timedelta(milliseconds=session._get_attribute_vi_int32(self._attribute_id))
+        return hightime.timedelta(milliseconds=session._get_attribute_vi_int32(self._attribute_id))
 
     def __set__(self, session, value):
         session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_milliseconds_int32(value).value)
@@ -51,7 +51,7 @@ class AttributeViReal64(Attribute):
 class AttributeViReal64TimeDeltaSeconds(Attribute):
 
     def __get__(self, session, session_type):
-        return datetime.timedelta(seconds=session._get_attribute_vi_real64(self._attribute_id))
+        return hightime.timedelta(seconds=session._get_attribute_vi_real64(self._attribute_id))
 
     def __set__(self, session, value):
         session._set_attribute_vi_real64(self._attribute_id, _converters.convert_timedelta_to_seconds_real64(value).value)

--- a/generated/nidigital/nidigital/_converters.py
+++ b/generated/nidigital/nidigital/_converters.py
@@ -5,8 +5,9 @@ import nidigital.errors as errors
 
 import array
 import collections
-import datetime
+import hightime
 import numbers
+import pytest
 
 from functools import singledispatch
 
@@ -144,7 +145,7 @@ def convert_repeated_capabilities_without_prefix(repeated_capability):
 
 def _convert_timedelta(value, library_type, scaling):
     try:
-        # We first assume it is a datetime.timedelta object
+        # We first assume it is a timedelta object
         scaled_value = value.total_seconds() * scaling
     except AttributeError:
         # If that doesn't work, assume it is a value in seconds
@@ -171,7 +172,7 @@ def convert_timedeltas_to_seconds_real64(values):
 
 
 def convert_seconds_real64_to_timedelta(value):
-    return datetime.timedelta(seconds=value)
+    return hightime.timedelta(seconds=value)
 
 
 def convert_seconds_real64_to_timedeltas(values):
@@ -179,7 +180,7 @@ def convert_seconds_real64_to_timedeltas(values):
 
 
 def convert_month_to_timedelta(months):
-    return datetime.timedelta(days=(30.4167 * months))
+    return hightime.timedelta(days=(30.4167 * months))
 
 
 # This converter is not called from the normal codegen path for function. Instead it is
@@ -285,11 +286,11 @@ def test_convert_init_with_options_dictionary():
 
 # Tests - time
 def test_convert_timedelta_to_seconds_double():
-    test_result = convert_timedelta_to_seconds_real64(datetime.timedelta(seconds=10))
+    test_result = convert_timedelta_to_seconds_real64(hightime.timedelta(seconds=10))
     assert test_result.value == 10.0
     assert isinstance(test_result, _visatype.ViReal64)
-    test_result = convert_timedelta_to_seconds_real64(datetime.timedelta(seconds=-1))
-    assert test_result.value == -1
+    test_result = convert_timedelta_to_seconds_real64(hightime.timedelta(nanoseconds=-0.5))
+    assert test_result.value == pytest.approx(-5e-10)
     assert isinstance(test_result, _visatype.ViReal64)
     test_result = convert_timedelta_to_seconds_real64(10.5)
     assert test_result.value == 10.5
@@ -300,11 +301,11 @@ def test_convert_timedelta_to_seconds_double():
 
 
 def test_convert_timedelta_to_milliseconds_int32():
-    test_result = convert_timedelta_to_milliseconds_int32(datetime.timedelta(seconds=10))
+    test_result = convert_timedelta_to_milliseconds_int32(hightime.timedelta(seconds=10))
     assert test_result.value == 10000
     assert isinstance(test_result, _visatype.ViInt32)
-    test_result = convert_timedelta_to_milliseconds_int32(datetime.timedelta(seconds=-1))
-    assert test_result.value == -1000
+    test_result = convert_timedelta_to_milliseconds_int32(hightime.timedelta(seconds=-5))
+    assert test_result.value == -5000
     assert isinstance(test_result, _visatype.ViInt32)
     test_result = convert_timedelta_to_milliseconds_int32(10.5)
     assert test_result.value == 10500
@@ -315,26 +316,28 @@ def test_convert_timedelta_to_milliseconds_int32():
 
 
 def test_convert_timedeltas_to_seconds_real64():
-    time_values = [10.5, -1]
+    time_values = [10.5, -5e-10]
     test_result = convert_timedeltas_to_seconds_real64(time_values)
-    assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
+    assert all([actual.value == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
-    timedeltas = [datetime.timedelta(seconds=s, milliseconds=ms) for s, ms in zip([10, -1], [500, 0])]
-    test_result = convert_timedeltas_to_seconds_real64(timedeltas)
-    assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
+    test_input = [hightime.timedelta(seconds=10.5), hightime.timedelta(nanoseconds=-0.5)]
+    test_result = convert_timedeltas_to_seconds_real64(test_input)
+    assert all([actual.value == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
 
 
 def test_convert_seconds_real64_to_timedelta():
-    time_value = 10.5
-    timedelta = convert_seconds_real64_to_timedelta(time_value)
-    assert timedelta.total_seconds() == time_value
+    time_value = -5e-10
+    test_result = convert_seconds_real64_to_timedelta(time_value)
+    assert test_result.total_seconds() == pytest.approx(time_value)
+    assert isinstance(test_result, hightime.timedelta)
 
 
 def test_convert_seconds_real64_to_timedeltas():
-    time_values = [10.5, -1]
-    timedeltas = convert_seconds_real64_to_timedeltas(time_values)
-    assert all([actual.total_seconds() == expected for actual, expected in zip(timedeltas, time_values)])
+    time_values = [10.5, -5e-10]
+    test_result = convert_seconds_real64_to_timedeltas(time_values)
+    assert all([actual.total_seconds() == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
+    assert all([isinstance(x, hightime.timedelta) for x in test_result])
 
 
 # Tests - repeated capabilities

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -2,7 +2,6 @@
 # This file was generated
 import array  # noqa: F401
 import ctypes
-import datetime  # noqa: F401
 # Used by @ivi_synchronized
 from functools import wraps
 
@@ -15,6 +14,7 @@ import nidigital.errors as errors
 
 import nidigital.history_ram_cycle_information as history_ram_cycle_information  # noqa: F401
 
+import hightime
 import nitclk
 
 # Used for __repr__
@@ -234,7 +234,7 @@ class _SessionBase(object):
     '''
     exported_start_trigger_output_terminal = _attributes.AttributeViString(1150032)
     frequency_counter_measurement_time = _attributes.AttributeViReal64TimeDeltaSeconds(1150069)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     Tip:
     This property can use repeated capabilities. If set or get directly on the
@@ -438,7 +438,7 @@ class _SessionBase(object):
     supported_instrument_models = _attributes.AttributeViString(1050327)
     tdr_endpoint_termination = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.TDREndpointTermination, 1150081)
     tdr_offset = _attributes.AttributeViReal64TimeDeltaSeconds(1150051)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     Tip:
     This property can use repeated capabilities. If set or get directly on the
@@ -456,7 +456,7 @@ class _SessionBase(object):
     nidigital.Session repeated capabilities container, and calling set/get value on the result.
     '''
     timing_absolute_delay = _attributes.AttributeViReal64TimeDeltaSeconds(1150072)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     Tip:
     This property can use repeated capabilities. If set or get directly on the
@@ -616,7 +616,7 @@ class _SessionBase(object):
         nidigital.Session repeated capabilities container, and calling this method on the result.
 
         Args:
-            offsets (basic sequence of float in seconds or datetime.timedelta):
+            offsets (basic sequence of float in seconds or hightime.timedelta):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -628,7 +628,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _burst_pattern(self, start_label, select_digital_function=True, wait_until_done=True, timeout=datetime.timedelta(seconds=10.0)):
+    def _burst_pattern(self, start_label, select_digital_function=True, wait_until_done=True, timeout=hightime.timedelta(seconds=10.0)):
         r'''_burst_pattern
 
         TBD
@@ -646,7 +646,7 @@ class _SessionBase(object):
 
             wait_until_done (bool):
 
-            timeout (float in seconds or datetime.timedelta):
+            timeout (float in seconds or hightime.timedelta):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -765,7 +765,7 @@ class _SessionBase(object):
         Args:
             time_set_name (str):
 
-            strobe_edge (float in seconds or datetime.timedelta):
+            strobe_edge (float in seconds or hightime.timedelta):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -791,9 +791,9 @@ class _SessionBase(object):
         Args:
             time_set_name (str):
 
-            strobe_edge (float in seconds or datetime.timedelta):
+            strobe_edge (float in seconds or hightime.timedelta):
 
-            strobe2_edge (float in seconds or datetime.timedelta):
+            strobe2_edge (float in seconds or hightime.timedelta):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -822,13 +822,13 @@ class _SessionBase(object):
 
             format (enums.DriveFormat):
 
-            drive_on_edge (float in seconds or datetime.timedelta):
+            drive_on_edge (float in seconds or hightime.timedelta):
 
-            drive_data_edge (float in seconds or datetime.timedelta):
+            drive_data_edge (float in seconds or hightime.timedelta):
 
-            drive_return_edge (float in seconds or datetime.timedelta):
+            drive_return_edge (float in seconds or hightime.timedelta):
 
-            drive_off_edge (float in seconds or datetime.timedelta):
+            drive_off_edge (float in seconds or hightime.timedelta):
 
         '''
         if type(format) is not enums.DriveFormat:
@@ -862,17 +862,17 @@ class _SessionBase(object):
 
             format (enums.DriveFormat):
 
-            drive_on_edge (float in seconds or datetime.timedelta):
+            drive_on_edge (float in seconds or hightime.timedelta):
 
-            drive_data_edge (float in seconds or datetime.timedelta):
+            drive_data_edge (float in seconds or hightime.timedelta):
 
-            drive_return_edge (float in seconds or datetime.timedelta):
+            drive_return_edge (float in seconds or hightime.timedelta):
 
-            drive_off_edge (float in seconds or datetime.timedelta):
+            drive_off_edge (float in seconds or hightime.timedelta):
 
-            drive_data2_edge (float in seconds or datetime.timedelta):
+            drive_data2_edge (float in seconds or hightime.timedelta):
 
-            drive_return2_edge (float in seconds or datetime.timedelta):
+            drive_return2_edge (float in seconds or hightime.timedelta):
 
         '''
         if type(format) is not enums.DriveFormat:
@@ -936,7 +936,7 @@ class _SessionBase(object):
 
             edge (enums.TimeSetEdgeType):
 
-            time (float in seconds or datetime.timedelta):
+            time (float in seconds or hightime.timedelta):
 
         '''
         if type(edge) is not enums.TimeSetEdgeType:
@@ -1166,7 +1166,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def burst_pattern(self, start_label, select_digital_function=True, wait_until_done=True, timeout=datetime.timedelta(seconds=10.0)):
+    def burst_pattern(self, start_label, select_digital_function=True, wait_until_done=True, timeout=hightime.timedelta(seconds=10.0)):
         '''burst_pattern
 
         Uses the start_label you specify to burst the pattern on the sites you specify. If you
@@ -1188,7 +1188,7 @@ class _SessionBase(object):
 
             wait_until_done (bool):
 
-            timeout (float in seconds or datetime.timedelta):
+            timeout (float in seconds or hightime.timedelta):
 
 
         Returns:
@@ -1229,7 +1229,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return data_array, actual_num_waveforms_ctype.value, actual_samples_per_waveform_ctype.value  # (modified)
 
-    def fetch_capture_waveform(self, waveform_name, samples_to_read, timeout=datetime.timedelta(seconds=10.0)):
+    def fetch_capture_waveform(self, waveform_name, samples_to_read, timeout=hightime.timedelta(seconds=10.0)):
         '''fetch_capture_waveform
 
         Returns dictionary where each key is a site number and value is a collection of digital states representing capture waveform data
@@ -1245,7 +1245,7 @@ class _SessionBase(object):
 
             samples_to_read (int):
 
-            timeout (float or datetime.timedelta):
+            timeout (float in seconds or hightime.timedelta):
 
 
         Returns:
@@ -2139,7 +2139,7 @@ class _SessionBase(object):
 
 
         Returns:
-            time (datetime.timedelta):
+            time (hightime.timedelta):
 
         '''
         if type(edge) is not enums.TimeSetEdgeType:
@@ -2507,7 +2507,7 @@ class _SessionBase(object):
 
 
         Returns:
-            offsets (list of datetime.timedelta):
+            offsets (list of hightime.timedelta):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -2759,7 +2759,7 @@ class Session(_SessionBase):
         Args:
             time_set_name (str):
 
-            period (float in seconds or datetime.timedelta):
+            period (float in seconds or hightime.timedelta):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -2989,7 +2989,7 @@ class Session(_SessionBase):
 
 
         Returns:
-            period (datetime.timedelta):
+            period (hightime.timedelta):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -3274,13 +3274,13 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def wait_until_done(self, timeout=datetime.timedelta(seconds=10.0)):
+    def wait_until_done(self, timeout=hightime.timedelta(seconds=10.0)):
         r'''wait_until_done
 
         TBD
 
         Args:
-            timeout (float in seconds or datetime.timedelta):
+            timeout (float in seconds or hightime.timedelta):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -234,7 +234,7 @@ class _SessionBase(object):
     '''
     exported_start_trigger_output_terminal = _attributes.AttributeViString(1150032)
     frequency_counter_measurement_time = _attributes.AttributeViReal64TimeDeltaSeconds(1150069)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
     Tip:
     This property can use repeated capabilities. If set or get directly on the
@@ -438,7 +438,7 @@ class _SessionBase(object):
     supported_instrument_models = _attributes.AttributeViString(1050327)
     tdr_endpoint_termination = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.TDREndpointTermination, 1150081)
     tdr_offset = _attributes.AttributeViReal64TimeDeltaSeconds(1150051)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
     Tip:
     This property can use repeated capabilities. If set or get directly on the
@@ -456,7 +456,7 @@ class _SessionBase(object):
     nidigital.Session repeated capabilities container, and calling set/get value on the result.
     '''
     timing_absolute_delay = _attributes.AttributeViReal64TimeDeltaSeconds(1150072)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
     Tip:
     This property can use repeated capabilities. If set or get directly on the
@@ -616,7 +616,7 @@ class _SessionBase(object):
         nidigital.Session repeated capabilities container, and calling this method on the result.
 
         Args:
-            offsets (basic sequence of float in seconds or hightime.timedelta):
+            offsets (basic sequence of hightime.timedelta, datetime.timedelta, or float in seconds):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -646,7 +646,7 @@ class _SessionBase(object):
 
             wait_until_done (bool):
 
-            timeout (float in seconds or hightime.timedelta):
+            timeout (hightime.timedelta, datetime.timedelta, or float in seconds):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -765,7 +765,7 @@ class _SessionBase(object):
         Args:
             time_set_name (str):
 
-            strobe_edge (float in seconds or hightime.timedelta):
+            strobe_edge (hightime.timedelta, datetime.timedelta, or float in seconds):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -791,9 +791,9 @@ class _SessionBase(object):
         Args:
             time_set_name (str):
 
-            strobe_edge (float in seconds or hightime.timedelta):
+            strobe_edge (hightime.timedelta, datetime.timedelta, or float in seconds):
 
-            strobe2_edge (float in seconds or hightime.timedelta):
+            strobe2_edge (hightime.timedelta, datetime.timedelta, or float in seconds):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -822,13 +822,13 @@ class _SessionBase(object):
 
             format (enums.DriveFormat):
 
-            drive_on_edge (float in seconds or hightime.timedelta):
+            drive_on_edge (hightime.timedelta, datetime.timedelta, or float in seconds):
 
-            drive_data_edge (float in seconds or hightime.timedelta):
+            drive_data_edge (hightime.timedelta, datetime.timedelta, or float in seconds):
 
-            drive_return_edge (float in seconds or hightime.timedelta):
+            drive_return_edge (hightime.timedelta, datetime.timedelta, or float in seconds):
 
-            drive_off_edge (float in seconds or hightime.timedelta):
+            drive_off_edge (hightime.timedelta, datetime.timedelta, or float in seconds):
 
         '''
         if type(format) is not enums.DriveFormat:
@@ -862,17 +862,17 @@ class _SessionBase(object):
 
             format (enums.DriveFormat):
 
-            drive_on_edge (float in seconds or hightime.timedelta):
+            drive_on_edge (hightime.timedelta, datetime.timedelta, or float in seconds):
 
-            drive_data_edge (float in seconds or hightime.timedelta):
+            drive_data_edge (hightime.timedelta, datetime.timedelta, or float in seconds):
 
-            drive_return_edge (float in seconds or hightime.timedelta):
+            drive_return_edge (hightime.timedelta, datetime.timedelta, or float in seconds):
 
-            drive_off_edge (float in seconds or hightime.timedelta):
+            drive_off_edge (hightime.timedelta, datetime.timedelta, or float in seconds):
 
-            drive_data2_edge (float in seconds or hightime.timedelta):
+            drive_data2_edge (hightime.timedelta, datetime.timedelta, or float in seconds):
 
-            drive_return2_edge (float in seconds or hightime.timedelta):
+            drive_return2_edge (hightime.timedelta, datetime.timedelta, or float in seconds):
 
         '''
         if type(format) is not enums.DriveFormat:
@@ -936,7 +936,7 @@ class _SessionBase(object):
 
             edge (enums.TimeSetEdgeType):
 
-            time (float in seconds or hightime.timedelta):
+            time (hightime.timedelta, datetime.timedelta, or float in seconds):
 
         '''
         if type(edge) is not enums.TimeSetEdgeType:
@@ -1188,7 +1188,7 @@ class _SessionBase(object):
 
             wait_until_done (bool):
 
-            timeout (float in seconds or hightime.timedelta):
+            timeout (hightime.timedelta, datetime.timedelta, or float in seconds):
 
 
         Returns:
@@ -1245,7 +1245,7 @@ class _SessionBase(object):
 
             samples_to_read (int):
 
-            timeout (float in seconds or hightime.timedelta):
+            timeout (hightime.timedelta, datetime.timedelta, or float in seconds):
 
 
         Returns:
@@ -2759,7 +2759,7 @@ class Session(_SessionBase):
         Args:
             time_set_name (str):
 
-            period (float in seconds or hightime.timedelta):
+            period (hightime.timedelta, datetime.timedelta, or float in seconds):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -3280,7 +3280,7 @@ class Session(_SessionBase):
         TBD
 
         Args:
-            timeout (float in seconds or hightime.timedelta):
+            timeout (hightime.timedelta, datetime.timedelta, or float in seconds):
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110

--- a/generated/nidigital/setup.py
+++ b/generated/nidigital/setup.py
@@ -45,6 +45,7 @@ setup(
     install_requires=[
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
+        'hightime',
         'nitclk',
     ],
     setup_requires=['pytest-runner', ],

--- a/generated/nidigital/tox-system_tests.ini
+++ b/generated/nidigital/tox-system_tests.ini
@@ -44,6 +44,7 @@ deps =
     nidigital-system_tests: pytest
     nidigital-system_tests: coverage
     nidigital-system_tests: numpy
+    nidigital-system_tests: hightime
     nidigital-system_tests: scipy
     nidigital-system_tests: fasteners
     nidigital-system_tests: pytest-json

--- a/generated/nidmm/nidmm/_attributes.py
+++ b/generated/nidmm/nidmm/_attributes.py
@@ -2,7 +2,7 @@
 # This file was generated
 import nidmm._converters as _converters
 
-import datetime
+import hightime
 
 
 class Attribute(object):
@@ -24,7 +24,7 @@ class AttributeViInt32(Attribute):
 class AttributeViInt32TimeDeltaMilliseconds(Attribute):
 
     def __get__(self, session, session_type):
-        return datetime.timedelta(milliseconds=session._get_attribute_vi_int32(self._attribute_id))
+        return hightime.timedelta(milliseconds=session._get_attribute_vi_int32(self._attribute_id))
 
     def __set__(self, session, value):
         session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_milliseconds_int32(value).value)
@@ -51,7 +51,7 @@ class AttributeViReal64(Attribute):
 class AttributeViReal64TimeDeltaSeconds(Attribute):
 
     def __get__(self, session, session_type):
-        return datetime.timedelta(seconds=session._get_attribute_vi_real64(self._attribute_id))
+        return hightime.timedelta(seconds=session._get_attribute_vi_real64(self._attribute_id))
 
     def __set__(self, session, value):
         session._set_attribute_vi_real64(self._attribute_id, _converters.convert_timedelta_to_seconds_real64(value).value)

--- a/generated/nidmm/nidmm/_converters.py
+++ b/generated/nidmm/nidmm/_converters.py
@@ -5,8 +5,9 @@ import nidmm.errors as errors
 
 import array
 import collections
-import datetime
+import hightime
 import numbers
+import pytest
 
 from functools import singledispatch
 
@@ -144,7 +145,7 @@ def convert_repeated_capabilities_without_prefix(repeated_capability):
 
 def _convert_timedelta(value, library_type, scaling):
     try:
-        # We first assume it is a datetime.timedelta object
+        # We first assume it is a timedelta object
         scaled_value = value.total_seconds() * scaling
     except AttributeError:
         # If that doesn't work, assume it is a value in seconds
@@ -171,7 +172,7 @@ def convert_timedeltas_to_seconds_real64(values):
 
 
 def convert_seconds_real64_to_timedelta(value):
-    return datetime.timedelta(seconds=value)
+    return hightime.timedelta(seconds=value)
 
 
 def convert_seconds_real64_to_timedeltas(values):
@@ -179,7 +180,7 @@ def convert_seconds_real64_to_timedeltas(values):
 
 
 def convert_month_to_timedelta(months):
-    return datetime.timedelta(days=(30.4167 * months))
+    return hightime.timedelta(days=(30.4167 * months))
 
 
 # This converter is not called from the normal codegen path for function. Instead it is
@@ -285,11 +286,11 @@ def test_convert_init_with_options_dictionary():
 
 # Tests - time
 def test_convert_timedelta_to_seconds_double():
-    test_result = convert_timedelta_to_seconds_real64(datetime.timedelta(seconds=10))
+    test_result = convert_timedelta_to_seconds_real64(hightime.timedelta(seconds=10))
     assert test_result.value == 10.0
     assert isinstance(test_result, _visatype.ViReal64)
-    test_result = convert_timedelta_to_seconds_real64(datetime.timedelta(seconds=-1))
-    assert test_result.value == -1
+    test_result = convert_timedelta_to_seconds_real64(hightime.timedelta(nanoseconds=-0.5))
+    assert test_result.value == pytest.approx(-5e-10)
     assert isinstance(test_result, _visatype.ViReal64)
     test_result = convert_timedelta_to_seconds_real64(10.5)
     assert test_result.value == 10.5
@@ -300,11 +301,11 @@ def test_convert_timedelta_to_seconds_double():
 
 
 def test_convert_timedelta_to_milliseconds_int32():
-    test_result = convert_timedelta_to_milliseconds_int32(datetime.timedelta(seconds=10))
+    test_result = convert_timedelta_to_milliseconds_int32(hightime.timedelta(seconds=10))
     assert test_result.value == 10000
     assert isinstance(test_result, _visatype.ViInt32)
-    test_result = convert_timedelta_to_milliseconds_int32(datetime.timedelta(seconds=-1))
-    assert test_result.value == -1000
+    test_result = convert_timedelta_to_milliseconds_int32(hightime.timedelta(seconds=-5))
+    assert test_result.value == -5000
     assert isinstance(test_result, _visatype.ViInt32)
     test_result = convert_timedelta_to_milliseconds_int32(10.5)
     assert test_result.value == 10500
@@ -315,26 +316,28 @@ def test_convert_timedelta_to_milliseconds_int32():
 
 
 def test_convert_timedeltas_to_seconds_real64():
-    time_values = [10.5, -1]
+    time_values = [10.5, -5e-10]
     test_result = convert_timedeltas_to_seconds_real64(time_values)
-    assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
+    assert all([actual.value == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
-    timedeltas = [datetime.timedelta(seconds=s, milliseconds=ms) for s, ms in zip([10, -1], [500, 0])]
-    test_result = convert_timedeltas_to_seconds_real64(timedeltas)
-    assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
+    test_input = [hightime.timedelta(seconds=10.5), hightime.timedelta(nanoseconds=-0.5)]
+    test_result = convert_timedeltas_to_seconds_real64(test_input)
+    assert all([actual.value == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
 
 
 def test_convert_seconds_real64_to_timedelta():
-    time_value = 10.5
-    timedelta = convert_seconds_real64_to_timedelta(time_value)
-    assert timedelta.total_seconds() == time_value
+    time_value = -5e-10
+    test_result = convert_seconds_real64_to_timedelta(time_value)
+    assert test_result.total_seconds() == pytest.approx(time_value)
+    assert isinstance(test_result, hightime.timedelta)
 
 
 def test_convert_seconds_real64_to_timedeltas():
-    time_values = [10.5, -1]
-    timedeltas = convert_seconds_real64_to_timedeltas(time_values)
-    assert all([actual.total_seconds() == expected for actual, expected in zip(timedeltas, time_values)])
+    time_values = [10.5, -5e-10]
+    test_result = convert_seconds_real64_to_timedeltas(time_values)
+    assert all([actual.total_seconds() == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
+    assert all([isinstance(x, hightime.timedelta) for x in test_result])
 
 
 # Tests - repeated capabilities

--- a/generated/nidmm/nidmm/session.py
+++ b/generated/nidmm/nidmm/session.py
@@ -2,7 +2,6 @@
 # This file was generated
 import array  # noqa: F401
 import ctypes
-import datetime  # noqa: F401
 # Used by @ivi_synchronized
 from functools import wraps
 
@@ -13,6 +12,7 @@ import nidmm._visatype as _visatype
 import nidmm.enums as enums
 import nidmm.errors as errors
 
+import hightime
 
 # Used for __repr__
 import pprint
@@ -320,7 +320,7 @@ class _SessionBase(object):
     Specifies the number of measurements the DMM takes each time it receives a  trigger in a multiple point acquisition.
     '''
     sample_interval = _attributes.AttributeViReal64TimeDeltaSeconds(1250303)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     Specifies the amount of time in seconds the DMM waits between measurement cycles.  This property only applies when the sample_trigger property is set to INTERVAL.
     On the NI 4060, the value for this property is used as the settling time.  When this property is set to 0, the NI 4060 does not settle between  measurement cycles. The onboard timing resolution is 1 µs on the NI 4060.
@@ -340,7 +340,7 @@ class _SessionBase(object):
     A string containing the serial number of the instrument. This property corresponds  to the serial number label that is attached to most products.
     '''
     settle_time = _attributes.AttributeViReal64TimeDeltaSeconds(1150028)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     Specifies the settling time in seconds. To override the default settling time,  set this property. To return to the default, set this property to  NIDMM_VAL_SETTLE_TIME_AUTO (-1).
     The NI 4050 and NI 4060 are not supported.
@@ -479,7 +479,7 @@ class _SessionBase(object):
     Refer to the Multiple Point Acquisitions section of the NI Digital Multimeters Help for more information.
     '''
     trigger_delay = _attributes.AttributeViReal64TimeDeltaSeconds(1250005)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     Specifies the time (in seconds) that the DMM waits after it has received a trigger before taking a measurement.  The default value is AUTO DELAY (-1), which means that the DMM waits an appropriate settling time before taking  the measurement. (-1) signifies that AUTO DELAY is on, and (-2) signifies that AUTO DELAY is off.
     The NI 4065 and NI 4070/4071/4072 use the value specified in this property as additional settling time.  For the The NI 4065 and NI 4070/4071/4072, the valid range for Trigger Delay is AUTO DELAY (-1) or 0.0-149.0  seconds and the onboard timing resolution is 34.72 ns.
@@ -1347,7 +1347,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_multi_point(self, trigger_count, sample_count, sample_trigger=enums.SampleTrigger.IMMEDIATE, sample_interval=datetime.timedelta(seconds=-1)):
+    def configure_multi_point(self, trigger_count, sample_count, sample_trigger=enums.SampleTrigger.IMMEDIATE, sample_interval=hightime.timedelta(seconds=-1)):
         r'''configure_multi_point
 
         Configures the properties for multipoint measurements. These properties
@@ -1379,7 +1379,7 @@ class Session(_SessionBase):
                 `LabWindows/CVI Trigger
                 Routing <REPLACE_DRIVER_SPECIFIC_URL_1(cvitrigger_routing)>`__ section.
 
-            sample_interval (float in seconds or datetime.timedelta): Sets the amount of time in seconds the DMM waits between measurement
+            sample_interval (float in seconds or hightime.timedelta): Sets the amount of time in seconds the DMM waits between measurement
                 cycles. The driver sets sample_interval to this value.
                 Specify a sample interval to add settling time between measurement
                 cycles or to decrease the measurement rate. **sample_interval** only
@@ -1566,7 +1566,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_trigger(self, trigger_source, trigger_delay=datetime.timedelta(seconds=-1)):
+    def configure_trigger(self, trigger_source, trigger_delay=hightime.timedelta(seconds=-1)):
         r'''configure_trigger
 
         Configures the DMM **Trigger_Source** and **Trigger_Delay**. Refer to
@@ -1585,7 +1585,7 @@ class Session(_SessionBase):
                 `LabWindows/CVI Trigger
                 Routing <REPLACE_DRIVER_SPECIFIC_URL_1(cvitrigger_routing)>`__ section.
 
-            trigger_delay (float in seconds or datetime.timedelta): Specifies the time that the DMM waits after it has received a trigger
+            trigger_delay (float in seconds or hightime.timedelta): Specifies the time that the DMM waits after it has received a trigger
                 before taking a measurement. The driver sets the
                 trigger_delay property to this value. By default,
                 **trigger_delay** is NIDMM_VAL_AUTO_DELAY (-1), which means the DMM
@@ -1792,14 +1792,14 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def fetch(self, maximum_time=datetime.timedelta(milliseconds=-1)):
+    def fetch(self, maximum_time=hightime.timedelta(milliseconds=-1)):
         r'''fetch
 
         Returns the value from a previously initiated measurement. You must call
         _initiate before calling this method.
 
         Args:
-            maximum_time (int in milliseconds or datetime.timedelta): Specifies the **maximum_time** allowed for this method to complete in
+            maximum_time (int in milliseconds or hightime.timedelta): Specifies the **maximum_time** allowed for this method to complete in
                 milliseconds. If the method does not complete within this time
                 interval, the method returns the NIDMM_ERROR_MAX_TIME_EXCEEDED
                 error code. This may happen if an external trigger has not been
@@ -1826,7 +1826,7 @@ class Session(_SessionBase):
         return float(reading_ctype.value)
 
     @ivi_synchronized
-    def fetch_multi_point(self, array_size, maximum_time=datetime.timedelta(milliseconds=-1)):
+    def fetch_multi_point(self, array_size, maximum_time=hightime.timedelta(milliseconds=-1)):
         r'''fetch_multi_point
 
         Returns an array of values from a previously initiated multipoint
@@ -1844,7 +1844,7 @@ class Session(_SessionBase):
                 once. The number of measurements can be a subset. The valid range is any
                 positive ViInt32. The default value is 1.
 
-            maximum_time (int in milliseconds or datetime.timedelta): Specifies the **maximum_time** allowed for this method to complete in
+            maximum_time (int in milliseconds or hightime.timedelta): Specifies the **maximum_time** allowed for this method to complete in
                 milliseconds. If the method does not complete within this time
                 interval, the method returns the NIDMM_ERROR_MAX_TIME_EXCEEDED
                 error code. This may happen if an external trigger has not been
@@ -1881,7 +1881,7 @@ class Session(_SessionBase):
         return reading_array_array
 
     @ivi_synchronized
-    def fetch_waveform(self, array_size, maximum_time=datetime.timedelta(milliseconds=-1)):
+    def fetch_waveform(self, array_size, maximum_time=hightime.timedelta(milliseconds=-1)):
         r'''fetch_waveform
 
         For the NI 4080/4081/4082 and the NI 4070/4071/4072, returns an array of
@@ -1894,7 +1894,7 @@ class Session(_SessionBase):
                 parameter of configure_waveform_acquisition. The default value is
                 1.
 
-            maximum_time (int in milliseconds or datetime.timedelta): Specifies the **maximum_time** allowed for this method to complete in
+            maximum_time (int in milliseconds or hightime.timedelta): Specifies the **maximum_time** allowed for this method to complete in
                 milliseconds. If the method does not complete within this time
                 interval, the method returns the NIDMM_ERROR_MAX_TIME_EXCEEDED
                 error code. This may happen if an external trigger has not been
@@ -1928,7 +1928,7 @@ class Session(_SessionBase):
         return waveform_array_array
 
     @ivi_synchronized
-    def fetch_waveform_into(self, waveform_array, maximum_time=datetime.timedelta(milliseconds=-1)):
+    def fetch_waveform_into(self, waveform_array, maximum_time=hightime.timedelta(milliseconds=-1)):
         r'''fetch_waveform
 
         For the NI 4080/4081/4082 and the NI 4070/4071/4072, returns an array of
@@ -1939,7 +1939,7 @@ class Session(_SessionBase):
             waveform_array (numpy.array(dtype=numpy.float64)): **Waveform Array** is an array of measurement values stored in waveform
                 data type.
 
-            maximum_time (int in milliseconds or datetime.timedelta): Specifies the **maximum_time** allowed for this method to complete in
+            maximum_time (int in milliseconds or hightime.timedelta): Specifies the **maximum_time** allowed for this method to complete in
                 milliseconds. If the method does not complete within this time
                 interval, the method returns the NIDMM_ERROR_MAX_TIME_EXCEEDED
                 error code. This may happen if an external trigger has not been
@@ -2060,7 +2060,7 @@ class Session(_SessionBase):
         Note: The NI 4050 and NI 4060 are not supported.
 
         Returns:
-            months (datetime.timedelta): Returns the recommended number of **months** between external
+            months (hightime.timedelta): Returns the recommended number of **months** between external
                 calibrations.
 
         '''
@@ -2094,11 +2094,11 @@ class Session(_SessionBase):
 
 
         Returns:
-            month (datetime.datetime): Indicates date and time of the last calibration.
+            month (hightime.datetime): Indicates date and time of the last calibration.
 
         '''
         month, day, year, hour, minute = self._get_cal_date_and_time(cal_type)
-        return datetime.datetime(year, month, day, hour, minute)
+        return hightime.datetime(year, month, day, hour, minute)
 
     @ivi_synchronized
     def get_last_cal_temp(self, cal_type):
@@ -2451,13 +2451,13 @@ class Session(_SessionBase):
         return float(resistance_ctype.value), float(reactance_ctype.value)
 
     @ivi_synchronized
-    def read(self, maximum_time=datetime.timedelta(milliseconds=-1)):
+    def read(self, maximum_time=hightime.timedelta(milliseconds=-1)):
         r'''read
 
         Acquires a single measurement and returns the measured value.
 
         Args:
-            maximum_time (int in milliseconds or datetime.timedelta): Specifies the **maximum_time** allowed for this method to complete in
+            maximum_time (int in milliseconds or hightime.timedelta): Specifies the **maximum_time** allowed for this method to complete in
                 milliseconds. If the method does not complete within this time
                 interval, the method returns the NIDMM_ERROR_MAX_TIME_EXCEEDED
                 error code. This may happen if an external trigger has not been
@@ -2484,7 +2484,7 @@ class Session(_SessionBase):
         return float(reading_ctype.value)
 
     @ivi_synchronized
-    def read_multi_point(self, array_size, maximum_time=datetime.timedelta(milliseconds=-1)):
+    def read_multi_point(self, array_size, maximum_time=hightime.timedelta(milliseconds=-1)):
         r'''read_multi_point
 
         Acquires multiple measurements and returns an array of measured values.
@@ -2501,7 +2501,7 @@ class Session(_SessionBase):
                 once. The number of measurements can be a subset. The valid range is any
                 positive ViInt32. The default value is 1.
 
-            maximum_time (int in milliseconds or datetime.timedelta): Specifies the **maximum_time** allowed for this method to complete in
+            maximum_time (int in milliseconds or hightime.timedelta): Specifies the **maximum_time** allowed for this method to complete in
                 milliseconds. If the method does not complete within this time
                 interval, the method returns the NIDMM_ERROR_MAX_TIME_EXCEEDED
                 error code. This may happen if an external trigger has not been
@@ -2583,7 +2583,7 @@ class Session(_SessionBase):
         return int(acquisition_backlog_ctype.value), enums.AcquisitionStatus(acquisition_status_ctype.value)
 
     @ivi_synchronized
-    def read_waveform(self, array_size, maximum_time=datetime.timedelta(milliseconds=-1)):
+    def read_waveform(self, array_size, maximum_time=hightime.timedelta(milliseconds=-1)):
         r'''read_waveform
 
         For the NI 4080/4081/4082 and the NI 4070/4071/4072, acquires a waveform
@@ -2598,7 +2598,7 @@ class Session(_SessionBase):
                 parameter of configure_waveform_acquisition. The default value is
                 1.
 
-            maximum_time (int in milliseconds or datetime.timedelta): Specifies the **maximum_time** allowed for this method to complete in
+            maximum_time (int in milliseconds or hightime.timedelta): Specifies the **maximum_time** allowed for this method to complete in
                 milliseconds. If the method does not complete within this time
                 interval, the method returns the NIDMM_ERROR_MAX_TIME_EXCEEDED
                 error code. This may happen if an external trigger has not been

--- a/generated/nidmm/nidmm/session.py
+++ b/generated/nidmm/nidmm/session.py
@@ -320,7 +320,7 @@ class _SessionBase(object):
     Specifies the number of measurements the DMM takes each time it receives a  trigger in a multiple point acquisition.
     '''
     sample_interval = _attributes.AttributeViReal64TimeDeltaSeconds(1250303)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
     Specifies the amount of time in seconds the DMM waits between measurement cycles.  This property only applies when the sample_trigger property is set to INTERVAL.
     On the NI 4060, the value for this property is used as the settling time.  When this property is set to 0, the NI 4060 does not settle between  measurement cycles. The onboard timing resolution is 1 µs on the NI 4060.
@@ -340,7 +340,7 @@ class _SessionBase(object):
     A string containing the serial number of the instrument. This property corresponds  to the serial number label that is attached to most products.
     '''
     settle_time = _attributes.AttributeViReal64TimeDeltaSeconds(1150028)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
     Specifies the settling time in seconds. To override the default settling time,  set this property. To return to the default, set this property to  NIDMM_VAL_SETTLE_TIME_AUTO (-1).
     The NI 4050 and NI 4060 are not supported.
@@ -479,7 +479,7 @@ class _SessionBase(object):
     Refer to the Multiple Point Acquisitions section of the NI Digital Multimeters Help for more information.
     '''
     trigger_delay = _attributes.AttributeViReal64TimeDeltaSeconds(1250005)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
     Specifies the time (in seconds) that the DMM waits after it has received a trigger before taking a measurement.  The default value is AUTO DELAY (-1), which means that the DMM waits an appropriate settling time before taking  the measurement. (-1) signifies that AUTO DELAY is on, and (-2) signifies that AUTO DELAY is off.
     The NI 4065 and NI 4070/4071/4072 use the value specified in this property as additional settling time.  For the The NI 4065 and NI 4070/4071/4072, the valid range for Trigger Delay is AUTO DELAY (-1) or 0.0-149.0  seconds and the onboard timing resolution is 34.72 ns.
@@ -1379,7 +1379,7 @@ class Session(_SessionBase):
                 `LabWindows/CVI Trigger
                 Routing <REPLACE_DRIVER_SPECIFIC_URL_1(cvitrigger_routing)>`__ section.
 
-            sample_interval (float in seconds or hightime.timedelta): Sets the amount of time in seconds the DMM waits between measurement
+            sample_interval (hightime.timedelta, datetime.timedelta, or float in seconds): Sets the amount of time in seconds the DMM waits between measurement
                 cycles. The driver sets sample_interval to this value.
                 Specify a sample interval to add settling time between measurement
                 cycles or to decrease the measurement rate. **sample_interval** only
@@ -1585,7 +1585,7 @@ class Session(_SessionBase):
                 `LabWindows/CVI Trigger
                 Routing <REPLACE_DRIVER_SPECIFIC_URL_1(cvitrigger_routing)>`__ section.
 
-            trigger_delay (float in seconds or hightime.timedelta): Specifies the time that the DMM waits after it has received a trigger
+            trigger_delay (hightime.timedelta, datetime.timedelta, or float in seconds): Specifies the time that the DMM waits after it has received a trigger
                 before taking a measurement. The driver sets the
                 trigger_delay property to this value. By default,
                 **trigger_delay** is NIDMM_VAL_AUTO_DELAY (-1), which means the DMM
@@ -1799,7 +1799,7 @@ class Session(_SessionBase):
         _initiate before calling this method.
 
         Args:
-            maximum_time (int in milliseconds or hightime.timedelta): Specifies the **maximum_time** allowed for this method to complete in
+            maximum_time (hightime.timedelta, datetime.timedelta, or int in milliseconds): Specifies the **maximum_time** allowed for this method to complete in
                 milliseconds. If the method does not complete within this time
                 interval, the method returns the NIDMM_ERROR_MAX_TIME_EXCEEDED
                 error code. This may happen if an external trigger has not been
@@ -1844,7 +1844,7 @@ class Session(_SessionBase):
                 once. The number of measurements can be a subset. The valid range is any
                 positive ViInt32. The default value is 1.
 
-            maximum_time (int in milliseconds or hightime.timedelta): Specifies the **maximum_time** allowed for this method to complete in
+            maximum_time (hightime.timedelta, datetime.timedelta, or int in milliseconds): Specifies the **maximum_time** allowed for this method to complete in
                 milliseconds. If the method does not complete within this time
                 interval, the method returns the NIDMM_ERROR_MAX_TIME_EXCEEDED
                 error code. This may happen if an external trigger has not been
@@ -1894,7 +1894,7 @@ class Session(_SessionBase):
                 parameter of configure_waveform_acquisition. The default value is
                 1.
 
-            maximum_time (int in milliseconds or hightime.timedelta): Specifies the **maximum_time** allowed for this method to complete in
+            maximum_time (hightime.timedelta, datetime.timedelta, or int in milliseconds): Specifies the **maximum_time** allowed for this method to complete in
                 milliseconds. If the method does not complete within this time
                 interval, the method returns the NIDMM_ERROR_MAX_TIME_EXCEEDED
                 error code. This may happen if an external trigger has not been
@@ -1939,7 +1939,7 @@ class Session(_SessionBase):
             waveform_array (numpy.array(dtype=numpy.float64)): **Waveform Array** is an array of measurement values stored in waveform
                 data type.
 
-            maximum_time (int in milliseconds or hightime.timedelta): Specifies the **maximum_time** allowed for this method to complete in
+            maximum_time (hightime.timedelta, datetime.timedelta, or int in milliseconds): Specifies the **maximum_time** allowed for this method to complete in
                 milliseconds. If the method does not complete within this time
                 interval, the method returns the NIDMM_ERROR_MAX_TIME_EXCEEDED
                 error code. This may happen if an external trigger has not been
@@ -2457,7 +2457,7 @@ class Session(_SessionBase):
         Acquires a single measurement and returns the measured value.
 
         Args:
-            maximum_time (int in milliseconds or hightime.timedelta): Specifies the **maximum_time** allowed for this method to complete in
+            maximum_time (hightime.timedelta, datetime.timedelta, or int in milliseconds): Specifies the **maximum_time** allowed for this method to complete in
                 milliseconds. If the method does not complete within this time
                 interval, the method returns the NIDMM_ERROR_MAX_TIME_EXCEEDED
                 error code. This may happen if an external trigger has not been
@@ -2501,7 +2501,7 @@ class Session(_SessionBase):
                 once. The number of measurements can be a subset. The valid range is any
                 positive ViInt32. The default value is 1.
 
-            maximum_time (int in milliseconds or hightime.timedelta): Specifies the **maximum_time** allowed for this method to complete in
+            maximum_time (hightime.timedelta, datetime.timedelta, or int in milliseconds): Specifies the **maximum_time** allowed for this method to complete in
                 milliseconds. If the method does not complete within this time
                 interval, the method returns the NIDMM_ERROR_MAX_TIME_EXCEEDED
                 error code. This may happen if an external trigger has not been
@@ -2598,7 +2598,7 @@ class Session(_SessionBase):
                 parameter of configure_waveform_acquisition. The default value is
                 1.
 
-            maximum_time (int in milliseconds or hightime.timedelta): Specifies the **maximum_time** allowed for this method to complete in
+            maximum_time (hightime.timedelta, datetime.timedelta, or int in milliseconds): Specifies the **maximum_time** allowed for this method to complete in
                 milliseconds. If the method does not complete within this time
                 interval, the method returns the NIDMM_ERROR_MAX_TIME_EXCEEDED
                 error code. This may happen if an external trigger has not been

--- a/generated/nidmm/setup.py
+++ b/generated/nidmm/setup.py
@@ -45,6 +45,7 @@ setup(
     install_requires=[
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
+        'hightime',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/nidmm/tox-system_tests.ini
+++ b/generated/nidmm/tox-system_tests.ini
@@ -37,6 +37,7 @@ deps =
     nidmm-system_tests: pytest
     nidmm-system_tests: coverage
     nidmm-system_tests: numpy
+    nidmm-system_tests: hightime
     nidmm-system_tests: scipy
     nidmm-system_tests: fasteners
     nidmm-system_tests: pytest-json

--- a/generated/nifake/nifake/_attributes.py
+++ b/generated/nifake/nifake/_attributes.py
@@ -2,7 +2,7 @@
 # This file was generated
 import nifake._converters as _converters
 
-import datetime
+import hightime
 
 
 class Attribute(object):
@@ -24,7 +24,7 @@ class AttributeViInt32(Attribute):
 class AttributeViInt32TimeDeltaMilliseconds(Attribute):
 
     def __get__(self, session, session_type):
-        return datetime.timedelta(milliseconds=session._get_attribute_vi_int32(self._attribute_id))
+        return hightime.timedelta(milliseconds=session._get_attribute_vi_int32(self._attribute_id))
 
     def __set__(self, session, value):
         session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_milliseconds_int32(value).value)
@@ -51,7 +51,7 @@ class AttributeViReal64(Attribute):
 class AttributeViReal64TimeDeltaSeconds(Attribute):
 
     def __get__(self, session, session_type):
-        return datetime.timedelta(seconds=session._get_attribute_vi_real64(self._attribute_id))
+        return hightime.timedelta(seconds=session._get_attribute_vi_real64(self._attribute_id))
 
     def __set__(self, session, value):
         session._set_attribute_vi_real64(self._attribute_id, _converters.convert_timedelta_to_seconds_real64(value).value)

--- a/generated/nifake/nifake/_converters.py
+++ b/generated/nifake/nifake/_converters.py
@@ -5,8 +5,9 @@ import nifake.errors as errors
 
 import array
 import collections
-import datetime
+import hightime
 import numbers
+import pytest
 
 from functools import singledispatch
 
@@ -144,7 +145,7 @@ def convert_repeated_capabilities_without_prefix(repeated_capability):
 
 def _convert_timedelta(value, library_type, scaling):
     try:
-        # We first assume it is a datetime.timedelta object
+        # We first assume it is a timedelta object
         scaled_value = value.total_seconds() * scaling
     except AttributeError:
         # If that doesn't work, assume it is a value in seconds
@@ -171,7 +172,7 @@ def convert_timedeltas_to_seconds_real64(values):
 
 
 def convert_seconds_real64_to_timedelta(value):
-    return datetime.timedelta(seconds=value)
+    return hightime.timedelta(seconds=value)
 
 
 def convert_seconds_real64_to_timedeltas(values):
@@ -179,7 +180,7 @@ def convert_seconds_real64_to_timedeltas(values):
 
 
 def convert_month_to_timedelta(months):
-    return datetime.timedelta(days=(30.4167 * months))
+    return hightime.timedelta(days=(30.4167 * months))
 
 
 # This converter is not called from the normal codegen path for function. Instead it is
@@ -290,11 +291,11 @@ def test_convert_init_with_options_dictionary():
 
 # Tests - time
 def test_convert_timedelta_to_seconds_double():
-    test_result = convert_timedelta_to_seconds_real64(datetime.timedelta(seconds=10))
+    test_result = convert_timedelta_to_seconds_real64(hightime.timedelta(seconds=10))
     assert test_result.value == 10.0
     assert isinstance(test_result, _visatype.ViReal64)
-    test_result = convert_timedelta_to_seconds_real64(datetime.timedelta(seconds=-1))
-    assert test_result.value == -1
+    test_result = convert_timedelta_to_seconds_real64(hightime.timedelta(nanoseconds=-0.5))
+    assert test_result.value == pytest.approx(-5e-10)
     assert isinstance(test_result, _visatype.ViReal64)
     test_result = convert_timedelta_to_seconds_real64(10.5)
     assert test_result.value == 10.5
@@ -305,11 +306,11 @@ def test_convert_timedelta_to_seconds_double():
 
 
 def test_convert_timedelta_to_milliseconds_int32():
-    test_result = convert_timedelta_to_milliseconds_int32(datetime.timedelta(seconds=10))
+    test_result = convert_timedelta_to_milliseconds_int32(hightime.timedelta(seconds=10))
     assert test_result.value == 10000
     assert isinstance(test_result, _visatype.ViInt32)
-    test_result = convert_timedelta_to_milliseconds_int32(datetime.timedelta(seconds=-1))
-    assert test_result.value == -1000
+    test_result = convert_timedelta_to_milliseconds_int32(hightime.timedelta(seconds=-5))
+    assert test_result.value == -5000
     assert isinstance(test_result, _visatype.ViInt32)
     test_result = convert_timedelta_to_milliseconds_int32(10.5)
     assert test_result.value == 10500
@@ -320,26 +321,28 @@ def test_convert_timedelta_to_milliseconds_int32():
 
 
 def test_convert_timedeltas_to_seconds_real64():
-    time_values = [10.5, -1]
+    time_values = [10.5, -5e-10]
     test_result = convert_timedeltas_to_seconds_real64(time_values)
-    assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
+    assert all([actual.value == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
-    timedeltas = [datetime.timedelta(seconds=s, milliseconds=ms) for s, ms in zip([10, -1], [500, 0])]
-    test_result = convert_timedeltas_to_seconds_real64(timedeltas)
-    assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
+    test_input = [hightime.timedelta(seconds=10.5), hightime.timedelta(nanoseconds=-0.5)]
+    test_result = convert_timedeltas_to_seconds_real64(test_input)
+    assert all([actual.value == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
 
 
 def test_convert_seconds_real64_to_timedelta():
-    time_value = 10.5
-    timedelta = convert_seconds_real64_to_timedelta(time_value)
-    assert timedelta.total_seconds() == time_value
+    time_value = -5e-10
+    test_result = convert_seconds_real64_to_timedelta(time_value)
+    assert test_result.total_seconds() == pytest.approx(time_value)
+    assert isinstance(test_result, hightime.timedelta)
 
 
 def test_convert_seconds_real64_to_timedeltas():
-    time_values = [10.5, -1]
-    timedeltas = convert_seconds_real64_to_timedeltas(time_values)
-    assert all([actual.total_seconds() == expected for actual, expected in zip(timedeltas, time_values)])
+    time_values = [10.5, -5e-10]
+    test_result = convert_seconds_real64_to_timedeltas(time_values)
+    assert all([actual.total_seconds() == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
+    assert all([isinstance(x, hightime.timedelta) for x in test_result])
 
 
 # Tests - repeated capabilities

--- a/generated/nifake/nifake/session.py
+++ b/generated/nifake/nifake/session.py
@@ -148,7 +148,7 @@ class _SessionBase(object):
     A property of type float with read/write access.
     '''
     read_write_double_with_converter = _attributes.AttributeViReal64TimeDeltaSeconds(1000007)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
     Property in seconds
     '''
@@ -172,7 +172,7 @@ class _SessionBase(object):
     A property of type integer with read/write access.
     '''
     read_write_integer_with_converter = _attributes.AttributeViInt32TimeDeltaMilliseconds(1000008)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or int in milliseconds
 
     Property in milliseconds
     '''
@@ -772,7 +772,7 @@ class Session(_SessionBase):
         Accepts list of floats or hightime.timedelta instances representing time delays.
 
         Args:
-            delays (float in seconds or hightime.timedelta): A collection of time delay values.
+            delays (hightime.timedelta, datetime.timedelta, or float in seconds): A collection of time delay values.
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110

--- a/generated/nifake/nifake/session.py
+++ b/generated/nifake/nifake/session.py
@@ -2,7 +2,6 @@
 # This file was generated
 import array  # noqa: F401
 import ctypes
-import datetime  # noqa: F401
 # Used by @ivi_synchronized
 from functools import wraps
 
@@ -15,6 +14,7 @@ import nifake.errors as errors
 
 import nifake.custom_struct as custom_struct  # noqa: F401
 
+import hightime
 import nitclk
 
 # Used for __repr__
@@ -148,7 +148,7 @@ class _SessionBase(object):
     A property of type float with read/write access.
     '''
     read_write_double_with_converter = _attributes.AttributeViReal64TimeDeltaSeconds(1000007)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     Property in seconds
     '''
@@ -172,7 +172,7 @@ class _SessionBase(object):
     A property of type integer with read/write access.
     '''
     read_write_integer_with_converter = _attributes.AttributeViInt32TimeDeltaMilliseconds(1000008)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     Property in milliseconds
     '''
@@ -461,7 +461,7 @@ class _SessionBase(object):
         nifake.Session repeated capabilities container, and calling this method on the result.
 
         Args:
-            maximum_time (datetime.timedelta): Specifies the **maximum_time** allowed in milliseconds.
+            maximum_time (hightime.timedelta): Specifies the **maximum_time** allowed in milliseconds.
 
 
         Returns:
@@ -769,10 +769,10 @@ class Session(_SessionBase):
     def accept_list_of_durations_in_seconds(self, delays):
         r'''accept_list_of_durations_in_seconds
 
-        Accepts list of floats or datetime.timedelta instances representing time delays.
+        Accepts list of floats or hightime.timedelta instances representing time delays.
 
         Args:
-            delays (float in seconds or datetime.timedelta): A collection of time delay values.
+            delays (float in seconds or hightime.timedelta): A collection of time delay values.
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -1186,7 +1186,7 @@ class Session(_SessionBase):
         Returns the recommended maximum interval, in **months**, between external calibrations.
 
         Returns:
-            months (datetime.timedelta): Specifies the recommended maximum interval, in **months**, between external calibrations.
+            months (hightime.timedelta): Specifies the recommended maximum interval, in **months**, between external calibrations.
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -1277,11 +1277,11 @@ class Session(_SessionBase):
 
 
         Returns:
-            month (datetime.datetime): Indicates date and time of the last calibration.
+            month (hightime.datetime): Indicates date and time of the last calibration.
 
         '''
         month, day, year, hour, minute = self._get_cal_date_and_time(cal_type)
-        return datetime.datetime(year, month, day, hour, minute)
+        return hightime.datetime(year, month, day, hour, minute)
 
     @ivi_synchronized
     def import_attribute_configuration_buffer(self, configuration):
@@ -1505,7 +1505,7 @@ class Session(_SessionBase):
         Acquires a single measurement and returns the measured value.
 
         Args:
-            maximum_time (datetime.timedelta): Specifies the **maximum_time** allowed in seconds.
+            maximum_time (hightime.timedelta): Specifies the **maximum_time** allowed in seconds.
 
 
         Returns:
@@ -1544,10 +1544,10 @@ class Session(_SessionBase):
     def return_duration_in_seconds(self):
         r'''return_duration_in_seconds
 
-        Returns a datetime.timedelta instance.
+        Returns a hightime.timedelta instance.
 
         Returns:
-            timedelta (datetime.timedelta): Duration in seconds.
+            timedelta (hightime.timedelta): Duration in seconds.
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -1560,14 +1560,14 @@ class Session(_SessionBase):
     def return_list_of_durations_in_seconds(self, number_of_elements):
         r'''return_list_of_durations_in_seconds
 
-        Returns a list of datetime.timedelta instances.
+        Returns a list of hightime.timedelta instances.
 
         Args:
             number_of_elements (int): Number of elements in output.
 
 
         Returns:
-            timedeltas (datetime.timedelta): Contains a list of datetime.timedelta instances.
+            timedeltas (hightime.timedelta): Contains a list of hightime.timedelta instances.
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110

--- a/generated/nifake/nifake/unit_tests/test_session.py
+++ b/generated/nifake/nifake/unit_tests/test_session.py
@@ -1,6 +1,7 @@
 import array
 import ctypes
 import datetime
+import hightime
 import math
 import nifake
 import nifake.errors
@@ -322,9 +323,9 @@ class TestSession(object):
         self.patched_library.niFake_close.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST))
 
     def test_single_point_read_timedelta(self):
-        test_maximum_time_ms = 100  # milliseconds
-        test_maximum_time_s = .1    # seconds
-        test_maximum_time_timedelta = datetime.timedelta(milliseconds=test_maximum_time_ms)
+        test_maximum_time_ns = 1    # nanoseconds
+        test_maximum_time_s = 1e-9  # seconds
+        test_maximum_time_timedelta = hightime.timedelta(nanoseconds=test_maximum_time_ns)
         test_reading = 5
         self.patched_library.niFake_Read.side_effect = self.side_effects_helper.niFake_Read
         self.side_effects_helper['Read']['reading'] = test_reading
@@ -334,7 +335,7 @@ class TestSession(object):
 
     def test_single_point_read_nan(self):
         test_maximum_time_s = 10.0
-        test_maximum_time = datetime.timedelta(seconds=test_maximum_time_s)
+        test_maximum_time = hightime.timedelta(seconds=test_maximum_time_s)
         test_reading = float('NaN')
         self.patched_library.niFake_Read.side_effect = self.side_effects_helper.niFake_Read
         self.side_effects_helper['Read']['reading'] = test_reading
@@ -717,7 +718,7 @@ class TestSession(object):
         warnings.filterwarnings("always", category=nifake.DriverWarning)
 
         test_maximum_time_s = 10.0
-        test_maximum_time = datetime.timedelta(seconds=test_maximum_time_s)
+        test_maximum_time = hightime.timedelta(seconds=test_maximum_time_s)
         test_reading = float('nan')
         test_error_code = 42
         test_error_desc = "The answer to the ultimate question, only positive"
@@ -825,7 +826,7 @@ class TestSession(object):
 
     def test_repeated_capability_method_on_session_timedelta(self):
         test_maximum_time_ms = 10     # milliseconds
-        test_maximum_time_timedelta = datetime.timedelta(milliseconds=test_maximum_time_ms)
+        test_maximum_time_timedelta = hightime.timedelta(milliseconds=test_maximum_time_ms)
         test_reading = 5
         self.patched_library.niFake_ReadFromChannel.side_effect = self.side_effects_helper.niFake_ReadFromChannel
         self.side_effects_helper['ReadFromChannel']['reading'] = test_reading
@@ -836,7 +837,7 @@ class TestSession(object):
 
     def test_repeated_capability_method_on_specific_channel(self):
         test_maximum_time_ms = 10     # milliseconds
-        test_maximum_time = datetime.timedelta(milliseconds=test_maximum_time_ms)
+        test_maximum_time = hightime.timedelta(milliseconds=test_maximum_time_ms)
         test_reading = 5
         self.patched_library.niFake_ReadFromChannel.side_effect = self.side_effects_helper.niFake_ReadFromChannel
         self.side_effects_helper['ReadFromChannel']['reading'] = test_reading
@@ -863,7 +864,7 @@ class TestSession(object):
 
     def test_chained_repeated_capability_method_on_specific_channel(self):
         test_maximum_time_ms = 10     # milliseconds
-        test_maximum_time = datetime.timedelta(milliseconds=test_maximum_time_ms)
+        test_maximum_time = hightime.timedelta(milliseconds=test_maximum_time_ms)
         test_reading = 5
         self.patched_library.niFake_ReadFromChannel.side_effect = self.side_effects_helper.niFake_ReadFromChannel
         self.side_effects_helper['ReadFromChannel']['reading'] = test_reading
@@ -907,7 +908,7 @@ class TestSession(object):
         attribute_id = 1000008
         test_number_ms = -10000
         with nifake.Session('dev1') as session:
-            session.read_write_integer_with_converter = datetime.timedelta(milliseconds=test_number_ms)
+            session.read_write_integer_with_converter = hightime.timedelta(milliseconds=test_number_ms)
             self.patched_library.niFake_SetAttributeViInt32.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt32Matcher(test_number_ms))
 
     def test_get_attribute_real64(self):
@@ -930,7 +931,7 @@ class TestSession(object):
     def test_get_attribute_real64_with_converter(self):
         self.patched_library.niFake_GetAttributeViReal64.side_effect = self.side_effects_helper.niFake_GetAttributeViReal64
         attribute_id = 1000007
-        test_number = 1.5
+        test_number = 1e-9
         self.side_effects_helper['GetAttributeViReal64']['attributeValue'] = test_number
         with nifake.Session('dev1') as session:
             attr_timedelta = session.read_write_double_with_converter
@@ -940,9 +941,9 @@ class TestSession(object):
     def test_set_attribute_real64_with_converter(self):
         self.patched_library.niFake_SetAttributeViReal64.side_effect = self.side_effects_helper.niFake_SetAttributeViReal64
         attribute_id = 1000007
-        test_number = -10.1
+        test_number = 1e-9
         with nifake.Session('dev1') as session:
-            session.read_write_double_with_converter = datetime.timedelta(seconds=test_number)
+            session.read_write_double_with_converter = hightime.timedelta(nanoseconds=1)
             self.patched_library.niFake_SetAttributeViReal64.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViReal64Matcher(test_number))
 
     def test_get_attribute_string(self):
@@ -1251,15 +1252,15 @@ class TestSession(object):
         self.side_effects_helper['GetCalDateAndTime']['minute'] = minute
         with nifake.Session('dev1') as session:
             last_cal = session.get_cal_date_and_time(0)
-            assert isinstance(last_cal, datetime.datetime)
-            assert datetime.datetime(year, month, day, hour, minute) == last_cal
+            assert isinstance(last_cal, hightime.datetime)
+            assert hightime.datetime(year, month, day, hour, minute) == last_cal
 
     def test_get_cal_interval(self):
         self.patched_library.niFake_GetCalInterval = self.side_effects_helper.niFake_GetCalInterval
         self.side_effects_helper['GetCalInterval']['months'] = 24
         with nifake.Session('dev1') as session:
             last_cal = session.get_cal_interval()
-            assert isinstance(last_cal, datetime.timedelta)
+            assert isinstance(last_cal, hightime.timedelta)
             assert 730 == last_cal.days
 
     # Import/Export functions
@@ -1453,8 +1454,8 @@ class TestSession(object):
 
     def test_accept_list_of_time_values_as_timedelta_instances(self):
         self.patched_library.niFake_AcceptListOfDurationsInSeconds.side_effect = self.side_effects_helper.niFake_AcceptListOfDurationsInSeconds
-        time_values = [-1.5, 2.0]
-        delays = [datetime.timedelta(seconds=i) for i in time_values]
+        time_values = [-1.5, 2e-9]
+        delays = [datetime.timedelta(seconds=-1.5), hightime.timedelta(nanoseconds=2)]
         with nifake.Session('dev1') as session:
             session.accept_list_of_durations_in_seconds(delays)
             self.patched_library.niFake_AcceptListOfDurationsInSeconds.assert_called_once_with(
@@ -1466,7 +1467,7 @@ class TestSession(object):
     def test_return_timedelta(self):
         self.patched_library.niFake_ReturnDurationInSeconds.side_effect = self.side_effects_helper.niFake_ReturnDurationInSeconds
         time_value = -1.5
-        expected_timedelta = datetime.timedelta(seconds=time_value)
+        expected_timedelta = hightime.timedelta(seconds=time_value)
         self.side_effects_helper['ReturnDurationInSeconds']['timedelta'] = time_value
         with nifake.Session('dev1') as session:
             returned_timedelta = session.return_duration_in_seconds()
@@ -1480,7 +1481,7 @@ class TestSession(object):
         self.patched_library.niFake_ReturnListOfDurationsInSeconds.side_effect = self.side_effects_helper.niFake_ReturnListOfDurationsInSeconds
         time_values = [-1.5, 2.0]
         time_values_ctype = (nifake._visatype.ViReal64 * len(time_values))(*time_values)
-        expected_timedeltas = [datetime.timedelta(seconds=i) for i in time_values]
+        expected_timedeltas = [hightime.timedelta(seconds=i) for i in time_values]
         self.side_effects_helper['ReturnListOfDurationsInSeconds']['timedeltas'] = time_values_ctype
         with nifake.Session('dev1') as session:
             returned_timedeltas = session.return_list_of_durations_in_seconds(len(expected_timedeltas))

--- a/generated/nifake/setup.py
+++ b/generated/nifake/setup.py
@@ -46,6 +46,7 @@ setup(
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
         'nitclk',
+        'hightime',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/nifake/setup.py
+++ b/generated/nifake/setup.py
@@ -45,8 +45,8 @@ setup(
     install_requires=[
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
-        'nitclk',
         'hightime',
+        'nitclk',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/nifake/tox-system_tests.ini
+++ b/generated/nifake/tox-system_tests.ini
@@ -44,6 +44,7 @@ deps =
     nifake-system_tests: pytest
     nifake-system_tests: coverage
     nifake-system_tests: numpy
+    nifake-system_tests: hightime
     nifake-system_tests: scipy
     nifake-system_tests: fasteners
     nifake-system_tests: pytest-json

--- a/generated/nifgen/nifgen/_attributes.py
+++ b/generated/nifgen/nifgen/_attributes.py
@@ -2,7 +2,7 @@
 # This file was generated
 import nifgen._converters as _converters
 
-import datetime
+import hightime
 
 
 class Attribute(object):
@@ -24,7 +24,7 @@ class AttributeViInt32(Attribute):
 class AttributeViInt32TimeDeltaMilliseconds(Attribute):
 
     def __get__(self, session, session_type):
-        return datetime.timedelta(milliseconds=session._get_attribute_vi_int32(self._attribute_id))
+        return hightime.timedelta(milliseconds=session._get_attribute_vi_int32(self._attribute_id))
 
     def __set__(self, session, value):
         session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_milliseconds_int32(value).value)
@@ -51,7 +51,7 @@ class AttributeViReal64(Attribute):
 class AttributeViReal64TimeDeltaSeconds(Attribute):
 
     def __get__(self, session, session_type):
-        return datetime.timedelta(seconds=session._get_attribute_vi_real64(self._attribute_id))
+        return hightime.timedelta(seconds=session._get_attribute_vi_real64(self._attribute_id))
 
     def __set__(self, session, value):
         session._set_attribute_vi_real64(self._attribute_id, _converters.convert_timedelta_to_seconds_real64(value).value)

--- a/generated/nifgen/nifgen/_converters.py
+++ b/generated/nifgen/nifgen/_converters.py
@@ -5,8 +5,9 @@ import nifgen.errors as errors
 
 import array
 import collections
-import datetime
+import hightime
 import numbers
+import pytest
 
 from functools import singledispatch
 
@@ -144,7 +145,7 @@ def convert_repeated_capabilities_without_prefix(repeated_capability):
 
 def _convert_timedelta(value, library_type, scaling):
     try:
-        # We first assume it is a datetime.timedelta object
+        # We first assume it is a timedelta object
         scaled_value = value.total_seconds() * scaling
     except AttributeError:
         # If that doesn't work, assume it is a value in seconds
@@ -171,7 +172,7 @@ def convert_timedeltas_to_seconds_real64(values):
 
 
 def convert_seconds_real64_to_timedelta(value):
-    return datetime.timedelta(seconds=value)
+    return hightime.timedelta(seconds=value)
 
 
 def convert_seconds_real64_to_timedeltas(values):
@@ -179,7 +180,7 @@ def convert_seconds_real64_to_timedeltas(values):
 
 
 def convert_month_to_timedelta(months):
-    return datetime.timedelta(days=(30.4167 * months))
+    return hightime.timedelta(days=(30.4167 * months))
 
 
 # This converter is not called from the normal codegen path for function. Instead it is
@@ -285,11 +286,11 @@ def test_convert_init_with_options_dictionary():
 
 # Tests - time
 def test_convert_timedelta_to_seconds_double():
-    test_result = convert_timedelta_to_seconds_real64(datetime.timedelta(seconds=10))
+    test_result = convert_timedelta_to_seconds_real64(hightime.timedelta(seconds=10))
     assert test_result.value == 10.0
     assert isinstance(test_result, _visatype.ViReal64)
-    test_result = convert_timedelta_to_seconds_real64(datetime.timedelta(seconds=-1))
-    assert test_result.value == -1
+    test_result = convert_timedelta_to_seconds_real64(hightime.timedelta(nanoseconds=-0.5))
+    assert test_result.value == pytest.approx(-5e-10)
     assert isinstance(test_result, _visatype.ViReal64)
     test_result = convert_timedelta_to_seconds_real64(10.5)
     assert test_result.value == 10.5
@@ -300,11 +301,11 @@ def test_convert_timedelta_to_seconds_double():
 
 
 def test_convert_timedelta_to_milliseconds_int32():
-    test_result = convert_timedelta_to_milliseconds_int32(datetime.timedelta(seconds=10))
+    test_result = convert_timedelta_to_milliseconds_int32(hightime.timedelta(seconds=10))
     assert test_result.value == 10000
     assert isinstance(test_result, _visatype.ViInt32)
-    test_result = convert_timedelta_to_milliseconds_int32(datetime.timedelta(seconds=-1))
-    assert test_result.value == -1000
+    test_result = convert_timedelta_to_milliseconds_int32(hightime.timedelta(seconds=-5))
+    assert test_result.value == -5000
     assert isinstance(test_result, _visatype.ViInt32)
     test_result = convert_timedelta_to_milliseconds_int32(10.5)
     assert test_result.value == 10500
@@ -315,26 +316,28 @@ def test_convert_timedelta_to_milliseconds_int32():
 
 
 def test_convert_timedeltas_to_seconds_real64():
-    time_values = [10.5, -1]
+    time_values = [10.5, -5e-10]
     test_result = convert_timedeltas_to_seconds_real64(time_values)
-    assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
+    assert all([actual.value == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
-    timedeltas = [datetime.timedelta(seconds=s, milliseconds=ms) for s, ms in zip([10, -1], [500, 0])]
-    test_result = convert_timedeltas_to_seconds_real64(timedeltas)
-    assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
+    test_input = [hightime.timedelta(seconds=10.5), hightime.timedelta(nanoseconds=-0.5)]
+    test_result = convert_timedeltas_to_seconds_real64(test_input)
+    assert all([actual.value == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
 
 
 def test_convert_seconds_real64_to_timedelta():
-    time_value = 10.5
-    timedelta = convert_seconds_real64_to_timedelta(time_value)
-    assert timedelta.total_seconds() == time_value
+    time_value = -5e-10
+    test_result = convert_seconds_real64_to_timedelta(time_value)
+    assert test_result.total_seconds() == pytest.approx(time_value)
+    assert isinstance(test_result, hightime.timedelta)
 
 
 def test_convert_seconds_real64_to_timedeltas():
-    time_values = [10.5, -1]
-    timedeltas = convert_seconds_real64_to_timedeltas(time_values)
-    assert all([actual.total_seconds() == expected for actual, expected in zip(timedeltas, time_values)])
+    time_values = [10.5, -5e-10]
+    test_result = convert_seconds_real64_to_timedeltas(time_values)
+    assert all([actual.total_seconds() == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
+    assert all([isinstance(x, hightime.timedelta) for x in test_result])
 
 
 # Tests - repeated capabilities

--- a/generated/nifgen/nifgen/_library.py
+++ b/generated/nifgen/nifgen/_library.py
@@ -383,7 +383,7 @@ class Library(object):
         with self._func_lock:
             if self.niFgen_GetLastExtCalLastDateAndTime_cfunc is None:
                 self.niFgen_GetLastExtCalLastDateAndTime_cfunc = self._library.niFgen_GetLastExtCalLastDateAndTime
-                self.niFgen_GetLastExtCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(datetime.datetime)]  # noqa: F405
+                self.niFgen_GetLastExtCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(hightime.datetime)]  # noqa: F405
                 self.niFgen_GetLastExtCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetLastExtCalLastDateAndTime_cfunc(vi, month)
 
@@ -391,7 +391,7 @@ class Library(object):
         with self._func_lock:
             if self.niFgen_GetLastSelfCalLastDateAndTime_cfunc is None:
                 self.niFgen_GetLastSelfCalLastDateAndTime_cfunc = self._library.niFgen_GetLastSelfCalLastDateAndTime
-                self.niFgen_GetLastSelfCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(datetime.datetime)]  # noqa: F405
+                self.niFgen_GetLastSelfCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(hightime.datetime)]  # noqa: F405
                 self.niFgen_GetLastSelfCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetLastSelfCalLastDateAndTime_cfunc(vi, month)
 

--- a/generated/nifgen/nifgen/session.py
+++ b/generated/nifgen/nifgen/session.py
@@ -875,7 +875,7 @@ class _SessionBase(object):
     Use in conjunction with streaming_space_available_in_waveform.
     '''
     streaming_write_timeout = _attributes.AttributeViReal64TimeDeltaSeconds(1150409)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
     Specifies the maximum amount of time allowed to complete a streaming write operation.
     '''
@@ -4333,7 +4333,7 @@ class Session(_SessionBase):
         expired.
 
         Args:
-            max_time (int in milliseconds or hightime.timedelta): Specifies the timeout value in milliseconds.
+            max_time (hightime.timedelta, datetime.timedelta, or int in milliseconds): Specifies the timeout value in milliseconds.
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110

--- a/generated/nifgen/nifgen/session.py
+++ b/generated/nifgen/nifgen/session.py
@@ -2,7 +2,6 @@
 # This file was generated
 import array  # noqa: F401
 import ctypes
-import datetime  # noqa: F401
 # Used by @ivi_synchronized
 from functools import wraps
 
@@ -13,6 +12,7 @@ import nifgen._visatype as _visatype
 import nifgen.enums as enums
 import nifgen.errors as errors
 
+import hightime
 import nitclk
 
 # Used for __repr__
@@ -875,7 +875,7 @@ class _SessionBase(object):
     Use in conjunction with streaming_space_available_in_waveform.
     '''
     streaming_write_timeout = _attributes.AttributeViReal64TimeDeltaSeconds(1150409)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     Specifies the maximum amount of time allowed to complete a streaming write operation.
     '''
@@ -3747,7 +3747,7 @@ class Session(_SessionBase):
         months.
 
         Returns:
-            months (datetime.timedelta): Specifies the recommended interval between external calibrations in
+            months (hightime.timedelta): Specifies the recommended interval between external calibrations in
                 months.
 
         '''
@@ -3797,11 +3797,11 @@ class Session(_SessionBase):
         Returns the date and time of the last successful external calibration. The time returned is 24-hour (military) local time; for example, if the device was calibrated at 2:30 PM, this method returns 14 for the **hour** parameter and 30 for the **minute** parameter.
 
         Returns:
-            month (datetime.datetime): Indicates date and time of the last calibration.
+            month (hightime.datetime): Indicates date and time of the last calibration.
 
         '''
         year, month, day, hour, minute = self._get_ext_cal_last_date_and_time()
-        return datetime.datetime(year, month, day, hour, minute)
+        return hightime.datetime(year, month, day, hour, minute)
 
     @ivi_synchronized
     def get_self_cal_last_date_and_time(self):
@@ -3810,11 +3810,11 @@ class Session(_SessionBase):
         Returns the date and time of the last successful self-calibration.
 
         Returns:
-            month (datetime.datetime): Returns the date and time the device was last calibrated.
+            month (hightime.datetime): Returns the date and time the device was last calibrated.
 
         '''
         year, month, day, hour, minute = self._get_self_cal_last_date_and_time()
-        return datetime.datetime(year, month, day, hour, minute)
+        return hightime.datetime(year, month, day, hour, minute)
 
     @ivi_synchronized
     def _get_self_cal_last_date_and_time(self):
@@ -4326,14 +4326,14 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def wait_until_done(self, max_time=datetime.timedelta(seconds=10.0)):
+    def wait_until_done(self, max_time=hightime.timedelta(seconds=10.0)):
         r'''wait_until_done
 
         Waits until the device is done generating or until the maximum time has
         expired.
 
         Args:
-            max_time (int in milliseconds or datetime.timedelta): Specifies the timeout value in milliseconds.
+            max_time (int in milliseconds or hightime.timedelta): Specifies the timeout value in milliseconds.
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110

--- a/generated/nifgen/setup.py
+++ b/generated/nifgen/setup.py
@@ -46,6 +46,7 @@ setup(
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
         'nitclk',
+        'hightime',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/nifgen/setup.py
+++ b/generated/nifgen/setup.py
@@ -45,8 +45,8 @@ setup(
     install_requires=[
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
-        'nitclk',
         'hightime',
+        'nitclk',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/nifgen/tox-system_tests.ini
+++ b/generated/nifgen/tox-system_tests.ini
@@ -44,6 +44,7 @@ deps =
     nifgen-system_tests: pytest
     nifgen-system_tests: coverage
     nifgen-system_tests: numpy
+    nifgen-system_tests: hightime
     nifgen-system_tests: scipy
     nifgen-system_tests: fasteners
     nifgen-system_tests: pytest-json

--- a/generated/nimodinst/nimodinst/_converters.py
+++ b/generated/nimodinst/nimodinst/_converters.py
@@ -5,8 +5,9 @@ import nimodinst.errors as errors
 
 import array
 import collections
-import datetime
+import hightime
 import numbers
+import pytest
 
 from functools import singledispatch
 
@@ -144,7 +145,7 @@ def convert_repeated_capabilities_without_prefix(repeated_capability):
 
 def _convert_timedelta(value, library_type, scaling):
     try:
-        # We first assume it is a datetime.timedelta object
+        # We first assume it is a timedelta object
         scaled_value = value.total_seconds() * scaling
     except AttributeError:
         # If that doesn't work, assume it is a value in seconds
@@ -171,7 +172,7 @@ def convert_timedeltas_to_seconds_real64(values):
 
 
 def convert_seconds_real64_to_timedelta(value):
-    return datetime.timedelta(seconds=value)
+    return hightime.timedelta(seconds=value)
 
 
 def convert_seconds_real64_to_timedeltas(values):
@@ -179,7 +180,7 @@ def convert_seconds_real64_to_timedeltas(values):
 
 
 def convert_month_to_timedelta(months):
-    return datetime.timedelta(days=(30.4167 * months))
+    return hightime.timedelta(days=(30.4167 * months))
 
 
 # This converter is not called from the normal codegen path for function. Instead it is
@@ -285,11 +286,11 @@ def test_convert_init_with_options_dictionary():
 
 # Tests - time
 def test_convert_timedelta_to_seconds_double():
-    test_result = convert_timedelta_to_seconds_real64(datetime.timedelta(seconds=10))
+    test_result = convert_timedelta_to_seconds_real64(hightime.timedelta(seconds=10))
     assert test_result.value == 10.0
     assert isinstance(test_result, _visatype.ViReal64)
-    test_result = convert_timedelta_to_seconds_real64(datetime.timedelta(seconds=-1))
-    assert test_result.value == -1
+    test_result = convert_timedelta_to_seconds_real64(hightime.timedelta(nanoseconds=-0.5))
+    assert test_result.value == pytest.approx(-5e-10)
     assert isinstance(test_result, _visatype.ViReal64)
     test_result = convert_timedelta_to_seconds_real64(10.5)
     assert test_result.value == 10.5
@@ -300,11 +301,11 @@ def test_convert_timedelta_to_seconds_double():
 
 
 def test_convert_timedelta_to_milliseconds_int32():
-    test_result = convert_timedelta_to_milliseconds_int32(datetime.timedelta(seconds=10))
+    test_result = convert_timedelta_to_milliseconds_int32(hightime.timedelta(seconds=10))
     assert test_result.value == 10000
     assert isinstance(test_result, _visatype.ViInt32)
-    test_result = convert_timedelta_to_milliseconds_int32(datetime.timedelta(seconds=-1))
-    assert test_result.value == -1000
+    test_result = convert_timedelta_to_milliseconds_int32(hightime.timedelta(seconds=-5))
+    assert test_result.value == -5000
     assert isinstance(test_result, _visatype.ViInt32)
     test_result = convert_timedelta_to_milliseconds_int32(10.5)
     assert test_result.value == 10500
@@ -315,26 +316,28 @@ def test_convert_timedelta_to_milliseconds_int32():
 
 
 def test_convert_timedeltas_to_seconds_real64():
-    time_values = [10.5, -1]
+    time_values = [10.5, -5e-10]
     test_result = convert_timedeltas_to_seconds_real64(time_values)
-    assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
+    assert all([actual.value == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
-    timedeltas = [datetime.timedelta(seconds=s, milliseconds=ms) for s, ms in zip([10, -1], [500, 0])]
-    test_result = convert_timedeltas_to_seconds_real64(timedeltas)
-    assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
+    test_input = [hightime.timedelta(seconds=10.5), hightime.timedelta(nanoseconds=-0.5)]
+    test_result = convert_timedeltas_to_seconds_real64(test_input)
+    assert all([actual.value == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
 
 
 def test_convert_seconds_real64_to_timedelta():
-    time_value = 10.5
-    timedelta = convert_seconds_real64_to_timedelta(time_value)
-    assert timedelta.total_seconds() == time_value
+    time_value = -5e-10
+    test_result = convert_seconds_real64_to_timedelta(time_value)
+    assert test_result.total_seconds() == pytest.approx(time_value)
+    assert isinstance(test_result, hightime.timedelta)
 
 
 def test_convert_seconds_real64_to_timedeltas():
-    time_values = [10.5, -1]
-    timedeltas = convert_seconds_real64_to_timedeltas(time_values)
-    assert all([actual.total_seconds() == expected for actual, expected in zip(timedeltas, time_values)])
+    time_values = [10.5, -5e-10]
+    test_result = convert_seconds_real64_to_timedeltas(time_values)
+    assert all([actual.total_seconds() == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
+    assert all([isinstance(x, hightime.timedelta) for x in test_result])
 
 
 def test_string_to_list_channel():

--- a/generated/nimodinst/setup.py
+++ b/generated/nimodinst/setup.py
@@ -45,6 +45,7 @@ setup(
     install_requires=[
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
+        'hightime',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/nimodinst/tox-system_tests.ini
+++ b/generated/nimodinst/tox-system_tests.ini
@@ -37,6 +37,7 @@ deps =
     nimodinst-system_tests: pytest
     nimodinst-system_tests: coverage
     nimodinst-system_tests: numpy
+    nimodinst-system_tests: hightime
     nimodinst-system_tests: scipy
     nimodinst-system_tests: fasteners
     nimodinst-system_tests: pytest-json

--- a/generated/niscope/niscope/_attributes.py
+++ b/generated/niscope/niscope/_attributes.py
@@ -2,7 +2,7 @@
 # This file was generated
 import niscope._converters as _converters
 
-import datetime
+import hightime
 
 
 class Attribute(object):
@@ -24,7 +24,7 @@ class AttributeViInt32(Attribute):
 class AttributeViInt32TimeDeltaMilliseconds(Attribute):
 
     def __get__(self, session, session_type):
-        return datetime.timedelta(milliseconds=session._get_attribute_vi_int32(self._attribute_id))
+        return hightime.timedelta(milliseconds=session._get_attribute_vi_int32(self._attribute_id))
 
     def __set__(self, session, value):
         session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_milliseconds_int32(value).value)
@@ -51,7 +51,7 @@ class AttributeViReal64(Attribute):
 class AttributeViReal64TimeDeltaSeconds(Attribute):
 
     def __get__(self, session, session_type):
-        return datetime.timedelta(seconds=session._get_attribute_vi_real64(self._attribute_id))
+        return hightime.timedelta(seconds=session._get_attribute_vi_real64(self._attribute_id))
 
     def __set__(self, session, value):
         session._set_attribute_vi_real64(self._attribute_id, _converters.convert_timedelta_to_seconds_real64(value).value)

--- a/generated/niscope/niscope/_converters.py
+++ b/generated/niscope/niscope/_converters.py
@@ -5,8 +5,9 @@ import niscope.errors as errors
 
 import array
 import collections
-import datetime
+import hightime
 import numbers
+import pytest
 
 from functools import singledispatch
 
@@ -144,7 +145,7 @@ def convert_repeated_capabilities_without_prefix(repeated_capability):
 
 def _convert_timedelta(value, library_type, scaling):
     try:
-        # We first assume it is a datetime.timedelta object
+        # We first assume it is a timedelta object
         scaled_value = value.total_seconds() * scaling
     except AttributeError:
         # If that doesn't work, assume it is a value in seconds
@@ -171,7 +172,7 @@ def convert_timedeltas_to_seconds_real64(values):
 
 
 def convert_seconds_real64_to_timedelta(value):
-    return datetime.timedelta(seconds=value)
+    return hightime.timedelta(seconds=value)
 
 
 def convert_seconds_real64_to_timedeltas(values):
@@ -179,7 +180,7 @@ def convert_seconds_real64_to_timedeltas(values):
 
 
 def convert_month_to_timedelta(months):
-    return datetime.timedelta(days=(30.4167 * months))
+    return hightime.timedelta(days=(30.4167 * months))
 
 
 # This converter is not called from the normal codegen path for function. Instead it is
@@ -285,11 +286,11 @@ def test_convert_init_with_options_dictionary():
 
 # Tests - time
 def test_convert_timedelta_to_seconds_double():
-    test_result = convert_timedelta_to_seconds_real64(datetime.timedelta(seconds=10))
+    test_result = convert_timedelta_to_seconds_real64(hightime.timedelta(seconds=10))
     assert test_result.value == 10.0
     assert isinstance(test_result, _visatype.ViReal64)
-    test_result = convert_timedelta_to_seconds_real64(datetime.timedelta(seconds=-1))
-    assert test_result.value == -1
+    test_result = convert_timedelta_to_seconds_real64(hightime.timedelta(nanoseconds=-0.5))
+    assert test_result.value == pytest.approx(-5e-10)
     assert isinstance(test_result, _visatype.ViReal64)
     test_result = convert_timedelta_to_seconds_real64(10.5)
     assert test_result.value == 10.5
@@ -300,11 +301,11 @@ def test_convert_timedelta_to_seconds_double():
 
 
 def test_convert_timedelta_to_milliseconds_int32():
-    test_result = convert_timedelta_to_milliseconds_int32(datetime.timedelta(seconds=10))
+    test_result = convert_timedelta_to_milliseconds_int32(hightime.timedelta(seconds=10))
     assert test_result.value == 10000
     assert isinstance(test_result, _visatype.ViInt32)
-    test_result = convert_timedelta_to_milliseconds_int32(datetime.timedelta(seconds=-1))
-    assert test_result.value == -1000
+    test_result = convert_timedelta_to_milliseconds_int32(hightime.timedelta(seconds=-5))
+    assert test_result.value == -5000
     assert isinstance(test_result, _visatype.ViInt32)
     test_result = convert_timedelta_to_milliseconds_int32(10.5)
     assert test_result.value == 10500
@@ -315,26 +316,28 @@ def test_convert_timedelta_to_milliseconds_int32():
 
 
 def test_convert_timedeltas_to_seconds_real64():
-    time_values = [10.5, -1]
+    time_values = [10.5, -5e-10]
     test_result = convert_timedeltas_to_seconds_real64(time_values)
-    assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
+    assert all([actual.value == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
-    timedeltas = [datetime.timedelta(seconds=s, milliseconds=ms) for s, ms in zip([10, -1], [500, 0])]
-    test_result = convert_timedeltas_to_seconds_real64(timedeltas)
-    assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
+    test_input = [hightime.timedelta(seconds=10.5), hightime.timedelta(nanoseconds=-0.5)]
+    test_result = convert_timedeltas_to_seconds_real64(test_input)
+    assert all([actual.value == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
 
 
 def test_convert_seconds_real64_to_timedelta():
-    time_value = 10.5
-    timedelta = convert_seconds_real64_to_timedelta(time_value)
-    assert timedelta.total_seconds() == time_value
+    time_value = -5e-10
+    test_result = convert_seconds_real64_to_timedelta(time_value)
+    assert test_result.total_seconds() == pytest.approx(time_value)
+    assert isinstance(test_result, hightime.timedelta)
 
 
 def test_convert_seconds_real64_to_timedeltas():
-    time_values = [10.5, -1]
-    timedeltas = convert_seconds_real64_to_timedeltas(time_values)
-    assert all([actual.total_seconds() == expected for actual, expected in zip(timedeltas, time_values)])
+    time_values = [10.5, -5e-10]
+    test_result = convert_seconds_real64_to_timedeltas(time_values)
+    assert all([actual.total_seconds() == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
+    assert all([isinstance(x, hightime.timedelta) for x in test_result])
 
 
 # Tests - repeated capabilities

--- a/generated/niscope/niscope/session.py
+++ b/generated/niscope/niscope/session.py
@@ -2,7 +2,6 @@
 # This file was generated
 import array  # noqa: F401
 import ctypes
-import datetime  # noqa: F401
 # Used by @ivi_synchronized
 from functools import wraps
 
@@ -15,6 +14,7 @@ import niscope.errors as errors
 
 import niscope.waveform_info as waveform_info  # noqa: F401
 
+import hightime
 import nitclk
 
 # Used for __repr__
@@ -128,7 +128,7 @@ class _SessionBase(object):
     _is_frozen = False
 
     absolute_sample_clock_offset = _attributes.AttributeViReal64TimeDeltaSeconds(1150374)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     Gets or sets the absolute time offset of the sample clock relative to
     the reference clock in terms of seconds.
@@ -143,7 +143,7 @@ class _SessionBase(object):
     offset is 0s.
     '''
     acquisition_start_time = _attributes.AttributeViReal64TimeDeltaSeconds(1250109)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     Specifies the length of time from the trigger event to the first point in the waveform record in seconds.  If the value is positive, the first point in the waveform record occurs after the trigger event (same as specifying trigger_delay_time).  If the value is negative, the first point in the waveform record occurs before the trigger event (same as specifying horz_record_ref_position).
     '''
@@ -369,7 +369,7 @@ class _SessionBase(object):
     Consult your device documentation for a specific list of valid destinations.
     '''
     end_of_record_to_advance_trigger_holdoff = _attributes.AttributeViReal64TimeDeltaSeconds(1150366)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     End of Record to Advance Trigger Holdoff is the length of time (in
     seconds) that a device waits between the completion of one record and
@@ -537,7 +537,7 @@ class _SessionBase(object):
     Units: Hertz (Samples / Second)
     '''
     horz_time_per_record = _attributes.AttributeViReal64TimeDeltaSeconds(1250007)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     Specifies the length of time that corresponds to the record length.
     Units: Seconds
@@ -1136,7 +1136,7 @@ class _SessionBase(object):
     Indicates which analog compare circuitry to use on the device.
     '''
     ref_trigger_minimum_quiet_time = _attributes.AttributeViReal64TimeDeltaSeconds(1150315)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     The amount of time the trigger circuit must not detect a signal above the trigger level before the trigger is armed.  This property is useful for triggering at the beginning and not in the middle of signal bursts.
     '''
@@ -1314,7 +1314,7 @@ class _SessionBase(object):
     A string that contains the name of the vendor that supplies this driver.
     '''
     start_to_ref_trigger_holdoff = _attributes.AttributeViReal64TimeDeltaSeconds(1150103)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     Pass the length of time you want the digitizer to wait after it starts acquiring data until the digitizer enables the trigger system to detect a reference (stop) trigger.
     Units: Seconds
@@ -1336,13 +1336,13 @@ class _SessionBase(object):
     Specifies how the digitizer couples the trigger source. This property affects instrument operation only when trigger_type is set to TriggerType.EDGE, TriggerType.HYSTERESIS, or TriggerType.WINDOW.
     '''
     trigger_delay_time = _attributes.AttributeViReal64TimeDeltaSeconds(1250015)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     Specifies the trigger delay time in seconds. The trigger delay time is the length of time the digitizer waits after it receives the trigger. The event that occurs when the trigger delay elapses is the Reference Event.
     Valid Values: 0.0 - 171.8
     '''
     trigger_holdoff = _attributes.AttributeViReal64TimeDeltaSeconds(1250016)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     Specifies the length of time (in seconds) the digitizer waits after detecting a trigger before enabling the trigger subsystem to detect another trigger. This property affects instrument operation only when the digitizer requires multiple acquisitions to build a complete waveform. The digitizer requires multiple waveform acquisitions when it uses equivalent-time sampling or when the digitizer is configured for a multi-record acquisition through a call to configure_horizontal_timing.
     Valid Values: 0.0 - 171.8
@@ -1867,7 +1867,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def fetch(self, num_samples=None, relative_to=enums.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout=datetime.timedelta(seconds=5.0)):
+    def fetch(self, num_samples=None, relative_to=enums.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout=hightime.timedelta(seconds=5.0)):
         '''fetch
 
         Returns the waveform from a previously initiated acquisition that the
@@ -1896,7 +1896,7 @@ class _SessionBase(object):
 
             num_records (int): Number of records to fetch. Use -1 to fetch all configured records.
 
-            timeout (float in seconds or datetime.timedelta): The time to wait for data to be acquired; using 0 for this parameter tells NI-SCOPE to fetch whatever is currently available. Using -1 seconds for this parameter implies infinite timeout.
+            timeout (float in seconds or hightime.timedelta): The time to wait for data to be acquired; using 0 for this parameter tells NI-SCOPE to fetch whatever is currently available. Using -1 seconds for this parameter implies infinite timeout.
 
 
         Returns:
@@ -1972,7 +1972,7 @@ class _SessionBase(object):
         return self._get_equalization_filter_coefficients(self.equalization_num_coefficients)
 
     @ivi_synchronized
-    def read(self, num_samples=None, relative_to=enums.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout=datetime.timedelta(seconds=5.0)):
+    def read(self, num_samples=None, relative_to=enums.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout=hightime.timedelta(seconds=5.0)):
         '''read
 
         Initiates an acquisition, waits for it to complete, and retrieves the
@@ -2004,7 +2004,7 @@ class _SessionBase(object):
 
             num_records (int): Number of records to fetch. Use -1 to fetch all configured records.
 
-            timeout (float in seconds or datetime.timedelta): The time to wait for data to be acquired; using 0 for this parameter tells NI-SCOPE to fetch whatever is currently available. Using -1 seconds for this parameter implies infinite timeout.
+            timeout (float in seconds or hightime.timedelta): The time to wait for data to be acquired; using 0 for this parameter tells NI-SCOPE to fetch whatever is currently available. Using -1 seconds for this parameter implies infinite timeout.
 
 
         Returns:
@@ -2066,7 +2066,7 @@ class _SessionBase(object):
         return wfm_info
 
     @ivi_synchronized
-    def _fetch(self, num_samples, timeout=datetime.timedelta(seconds=5.0)):
+    def _fetch(self, num_samples, timeout=hightime.timedelta(seconds=5.0)):
         r'''_fetch
 
         Returns the waveform from a previously initiated acquisition that the
@@ -2099,7 +2099,7 @@ class _SessionBase(object):
                 timeout of 0 was used. If it fails to complete within the timeout
                 period, the method returns an error.
 
-            timeout (float in seconds or datetime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
+            timeout (float in seconds or hightime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
                 parameter tells NI-SCOPE to fetch whatever is currently available. Using
                 -1 for this parameter implies infinite timeout.
 
@@ -2166,7 +2166,7 @@ class _SessionBase(object):
         return waveform_array, [waveform_info.WaveformInfo(wfm_info_ctype[i]) for i in range(self._actual_num_wfms())]
 
     @ivi_synchronized
-    def _fetch_into_numpy(self, num_samples, waveform, timeout=datetime.timedelta(seconds=5.0)):
+    def _fetch_into_numpy(self, num_samples, waveform, timeout=hightime.timedelta(seconds=5.0)):
         r'''_fetch
 
         Returns the waveform from a previously initiated acquisition that the
@@ -2220,7 +2220,7 @@ class _SessionBase(object):
                 Note:
                 One or more of the referenced methods are not in the Python API for this driver.
 
-            timeout (float in seconds or datetime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
+            timeout (float in seconds or hightime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
                 parameter tells NI-SCOPE to fetch whatever is currently available. Using
                 -1 for this parameter implies infinite timeout.
 
@@ -2293,7 +2293,7 @@ class _SessionBase(object):
         return [waveform_info.WaveformInfo(wfm_info_ctype[i]) for i in range(self._actual_num_wfms())]
 
     @ivi_synchronized
-    def _fetch_array_measurement(self, array_meas_function, timeout=datetime.timedelta(seconds=5.0)):
+    def _fetch_array_measurement(self, array_meas_function, timeout=hightime.timedelta(seconds=5.0)):
         r'''_fetch_array_measurement
 
         Obtains a waveform from the digitizer and returns the specified
@@ -2318,7 +2318,7 @@ class _SessionBase(object):
                 measurement <REPLACE_DRIVER_SPECIFIC_URL_2(array_measurements_refs)>`__
                 to perform.
 
-            timeout (float in seconds or datetime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
+            timeout (float in seconds or hightime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
                 parameter tells NI-SCOPE to fetch whatever is currently available. Using
                 -1 for this parameter implies infinite timeout.
 
@@ -2385,7 +2385,7 @@ class _SessionBase(object):
         return [float(meas_wfm_ctype[i]) for i in range((self._actual_meas_wfm_size(array_meas_function) * self._actual_num_wfms()))], [waveform_info.WaveformInfo(wfm_info_ctype[i]) for i in range(self._actual_num_wfms())]
 
     @ivi_synchronized
-    def _fetch_binary16_into_numpy(self, num_samples, waveform, timeout=datetime.timedelta(seconds=5.0)):
+    def _fetch_binary16_into_numpy(self, num_samples, waveform, timeout=hightime.timedelta(seconds=5.0)):
         r'''_fetch_binary16
 
         Retrieves data from a previously initiated acquisition and returns
@@ -2437,7 +2437,7 @@ class _SessionBase(object):
                 Note:
                 One or more of the referenced methods are not in the Python API for this driver.
 
-            timeout (float in seconds or datetime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
+            timeout (float in seconds or hightime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
                 parameter tells NI-SCOPE to fetch whatever is currently available. Using
                 -1 for this parameter implies infinite timeout.
 
@@ -2510,7 +2510,7 @@ class _SessionBase(object):
         return [waveform_info.WaveformInfo(wfm_info_ctype[i]) for i in range(self._actual_num_wfms())]
 
     @ivi_synchronized
-    def _fetch_binary32_into_numpy(self, num_samples, waveform, timeout=datetime.timedelta(seconds=5.0)):
+    def _fetch_binary32_into_numpy(self, num_samples, waveform, timeout=hightime.timedelta(seconds=5.0)):
         r'''_fetch_binary32
 
         Retrieves data from a previously initiated acquisition and returns
@@ -2562,7 +2562,7 @@ class _SessionBase(object):
                 Note:
                 One or more of the referenced methods are not in the Python API for this driver.
 
-            timeout (float in seconds or datetime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
+            timeout (float in seconds or hightime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
                 parameter tells NI-SCOPE to fetch whatever is currently available. Using
                 -1 for this parameter implies infinite timeout.
 
@@ -2635,7 +2635,7 @@ class _SessionBase(object):
         return [waveform_info.WaveformInfo(wfm_info_ctype[i]) for i in range(self._actual_num_wfms())]
 
     @ivi_synchronized
-    def _fetch_binary8_into_numpy(self, num_samples, waveform, timeout=datetime.timedelta(seconds=5.0)):
+    def _fetch_binary8_into_numpy(self, num_samples, waveform, timeout=hightime.timedelta(seconds=5.0)):
         r'''_fetch_binary8
 
         Retrieves data from a previously initiated acquisition and returns
@@ -2687,7 +2687,7 @@ class _SessionBase(object):
                 Note:
                 One or more of the referenced methods are not in the Python API for this driver.
 
-            timeout (float in seconds or datetime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
+            timeout (float in seconds or hightime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
                 parameter tells NI-SCOPE to fetch whatever is currently available. Using
                 -1 for this parameter implies infinite timeout.
 
@@ -2760,7 +2760,7 @@ class _SessionBase(object):
         return [waveform_info.WaveformInfo(wfm_info_ctype[i]) for i in range(self._actual_num_wfms())]
 
     @ivi_synchronized
-    def fetch_into(self, waveform, relative_to=enums.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout=datetime.timedelta(seconds=5.0)):
+    def fetch_into(self, waveform, relative_to=enums.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout=hightime.timedelta(seconds=5.0)):
         '''fetch
 
         Returns the waveform from a previously initiated acquisition that the
@@ -2803,7 +2803,7 @@ class _SessionBase(object):
 
             num_records (int): Number of records to fetch. Use -1 to fetch all configured records.
 
-            timeout (float in seconds or datetime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this parameter tells NI-SCOPE to fetch whatever is currently available. Using -1 for this parameter implies infinite timeout.
+            timeout (float in seconds or hightime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this parameter tells NI-SCOPE to fetch whatever is currently available. Using -1 for this parameter implies infinite timeout.
 
 
         Returns:
@@ -2875,7 +2875,7 @@ class _SessionBase(object):
         return wfm_info
 
     @ivi_synchronized
-    def _fetch_measurement(self, scalar_meas_function, timeout=datetime.timedelta(seconds=5.0)):
+    def _fetch_measurement(self, scalar_meas_function, timeout=hightime.timedelta(seconds=5.0)):
         r'''_fetch_measurement
 
         Fetches a waveform from the digitizer and performs the specified
@@ -2901,7 +2901,7 @@ class _SessionBase(object):
                 measurement <REPLACE_DRIVER_SPECIFIC_URL_2(scalar_measurements_refs)>`__
                 to be performed.
 
-            timeout (float in seconds or datetime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
+            timeout (float in seconds or hightime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
                 parameter tells NI-SCOPE to fetch whatever is currently available. Using
                 -1 for this parameter implies infinite timeout.
 
@@ -2924,7 +2924,7 @@ class _SessionBase(object):
         return [float(result_ctype[i]) for i in range(self._actual_num_wfms())]
 
     @ivi_synchronized
-    def _fetch_measurement_stats(self, scalar_meas_function, timeout=datetime.timedelta(seconds=5.0)):
+    def _fetch_measurement_stats(self, scalar_meas_function, timeout=hightime.timedelta(seconds=5.0)):
         r'''_fetch_measurement_stats
 
         Obtains a waveform measurement and returns the measurement value. This
@@ -2963,7 +2963,7 @@ class _SessionBase(object):
                 measurement <REPLACE_DRIVER_SPECIFIC_URL_2(scalar_measurements_refs)>`__
                 to be performed on each fetched waveform.
 
-            timeout (float in seconds or datetime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
+            timeout (float in seconds or hightime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
                 parameter tells NI-SCOPE to fetch whatever is currently available. Using
                 -1 for this parameter implies infinite timeout.
 
@@ -3336,7 +3336,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _read(self, num_samples, timeout=datetime.timedelta(seconds=5.0)):
+    def _read(self, num_samples, timeout=hightime.timedelta(seconds=5.0)):
         r'''_read
 
         Initiates an acquisition, waits for it to complete, and retrieves the
@@ -3368,7 +3368,7 @@ class _SessionBase(object):
                 timeout of 0 was used. If it fails to complete within the timeout
                 period, the method returns an error.
 
-            timeout (float in seconds or datetime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
+            timeout (float in seconds or hightime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
                 parameter tells NI-SCOPE to fetch whatever is currently available. Using
                 -1 for this parameter implies infinite timeout.
 
@@ -3435,7 +3435,7 @@ class _SessionBase(object):
         return waveform_array, [waveform_info.WaveformInfo(wfm_info_ctype[i]) for i in range(self._actual_num_wfms())]
 
     @ivi_synchronized
-    def _read_measurement(self, scalar_meas_function, timeout=datetime.timedelta(seconds=5.0)):
+    def _read_measurement(self, scalar_meas_function, timeout=hightime.timedelta(seconds=5.0)):
         r'''_read_measurement
 
         Initiates an acquisition, waits for it to complete, and performs the
@@ -3464,7 +3464,7 @@ class _SessionBase(object):
                 measurement <REPLACE_DRIVER_SPECIFIC_URL_2(scalar_measurements_refs)>`__
                 to be performed
 
-            timeout (float in seconds or datetime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
+            timeout (float in seconds or hightime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
                 parameter tells NI-SCOPE to fetch whatever is currently available. Using
                 -1 for this parameter implies infinite timeout.
 
@@ -4194,7 +4194,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_trigger_digital(self, trigger_source, slope=enums.TriggerSlope.POSITIVE, holdoff=datetime.timedelta(seconds=0.0), delay=datetime.timedelta(seconds=0.0)):
+    def configure_trigger_digital(self, trigger_source, slope=enums.TriggerSlope.POSITIVE, holdoff=hightime.timedelta(seconds=0.0), delay=hightime.timedelta(seconds=0.0)):
         r'''configure_trigger_digital
 
         Configures the common properties of a digital trigger.
@@ -4235,11 +4235,11 @@ class Session(_SessionBase):
                 the digitizer. Refer to trigger_slope for more
                 information.
 
-            holdoff (float in seconds or datetime.timedelta): The length of time the digitizer waits after detecting a trigger before
+            holdoff (float in seconds or hightime.timedelta): The length of time the digitizer waits after detecting a trigger before
                 enabling NI-SCOPE to detect another trigger. Refer to
                 trigger_holdoff for more information.
 
-            delay (float in seconds or datetime.timedelta): How long the digitizer waits after receiving the trigger to start
+            delay (float in seconds or hightime.timedelta): How long the digitizer waits after receiving the trigger to start
                 acquiring data. Refer to trigger_delay_time for more
                 information.
 
@@ -4256,7 +4256,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_trigger_edge(self, trigger_source, level, trigger_coupling, slope=enums.TriggerSlope.POSITIVE, holdoff=datetime.timedelta(seconds=0.0), delay=datetime.timedelta(seconds=0.0)):
+    def configure_trigger_edge(self, trigger_source, level, trigger_coupling, slope=enums.TriggerSlope.POSITIVE, holdoff=hightime.timedelta(seconds=0.0), delay=hightime.timedelta(seconds=0.0)):
         r'''configure_trigger_edge
 
         Configures common properties for analog edge triggering.
@@ -4293,11 +4293,11 @@ class Session(_SessionBase):
                 the digitizer. Refer to trigger_slope for more
                 information.
 
-            holdoff (float in seconds or datetime.timedelta): The length of time the digitizer waits after detecting a trigger before
+            holdoff (float in seconds or hightime.timedelta): The length of time the digitizer waits after detecting a trigger before
                 enabling NI-SCOPE to detect another trigger. Refer to
                 trigger_holdoff for more information.
 
-            delay (float in seconds or datetime.timedelta): How long the digitizer waits after receiving the trigger to start
+            delay (float in seconds or hightime.timedelta): How long the digitizer waits after receiving the trigger to start
                 acquiring data. Refer to trigger_delay_time for more
                 information.
 
@@ -4318,7 +4318,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_trigger_hysteresis(self, trigger_source, level, hysteresis, trigger_coupling, slope=enums.TriggerSlope.POSITIVE, holdoff=datetime.timedelta(seconds=0.0), delay=datetime.timedelta(seconds=0.0)):
+    def configure_trigger_hysteresis(self, trigger_source, level, hysteresis, trigger_coupling, slope=enums.TriggerSlope.POSITIVE, holdoff=hightime.timedelta(seconds=0.0), delay=hightime.timedelta(seconds=0.0)):
         r'''configure_trigger_hysteresis
 
         Configures common properties for analog hysteresis triggering. This kind
@@ -4365,11 +4365,11 @@ class Session(_SessionBase):
                 the digitizer. Refer to trigger_slope for more
                 information.
 
-            holdoff (float in seconds or datetime.timedelta): The length of time the digitizer waits after detecting a trigger before
+            holdoff (float in seconds or hightime.timedelta): The length of time the digitizer waits after detecting a trigger before
                 enabling NI-SCOPE to detect another trigger. Refer to
                 trigger_holdoff for more information.
 
-            delay (float in seconds or datetime.timedelta): How long the digitizer waits after receiving the trigger to start
+            delay (float in seconds or hightime.timedelta): How long the digitizer waits after receiving the trigger to start
                 acquiring data. Refer to trigger_delay_time for more
                 information.
 
@@ -4407,7 +4407,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_trigger_software(self, holdoff=datetime.timedelta(seconds=0.0), delay=datetime.timedelta(seconds=0.0)):
+    def configure_trigger_software(self, holdoff=hightime.timedelta(seconds=0.0), delay=hightime.timedelta(seconds=0.0)):
         r'''configure_trigger_software
 
         Configures common properties for software triggering.
@@ -4433,11 +4433,11 @@ class Session(_SessionBase):
         more information.
 
         Args:
-            holdoff (float in seconds or datetime.timedelta): The length of time the digitizer waits after detecting a trigger before
+            holdoff (float in seconds or hightime.timedelta): The length of time the digitizer waits after detecting a trigger before
                 enabling NI-SCOPE to detect another trigger. Refer to
                 trigger_holdoff for more information.
 
-            delay (float in seconds or datetime.timedelta): How long the digitizer waits after receiving the trigger to start
+            delay (float in seconds or hightime.timedelta): How long the digitizer waits after receiving the trigger to start
                 acquiring data. Refer to trigger_delay_time for more
                 information.
 
@@ -4450,7 +4450,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_trigger_video(self, trigger_source, signal_format, event, polarity, trigger_coupling, enable_dc_restore=False, line_number=1, holdoff=datetime.timedelta(seconds=0.0), delay=datetime.timedelta(seconds=0.0)):
+    def configure_trigger_video(self, trigger_source, signal_format, event, polarity, trigger_coupling, enable_dc_restore=False, line_number=1, holdoff=hightime.timedelta(seconds=0.0), delay=hightime.timedelta(seconds=0.0)):
         r'''configure_trigger_video
 
         Configures the common properties for video triggering, including the
@@ -4504,11 +4504,11 @@ class Session(_SessionBase):
 
                 Default value: 1
 
-            holdoff (float in seconds or datetime.timedelta): The length of time the digitizer waits after detecting a trigger before
+            holdoff (float in seconds or hightime.timedelta): The length of time the digitizer waits after detecting a trigger before
                 enabling NI-SCOPE to detect another trigger. Refer to
                 trigger_holdoff for more information.
 
-            delay (float in seconds or datetime.timedelta): How long the digitizer waits after receiving the trigger to start
+            delay (float in seconds or hightime.timedelta): How long the digitizer waits after receiving the trigger to start
                 acquiring data. Refer to trigger_delay_time for more
                 information.
 
@@ -4536,7 +4536,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_trigger_window(self, trigger_source, low_level, high_level, window_mode, trigger_coupling, holdoff=datetime.timedelta(seconds=0.0), delay=datetime.timedelta(seconds=0.0)):
+    def configure_trigger_window(self, trigger_source, low_level, high_level, window_mode, trigger_coupling, holdoff=hightime.timedelta(seconds=0.0), delay=hightime.timedelta(seconds=0.0)):
         r'''configure_trigger_window
 
         Configures common properties for analog window triggering. A window
@@ -4575,11 +4575,11 @@ class Session(_SessionBase):
             trigger_coupling (enums.TriggerCoupling): Applies coupling and filtering options to the trigger signal. Refer to
                 trigger_coupling for more information.
 
-            holdoff (float in seconds or datetime.timedelta): The length of time the digitizer waits after detecting a trigger before
+            holdoff (float in seconds or hightime.timedelta): The length of time the digitizer waits after detecting a trigger before
                 enabling NI-SCOPE to detect another trigger. Refer to
                 trigger_holdoff for more information.
 
-            delay (float in seconds or datetime.timedelta): How long the digitizer waits after receiving the trigger to start
+            delay (float in seconds or hightime.timedelta): How long the digitizer waits after receiving the trigger to start
                 acquiring data. Refer to trigger_delay_time for more
                 information.
 

--- a/generated/niscope/niscope/session.py
+++ b/generated/niscope/niscope/session.py
@@ -128,7 +128,7 @@ class _SessionBase(object):
     _is_frozen = False
 
     absolute_sample_clock_offset = _attributes.AttributeViReal64TimeDeltaSeconds(1150374)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
     Gets or sets the absolute time offset of the sample clock relative to
     the reference clock in terms of seconds.
@@ -143,7 +143,7 @@ class _SessionBase(object):
     offset is 0s.
     '''
     acquisition_start_time = _attributes.AttributeViReal64TimeDeltaSeconds(1250109)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
     Specifies the length of time from the trigger event to the first point in the waveform record in seconds.  If the value is positive, the first point in the waveform record occurs after the trigger event (same as specifying trigger_delay_time).  If the value is negative, the first point in the waveform record occurs before the trigger event (same as specifying horz_record_ref_position).
     '''
@@ -369,7 +369,7 @@ class _SessionBase(object):
     Consult your device documentation for a specific list of valid destinations.
     '''
     end_of_record_to_advance_trigger_holdoff = _attributes.AttributeViReal64TimeDeltaSeconds(1150366)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
     End of Record to Advance Trigger Holdoff is the length of time (in
     seconds) that a device waits between the completion of one record and
@@ -537,7 +537,7 @@ class _SessionBase(object):
     Units: Hertz (Samples / Second)
     '''
     horz_time_per_record = _attributes.AttributeViReal64TimeDeltaSeconds(1250007)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
     Specifies the length of time that corresponds to the record length.
     Units: Seconds
@@ -1136,7 +1136,7 @@ class _SessionBase(object):
     Indicates which analog compare circuitry to use on the device.
     '''
     ref_trigger_minimum_quiet_time = _attributes.AttributeViReal64TimeDeltaSeconds(1150315)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
     The amount of time the trigger circuit must not detect a signal above the trigger level before the trigger is armed.  This property is useful for triggering at the beginning and not in the middle of signal bursts.
     '''
@@ -1314,7 +1314,7 @@ class _SessionBase(object):
     A string that contains the name of the vendor that supplies this driver.
     '''
     start_to_ref_trigger_holdoff = _attributes.AttributeViReal64TimeDeltaSeconds(1150103)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
     Pass the length of time you want the digitizer to wait after it starts acquiring data until the digitizer enables the trigger system to detect a reference (stop) trigger.
     Units: Seconds
@@ -1336,13 +1336,13 @@ class _SessionBase(object):
     Specifies how the digitizer couples the trigger source. This property affects instrument operation only when trigger_type is set to TriggerType.EDGE, TriggerType.HYSTERESIS, or TriggerType.WINDOW.
     '''
     trigger_delay_time = _attributes.AttributeViReal64TimeDeltaSeconds(1250015)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
     Specifies the trigger delay time in seconds. The trigger delay time is the length of time the digitizer waits after it receives the trigger. The event that occurs when the trigger delay elapses is the Reference Event.
     Valid Values: 0.0 - 171.8
     '''
     trigger_holdoff = _attributes.AttributeViReal64TimeDeltaSeconds(1250016)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
     Specifies the length of time (in seconds) the digitizer waits after detecting a trigger before enabling the trigger subsystem to detect another trigger. This property affects instrument operation only when the digitizer requires multiple acquisitions to build a complete waveform. The digitizer requires multiple waveform acquisitions when it uses equivalent-time sampling or when the digitizer is configured for a multi-record acquisition through a call to configure_horizontal_timing.
     Valid Values: 0.0 - 171.8
@@ -1896,7 +1896,7 @@ class _SessionBase(object):
 
             num_records (int): Number of records to fetch. Use -1 to fetch all configured records.
 
-            timeout (float in seconds or hightime.timedelta): The time to wait for data to be acquired; using 0 for this parameter tells NI-SCOPE to fetch whatever is currently available. Using -1 seconds for this parameter implies infinite timeout.
+            timeout (hightime.timedelta, datetime.timedelta, or float in seconds): The time to wait for data to be acquired; using 0 for this parameter tells NI-SCOPE to fetch whatever is currently available. Using -1 seconds for this parameter implies infinite timeout.
 
 
         Returns:
@@ -2004,7 +2004,7 @@ class _SessionBase(object):
 
             num_records (int): Number of records to fetch. Use -1 to fetch all configured records.
 
-            timeout (float in seconds or hightime.timedelta): The time to wait for data to be acquired; using 0 for this parameter tells NI-SCOPE to fetch whatever is currently available. Using -1 seconds for this parameter implies infinite timeout.
+            timeout (hightime.timedelta, datetime.timedelta, or float in seconds): The time to wait for data to be acquired; using 0 for this parameter tells NI-SCOPE to fetch whatever is currently available. Using -1 seconds for this parameter implies infinite timeout.
 
 
         Returns:
@@ -2099,7 +2099,7 @@ class _SessionBase(object):
                 timeout of 0 was used. If it fails to complete within the timeout
                 period, the method returns an error.
 
-            timeout (float in seconds or hightime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
+            timeout (hightime.timedelta, datetime.timedelta, or float in seconds): The time to wait in seconds for data to be acquired; using 0 for this
                 parameter tells NI-SCOPE to fetch whatever is currently available. Using
                 -1 for this parameter implies infinite timeout.
 
@@ -2220,7 +2220,7 @@ class _SessionBase(object):
                 Note:
                 One or more of the referenced methods are not in the Python API for this driver.
 
-            timeout (float in seconds or hightime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
+            timeout (hightime.timedelta, datetime.timedelta, or float in seconds): The time to wait in seconds for data to be acquired; using 0 for this
                 parameter tells NI-SCOPE to fetch whatever is currently available. Using
                 -1 for this parameter implies infinite timeout.
 
@@ -2318,7 +2318,7 @@ class _SessionBase(object):
                 measurement <REPLACE_DRIVER_SPECIFIC_URL_2(array_measurements_refs)>`__
                 to perform.
 
-            timeout (float in seconds or hightime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
+            timeout (hightime.timedelta, datetime.timedelta, or float in seconds): The time to wait in seconds for data to be acquired; using 0 for this
                 parameter tells NI-SCOPE to fetch whatever is currently available. Using
                 -1 for this parameter implies infinite timeout.
 
@@ -2437,7 +2437,7 @@ class _SessionBase(object):
                 Note:
                 One or more of the referenced methods are not in the Python API for this driver.
 
-            timeout (float in seconds or hightime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
+            timeout (hightime.timedelta, datetime.timedelta, or float in seconds): The time to wait in seconds for data to be acquired; using 0 for this
                 parameter tells NI-SCOPE to fetch whatever is currently available. Using
                 -1 for this parameter implies infinite timeout.
 
@@ -2562,7 +2562,7 @@ class _SessionBase(object):
                 Note:
                 One or more of the referenced methods are not in the Python API for this driver.
 
-            timeout (float in seconds or hightime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
+            timeout (hightime.timedelta, datetime.timedelta, or float in seconds): The time to wait in seconds for data to be acquired; using 0 for this
                 parameter tells NI-SCOPE to fetch whatever is currently available. Using
                 -1 for this parameter implies infinite timeout.
 
@@ -2687,7 +2687,7 @@ class _SessionBase(object):
                 Note:
                 One or more of the referenced methods are not in the Python API for this driver.
 
-            timeout (float in seconds or hightime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
+            timeout (hightime.timedelta, datetime.timedelta, or float in seconds): The time to wait in seconds for data to be acquired; using 0 for this
                 parameter tells NI-SCOPE to fetch whatever is currently available. Using
                 -1 for this parameter implies infinite timeout.
 
@@ -2803,7 +2803,7 @@ class _SessionBase(object):
 
             num_records (int): Number of records to fetch. Use -1 to fetch all configured records.
 
-            timeout (float in seconds or hightime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this parameter tells NI-SCOPE to fetch whatever is currently available. Using -1 for this parameter implies infinite timeout.
+            timeout (hightime.timedelta, datetime.timedelta, or float in seconds): The time to wait in seconds for data to be acquired; using 0 for this parameter tells NI-SCOPE to fetch whatever is currently available. Using -1 for this parameter implies infinite timeout.
 
 
         Returns:
@@ -2901,7 +2901,7 @@ class _SessionBase(object):
                 measurement <REPLACE_DRIVER_SPECIFIC_URL_2(scalar_measurements_refs)>`__
                 to be performed.
 
-            timeout (float in seconds or hightime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
+            timeout (hightime.timedelta, datetime.timedelta, or float in seconds): The time to wait in seconds for data to be acquired; using 0 for this
                 parameter tells NI-SCOPE to fetch whatever is currently available. Using
                 -1 for this parameter implies infinite timeout.
 
@@ -2963,7 +2963,7 @@ class _SessionBase(object):
                 measurement <REPLACE_DRIVER_SPECIFIC_URL_2(scalar_measurements_refs)>`__
                 to be performed on each fetched waveform.
 
-            timeout (float in seconds or hightime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
+            timeout (hightime.timedelta, datetime.timedelta, or float in seconds): The time to wait in seconds for data to be acquired; using 0 for this
                 parameter tells NI-SCOPE to fetch whatever is currently available. Using
                 -1 for this parameter implies infinite timeout.
 
@@ -3368,7 +3368,7 @@ class _SessionBase(object):
                 timeout of 0 was used. If it fails to complete within the timeout
                 period, the method returns an error.
 
-            timeout (float in seconds or hightime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
+            timeout (hightime.timedelta, datetime.timedelta, or float in seconds): The time to wait in seconds for data to be acquired; using 0 for this
                 parameter tells NI-SCOPE to fetch whatever is currently available. Using
                 -1 for this parameter implies infinite timeout.
 
@@ -3464,7 +3464,7 @@ class _SessionBase(object):
                 measurement <REPLACE_DRIVER_SPECIFIC_URL_2(scalar_measurements_refs)>`__
                 to be performed
 
-            timeout (float in seconds or hightime.timedelta): The time to wait in seconds for data to be acquired; using 0 for this
+            timeout (hightime.timedelta, datetime.timedelta, or float in seconds): The time to wait in seconds for data to be acquired; using 0 for this
                 parameter tells NI-SCOPE to fetch whatever is currently available. Using
                 -1 for this parameter implies infinite timeout.
 
@@ -4235,11 +4235,11 @@ class Session(_SessionBase):
                 the digitizer. Refer to trigger_slope for more
                 information.
 
-            holdoff (float in seconds or hightime.timedelta): The length of time the digitizer waits after detecting a trigger before
+            holdoff (hightime.timedelta, datetime.timedelta, or float in seconds): The length of time the digitizer waits after detecting a trigger before
                 enabling NI-SCOPE to detect another trigger. Refer to
                 trigger_holdoff for more information.
 
-            delay (float in seconds or hightime.timedelta): How long the digitizer waits after receiving the trigger to start
+            delay (hightime.timedelta, datetime.timedelta, or float in seconds): How long the digitizer waits after receiving the trigger to start
                 acquiring data. Refer to trigger_delay_time for more
                 information.
 
@@ -4293,11 +4293,11 @@ class Session(_SessionBase):
                 the digitizer. Refer to trigger_slope for more
                 information.
 
-            holdoff (float in seconds or hightime.timedelta): The length of time the digitizer waits after detecting a trigger before
+            holdoff (hightime.timedelta, datetime.timedelta, or float in seconds): The length of time the digitizer waits after detecting a trigger before
                 enabling NI-SCOPE to detect another trigger. Refer to
                 trigger_holdoff for more information.
 
-            delay (float in seconds or hightime.timedelta): How long the digitizer waits after receiving the trigger to start
+            delay (hightime.timedelta, datetime.timedelta, or float in seconds): How long the digitizer waits after receiving the trigger to start
                 acquiring data. Refer to trigger_delay_time for more
                 information.
 
@@ -4365,11 +4365,11 @@ class Session(_SessionBase):
                 the digitizer. Refer to trigger_slope for more
                 information.
 
-            holdoff (float in seconds or hightime.timedelta): The length of time the digitizer waits after detecting a trigger before
+            holdoff (hightime.timedelta, datetime.timedelta, or float in seconds): The length of time the digitizer waits after detecting a trigger before
                 enabling NI-SCOPE to detect another trigger. Refer to
                 trigger_holdoff for more information.
 
-            delay (float in seconds or hightime.timedelta): How long the digitizer waits after receiving the trigger to start
+            delay (hightime.timedelta, datetime.timedelta, or float in seconds): How long the digitizer waits after receiving the trigger to start
                 acquiring data. Refer to trigger_delay_time for more
                 information.
 
@@ -4433,11 +4433,11 @@ class Session(_SessionBase):
         more information.
 
         Args:
-            holdoff (float in seconds or hightime.timedelta): The length of time the digitizer waits after detecting a trigger before
+            holdoff (hightime.timedelta, datetime.timedelta, or float in seconds): The length of time the digitizer waits after detecting a trigger before
                 enabling NI-SCOPE to detect another trigger. Refer to
                 trigger_holdoff for more information.
 
-            delay (float in seconds or hightime.timedelta): How long the digitizer waits after receiving the trigger to start
+            delay (hightime.timedelta, datetime.timedelta, or float in seconds): How long the digitizer waits after receiving the trigger to start
                 acquiring data. Refer to trigger_delay_time for more
                 information.
 
@@ -4504,11 +4504,11 @@ class Session(_SessionBase):
 
                 Default value: 1
 
-            holdoff (float in seconds or hightime.timedelta): The length of time the digitizer waits after detecting a trigger before
+            holdoff (hightime.timedelta, datetime.timedelta, or float in seconds): The length of time the digitizer waits after detecting a trigger before
                 enabling NI-SCOPE to detect another trigger. Refer to
                 trigger_holdoff for more information.
 
-            delay (float in seconds or hightime.timedelta): How long the digitizer waits after receiving the trigger to start
+            delay (hightime.timedelta, datetime.timedelta, or float in seconds): How long the digitizer waits after receiving the trigger to start
                 acquiring data. Refer to trigger_delay_time for more
                 information.
 
@@ -4575,11 +4575,11 @@ class Session(_SessionBase):
             trigger_coupling (enums.TriggerCoupling): Applies coupling and filtering options to the trigger signal. Refer to
                 trigger_coupling for more information.
 
-            holdoff (float in seconds or hightime.timedelta): The length of time the digitizer waits after detecting a trigger before
+            holdoff (hightime.timedelta, datetime.timedelta, or float in seconds): The length of time the digitizer waits after detecting a trigger before
                 enabling NI-SCOPE to detect another trigger. Refer to
                 trigger_holdoff for more information.
 
-            delay (float in seconds or hightime.timedelta): How long the digitizer waits after receiving the trigger to start
+            delay (hightime.timedelta, datetime.timedelta, or float in seconds): How long the digitizer waits after receiving the trigger to start
                 acquiring data. Refer to trigger_delay_time for more
                 information.
 

--- a/generated/niscope/setup.py
+++ b/generated/niscope/setup.py
@@ -46,6 +46,7 @@ setup(
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
         'nitclk',
+        'hightime',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/niscope/setup.py
+++ b/generated/niscope/setup.py
@@ -45,8 +45,8 @@ setup(
     install_requires=[
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
-        'nitclk',
         'hightime',
+        'nitclk',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/niscope/tox-system_tests.ini
+++ b/generated/niscope/tox-system_tests.ini
@@ -44,6 +44,7 @@ deps =
     niscope-system_tests: pytest
     niscope-system_tests: coverage
     niscope-system_tests: numpy
+    niscope-system_tests: hightime
     niscope-system_tests: scipy
     niscope-system_tests: fasteners
     niscope-system_tests: pytest-json

--- a/generated/nise/nise/_converters.py
+++ b/generated/nise/nise/_converters.py
@@ -5,8 +5,9 @@ import nise.errors as errors
 
 import array
 import collections
-import datetime
+import hightime
 import numbers
+import pytest
 
 from functools import singledispatch
 
@@ -144,7 +145,7 @@ def convert_repeated_capabilities_without_prefix(repeated_capability):
 
 def _convert_timedelta(value, library_type, scaling):
     try:
-        # We first assume it is a datetime.timedelta object
+        # We first assume it is a timedelta object
         scaled_value = value.total_seconds() * scaling
     except AttributeError:
         # If that doesn't work, assume it is a value in seconds
@@ -171,7 +172,7 @@ def convert_timedeltas_to_seconds_real64(values):
 
 
 def convert_seconds_real64_to_timedelta(value):
-    return datetime.timedelta(seconds=value)
+    return hightime.timedelta(seconds=value)
 
 
 def convert_seconds_real64_to_timedeltas(values):
@@ -179,7 +180,7 @@ def convert_seconds_real64_to_timedeltas(values):
 
 
 def convert_month_to_timedelta(months):
-    return datetime.timedelta(days=(30.4167 * months))
+    return hightime.timedelta(days=(30.4167 * months))
 
 
 # This converter is not called from the normal codegen path for function. Instead it is
@@ -285,11 +286,11 @@ def test_convert_init_with_options_dictionary():
 
 # Tests - time
 def test_convert_timedelta_to_seconds_double():
-    test_result = convert_timedelta_to_seconds_real64(datetime.timedelta(seconds=10))
+    test_result = convert_timedelta_to_seconds_real64(hightime.timedelta(seconds=10))
     assert test_result.value == 10.0
     assert isinstance(test_result, _visatype.ViReal64)
-    test_result = convert_timedelta_to_seconds_real64(datetime.timedelta(seconds=-1))
-    assert test_result.value == -1
+    test_result = convert_timedelta_to_seconds_real64(hightime.timedelta(nanoseconds=-0.5))
+    assert test_result.value == pytest.approx(-5e-10)
     assert isinstance(test_result, _visatype.ViReal64)
     test_result = convert_timedelta_to_seconds_real64(10.5)
     assert test_result.value == 10.5
@@ -300,11 +301,11 @@ def test_convert_timedelta_to_seconds_double():
 
 
 def test_convert_timedelta_to_milliseconds_int32():
-    test_result = convert_timedelta_to_milliseconds_int32(datetime.timedelta(seconds=10))
+    test_result = convert_timedelta_to_milliseconds_int32(hightime.timedelta(seconds=10))
     assert test_result.value == 10000
     assert isinstance(test_result, _visatype.ViInt32)
-    test_result = convert_timedelta_to_milliseconds_int32(datetime.timedelta(seconds=-1))
-    assert test_result.value == -1000
+    test_result = convert_timedelta_to_milliseconds_int32(hightime.timedelta(seconds=-5))
+    assert test_result.value == -5000
     assert isinstance(test_result, _visatype.ViInt32)
     test_result = convert_timedelta_to_milliseconds_int32(10.5)
     assert test_result.value == 10500
@@ -315,26 +316,28 @@ def test_convert_timedelta_to_milliseconds_int32():
 
 
 def test_convert_timedeltas_to_seconds_real64():
-    time_values = [10.5, -1]
+    time_values = [10.5, -5e-10]
     test_result = convert_timedeltas_to_seconds_real64(time_values)
-    assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
+    assert all([actual.value == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
-    timedeltas = [datetime.timedelta(seconds=s, milliseconds=ms) for s, ms in zip([10, -1], [500, 0])]
-    test_result = convert_timedeltas_to_seconds_real64(timedeltas)
-    assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
+    test_input = [hightime.timedelta(seconds=10.5), hightime.timedelta(nanoseconds=-0.5)]
+    test_result = convert_timedeltas_to_seconds_real64(test_input)
+    assert all([actual.value == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
 
 
 def test_convert_seconds_real64_to_timedelta():
-    time_value = 10.5
-    timedelta = convert_seconds_real64_to_timedelta(time_value)
-    assert timedelta.total_seconds() == time_value
+    time_value = -5e-10
+    test_result = convert_seconds_real64_to_timedelta(time_value)
+    assert test_result.total_seconds() == pytest.approx(time_value)
+    assert isinstance(test_result, hightime.timedelta)
 
 
 def test_convert_seconds_real64_to_timedeltas():
-    time_values = [10.5, -1]
-    timedeltas = convert_seconds_real64_to_timedeltas(time_values)
-    assert all([actual.total_seconds() == expected for actual, expected in zip(timedeltas, time_values)])
+    time_values = [10.5, -5e-10]
+    test_result = convert_seconds_real64_to_timedeltas(time_values)
+    assert all([actual.total_seconds() == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
+    assert all([isinstance(x, hightime.timedelta) for x in test_result])
 
 
 # Tests - repeated capabilities

--- a/generated/nise/nise/session.py
+++ b/generated/nise/nise/session.py
@@ -2,7 +2,6 @@
 # This file was generated
 import array  # noqa: F401
 import ctypes
-import datetime  # noqa: F401
 
 import nise._converters as _converters
 import nise._library_singleton as _library_singleton
@@ -10,6 +9,7 @@ import nise._visatype as _visatype
 import nise.enums as enums
 import nise.errors as errors
 
+import hightime
 
 # Used for __repr__
 import pprint
@@ -763,7 +763,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(vi_ctype.value)
 
-    def wait_for_debounce(self, maximum_time_ms=datetime.timedelta(milliseconds=-1)):
+    def wait_for_debounce(self, maximum_time_ms=hightime.timedelta(milliseconds=-1)):
         r'''wait_for_debounce
 
         Waits for all of the switches in the NI Switch Executive virtual device
@@ -777,7 +777,7 @@ class Session(_SessionBase):
         signals connected to the switching system.
 
         Args:
-            maximum_time_ms (int in milliseconds or datetime.timedelta): The amount of time to wait (in milliseconds) for the debounce to
+            maximum_time_ms (int in milliseconds or hightime.timedelta): The amount of time to wait (in milliseconds) for the debounce to
                 complete. A value of 0 checks for debouncing once and returns an error
                 if the system is not debounced at that time. A value of -1 means to
                 block for an infinite period of time until the system is debounced.

--- a/generated/nise/nise/session.py
+++ b/generated/nise/nise/session.py
@@ -777,7 +777,7 @@ class Session(_SessionBase):
         signals connected to the switching system.
 
         Args:
-            maximum_time_ms (int in milliseconds or hightime.timedelta): The amount of time to wait (in milliseconds) for the debounce to
+            maximum_time_ms (hightime.timedelta, datetime.timedelta, or int in milliseconds): The amount of time to wait (in milliseconds) for the debounce to
                 complete. A value of 0 checks for debouncing once and returns an error
                 if the system is not debounced at that time. A value of -1 means to
                 block for an infinite period of time until the system is debounced.

--- a/generated/nise/setup.py
+++ b/generated/nise/setup.py
@@ -45,6 +45,7 @@ setup(
     install_requires=[
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
+        'hightime',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/nise/tox-system_tests.ini
+++ b/generated/nise/tox-system_tests.ini
@@ -37,6 +37,7 @@ deps =
     nise-system_tests: pytest
     nise-system_tests: coverage
     nise-system_tests: numpy
+    nise-system_tests: hightime
     nise-system_tests: scipy
     nise-system_tests: fasteners
     nise-system_tests: pytest-json

--- a/generated/niswitch/niswitch/_attributes.py
+++ b/generated/niswitch/niswitch/_attributes.py
@@ -2,7 +2,7 @@
 # This file was generated
 import niswitch._converters as _converters
 
-import datetime
+import hightime
 
 
 class Attribute(object):
@@ -24,7 +24,7 @@ class AttributeViInt32(Attribute):
 class AttributeViInt32TimeDeltaMilliseconds(Attribute):
 
     def __get__(self, session, session_type):
-        return datetime.timedelta(milliseconds=session._get_attribute_vi_int32(self._attribute_id))
+        return hightime.timedelta(milliseconds=session._get_attribute_vi_int32(self._attribute_id))
 
     def __set__(self, session, value):
         session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_milliseconds_int32(value).value)
@@ -51,7 +51,7 @@ class AttributeViReal64(Attribute):
 class AttributeViReal64TimeDeltaSeconds(Attribute):
 
     def __get__(self, session, session_type):
-        return datetime.timedelta(seconds=session._get_attribute_vi_real64(self._attribute_id))
+        return hightime.timedelta(seconds=session._get_attribute_vi_real64(self._attribute_id))
 
     def __set__(self, session, value):
         session._set_attribute_vi_real64(self._attribute_id, _converters.convert_timedelta_to_seconds_real64(value).value)

--- a/generated/niswitch/niswitch/_converters.py
+++ b/generated/niswitch/niswitch/_converters.py
@@ -5,8 +5,9 @@ import niswitch.errors as errors
 
 import array
 import collections
-import datetime
+import hightime
 import numbers
+import pytest
 
 from functools import singledispatch
 
@@ -144,7 +145,7 @@ def convert_repeated_capabilities_without_prefix(repeated_capability):
 
 def _convert_timedelta(value, library_type, scaling):
     try:
-        # We first assume it is a datetime.timedelta object
+        # We first assume it is a timedelta object
         scaled_value = value.total_seconds() * scaling
     except AttributeError:
         # If that doesn't work, assume it is a value in seconds
@@ -171,7 +172,7 @@ def convert_timedeltas_to_seconds_real64(values):
 
 
 def convert_seconds_real64_to_timedelta(value):
-    return datetime.timedelta(seconds=value)
+    return hightime.timedelta(seconds=value)
 
 
 def convert_seconds_real64_to_timedeltas(values):
@@ -179,7 +180,7 @@ def convert_seconds_real64_to_timedeltas(values):
 
 
 def convert_month_to_timedelta(months):
-    return datetime.timedelta(days=(30.4167 * months))
+    return hightime.timedelta(days=(30.4167 * months))
 
 
 # This converter is not called from the normal codegen path for function. Instead it is
@@ -285,11 +286,11 @@ def test_convert_init_with_options_dictionary():
 
 # Tests - time
 def test_convert_timedelta_to_seconds_double():
-    test_result = convert_timedelta_to_seconds_real64(datetime.timedelta(seconds=10))
+    test_result = convert_timedelta_to_seconds_real64(hightime.timedelta(seconds=10))
     assert test_result.value == 10.0
     assert isinstance(test_result, _visatype.ViReal64)
-    test_result = convert_timedelta_to_seconds_real64(datetime.timedelta(seconds=-1))
-    assert test_result.value == -1
+    test_result = convert_timedelta_to_seconds_real64(hightime.timedelta(nanoseconds=-0.5))
+    assert test_result.value == pytest.approx(-5e-10)
     assert isinstance(test_result, _visatype.ViReal64)
     test_result = convert_timedelta_to_seconds_real64(10.5)
     assert test_result.value == 10.5
@@ -300,11 +301,11 @@ def test_convert_timedelta_to_seconds_double():
 
 
 def test_convert_timedelta_to_milliseconds_int32():
-    test_result = convert_timedelta_to_milliseconds_int32(datetime.timedelta(seconds=10))
+    test_result = convert_timedelta_to_milliseconds_int32(hightime.timedelta(seconds=10))
     assert test_result.value == 10000
     assert isinstance(test_result, _visatype.ViInt32)
-    test_result = convert_timedelta_to_milliseconds_int32(datetime.timedelta(seconds=-1))
-    assert test_result.value == -1000
+    test_result = convert_timedelta_to_milliseconds_int32(hightime.timedelta(seconds=-5))
+    assert test_result.value == -5000
     assert isinstance(test_result, _visatype.ViInt32)
     test_result = convert_timedelta_to_milliseconds_int32(10.5)
     assert test_result.value == 10500
@@ -315,26 +316,28 @@ def test_convert_timedelta_to_milliseconds_int32():
 
 
 def test_convert_timedeltas_to_seconds_real64():
-    time_values = [10.5, -1]
+    time_values = [10.5, -5e-10]
     test_result = convert_timedeltas_to_seconds_real64(time_values)
-    assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
+    assert all([actual.value == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
-    timedeltas = [datetime.timedelta(seconds=s, milliseconds=ms) for s, ms in zip([10, -1], [500, 0])]
-    test_result = convert_timedeltas_to_seconds_real64(timedeltas)
-    assert all([actual.value == expected for actual, expected in zip(test_result, time_values)])
+    test_input = [hightime.timedelta(seconds=10.5), hightime.timedelta(nanoseconds=-0.5)]
+    test_result = convert_timedeltas_to_seconds_real64(test_input)
+    assert all([actual.value == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
     assert all([isinstance(i, _visatype.ViReal64) for i in test_result])
 
 
 def test_convert_seconds_real64_to_timedelta():
-    time_value = 10.5
-    timedelta = convert_seconds_real64_to_timedelta(time_value)
-    assert timedelta.total_seconds() == time_value
+    time_value = -5e-10
+    test_result = convert_seconds_real64_to_timedelta(time_value)
+    assert test_result.total_seconds() == pytest.approx(time_value)
+    assert isinstance(test_result, hightime.timedelta)
 
 
 def test_convert_seconds_real64_to_timedeltas():
-    time_values = [10.5, -1]
-    timedeltas = convert_seconds_real64_to_timedeltas(time_values)
-    assert all([actual.total_seconds() == expected for actual, expected in zip(timedeltas, time_values)])
+    time_values = [10.5, -5e-10]
+    test_result = convert_seconds_real64_to_timedeltas(time_values)
+    assert all([actual.total_seconds() == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
+    assert all([isinstance(x, hightime.timedelta) for x in test_result])
 
 
 # Tests - repeated capabilities

--- a/generated/niswitch/niswitch/session.py
+++ b/generated/niswitch/niswitch/session.py
@@ -408,7 +408,7 @@ class _SessionBase(object):
     '''
     scan_advanced_polarity = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.ScanAdvancedPolarity, 1150011)
     scan_delay = _attributes.AttributeViReal64TimeDeltaSeconds(1250025)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
     This property specifies the minimum amount of time the switch device  waits before it asserts the scan advanced output trigger after opening or  closing the switch.  The switch device always waits for debounce before  asserting the trigger. The units are seconds.
     the greater value of the settling time and the value you specify as the  scan delay.
@@ -446,7 +446,7 @@ class _SessionBase(object):
     This read-only property returns the serial number for the switch device  controlled by this instrument driver.  If the device does not return a  serial number, the driver returns the IVI_ERROR_ATTRIBUTE_NOT_SUPPORTED error.
     '''
     settling_time = _attributes.AttributeViReal64TimeDeltaSeconds(1250004)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
     This channel-based property returns the maximum length of time from after  you make a connection until the signal flowing through the channel  settles. The units are seconds.
     the greater value of the settling time and the value you specify as the  scan delay.
@@ -2364,7 +2364,7 @@ class Session(_SessionBase):
         NISWITCH_ERROR_MAX_TIME_EXCEEDED error.
 
         Args:
-            maximum_time_ms (int in milliseconds or hightime.timedelta): Specifies the maximum length of time to wait for all relays in the
+            maximum_time_ms (hightime.timedelta, datetime.timedelta, or int in milliseconds): Specifies the maximum length of time to wait for all relays in the
                 switch module to activate or deactivate. If the specified time elapses
                 before all relays active or deactivate, a timeout error is returned.
                 Default Value:5000 ms
@@ -2387,7 +2387,7 @@ class Session(_SessionBase):
         error.
 
         Args:
-            maximum_time_ms (int in milliseconds or hightime.timedelta): Specifies the maximum length of time to wait for the switch module to
+            maximum_time_ms (hightime.timedelta, datetime.timedelta, or int in milliseconds): Specifies the maximum length of time to wait for the switch module to
                 stop scanning. If the specified time elapses before the scan ends,
                 NISWITCH_ERROR_MAX_TIME_EXCEEDED error is returned. Default
                 Value:5000 ms

--- a/generated/niswitch/niswitch/session.py
+++ b/generated/niswitch/niswitch/session.py
@@ -2,7 +2,6 @@
 # This file was generated
 import array  # noqa: F401
 import ctypes
-import datetime  # noqa: F401
 # Used by @ivi_synchronized
 from functools import wraps
 
@@ -13,6 +12,7 @@ import niswitch._visatype as _visatype
 import niswitch.enums as enums
 import niswitch.errors as errors
 
+import hightime
 
 # Used for __repr__
 import pprint
@@ -408,7 +408,7 @@ class _SessionBase(object):
     '''
     scan_advanced_polarity = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.ScanAdvancedPolarity, 1150011)
     scan_delay = _attributes.AttributeViReal64TimeDeltaSeconds(1250025)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     This property specifies the minimum amount of time the switch device  waits before it asserts the scan advanced output trigger after opening or  closing the switch.  The switch device always waits for debounce before  asserting the trigger. The units are seconds.
     the greater value of the settling time and the value you specify as the  scan delay.
@@ -446,7 +446,7 @@ class _SessionBase(object):
     This read-only property returns the serial number for the switch device  controlled by this instrument driver.  If the device does not return a  serial number, the driver returns the IVI_ERROR_ATTRIBUTE_NOT_SUPPORTED error.
     '''
     settling_time = _attributes.AttributeViReal64TimeDeltaSeconds(1250004)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     This channel-based property returns the maximum length of time from after  you make a connection until the signal flowing through the channel  settles. The units are seconds.
     the greater value of the settling time and the value you specify as the  scan delay.
@@ -2355,7 +2355,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def wait_for_debounce(self, maximum_time_ms=datetime.timedelta(milliseconds=5000)):
+    def wait_for_debounce(self, maximum_time_ms=hightime.timedelta(milliseconds=5000)):
         r'''wait_for_debounce
 
         Pauses until all created paths have settled. If the time you specify
@@ -2364,7 +2364,7 @@ class Session(_SessionBase):
         NISWITCH_ERROR_MAX_TIME_EXCEEDED error.
 
         Args:
-            maximum_time_ms (int in milliseconds or datetime.timedelta): Specifies the maximum length of time to wait for all relays in the
+            maximum_time_ms (int in milliseconds or hightime.timedelta): Specifies the maximum length of time to wait for all relays in the
                 switch module to activate or deactivate. If the specified time elapses
                 before all relays active or deactivate, a timeout error is returned.
                 Default Value:5000 ms
@@ -2377,7 +2377,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def wait_for_scan_complete(self, maximum_time_ms=datetime.timedelta(milliseconds=5000)):
+    def wait_for_scan_complete(self, maximum_time_ms=hightime.timedelta(milliseconds=5000)):
         r'''wait_for_scan_complete
 
         Pauses until the switch module stops scanning or the maximum time has
@@ -2387,7 +2387,7 @@ class Session(_SessionBase):
         error.
 
         Args:
-            maximum_time_ms (int in milliseconds or datetime.timedelta): Specifies the maximum length of time to wait for the switch module to
+            maximum_time_ms (int in milliseconds or hightime.timedelta): Specifies the maximum length of time to wait for the switch module to
                 stop scanning. If the specified time elapses before the scan ends,
                 NISWITCH_ERROR_MAX_TIME_EXCEEDED error is returned. Default
                 Value:5000 ms

--- a/generated/niswitch/setup.py
+++ b/generated/niswitch/setup.py
@@ -45,6 +45,7 @@ setup(
     install_requires=[
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
+        'hightime',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/niswitch/tox-system_tests.ini
+++ b/generated/niswitch/tox-system_tests.ini
@@ -37,6 +37,7 @@ deps =
     niswitch-system_tests: pytest
     niswitch-system_tests: coverage
     niswitch-system_tests: numpy
+    niswitch-system_tests: hightime
     niswitch-system_tests: scipy
     niswitch-system_tests: fasteners
     niswitch-system_tests: pytest-json

--- a/generated/nitclk/nitclk/_attributes.py
+++ b/generated/nitclk/nitclk/_attributes.py
@@ -2,7 +2,7 @@
 # This file was generated
 import nitclk._converters as _converters
 
-import datetime
+import hightime
 
 
 class Attribute(object):
@@ -24,7 +24,7 @@ class AttributeViInt32(Attribute):
 class AttributeViInt32TimeDeltaMilliseconds(Attribute):
 
     def __get__(self, session, session_type):
-        return datetime.timedelta(milliseconds=session._get_attribute_vi_int32(self._attribute_id))
+        return hightime.timedelta(milliseconds=session._get_attribute_vi_int32(self._attribute_id))
 
     def __set__(self, session, value):
         session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_milliseconds_int32(value).value)
@@ -51,7 +51,7 @@ class AttributeViReal64(Attribute):
 class AttributeViReal64TimeDeltaSeconds(Attribute):
 
     def __get__(self, session, session_type):
-        return datetime.timedelta(seconds=session._get_attribute_vi_real64(self._attribute_id))
+        return hightime.timedelta(seconds=session._get_attribute_vi_real64(self._attribute_id))
 
     def __set__(self, session, value):
         session._set_attribute_vi_real64(self._attribute_id, _converters.convert_timedelta_to_seconds_real64(value).value)

--- a/generated/nitclk/nitclk/session.py
+++ b/generated/nitclk/nitclk/session.py
@@ -88,7 +88,7 @@ class SessionReference(object):
     For external triggers, the session that originally receives the trigger.  For None (no trigger configured) or software triggers, the session that  originally generates the trigger.
     '''
     sample_clock_delay = _attributes.AttributeViReal64TimeDeltaSeconds(11)
-    '''Type: float in seconds or hightime.timedelta
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
     Specifies the sample clock delay.
     Specifies the delay, in seconds, to apply to the session sample clock  relative to the other synchronized sessions. During synchronization,  NI-TClk aligns the sample clocks on the synchronized devices. If you want  to delay the sample clocks, set this property before calling  synchronize.
@@ -604,7 +604,7 @@ class _Session(object):
         Args:
             sessions (list of (nimi-python Session class or nitclk.SessionReference)): sessions is an array of sessions that are being synchronized.
 
-            min_time (float in seconds or hightime.timedelta): Minimal period of TClk, expressed in seconds. Supported values are
+            min_time (hightime.timedelta, datetime.timedelta, or float in seconds): Minimal period of TClk, expressed in seconds. Supported values are
                 between 0.0 s and 0.050 s (50 ms). Minimal period for a single
                 chassis/PC is 200 ns. If the specified value is less than 200 ns,
                 NI-TClk automatically coerces minTime to 200 ns. For multichassis
@@ -695,7 +695,7 @@ class _Session(object):
         Args:
             sessions (list of (Driver Session or nitclk.SessionReference)): sessions is an array of sessions that are being synchronized.
 
-            min_time (float in seconds or hightime.timedelta): Minimal period of TClk, expressed in seconds. Supported values are
+            min_time (hightime.timedelta, datetime.timedelta, or float in seconds): Minimal period of TClk, expressed in seconds. Supported values are
                 between 0.0 s and 0.050 s (50 ms). Minimal period for a single
                 chassis/PC is 200 ns. If the specified value is less than 200 ns,
                 NI-TClk automatically coerces minTime to 200 ns. For multichassis
@@ -723,7 +723,7 @@ class _Session(object):
         Args:
             sessions (list of (Driver Session or nitclk.SessionReference)): sessions is an array of sessions that are being synchronized.
 
-            min_tclk_period (float in seconds or hightime.timedelta): Minimal period of TClk, expressed in seconds. Supported values are
+            min_tclk_period (hightime.timedelta, datetime.timedelta, or float in seconds): Minimal period of TClk, expressed in seconds. Supported values are
                 between 0.0 s and 0.050 s (50 ms). Minimal period for a single
                 chassis/PC is 200 ns. If the specified value is less than 200 ns,
                 NI-TClk automatically coerces minTime to 200 ns. For multichassis
@@ -746,7 +746,7 @@ class _Session(object):
         Args:
             sessions (list of (Driver Session or nitclk.SessionReference)): sessions is an array of sessions that are being synchronized.
 
-            min_time (float in seconds or hightime.timedelta): Minimal period of TClk, expressed in seconds. Supported values are
+            min_time (hightime.timedelta, datetime.timedelta, or float in seconds): Minimal period of TClk, expressed in seconds. Supported values are
                 between 0.0 s and 0.050 s (50 ms). Minimal period for a single
                 chassis/PC is 200 ns. If the specified value is less than 200 ns,
                 NI-TClk automatically coerces minTime to 200 ns. For multichassis
@@ -776,7 +776,7 @@ class _Session(object):
         Args:
             sessions (list of (Driver Session or nitclk.SessionReference)): sessions is an array of sessions that are being synchronized.
 
-            timeout (float in seconds or hightime.timedelta): The amount of time in seconds that wait_until_done waits for the
+            timeout (hightime.timedelta, datetime.timedelta, or float in seconds): The amount of time in seconds that wait_until_done waits for the
                 sessions to complete. If timeout is exceeded, wait_until_done
                 returns an error.
 
@@ -929,7 +929,7 @@ def finish_sync_pulse_sender_synchronize(sessions, min_time):
     Args:
         sessions (list of (nimi-python Session class or nitclk.SessionReference)): sessions is an array of sessions that are being synchronized.
 
-        min_time (float in seconds or hightime.timedelta): Minimal period of TClk, expressed in seconds. Supported values are
+        min_time (hightime.timedelta, datetime.timedelta, or float in seconds): Minimal period of TClk, expressed in seconds. Supported values are
             between 0.0 s and 0.050 s (50 ms). Minimal period for a single
             chassis/PC is 200 ns. If the specified value is less than 200 ns,
             NI-TClk automatically coerces minTime to 200 ns. For multichassis
@@ -983,7 +983,7 @@ def setup_for_sync_pulse_sender_synchronize(sessions, min_time):
     Args:
         sessions (list of (Driver Session or nitclk.SessionReference)): sessions is an array of sessions that are being synchronized.
 
-        min_time (float in seconds or hightime.timedelta): Minimal period of TClk, expressed in seconds. Supported values are
+        min_time (hightime.timedelta, datetime.timedelta, or float in seconds): Minimal period of TClk, expressed in seconds. Supported values are
             between 0.0 s and 0.050 s (50 ms). Minimal period for a single
             chassis/PC is 200 ns. If the specified value is less than 200 ns,
             NI-TClk automatically coerces minTime to 200 ns. For multichassis
@@ -1007,7 +1007,7 @@ def synchronize(sessions, min_tclk_period):
     Args:
         sessions (list of (Driver Session or nitclk.SessionReference)): sessions is an array of sessions that are being synchronized.
 
-        min_tclk_period (float in seconds or hightime.timedelta): Minimal period of TClk, expressed in seconds. Supported values are
+        min_tclk_period (hightime.timedelta, datetime.timedelta, or float in seconds): Minimal period of TClk, expressed in seconds. Supported values are
             between 0.0 s and 0.050 s (50 ms). Minimal period for a single
             chassis/PC is 200 ns. If the specified value is less than 200 ns,
             NI-TClk automatically coerces minTime to 200 ns. For multichassis
@@ -1026,7 +1026,7 @@ def synchronize_to_sync_pulse_sender(sessions, min_time):
     Args:
         sessions (list of (Driver Session or nitclk.SessionReference)): sessions is an array of sessions that are being synchronized.
 
-        min_time (float in seconds or hightime.timedelta): Minimal period of TClk, expressed in seconds. Supported values are
+        min_time (hightime.timedelta, datetime.timedelta, or float in seconds): Minimal period of TClk, expressed in seconds. Supported values are
             between 0.0 s and 0.050 s (50 ms). Minimal period for a single
             chassis/PC is 200 ns. If the specified value is less than 200 ns,
             NI-TClk automatically coerces minTime to 200 ns. For multichassis
@@ -1052,7 +1052,7 @@ def wait_until_done(sessions, timeout):
     Args:
         sessions (list of (Driver Session or nitclk.SessionReference)): sessions is an array of sessions that are being synchronized.
 
-        timeout (float in seconds or hightime.timedelta): The amount of time in seconds that wait_until_done waits for the
+        timeout (hightime.timedelta, datetime.timedelta, or float in seconds): The amount of time in seconds that wait_until_done waits for the
             sessions to complete. If timeout is exceeded, wait_until_done
             returns an error.
 

--- a/generated/nitclk/nitclk/session.py
+++ b/generated/nitclk/nitclk/session.py
@@ -2,7 +2,7 @@
 
 import array
 import ctypes
-import datetime
+import hightime
 import threading
 
 import nitclk._attributes as _attributes
@@ -88,7 +88,7 @@ class SessionReference(object):
     For external triggers, the session that originally receives the trigger.  For None (no trigger configured) or software triggers, the session that  originally generates the trigger.
     '''
     sample_clock_delay = _attributes.AttributeViReal64TimeDeltaSeconds(11)
-    '''Type: float in seconds or datetime.timedelta
+    '''Type: float in seconds or hightime.timedelta
 
     Specifies the sample clock delay.
     Specifies the delay, in seconds, to apply to the session sample clock  relative to the other synchronized sessions. During synchronization,  NI-TClk aligns the sample clocks on the synchronized devices. If you want  to delay the sample clocks, set this property before calling  synchronize.
@@ -596,7 +596,7 @@ class _Session(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def finish_sync_pulse_sender_synchronize(self, sessions, min_time=datetime.timedelta(seconds=0.0)):
+    def finish_sync_pulse_sender_synchronize(self, sessions, min_time=hightime.timedelta(seconds=0.0)):
         r'''finish_sync_pulse_sender_synchronize
 
         Finishes synchronizing the Sync Pulse Sender.
@@ -604,7 +604,7 @@ class _Session(object):
         Args:
             sessions (list of (nimi-python Session class or nitclk.SessionReference)): sessions is an array of sessions that are being synchronized.
 
-            min_time (float in seconds or datetime.timedelta): Minimal period of TClk, expressed in seconds. Supported values are
+            min_time (float in seconds or hightime.timedelta): Minimal period of TClk, expressed in seconds. Supported values are
                 between 0.0 s and 0.050 s (50 ms). Minimal period for a single
                 chassis/PC is 200 ns. If the specified value is less than 200 ns,
                 NI-TClk automatically coerces minTime to 200 ns. For multichassis
@@ -687,7 +687,7 @@ class _Session(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return bool(done_ctype.value)
 
-    def setup_for_sync_pulse_sender_synchronize(self, sessions, min_time=datetime.timedelta(seconds=0.0)):
+    def setup_for_sync_pulse_sender_synchronize(self, sessions, min_time=hightime.timedelta(seconds=0.0)):
         r'''setup_for_sync_pulse_sender_synchronize
 
         Configures the TClks on all the devices and prepares the Sync Pulse Sender for synchronization
@@ -695,7 +695,7 @@ class _Session(object):
         Args:
             sessions (list of (Driver Session or nitclk.SessionReference)): sessions is an array of sessions that are being synchronized.
 
-            min_time (float in seconds or datetime.timedelta): Minimal period of TClk, expressed in seconds. Supported values are
+            min_time (float in seconds or hightime.timedelta): Minimal period of TClk, expressed in seconds. Supported values are
                 between 0.0 s and 0.050 s (50 ms). Minimal period for a single
                 chassis/PC is 200 ns. If the specified value is less than 200 ns,
                 NI-TClk automatically coerces minTime to 200 ns. For multichassis
@@ -710,7 +710,7 @@ class _Session(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def synchronize(self, sessions, min_tclk_period=datetime.timedelta(seconds=0.0)):
+    def synchronize(self, sessions, min_tclk_period=hightime.timedelta(seconds=0.0)):
         r'''synchronize
 
         Synchronizes the TClk signals on the given sessions. After
@@ -723,7 +723,7 @@ class _Session(object):
         Args:
             sessions (list of (Driver Session or nitclk.SessionReference)): sessions is an array of sessions that are being synchronized.
 
-            min_tclk_period (float in seconds or datetime.timedelta): Minimal period of TClk, expressed in seconds. Supported values are
+            min_tclk_period (float in seconds or hightime.timedelta): Minimal period of TClk, expressed in seconds. Supported values are
                 between 0.0 s and 0.050 s (50 ms). Minimal period for a single
                 chassis/PC is 200 ns. If the specified value is less than 200 ns,
                 NI-TClk automatically coerces minTime to 200 ns. For multichassis
@@ -738,7 +738,7 @@ class _Session(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def synchronize_to_sync_pulse_sender(self, sessions, min_time=datetime.timedelta(seconds=0.0)):
+    def synchronize_to_sync_pulse_sender(self, sessions, min_time=hightime.timedelta(seconds=0.0)):
         r'''synchronize_to_sync_pulse_sender
 
         Synchronizes the other devices to the Sync Pulse Sender.
@@ -746,7 +746,7 @@ class _Session(object):
         Args:
             sessions (list of (Driver Session or nitclk.SessionReference)): sessions is an array of sessions that are being synchronized.
 
-            min_time (float in seconds or datetime.timedelta): Minimal period of TClk, expressed in seconds. Supported values are
+            min_time (float in seconds or hightime.timedelta): Minimal period of TClk, expressed in seconds. Supported values are
                 between 0.0 s and 0.050 s (50 ms). Minimal period for a single
                 chassis/PC is 200 ns. If the specified value is less than 200 ns,
                 NI-TClk automatically coerces minTime to 200 ns. For multichassis
@@ -761,7 +761,7 @@ class _Session(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def wait_until_done(self, sessions, timeout=datetime.timedelta(seconds=0.0)):
+    def wait_until_done(self, sessions, timeout=hightime.timedelta(seconds=0.0)):
         r'''wait_until_done
 
         Call this method to pause execution of your program until the
@@ -776,7 +776,7 @@ class _Session(object):
         Args:
             sessions (list of (Driver Session or nitclk.SessionReference)): sessions is an array of sessions that are being synchronized.
 
-            timeout (float in seconds or datetime.timedelta): The amount of time in seconds that wait_until_done waits for the
+            timeout (float in seconds or hightime.timedelta): The amount of time in seconds that wait_until_done waits for the
                 sessions to complete. If timeout is exceeded, wait_until_done
                 returns an error.
 
@@ -929,7 +929,7 @@ def finish_sync_pulse_sender_synchronize(sessions, min_time):
     Args:
         sessions (list of (nimi-python Session class or nitclk.SessionReference)): sessions is an array of sessions that are being synchronized.
 
-        min_time (float in seconds or datetime.timedelta): Minimal period of TClk, expressed in seconds. Supported values are
+        min_time (float in seconds or hightime.timedelta): Minimal period of TClk, expressed in seconds. Supported values are
             between 0.0 s and 0.050 s (50 ms). Minimal period for a single
             chassis/PC is 200 ns. If the specified value is less than 200 ns,
             NI-TClk automatically coerces minTime to 200 ns. For multichassis
@@ -983,7 +983,7 @@ def setup_for_sync_pulse_sender_synchronize(sessions, min_time):
     Args:
         sessions (list of (Driver Session or nitclk.SessionReference)): sessions is an array of sessions that are being synchronized.
 
-        min_time (float in seconds or datetime.timedelta): Minimal period of TClk, expressed in seconds. Supported values are
+        min_time (float in seconds or hightime.timedelta): Minimal period of TClk, expressed in seconds. Supported values are
             between 0.0 s and 0.050 s (50 ms). Minimal period for a single
             chassis/PC is 200 ns. If the specified value is less than 200 ns,
             NI-TClk automatically coerces minTime to 200 ns. For multichassis
@@ -1007,7 +1007,7 @@ def synchronize(sessions, min_tclk_period):
     Args:
         sessions (list of (Driver Session or nitclk.SessionReference)): sessions is an array of sessions that are being synchronized.
 
-        min_tclk_period (float in seconds or datetime.timedelta): Minimal period of TClk, expressed in seconds. Supported values are
+        min_tclk_period (float in seconds or hightime.timedelta): Minimal period of TClk, expressed in seconds. Supported values are
             between 0.0 s and 0.050 s (50 ms). Minimal period for a single
             chassis/PC is 200 ns. If the specified value is less than 200 ns,
             NI-TClk automatically coerces minTime to 200 ns. For multichassis
@@ -1026,7 +1026,7 @@ def synchronize_to_sync_pulse_sender(sessions, min_time):
     Args:
         sessions (list of (Driver Session or nitclk.SessionReference)): sessions is an array of sessions that are being synchronized.
 
-        min_time (float in seconds or datetime.timedelta): Minimal period of TClk, expressed in seconds. Supported values are
+        min_time (float in seconds or hightime.timedelta): Minimal period of TClk, expressed in seconds. Supported values are
             between 0.0 s and 0.050 s (50 ms). Minimal period for a single
             chassis/PC is 200 ns. If the specified value is less than 200 ns,
             NI-TClk automatically coerces minTime to 200 ns. For multichassis
@@ -1052,7 +1052,7 @@ def wait_until_done(sessions, timeout):
     Args:
         sessions (list of (Driver Session or nitclk.SessionReference)): sessions is an array of sessions that are being synchronized.
 
-        timeout (float in seconds or datetime.timedelta): The amount of time in seconds that wait_until_done waits for the
+        timeout (float in seconds or hightime.timedelta): The amount of time in seconds that wait_until_done waits for the
             sessions to complete. If timeout is exceeded, wait_until_done
             returns an error.
 

--- a/generated/nitclk/nitclk/unit_tests/test_nitclk.py
+++ b/generated/nitclk/nitclk/unit_tests/test_nitclk.py
@@ -1,7 +1,7 @@
 import _matchers
 import _mock_helper
 
-import datetime
+import hightime
 import nitclk
 
 from mock import patch
@@ -88,7 +88,7 @@ class TestNitclkApi(object):
         return
 
     def test_synchronize_timedelta(self):
-        min_time = datetime.timedelta(seconds=0.042)
+        min_time = hightime.timedelta(seconds=0.042)
         self.patched_library.niTClk_Synchronize.side_effect = self.side_effects_helper.niTClk_Synchronize
         nitclk.synchronize(multiple_session_references, min_time)
         self.patched_library.niTClk_Synchronize.assert_called_once_with(_matchers.ViUInt32Matcher(len(multiple_sessions)), _matchers.ViSessionBufferMatcher(multiple_sessions), _matchers.ViReal64Matcher(min_time.total_seconds()))
@@ -197,7 +197,7 @@ class TestNitclkApi(object):
         self.patched_library.niTClk_SetAttributeViReal64.side_effect = self.side_effects_helper.niTClk_SetAttributeViReal64
         attribute_id = 11
         test_number = 4.2
-        session.sample_clock_delay = datetime.timedelta(seconds=test_number)
+        session.sample_clock_delay = hightime.timedelta(seconds=test_number)
         self.patched_library.niTClk_SetAttributeViReal64.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViReal64Matcher(test_number))
 
     def test_get_timedelta(self):

--- a/generated/nitclk/setup.py
+++ b/generated/nitclk/setup.py
@@ -45,6 +45,7 @@ setup(
     install_requires=[
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
+        'hightime',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/nitclk/tox-system_tests.ini
+++ b/generated/nitclk/tox-system_tests.ini
@@ -44,6 +44,7 @@ deps =
     nitclk-system_tests: pytest
     nitclk-system_tests: coverage
     nitclk-system_tests: numpy
+    nitclk-system_tests: hightime
     nitclk-system_tests: scipy
     nitclk-system_tests: fasteners
     nitclk-system_tests: pytest-json

--- a/src/nidcpower/disabled_examples/nidcpower_advanced_sequence.py
+++ b/src/nidcpower/disabled_examples/nidcpower_advanced_sequence.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 import argparse
-import datetime
+import hightime
 import nidcpower
 import sys
 
@@ -26,7 +26,7 @@ def example(resource_name, channels, options, steps, voltage_start, voltage_fina
     with nidcpower.Session(resource_name=resource_name, channels=channels, options=options) as session:
 
         session.source_mode = nidcpower.SourceMode.SEQUENCE
-        session.source_delay = datetime.timedelta(seconds=0.1)
+        session.source_delay = hightime.timedelta(seconds=0.1)
         session.voltage_level_autorange = True
         session.current_level_autorange = True
         session._create_advanced_sequence(sequence_name='my_sequence', attribute_ids=attribute_ids)

--- a/src/nidcpower/examples/nidcpower_advanced_sequence.py
+++ b/src/nidcpower/examples/nidcpower_advanced_sequence.py
@@ -1,13 +1,13 @@
 #!/usr/bin/python
 
 import argparse
-import datetime
+import hightime
 import nidcpower
 import sys
 
 
 def example(resource_name, channels, options, voltage_max, current_max, points_per_output_function, delay_in_seconds):
-    timeout = datetime.timedelta(seconds=(delay_in_seconds + 1.0))
+    timeout = hightime.timedelta(seconds=(delay_in_seconds + 1.0))
 
     with nidcpower.Session(resource_name=resource_name, channels=channels, options=options) as session:
 
@@ -15,7 +15,7 @@ def example(resource_name, channels, options, voltage_max, current_max, points_p
         session.source_mode = nidcpower.SourceMode.SEQUENCE
         session.voltage_level_autorange = True
         session.current_limit_autorange = True
-        session.source_delay = datetime.timedelta(seconds=delay_in_seconds)
+        session.source_delay = hightime.timedelta(seconds=delay_in_seconds)
         properties_used = ['output_function', 'voltage_level', 'current_level']
         session.create_advanced_sequence(sequence_name='my_sequence', property_names=properties_used, set_as_active_sequence=True)
 

--- a/src/nidcpower/examples/nidcpower_source_delay_measure.py
+++ b/src/nidcpower/examples/nidcpower_source_delay_measure.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 import argparse
-import datetime
+import hightime
 import nidcpower
 import sys
 
@@ -13,7 +13,7 @@ def print_fetched_measurements(measurements):
 
 
 def example(resource_name, channels, options, voltage1, voltage2, delay):
-    timeout = datetime.timedelta(seconds=(delay + 1.0))
+    timeout = hightime.timedelta(seconds=(delay + 1.0))
 
     with nidcpower.Session(resource_name=resource_name, channels=channels, options=options) as session:
 
@@ -23,7 +23,7 @@ def example(resource_name, channels, options, voltage1, voltage2, delay):
         session.current_limit = .06
         session.voltage_level_range = 5.0
         session.current_limit_range = .06
-        session.source_delay = datetime.timedelta(seconds=delay)
+        session.source_delay = hightime.timedelta(seconds=delay)
         session.measure_when = nidcpower.MeasureWhen.AUTOMATICALLY_AFTER_SOURCE_COMPLETE
         session.voltage_level = voltage1
 

--- a/src/nidcpower/metadata/attributes.py
+++ b/src/nidcpower/metadata/attributes.py
@@ -666,7 +666,7 @@ attributes = {
         'name': 'MEASURE_COMPLETE_EVENT_DELAY',
         'resettable': False,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or hightime.timedelta'
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
     },
     1150047: {
         'access': 'read-write',
@@ -729,7 +729,7 @@ attributes = {
         'name': 'SOURCE_DELAY',
         'resettable': False,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or hightime.timedelta'
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
     },
     1150054: {
         'access': 'read-write',
@@ -876,7 +876,7 @@ attributes = {
         'name': 'MEASURE_RECORD_DELTA_TIME',
         'resettable': False,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or hightime.timedelta'
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
     },
     1150066: {
         'access': 'read-write',
@@ -1192,7 +1192,7 @@ attributes = {
         'name': 'PULSE_ON_TIME',
         'resettable': False,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or hightime.timedelta'
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
     },
     1150094: {
         'access': 'read-write',
@@ -1206,7 +1206,7 @@ attributes = {
         'name': 'PULSE_OFF_TIME',
         'resettable': False,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or hightime.timedelta'
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
     },
     1150095: {
         'access': 'read-write',

--- a/src/nidcpower/metadata/attributes.py
+++ b/src/nidcpower/metadata/attributes.py
@@ -666,7 +666,7 @@ attributes = {
         'name': 'MEASURE_COMPLETE_EVENT_DELAY',
         'resettable': False,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or datetime.timedelta'
+        'type_in_documentation': 'float in seconds or hightime.timedelta'
     },
     1150047: {
         'access': 'read-write',
@@ -729,7 +729,7 @@ attributes = {
         'name': 'SOURCE_DELAY',
         'resettable': False,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or datetime.timedelta'
+        'type_in_documentation': 'float in seconds or hightime.timedelta'
     },
     1150054: {
         'access': 'read-write',
@@ -876,7 +876,7 @@ attributes = {
         'name': 'MEASURE_RECORD_DELTA_TIME',
         'resettable': False,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or datetime.timedelta'
+        'type_in_documentation': 'float in seconds or hightime.timedelta'
     },
     1150066: {
         'access': 'read-write',
@@ -1192,7 +1192,7 @@ attributes = {
         'name': 'PULSE_ON_TIME',
         'resettable': False,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or datetime.timedelta'
+        'type_in_documentation': 'float in seconds or hightime.timedelta'
     },
     1150094: {
         'access': 'read-write',
@@ -1206,7 +1206,7 @@ attributes = {
         'name': 'PULSE_OFF_TIME',
         'resettable': False,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or datetime.timedelta'
+        'type_in_documentation': 'float in seconds or hightime.timedelta'
     },
     1150095: {
         'access': 'read-write',

--- a/src/nidcpower/metadata/functions.py
+++ b/src/nidcpower/metadata/functions.py
@@ -922,7 +922,7 @@ functions = {
                 'type': 'ViInt32'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=1.0)',
+                'default_value': 'hightime.timedelta(seconds=1.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': 'Specifies the maximum time allowed for this function to complete. If the function does not complete within this time interval, NI-DCPower returns an error.',
@@ -931,7 +931,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
                 'direction': 'out',
@@ -1030,7 +1030,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
                 'direction': 'in',
@@ -1502,7 +1502,7 @@ functions = {
                 'name': 'months',
                 'python_api_converter_name': 'convert_month_to_timedelta',
                 'type': 'ViInt32',
-                'type_in_documentation': 'datetime.timedelta'
+                'type_in_documentation': 'hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -1534,7 +1534,7 @@ functions = {
                     'description': 'Indicates date and time of the last calibration.'
                 },
                 'name': 'month',
-                'type': 'datetime.datetime'
+                'type': 'hightime.datetime'
             }
         ],
         'python_name': 'get_ext_cal_last_date_and_time',
@@ -1569,7 +1569,7 @@ functions = {
                     'description': 'Returns the date and time the device was last calibrated.'
                 },
                 'name': 'month',
-                'type': 'datetime.datetime'
+                'type': 'hightime.datetime'
             }
         ],
         'python_name': 'get_self_cal_last_date_and_time',
@@ -2620,7 +2620,7 @@ functions = {
                 'type': 'ViInt32'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=10.0)',
+                'default_value': 'hightime.timedelta(seconds=10.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nSpecifies the maximum time allowed for this function to complete, in\nseconds. If the function does not complete within this time interval,\nNI-DCPower returns an error.\n',
@@ -2629,7 +2629,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'

--- a/src/nidcpower/metadata/functions.py
+++ b/src/nidcpower/metadata/functions.py
@@ -931,7 +931,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'out',
@@ -1030,7 +1030,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'in',
@@ -2629,7 +2629,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
         'returns': 'ViStatus'

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -1,4 +1,4 @@
-import datetime
+import hightime
 import nidcpower
 import os
 import pytest
@@ -223,7 +223,7 @@ def test_wait_for_event_default_timeout(single_channel_session):
 
 def test_wait_for_event_with_timeout(single_channel_session):
     with single_channel_session.initiate():
-        single_channel_session.wait_for_event(nidcpower.Event.SOURCE_COMPLETE, datetime.timedelta(seconds=0.5))
+        single_channel_session.wait_for_event(nidcpower.Event.SOURCE_COMPLETE, hightime.timedelta(seconds=0.5))
 
 
 def test_commit(single_channel_session):

--- a/src/nidigital/metadata/attributes.py
+++ b/src/nidigital/metadata/attributes.py
@@ -440,7 +440,7 @@ attributes = {
         'name': 'TDR_OFFSET',
         'resettable': True,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or datetime.timedelta'
+        'type_in_documentation': 'float in seconds or hightime.timedelta'
     },
     1150052: {
         'access': 'read-write',
@@ -506,7 +506,7 @@ attributes = {
         'name': 'FREQUENCY_COUNTER_MEASUREMENT_TIME',
         'resettable': True,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or datetime.timedelta'
+        'type_in_documentation': 'float in seconds or hightime.timedelta'
     },
     1150071: {
         'access': 'read-write',
@@ -523,7 +523,7 @@ attributes = {
         'repeated_capability_type': 'instruments',
         'resettable': True,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or datetime.timedelta'
+        'type_in_documentation': 'float in seconds or hightime.timedelta'
     },
     1150073: {
         'access': 'read-write',

--- a/src/nidigital/metadata/attributes.py
+++ b/src/nidigital/metadata/attributes.py
@@ -440,7 +440,7 @@ attributes = {
         'name': 'TDR_OFFSET',
         'resettable': True,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or hightime.timedelta'
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
     },
     1150052: {
         'access': 'read-write',
@@ -506,7 +506,7 @@ attributes = {
         'name': 'FREQUENCY_COUNTER_MEASUREMENT_TIME',
         'resettable': True,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or hightime.timedelta'
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
     },
     1150071: {
         'access': 'read-write',
@@ -523,7 +523,7 @@ attributes = {
         'repeated_capability_type': 'instruments',
         'resettable': True,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or hightime.timedelta'
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
     },
     1150073: {
         'access': 'read-write',

--- a/src/nidigital/metadata/config.py
+++ b/src/nidigital/metadata/config.py
@@ -68,5 +68,4 @@ config = {
     'session_class_description': 'An NI-Digital Pattern Driver session',
     'session_handle_parameter_name': 'vi',
     'uses_nitclk': True,
-    'uses_hightime': True,
 }

--- a/src/nidigital/metadata/functions.py
+++ b/src/nidigital/metadata/functions.py
@@ -119,7 +119,7 @@ functions = {
                     'value': 'numOffsets'
                 },
                 'type': 'ViReal64[]',
-                'type_in_documentation': 'basic sequence of float in seconds or datetime.timedelta'
+                'type_in_documentation': 'basic sequence of float in seconds or hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -160,12 +160,12 @@ functions = {
                 'type': 'ViBoolean'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=10.0)',
+                'default_value': 'hightime.timedelta(seconds=10.0)',
                 'direction': 'in',
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -346,7 +346,7 @@ functions = {
                 'name': 'strobeEdge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -378,14 +378,14 @@ functions = {
                 'name': 'strobeEdge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
                 'direction': 'in',
                 'name': 'strobe2Edge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -423,28 +423,28 @@ functions = {
                 'name': 'driveOnEdge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
                 'direction': 'in',
                 'name': 'driveDataEdge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
                 'direction': 'in',
                 'name': 'driveReturnEdge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
                 'direction': 'in',
                 'name': 'driveOffEdge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -482,42 +482,42 @@ functions = {
                 'name': 'driveOnEdge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
                 'direction': 'in',
                 'name': 'driveDataEdge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
                 'direction': 'in',
                 'name': 'driveReturnEdge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
                 'direction': 'in',
                 'name': 'driveOffEdge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
                 'direction': 'in',
                 'name': 'driveData2Edge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
                 'direction': 'in',
                 'name': 'driveReturn2Edge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -586,7 +586,7 @@ functions = {
                 'name': 'time',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -641,7 +641,7 @@ functions = {
                 'name': 'period',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -1910,7 +1910,7 @@ the trigger conditions are met.
                 'name': 'time',
                 'python_api_converter_name': 'convert_seconds_real64_to_timedelta',
                 'type': 'ViReal64',
-                'type_in_documentation': 'datetime.timedelta'
+                'type_in_documentation': 'hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -1998,7 +1998,7 @@ the trigger conditions are met.
                 'name': 'period',
                 'python_api_converter_name': 'convert_seconds_real64_to_timedelta',
                 'type': 'ViReal64',
-                'type_in_documentation': 'datetime.timedelta'
+                'type_in_documentation': 'hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -2655,7 +2655,7 @@ conditionalJumpTrigger1, conditionalJumpTrigger2, and conditionalJumpTrigger3.
                     'value_twist': 'actualNumOffsets'
                 },
                 'type': 'ViReal64[]',
-                'type_in_documentation': 'list of datetime.timedelta'
+                'type_in_documentation': 'list of hightime.timedelta'
             },
             {
                 'direction': 'out',
@@ -2742,12 +2742,12 @@ conditionalJumpTrigger1, conditionalJumpTrigger2, and conditionalJumpTrigger3.
                 'type': 'ViSession'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=10.0)',
+                'default_value': 'hightime.timedelta(seconds=10.0)',
                 'direction': 'in',
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'

--- a/src/nidigital/metadata/functions.py
+++ b/src/nidigital/metadata/functions.py
@@ -119,7 +119,7 @@ functions = {
                     'value': 'numOffsets'
                 },
                 'type': 'ViReal64[]',
-                'type_in_documentation': 'basic sequence of float in seconds or hightime.timedelta'
+                'type_in_documentation': 'basic sequence of hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
         'returns': 'ViStatus'
@@ -165,7 +165,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
         'returns': 'ViStatus'
@@ -346,7 +346,7 @@ functions = {
                 'name': 'strobeEdge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
         'returns': 'ViStatus'
@@ -378,14 +378,14 @@ functions = {
                 'name': 'strobeEdge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'in',
                 'name': 'strobe2Edge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
         'returns': 'ViStatus'
@@ -423,28 +423,28 @@ functions = {
                 'name': 'driveOnEdge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'in',
                 'name': 'driveDataEdge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'in',
                 'name': 'driveReturnEdge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'in',
                 'name': 'driveOffEdge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
         'returns': 'ViStatus'
@@ -482,42 +482,42 @@ functions = {
                 'name': 'driveOnEdge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'in',
                 'name': 'driveDataEdge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'in',
                 'name': 'driveReturnEdge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'in',
                 'name': 'driveOffEdge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'in',
                 'name': 'driveData2Edge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'in',
                 'name': 'driveReturn2Edge',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
         'returns': 'ViStatus'
@@ -586,7 +586,7 @@ functions = {
                 'name': 'time',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
         'returns': 'ViStatus'
@@ -641,7 +641,7 @@ functions = {
                 'name': 'period',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
         'returns': 'ViStatus'
@@ -2747,7 +2747,7 @@ conditionalJumpTrigger1, conditionalJumpTrigger2, and conditionalJumpTrigger3.
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
         'returns': 'ViStatus'

--- a/src/nidigital/metadata/functions_addon.py
+++ b/src/nidigital/metadata/functions_addon.py
@@ -55,12 +55,12 @@ niDigital_WriteStatic, or a call to niDigital_ApplyLevelsAndTiming.
                 'type': 'ViBoolean'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=10.0)',
+                'default_value': 'hightime.timedelta(seconds=10.0)',
                 'direction': 'in',
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta',
             },
             {
                 'direction': 'out',
@@ -241,12 +241,12 @@ functions_additional_fetch_capture_waveform = {
                 'type': 'ViInt32'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=10.0)',
+                'default_value': 'hightime.timedelta(seconds=10.0)',
                 'direction': 'in',
                 'name': 'timeout',
                 'type': 'ViReal64',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
-                'python_type': 'float or datetime.timedelta',
+                'type_in_documentation': 'float in seconds or hightime.timedelta',
             },
             {
                 'direction': 'out',

--- a/src/nidigital/metadata/functions_addon.py
+++ b/src/nidigital/metadata/functions_addon.py
@@ -60,7 +60,7 @@ niDigital_WriteStatic, or a call to niDigital_ApplyLevelsAndTiming.
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta',
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds',
             },
             {
                 'direction': 'out',
@@ -246,7 +246,7 @@ functions_additional_fetch_capture_waveform = {
                 'name': 'timeout',
                 'type': 'ViReal64',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta',
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds',
             },
             {
                 'direction': 'out',

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -1,8 +1,8 @@
 import array
 import collections
-import datetime
 import os
 
+import hightime
 import numpy
 import pytest
 
@@ -115,8 +115,8 @@ def test_chained_sites_pins_rep_cap(multi_instrument_session):
 
 def test_instruments_rep_cap(multi_instrument_session):
     multi_instrument_session.timing_absolute_delay_enabled = True
-    delay0 = datetime.timedelta(microseconds=5e-3)
-    delay1 = datetime.timedelta(microseconds=-5e-3)
+    delay0 = hightime.timedelta(microseconds=5e-3)
+    delay1 = hightime.timedelta(microseconds=-5e-3)
     multi_instrument_session.instruments[instruments[0]].timing_absolute_delay = delay0
     multi_instrument_session.instruments[instruments[1]].timing_absolute_delay = delay1
     assert multi_instrument_session.instruments[instruments[0]].timing_absolute_delay == delay0
@@ -739,7 +739,7 @@ def test_clock_generator_generate_clock(multi_instrument_session):
 def test_frequency_counter_measure_frequency(multi_instrument_session):
     multi_instrument_session.load_pin_map(os.path.join(test_files_base_dir, "pin_map.pinmap"))
     multi_instrument_session.pins['site0/PinA', 'site1/PinC'].selected_function = nidigital.SelectedFunction.DIGITAL
-    multi_instrument_session.pins['site0/PinA', 'site1/PinC'].frequency_counter_measurement_time = datetime.timedelta(milliseconds=5)
+    multi_instrument_session.pins['site0/PinA', 'site1/PinC'].frequency_counter_measurement_time = hightime.timedelta(milliseconds=5)
     frequencies = multi_instrument_session.pins['site0/PinA', 'site1/PinC'].frequency_counter_measure_frequency()
     assert frequencies == [0] * 2
 
@@ -775,11 +775,11 @@ def test_configure_get_time_set_period(multi_instrument_session):
     - get_time_set_period
     '''
     time_set_name = 'time_set_abc'
-    time_set_period = datetime.timedelta(microseconds=10)
+    time_set_period = hightime.timedelta(microseconds=10)
     multi_instrument_session.load_pin_map(os.path.join(test_files_base_dir, "pin_map.pinmap"))
 
     multi_instrument_session.create_time_set(time_set_name)
-    assert multi_instrument_session.get_time_set_period(time_set_name) == datetime.timedelta(microseconds=1)
+    assert multi_instrument_session.get_time_set_period(time_set_name) == hightime.timedelta(microseconds=1)
     multi_instrument_session.configure_time_set_period(time_set_name, time_set_period)
     assert multi_instrument_session.get_time_set_period(time_set_name) == time_set_period
 
@@ -807,7 +807,7 @@ def test_configure_get_time_set_edge(multi_instrument_session):
     - get_time_set_edge
     '''
     time_set_name = 'time_set_abc'
-    time_set_period = datetime.timedelta(microseconds=10)
+    time_set_period = hightime.timedelta(microseconds=10)
     time_set_drive_on = time_set_period * 0.5
     multi_instrument_session.load_pin_map(os.path.join(test_files_base_dir, "pin_map.pinmap"))
 
@@ -815,7 +815,7 @@ def test_configure_get_time_set_edge(multi_instrument_session):
     multi_instrument_session.configure_time_set_period(time_set_name, time_set_period)
     assert multi_instrument_session.pins['site0/PinA', 'site1/PinC'].get_time_set_edge(
         time_set_name,
-        nidigital.TimeSetEdgeType.DRIVE_ON) == datetime.timedelta(seconds=0)
+        nidigital.TimeSetEdgeType.DRIVE_ON) == hightime.timedelta(seconds=0)
     multi_instrument_session.pins['site0/PinA', 'site1/PinC'].configure_time_set_edge(
         time_set_name,
         nidigital.TimeSetEdgeType.DRIVE_ON,
@@ -827,7 +827,7 @@ def test_configure_get_time_set_edge(multi_instrument_session):
 
 def test_configure_time_set_drive_edges(multi_instrument_session):
     time_set_name = 'time_set_abc'
-    time_set_period = datetime.timedelta(microseconds=10)
+    time_set_period = hightime.timedelta(microseconds=10)
     time_set_drive_format = nidigital.DriveFormat.RL
     time_set_drive_on = time_set_period * 0.1
     time_set_drive_data = time_set_period * 0.2
@@ -862,7 +862,7 @@ def test_configure_time_set_drive_edges(multi_instrument_session):
 
 def test_configure_time_set_compare_edges_strobe(multi_instrument_session):
     time_set_name = 'time_set_abc'
-    time_set_period = datetime.timedelta(microseconds=10)
+    time_set_period = hightime.timedelta(microseconds=10)
     time_set_strobe = time_set_period * 0.5
 
     multi_instrument_session.load_pin_map(os.path.join(test_files_base_dir, "pin_map.pinmap"))
@@ -884,7 +884,7 @@ def test_configure_get_time_set_edge_multiplier(multi_instrument_session):
     - get_time_set_edge_multiplier
     '''
     time_set_name = 'time_set_abc'
-    time_set_period = datetime.timedelta(microseconds=10)
+    time_set_period = hightime.timedelta(microseconds=10)
     time_set_edge_multiplier = 2
 
     multi_instrument_session.load_pin_map(os.path.join(test_files_base_dir, "pin_map.pinmap"))
@@ -898,7 +898,7 @@ def test_configure_get_time_set_edge_multiplier(multi_instrument_session):
 
 def test_configure_time_set_drive_edges2x(multi_instrument_session):
     time_set_name = 'time_set_abc'
-    time_set_period = datetime.timedelta(microseconds=10)
+    time_set_period = hightime.timedelta(microseconds=10)
     time_set_drive_format = nidigital.DriveFormat.RL
     time_set_drive_on = time_set_period * 0.1
     time_set_drive_data = time_set_period * 0.2
@@ -944,7 +944,7 @@ def test_configure_time_set_drive_edges2x(multi_instrument_session):
 
 def test_configure_time_set_compare_edges_strobe2x(multi_instrument_session):
     time_set_name = 'time_set_abc'
-    time_set_period = datetime.timedelta(microseconds=10)
+    time_set_period = hightime.timedelta(microseconds=10)
     time_set_strobe = time_set_period * 0.4
     time_set_strobe2 = time_set_period * 0.8
 
@@ -1046,7 +1046,7 @@ def test_configure_pattern_burst_sites(multi_instrument_session):
     multi_instrument_session.sites[0, 2, 3].configure_pattern_burst_sites()
 
     multi_instrument_session.initiate()
-    multi_instrument_session.wait_until_done(timeout=datetime.timedelta(seconds=5.0))
+    multi_instrument_session.wait_until_done(timeout=hightime.timedelta(seconds=5.0))
     result = multi_instrument_session.sites[0, 1, 3].get_site_pass_fail()
     assert result == {0: True, 3: True}
 
@@ -1072,7 +1072,7 @@ def test_initiate_context_manager_and_wait_until_done(multi_instrument_session):
 
     with multi_instrument_session.initiate():
         # note that wait_until_done will return immediately with simulated hardware
-        multi_instrument_session.wait_until_done(timeout=datetime.timedelta(seconds=5.0))
+        multi_instrument_session.wait_until_done(timeout=hightime.timedelta(seconds=5.0))
     assert multi_instrument_session.is_done()
 
 
@@ -1225,7 +1225,7 @@ def test_send_software_edge_trigger(multi_instrument_session):
         trigger_identifier='')
 
     # We shouldn't time out, having sent the trigger, though in simulation it might complete, anyway
-    multi_instrument_session.wait_until_done(timeout=datetime.timedelta(seconds=5.0))
+    multi_instrument_session.wait_until_done(timeout=hightime.timedelta(seconds=5.0))
 
 
 def test_specifications_levels_and_timing_single(multi_instrument_session):

--- a/src/nidmm/metadata/attributes.py
+++ b/src/nidmm/metadata/attributes.py
@@ -258,7 +258,7 @@ attributes = {
         'name': 'SETTLE_TIME',
         'resettable': False,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or hightime.timedelta'
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
     },
     1150029: {
         'access': 'read-write',
@@ -563,7 +563,7 @@ attributes = {
         'name': 'TRIGGER_DELAY',
         'resettable': False,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or hightime.timedelta'
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
     },
     1250006: {
         'access': 'read-write',
@@ -701,7 +701,7 @@ attributes = {
         'name': 'SAMPLE_INTERVAL',
         'resettable': False,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or hightime.timedelta'
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
     },
     1250304: {
         'access': 'read-write',

--- a/src/nidmm/metadata/attributes.py
+++ b/src/nidmm/metadata/attributes.py
@@ -258,7 +258,7 @@ attributes = {
         'name': 'SETTLE_TIME',
         'resettable': False,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or datetime.timedelta'
+        'type_in_documentation': 'float in seconds or hightime.timedelta'
     },
     1150029: {
         'access': 'read-write',
@@ -563,7 +563,7 @@ attributes = {
         'name': 'TRIGGER_DELAY',
         'resettable': False,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or datetime.timedelta'
+        'type_in_documentation': 'float in seconds or hightime.timedelta'
     },
     1250006: {
         'access': 'read-write',
@@ -701,7 +701,7 @@ attributes = {
         'name': 'SAMPLE_INTERVAL',
         'resettable': False,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or datetime.timedelta'
+        'type_in_documentation': 'float in seconds or hightime.timedelta'
     },
     1250304: {
         'access': 'read-write',

--- a/src/nidmm/metadata/functions.py
+++ b/src/nidmm/metadata/functions.py
@@ -187,7 +187,7 @@ functions = {
                 'name': 'sampleInterval',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
         'returns': 'ViStatus'
@@ -477,7 +477,7 @@ functions = {
                 'name': 'triggerDelay',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
         'returns': 'ViStatus'
@@ -646,7 +646,7 @@ functions = {
                 'name': 'maximumTime',
                 'python_api_converter_name': 'convert_timedelta_to_milliseconds_int32',
                 'type': 'ViInt32',
-                'type_in_documentation': 'int in milliseconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or int in milliseconds'
             },
             {
                 'direction': 'out',
@@ -681,7 +681,7 @@ functions = {
                 'name': 'maximumTime',
                 'python_api_converter_name': 'convert_timedelta_to_milliseconds_int32',
                 'type': 'ViInt32',
-                'type_in_documentation': 'int in milliseconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or int in milliseconds'
             },
             {
                 'direction': 'in',
@@ -751,7 +751,7 @@ functions = {
                 'name': 'maximumTime',
                 'python_api_converter_name': 'convert_timedelta_to_milliseconds_int32',
                 'type': 'ViInt32',
-                'type_in_documentation': 'int in milliseconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or int in milliseconds'
             },
             {
                 'direction': 'in',
@@ -1611,7 +1611,7 @@ functions = {
                 'name': 'maximumTime',
                 'python_api_converter_name': 'convert_timedelta_to_milliseconds_int32',
                 'type': 'ViInt32',
-                'type_in_documentation': 'int in milliseconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or int in milliseconds'
             },
             {
                 'direction': 'out',
@@ -1646,7 +1646,7 @@ functions = {
                 'name': 'maximumTime',
                 'python_api_converter_name': 'convert_timedelta_to_milliseconds_int32',
                 'type': 'ViInt32',
-                'type_in_documentation': 'int in milliseconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or int in milliseconds'
             },
             {
                 'direction': 'in',
@@ -1761,7 +1761,7 @@ functions = {
                 'name': 'maximumTime',
                 'python_api_converter_name': 'convert_timedelta_to_milliseconds_int32',
                 'type': 'ViInt32',
-                'type_in_documentation': 'int in milliseconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or int in milliseconds'
             },
             {
                 'direction': 'in',

--- a/src/nidmm/metadata/functions.py
+++ b/src/nidmm/metadata/functions.py
@@ -178,7 +178,7 @@ functions = {
                 'type': 'ViInt32'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=-1)',
+                'default_value': 'hightime.timedelta(seconds=-1)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nSets the amount of time in seconds the DMM waits between measurement\ncycles. The driver sets NIDMM_ATTR_SAMPLE_INTERVAL to this value.\nSpecify a sample interval to add settling time between measurement\ncycles or to decrease the measurement rate. **sample_interval** only\napplies when the **Sample_Trigger** is set to INTERVAL.\n\nOn the NI 4060, the **sample_interval** value is used as the settling\ntime. When sample interval is set to 0, the DMM does not settle between\nmeasurement cycles. The NI 4065 and NI 4070/4071/4072 use the value\nspecified in **sample_interval** as additional delay. The default value\n(-1) ensures that the DMM settles for a recommended time. This is the\nsame as using an Immediate trigger.\n',
@@ -187,7 +187,7 @@ functions = {
                 'name': 'sampleInterval',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -468,7 +468,7 @@ functions = {
                 'type': 'ViInt32'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=-1)',
+                'default_value': 'hightime.timedelta(seconds=-1)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nSpecifies the time that the DMM waits after it has received a trigger\nbefore taking a measurement. The driver sets the\nNIDMM_ATTR_TRIGGER_DELAY attribute to this value. By default,\n**trigger_delay** is NIDMM_VAL_AUTO_DELAY (-1), which means the DMM\nwaits an appropriate settling time before taking the measurement. On the\nNI 4060, if you set **trigger_delay** to 0, the DMM does not settle\nbefore taking the measurement. The NI 4065 and NI 4070/4071/4072 use the\nvalue specified in **trigger_delay** as additional settling time.\n',
@@ -477,7 +477,7 @@ functions = {
                 'name': 'triggerDelay',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -638,7 +638,7 @@ functions = {
                 'type': 'ViSession'
             },
             {
-                'default_value': 'datetime.timedelta(milliseconds=-1)',
+                'default_value': 'hightime.timedelta(milliseconds=-1)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nSpecifies the **maximum_time** allowed for this function to complete in\nmilliseconds. If the function does not complete within this time\ninterval, the function returns the NIDMM_ERROR_MAX_TIME_EXCEEDED\nerror code. This may happen if an external trigger has not been\nreceived, or if the specified timeout is not long enough for the\nacquisition to complete.\n\nThe valid range is 0–86400000. The default value is\nNIDMM_VAL_TIME_LIMIT_AUTO (-1). The DMM calculates the timeout\nautomatically.\n'
@@ -646,7 +646,7 @@ functions = {
                 'name': 'maximumTime',
                 'python_api_converter_name': 'convert_timedelta_to_milliseconds_int32',
                 'type': 'ViInt32',
-                'type_in_documentation': 'int in milliseconds or datetime.timedelta'
+                'type_in_documentation': 'int in milliseconds or hightime.timedelta'
             },
             {
                 'direction': 'out',
@@ -673,7 +673,7 @@ functions = {
                 'type': 'ViSession'
             },
             {
-                'default_value': 'datetime.timedelta(milliseconds=-1)',
+                'default_value': 'hightime.timedelta(milliseconds=-1)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nSpecifies the **maximum_time** allowed for this function to complete in\nmilliseconds. If the function does not complete within this time\ninterval, the function returns the NIDMM_ERROR_MAX_TIME_EXCEEDED\nerror code. This may happen if an external trigger has not been\nreceived, or if the specified timeout is not long enough for the\nacquisition to complete.\n\nThe valid range is 0–86400000. The default value is\nNIDMM_VAL_TIME_LIMIT_AUTO (-1). The DMM calculates the timeout\nautomatically.\n'
@@ -681,7 +681,7 @@ functions = {
                 'name': 'maximumTime',
                 'python_api_converter_name': 'convert_timedelta_to_milliseconds_int32',
                 'type': 'ViInt32',
-                'type_in_documentation': 'int in milliseconds or datetime.timedelta'
+                'type_in_documentation': 'int in milliseconds or hightime.timedelta'
             },
             {
                 'direction': 'in',
@@ -743,7 +743,7 @@ functions = {
                 'type': 'ViSession'
             },
             {
-                'default_value': 'datetime.timedelta(milliseconds=-1)',
+                'default_value': 'hightime.timedelta(milliseconds=-1)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nSpecifies the **maximum_time** allowed for this function to complete in\nmilliseconds. If the function does not complete within this time\ninterval, the function returns the NIDMM_ERROR_MAX_TIME_EXCEEDED\nerror code. This may happen if an external trigger has not been\nreceived, or if the specified timeout is not long enough for the\nacquisition to complete.\n\nThe valid range is 0–86400000. The default value is\nNIDMM_VAL_TIME_LIMIT_AUTO (-1). The DMM calculates the timeout\nautomatically.\n'
@@ -751,7 +751,7 @@ functions = {
                 'name': 'maximumTime',
                 'python_api_converter_name': 'convert_timedelta_to_milliseconds_int32',
                 'type': 'ViInt32',
-                'type_in_documentation': 'int in milliseconds or datetime.timedelta'
+                'type_in_documentation': 'int in milliseconds or hightime.timedelta'
             },
             {
                 'direction': 'in',
@@ -1147,7 +1147,7 @@ functions = {
                 'name': 'months',
                 'python_api_converter_name': 'convert_month_to_timedelta',
                 'type': 'ViInt32',
-                'type_in_documentation': 'datetime.timedelta'
+                'type_in_documentation': 'hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -1201,7 +1201,7 @@ functions = {
                     'description': 'Indicates date and time of the last calibration.'
                 },
                 'name': 'month',
-                'type': 'datetime.datetime'
+                'type': 'hightime.datetime'
             }
         ],
         'python_name': 'get_cal_date_and_time',
@@ -1603,7 +1603,7 @@ functions = {
                 'type': 'ViSession'
             },
             {
-                'default_value': 'datetime.timedelta(milliseconds=-1)',
+                'default_value': 'hightime.timedelta(milliseconds=-1)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nSpecifies the **maximum_time** allowed for this function to complete in\nmilliseconds. If the function does not complete within this time\ninterval, the function returns the NIDMM_ERROR_MAX_TIME_EXCEEDED\nerror code. This may happen if an external trigger has not been\nreceived, or if the specified timeout is not long enough for the\nacquisition to complete.\n\nThe valid range is 0–86400000. The default value is\nNIDMM_VAL_TIME_LIMIT_AUTO (-1). The DMM calculates the timeout\nautomatically.\n'
@@ -1611,7 +1611,7 @@ functions = {
                 'name': 'maximumTime',
                 'python_api_converter_name': 'convert_timedelta_to_milliseconds_int32',
                 'type': 'ViInt32',
-                'type_in_documentation': 'int in milliseconds or datetime.timedelta'
+                'type_in_documentation': 'int in milliseconds or hightime.timedelta'
             },
             {
                 'direction': 'out',
@@ -1638,7 +1638,7 @@ functions = {
                 'type': 'ViSession'
             },
             {
-                'default_value': 'datetime.timedelta(milliseconds=-1)',
+                'default_value': 'hightime.timedelta(milliseconds=-1)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nSpecifies the **maximum_time** allowed for this function to complete in\nmilliseconds. If the function does not complete within this time\ninterval, the function returns the NIDMM_ERROR_MAX_TIME_EXCEEDED\nerror code. This may happen if an external trigger has not been\nreceived, or if the specified timeout is not long enough for the\nacquisition to complete.\n\nThe valid range is 0–86400000. The default value is\nNIDMM_VAL_TIME_LIMIT_AUTO (-1). The DMM calculates the timeout\nautomatically.\n'
@@ -1646,7 +1646,7 @@ functions = {
                 'name': 'maximumTime',
                 'python_api_converter_name': 'convert_timedelta_to_milliseconds_int32',
                 'type': 'ViInt32',
-                'type_in_documentation': 'int in milliseconds or datetime.timedelta'
+                'type_in_documentation': 'int in milliseconds or hightime.timedelta'
             },
             {
                 'direction': 'in',
@@ -1753,7 +1753,7 @@ functions = {
                 'type': 'ViSession'
             },
             {
-                'default_value': 'datetime.timedelta(milliseconds=-1)',
+                'default_value': 'hightime.timedelta(milliseconds=-1)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nSpecifies the **maximum_time** allowed for this function to complete in\nmilliseconds. If the function does not complete within this time\ninterval, the function returns the NIDMM_ERROR_MAX_TIME_EXCEEDED\nerror code. This may happen if an external trigger has not been\nreceived, or if the specified timeout is not long enough for the\nacquisition to complete.\n\nThe valid range is 0–86400000. The default value is\nNIDMM_VAL_TIME_LIMIT_AUTO (-1). The DMM calculates the timeout\nautomatically.\n'
@@ -1761,7 +1761,7 @@ functions = {
                 'name': 'maximumTime',
                 'python_api_converter_name': 'convert_timedelta_to_milliseconds_int32',
                 'type': 'ViInt32',
-                'type_in_documentation': 'int in milliseconds or datetime.timedelta'
+                'type_in_documentation': 'int in milliseconds or hightime.timedelta'
             },
             {
                 'direction': 'in',

--- a/src/nidmm/system_tests/test_system_nidmm.py
+++ b/src/nidmm/system_tests/test_system_nidmm.py
@@ -1,4 +1,4 @@
-import datetime
+import hightime
 import math
 import nidmm
 import numpy
@@ -239,7 +239,7 @@ def test_fetch_waveform_error(session):
     try:
         session.configure_waveform_acquisition(nidmm.Function.WAVEFORM_VOLTAGE, 10, 1800000, number_of_points_to_read)
         with session.initiate():
-            session.fetch_waveform(number_of_points_to_read * 2, maximum_time=datetime.timedelta(milliseconds=1))   # trying to fetch points more than configured
+            session.fetch_waveform(number_of_points_to_read * 2, maximum_time=hightime.timedelta(milliseconds=1))   # trying to fetch points more than configured
             assert False
     except nidmm.Error as e:
         assert e.code == -1074126845  # Max Time exceeded before operation completed

--- a/src/nifake/metadata/attributes.py
+++ b/src/nifake/metadata/attributes.py
@@ -91,7 +91,7 @@ attributes = {
         'name': 'READ_WRITE_DOUBLE_WITH_CONVERTER',
         'resettable': False,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or hightime.timedelta'
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
     },
     1000008: {
         'access': 'read-write',
@@ -104,7 +104,7 @@ attributes = {
         'name': 'READ_WRITE_INTEGER_WITH_CONVERTER',
         'resettable': False,
         'type': 'ViInt32',
-        'type_in_documentation': 'float in seconds or hightime.timedelta'
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or int in milliseconds'
     },
     1000009: {
         'access': 'read-write',

--- a/src/nifake/metadata/attributes.py
+++ b/src/nifake/metadata/attributes.py
@@ -91,7 +91,7 @@ attributes = {
         'name': 'READ_WRITE_DOUBLE_WITH_CONVERTER',
         'resettable': False,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or datetime.timedelta'
+        'type_in_documentation': 'float in seconds or hightime.timedelta'
     },
     1000008: {
         'access': 'read-write',
@@ -104,7 +104,7 @@ attributes = {
         'name': 'READ_WRITE_INTEGER_WITH_CONVERTER',
         'resettable': False,
         'type': 'ViInt32',
-        'type_in_documentation': 'float in seconds or datetime.timedelta'
+        'type_in_documentation': 'float in seconds or hightime.timedelta'
     },
     1000009: {
         'access': 'read-write',

--- a/src/nifake/metadata/functions.py
+++ b/src/nifake/metadata/functions.py
@@ -52,7 +52,7 @@ functions = {
                     'value': 'count'
                 },
                 'type': 'ViReal64[]',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
         'returns': 'ViStatus'

--- a/src/nifake/metadata/functions.py
+++ b/src/nifake/metadata/functions.py
@@ -21,7 +21,7 @@ functions = {
     'AcceptListOfDurationsInSeconds': {
         'codegen_method': 'public',
         'documentation': {
-            'description': 'Accepts list of floats or datetime.timedelta instances representing time delays.'
+            'description': 'Accepts list of floats or hightime.timedelta instances representing time delays.'
         },
         'parameters': [
             {
@@ -52,7 +52,7 @@ functions = {
                     'value': 'count'
                 },
                 'type': 'ViReal64[]',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -942,7 +942,7 @@ functions = {
                 'name': 'months',
                 'python_api_converter_name': 'convert_month_to_timedelta',
                 'type': 'ViInt32',
-                'type_in_documentation': 'datetime.timedelta'
+                'type_in_documentation': 'hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -1145,7 +1145,7 @@ functions = {
                     'description': 'Indicates date and time of the last calibration.'
                 },
                 'name': 'month',
-                'type': 'datetime.datetime'
+                'type': 'hightime.datetime'
             }
         ],
         'python_name': 'get_cal_date_and_time',
@@ -1637,7 +1637,7 @@ functions = {
                 'name': 'maximumTime',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'datetime.timedelta'
+                'type_in_documentation': 'hightime.timedelta'
             },
             {
                 'direction': 'out',
@@ -1680,7 +1680,7 @@ functions = {
                 'name': 'maximumTime',
                 'python_api_converter_name': 'convert_timedelta_to_milliseconds_int32',
                 'type': 'ViInt32',
-                'type_in_documentation': 'datetime.timedelta'
+                'type_in_documentation': 'hightime.timedelta'
             },
             {
                 'direction': 'out',
@@ -1734,7 +1734,7 @@ functions = {
     'ReturnDurationInSeconds': {
         'codegen_method': 'public',
         'documentation': {
-            'description': 'Returns a datetime.timedelta instance.'
+            'description': 'Returns a hightime.timedelta instance.'
         },
         'parameters': [
             {
@@ -1753,7 +1753,7 @@ functions = {
                 'name': 'timedelta',
                 'python_api_converter_name': 'convert_seconds_real64_to_timedelta',
                 'type': 'ViReal64',
-                'type_in_documentation': 'datetime.timedelta'
+                'type_in_documentation': 'hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -1761,7 +1761,7 @@ functions = {
     'ReturnListOfDurationsInSeconds': {
         'codegen_method': 'public',
         'documentation': {
-            'description': 'Returns a list of datetime.timedelta instances.'
+            'description': 'Returns a list of hightime.timedelta instances.'
         },
         'parameters': [
             {
@@ -1783,7 +1783,7 @@ functions = {
             {
                 'direction': 'out',
                 'documentation': {
-                    'description': 'Contains a list of datetime.timedelta instances.'
+                    'description': 'Contains a list of hightime.timedelta instances.'
                 },
                 'name': 'timedeltas',
                 'python_api_converter_name': 'convert_seconds_real64_to_timedeltas',
@@ -1792,7 +1792,7 @@ functions = {
                     'value': 'numberOfElements'
                 },
                 'type': 'ViReal64[]',
-                'type_in_documentation': 'datetime.timedelta'
+                'type_in_documentation': 'hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -1,6 +1,7 @@
 import array
 import ctypes
 import datetime
+import hightime
 import math
 import nifake
 import nifake.errors
@@ -322,9 +323,9 @@ class TestSession(object):
         self.patched_library.niFake_close.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST))
 
     def test_single_point_read_timedelta(self):
-        test_maximum_time_ms = 100  # milliseconds
-        test_maximum_time_s = .1    # seconds
-        test_maximum_time_timedelta = datetime.timedelta(milliseconds=test_maximum_time_ms)
+        test_maximum_time_ns = 1    # nanoseconds
+        test_maximum_time_s = 1e-9  # seconds
+        test_maximum_time_timedelta = hightime.timedelta(nanoseconds=test_maximum_time_ns)
         test_reading = 5
         self.patched_library.niFake_Read.side_effect = self.side_effects_helper.niFake_Read
         self.side_effects_helper['Read']['reading'] = test_reading
@@ -334,7 +335,7 @@ class TestSession(object):
 
     def test_single_point_read_nan(self):
         test_maximum_time_s = 10.0
-        test_maximum_time = datetime.timedelta(seconds=test_maximum_time_s)
+        test_maximum_time = hightime.timedelta(seconds=test_maximum_time_s)
         test_reading = float('NaN')
         self.patched_library.niFake_Read.side_effect = self.side_effects_helper.niFake_Read
         self.side_effects_helper['Read']['reading'] = test_reading
@@ -717,7 +718,7 @@ class TestSession(object):
         warnings.filterwarnings("always", category=nifake.DriverWarning)
 
         test_maximum_time_s = 10.0
-        test_maximum_time = datetime.timedelta(seconds=test_maximum_time_s)
+        test_maximum_time = hightime.timedelta(seconds=test_maximum_time_s)
         test_reading = float('nan')
         test_error_code = 42
         test_error_desc = "The answer to the ultimate question, only positive"
@@ -825,7 +826,7 @@ class TestSession(object):
 
     def test_repeated_capability_method_on_session_timedelta(self):
         test_maximum_time_ms = 10     # milliseconds
-        test_maximum_time_timedelta = datetime.timedelta(milliseconds=test_maximum_time_ms)
+        test_maximum_time_timedelta = hightime.timedelta(milliseconds=test_maximum_time_ms)
         test_reading = 5
         self.patched_library.niFake_ReadFromChannel.side_effect = self.side_effects_helper.niFake_ReadFromChannel
         self.side_effects_helper['ReadFromChannel']['reading'] = test_reading
@@ -836,7 +837,7 @@ class TestSession(object):
 
     def test_repeated_capability_method_on_specific_channel(self):
         test_maximum_time_ms = 10     # milliseconds
-        test_maximum_time = datetime.timedelta(milliseconds=test_maximum_time_ms)
+        test_maximum_time = hightime.timedelta(milliseconds=test_maximum_time_ms)
         test_reading = 5
         self.patched_library.niFake_ReadFromChannel.side_effect = self.side_effects_helper.niFake_ReadFromChannel
         self.side_effects_helper['ReadFromChannel']['reading'] = test_reading
@@ -863,7 +864,7 @@ class TestSession(object):
 
     def test_chained_repeated_capability_method_on_specific_channel(self):
         test_maximum_time_ms = 10     # milliseconds
-        test_maximum_time = datetime.timedelta(milliseconds=test_maximum_time_ms)
+        test_maximum_time = hightime.timedelta(milliseconds=test_maximum_time_ms)
         test_reading = 5
         self.patched_library.niFake_ReadFromChannel.side_effect = self.side_effects_helper.niFake_ReadFromChannel
         self.side_effects_helper['ReadFromChannel']['reading'] = test_reading
@@ -907,7 +908,7 @@ class TestSession(object):
         attribute_id = 1000008
         test_number_ms = -10000
         with nifake.Session('dev1') as session:
-            session.read_write_integer_with_converter = datetime.timedelta(milliseconds=test_number_ms)
+            session.read_write_integer_with_converter = hightime.timedelta(milliseconds=test_number_ms)
             self.patched_library.niFake_SetAttributeViInt32.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt32Matcher(test_number_ms))
 
     def test_get_attribute_real64(self):
@@ -930,7 +931,7 @@ class TestSession(object):
     def test_get_attribute_real64_with_converter(self):
         self.patched_library.niFake_GetAttributeViReal64.side_effect = self.side_effects_helper.niFake_GetAttributeViReal64
         attribute_id = 1000007
-        test_number = 1.5
+        test_number = 1e-9
         self.side_effects_helper['GetAttributeViReal64']['attributeValue'] = test_number
         with nifake.Session('dev1') as session:
             attr_timedelta = session.read_write_double_with_converter
@@ -940,9 +941,9 @@ class TestSession(object):
     def test_set_attribute_real64_with_converter(self):
         self.patched_library.niFake_SetAttributeViReal64.side_effect = self.side_effects_helper.niFake_SetAttributeViReal64
         attribute_id = 1000007
-        test_number = -10.1
+        test_number = 1e-9
         with nifake.Session('dev1') as session:
-            session.read_write_double_with_converter = datetime.timedelta(seconds=test_number)
+            session.read_write_double_with_converter = hightime.timedelta(nanoseconds=1)
             self.patched_library.niFake_SetAttributeViReal64.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViReal64Matcher(test_number))
 
     def test_get_attribute_string(self):
@@ -1251,15 +1252,15 @@ class TestSession(object):
         self.side_effects_helper['GetCalDateAndTime']['minute'] = minute
         with nifake.Session('dev1') as session:
             last_cal = session.get_cal_date_and_time(0)
-            assert isinstance(last_cal, datetime.datetime)
-            assert datetime.datetime(year, month, day, hour, minute) == last_cal
+            assert isinstance(last_cal, hightime.datetime)
+            assert hightime.datetime(year, month, day, hour, minute) == last_cal
 
     def test_get_cal_interval(self):
         self.patched_library.niFake_GetCalInterval = self.side_effects_helper.niFake_GetCalInterval
         self.side_effects_helper['GetCalInterval']['months'] = 24
         with nifake.Session('dev1') as session:
             last_cal = session.get_cal_interval()
-            assert isinstance(last_cal, datetime.timedelta)
+            assert isinstance(last_cal, hightime.timedelta)
             assert 730 == last_cal.days
 
     # Import/Export functions
@@ -1453,8 +1454,8 @@ class TestSession(object):
 
     def test_accept_list_of_time_values_as_timedelta_instances(self):
         self.patched_library.niFake_AcceptListOfDurationsInSeconds.side_effect = self.side_effects_helper.niFake_AcceptListOfDurationsInSeconds
-        time_values = [-1.5, 2.0]
-        delays = [datetime.timedelta(seconds=i) for i in time_values]
+        time_values = [-1.5, 2e-9]
+        delays = [datetime.timedelta(seconds=-1.5), hightime.timedelta(nanoseconds=2)]
         with nifake.Session('dev1') as session:
             session.accept_list_of_durations_in_seconds(delays)
             self.patched_library.niFake_AcceptListOfDurationsInSeconds.assert_called_once_with(
@@ -1466,7 +1467,7 @@ class TestSession(object):
     def test_return_timedelta(self):
         self.patched_library.niFake_ReturnDurationInSeconds.side_effect = self.side_effects_helper.niFake_ReturnDurationInSeconds
         time_value = -1.5
-        expected_timedelta = datetime.timedelta(seconds=time_value)
+        expected_timedelta = hightime.timedelta(seconds=time_value)
         self.side_effects_helper['ReturnDurationInSeconds']['timedelta'] = time_value
         with nifake.Session('dev1') as session:
             returned_timedelta = session.return_duration_in_seconds()
@@ -1480,7 +1481,7 @@ class TestSession(object):
         self.patched_library.niFake_ReturnListOfDurationsInSeconds.side_effect = self.side_effects_helper.niFake_ReturnListOfDurationsInSeconds
         time_values = [-1.5, 2.0]
         time_values_ctype = (nifake._visatype.ViReal64 * len(time_values))(*time_values)
-        expected_timedeltas = [datetime.timedelta(seconds=i) for i in time_values]
+        expected_timedeltas = [hightime.timedelta(seconds=i) for i in time_values]
         self.side_effects_helper['ReturnListOfDurationsInSeconds']['timedeltas'] = time_values_ctype
         with nifake.Session('dev1') as session:
             returned_timedeltas = session.return_list_of_durations_in_seconds(len(expected_timedeltas))

--- a/src/nifgen/metadata/attributes.py
+++ b/src/nifgen/metadata/attributes.py
@@ -1071,7 +1071,7 @@ attributes = {
         'name': 'STREAMING_WRITE_TIMEOUT',
         'resettable': True,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or datetime.timedelta'
+        'type_in_documentation': 'float in seconds or hightime.timedelta'
     },
     1150411: {
         'access': 'read-write',

--- a/src/nifgen/metadata/attributes.py
+++ b/src/nifgen/metadata/attributes.py
@@ -1071,7 +1071,7 @@ attributes = {
         'name': 'STREAMING_WRITE_TIMEOUT',
         'resettable': True,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or hightime.timedelta'
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
     },
     1150411: {
         'access': 'read-write',

--- a/src/nifgen/metadata/functions.py
+++ b/src/nifgen/metadata/functions.py
@@ -2879,7 +2879,7 @@ functions = {
                 'name': 'maxTime',
                 'python_api_converter_name': 'convert_timedelta_to_milliseconds_int32',
                 'type': 'ViInt32',
-                'type_in_documentation': 'int in milliseconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or int in milliseconds'
             }
         ],
         'returns': 'ViStatus'

--- a/src/nifgen/metadata/functions.py
+++ b/src/nifgen/metadata/functions.py
@@ -1655,7 +1655,7 @@ functions = {
                 'name': 'months',
                 'python_api_converter_name': 'convert_month_to_timedelta',
                 'type': 'ViInt32',
-                'type_in_documentation': 'datetime.timedelta'
+                'type_in_documentation': 'hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -1735,7 +1735,7 @@ functions = {
                     'description': 'Indicates date and time of the last calibration.'
                 },
                 'name': 'month',
-                'type': 'datetime.datetime'
+                'type': 'hightime.datetime'
             }
         ],
         'python_name': 'get_ext_cal_last_date_and_time',
@@ -1769,7 +1769,7 @@ functions = {
                     'description': 'Returns the date and time the device was last calibrated.'
                 },
                 'name': 'month',
-                'type': 'datetime.datetime'
+                'type': 'hightime.datetime'
             }
         ],
         'python_name': 'get_self_cal_last_date_and_time',
@@ -2871,7 +2871,7 @@ functions = {
                 'type': 'ViSession'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=10.0)',
+                'default_value': 'hightime.timedelta(seconds=10.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': 'Specifies the timeout value in milliseconds.'
@@ -2879,7 +2879,7 @@ functions = {
                 'name': 'maxTime',
                 'python_api_converter_name': 'convert_timedelta_to_milliseconds_int32',
                 'type': 'ViInt32',
-                'type_in_documentation': 'int in milliseconds or datetime.timedelta'
+                'type_in_documentation': 'int in milliseconds or hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -1,5 +1,5 @@
-import datetime
 import fasteners
+import hightime
 import nifgen
 import numpy
 import os
@@ -412,7 +412,7 @@ def test_write_waveform_from_file_f64(session):
 
 
 def test_wait_until_done(session):
-    session.wait_until_done(datetime.timedelta(milliseconds=20))
+    session.wait_until_done(hightime.timedelta(milliseconds=20))
 
 
 def test_user_standard_waveform(session):

--- a/src/niscope/examples/niscope_fetch_forever.py
+++ b/src/niscope/examples/niscope_fetch_forever.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 import argparse
-import datetime
+import hightime
 import niscope
 import numpy as np
 import pprint
@@ -38,7 +38,7 @@ def example(resource_name, options, total_acquisition_time_in_seconds, voltage, 
                 for channel, waveform in zip(channel_list, waveforms):
                     # 5. fetching - we return the slice of the waveform array that we want to "fetch into"
                     session.channels[channel].fetch_into(waveform[current_pos:current_pos + samples_per_fetch], relative_to=niscope.FetchRelativeTo.READ_POINTER,
-                                                         offset=0, record_number=0, num_records=1, timeout=datetime.timedelta(seconds=5.0))
+                                                         offset=0, record_number=0, num_records=1, timeout=hightime.timedelta(seconds=5.0))
                 current_pos += samples_per_fetch
 
 

--- a/src/niscope/metadata/attributes.py
+++ b/src/niscope/metadata/attributes.py
@@ -980,7 +980,7 @@ attributes = {
         'name': 'START_TO_REF_TRIGGER_HOLDOFF',
         'resettable': True,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or hightime.timedelta'
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
     },
     1150104: {
         'access': 'read only',
@@ -1276,7 +1276,7 @@ attributes = {
         'name': 'REF_TRIGGER_MINIMUM_QUIET_TIME',
         'resettable': True,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or hightime.timedelta'
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
     },
     1150316: {
         'access': 'read-write',
@@ -1333,7 +1333,7 @@ attributes = {
         'name': 'END_OF_RECORD_TO_ADVANCE_TRIGGER_HOLDOFF',
         'resettable': True,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or hightime.timedelta'
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
     },
     1150367: {
         'access': 'read-write',
@@ -1358,7 +1358,7 @@ attributes = {
         'name': 'ABSOLUTE_SAMPLE_CLOCK_OFFSET',
         'resettable': True,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or hightime.timedelta'
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
     },
     1150375: {
         'access': 'read only',
@@ -1485,7 +1485,7 @@ attributes = {
         'name': 'HORZ_TIME_PER_RECORD',
         'resettable': True,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or hightime.timedelta'
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
     },
     1250008: {
         'access': 'read only',
@@ -1577,7 +1577,7 @@ attributes = {
         'name': 'TRIGGER_DELAY_TIME',
         'resettable': True,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or hightime.timedelta'
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
     },
     1250016: {
         'access': 'read-write',
@@ -1590,7 +1590,7 @@ attributes = {
         'name': 'TRIGGER_HOLDOFF',
         'resettable': True,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or hightime.timedelta'
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
     },
     1250017: {
         'access': 'read-write',
@@ -1672,7 +1672,7 @@ attributes = {
         'name': 'ACQUISITION_START_TIME',
         'resettable': True,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or hightime.timedelta'
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
     },
     1250201: {
         'access': 'read-write',

--- a/src/niscope/metadata/attributes.py
+++ b/src/niscope/metadata/attributes.py
@@ -980,7 +980,7 @@ attributes = {
         'name': 'START_TO_REF_TRIGGER_HOLDOFF',
         'resettable': True,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or datetime.timedelta'
+        'type_in_documentation': 'float in seconds or hightime.timedelta'
     },
     1150104: {
         'access': 'read only',
@@ -1276,7 +1276,7 @@ attributes = {
         'name': 'REF_TRIGGER_MINIMUM_QUIET_TIME',
         'resettable': True,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or datetime.timedelta'
+        'type_in_documentation': 'float in seconds or hightime.timedelta'
     },
     1150316: {
         'access': 'read-write',
@@ -1333,7 +1333,7 @@ attributes = {
         'name': 'END_OF_RECORD_TO_ADVANCE_TRIGGER_HOLDOFF',
         'resettable': True,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or datetime.timedelta'
+        'type_in_documentation': 'float in seconds or hightime.timedelta'
     },
     1150367: {
         'access': 'read-write',
@@ -1358,7 +1358,7 @@ attributes = {
         'name': 'ABSOLUTE_SAMPLE_CLOCK_OFFSET',
         'resettable': True,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or datetime.timedelta'
+        'type_in_documentation': 'float in seconds or hightime.timedelta'
     },
     1150375: {
         'access': 'read only',
@@ -1485,7 +1485,7 @@ attributes = {
         'name': 'HORZ_TIME_PER_RECORD',
         'resettable': True,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or datetime.timedelta'
+        'type_in_documentation': 'float in seconds or hightime.timedelta'
     },
     1250008: {
         'access': 'read only',
@@ -1577,7 +1577,7 @@ attributes = {
         'name': 'TRIGGER_DELAY_TIME',
         'resettable': True,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or datetime.timedelta'
+        'type_in_documentation': 'float in seconds or hightime.timedelta'
     },
     1250016: {
         'access': 'read-write',
@@ -1590,7 +1590,7 @@ attributes = {
         'name': 'TRIGGER_HOLDOFF',
         'resettable': True,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or datetime.timedelta'
+        'type_in_documentation': 'float in seconds or hightime.timedelta'
     },
     1250017: {
         'access': 'read-write',
@@ -1672,7 +1672,7 @@ attributes = {
         'name': 'ACQUISITION_START_TIME',
         'resettable': True,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or datetime.timedelta'
+        'type_in_documentation': 'float in seconds or hightime.timedelta'
     },
     1250201: {
         'access': 'read-write',

--- a/src/niscope/metadata/functions.py
+++ b/src/niscope/metadata/functions.py
@@ -594,7 +594,7 @@ functions = {
                 'name': 'holdoff',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'default_value': 'hightime.timedelta(seconds=0.0)',
@@ -605,7 +605,7 @@ functions = {
                 'name': 'delay',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
         'returns': 'ViStatus'
@@ -668,7 +668,7 @@ functions = {
                 'name': 'holdoff',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'default_value': 'hightime.timedelta(seconds=0.0)',
@@ -679,7 +679,7 @@ functions = {
                 'name': 'delay',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
         'returns': 'ViStatus'
@@ -750,7 +750,7 @@ functions = {
                 'name': 'holdoff',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'default_value': 'hightime.timedelta(seconds=0.0)',
@@ -761,7 +761,7 @@ functions = {
                 'name': 'delay',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
         'returns': 'ViStatus'
@@ -805,7 +805,7 @@ functions = {
                 'name': 'holdoff',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'default_value': 'hightime.timedelta(seconds=0.0)',
@@ -816,7 +816,7 @@ functions = {
                 'name': 'delay',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
         'returns': 'ViStatus'
@@ -906,7 +906,7 @@ functions = {
                 'name': 'holdoff',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'default_value': 'hightime.timedelta(seconds=0.0)',
@@ -917,7 +917,7 @@ functions = {
                 'name': 'delay',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
         'returns': 'ViStatus'
@@ -987,7 +987,7 @@ functions = {
                 'name': 'holdoff',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'default_value': 'hightime.timedelta(seconds=0.0)',
@@ -998,7 +998,7 @@ functions = {
                 'name': 'delay',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
         'returns': 'ViStatus'
@@ -1236,7 +1236,7 @@ functions = {
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'python_type': 'float or hightime.timedelta',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'out',
@@ -1373,7 +1373,7 @@ functions = {
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'python_type': 'float or hightime.timedelta',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'out',
@@ -1434,7 +1434,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'in',
@@ -1505,7 +1505,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'in',
@@ -1595,7 +1595,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'in',
@@ -1673,7 +1673,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'in',
@@ -1751,7 +1751,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'in',
@@ -1875,7 +1875,7 @@ functions = {
                 },
                 'name': 'timeout',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'out',
@@ -1924,7 +1924,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'in',
@@ -1981,7 +1981,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'in',
@@ -2649,7 +2649,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'in',
@@ -2718,7 +2718,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'in',

--- a/src/niscope/metadata/functions.py
+++ b/src/niscope/metadata/functions.py
@@ -586,7 +586,7 @@ functions = {
                 'type': 'ViInt32'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=0.0)',
+                'default_value': 'hightime.timedelta(seconds=0.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nThe length of time the digitizer waits after detecting a trigger before\nenabling NI-SCOPE to detect another trigger. Refer to\nNISCOPE_ATTR_TRIGGER_HOLDOFF for more information.\n'
@@ -594,10 +594,10 @@ functions = {
                 'name': 'holdoff',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=0.0)',
+                'default_value': 'hightime.timedelta(seconds=0.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nHow long the digitizer waits after receiving the trigger to start\nacquiring data. Refer to NISCOPE_ATTR_TRIGGER_DELAY_TIME for more\ninformation.\n'
@@ -605,7 +605,7 @@ functions = {
                 'name': 'delay',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -660,7 +660,7 @@ functions = {
                 'type': 'ViInt32'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=0.0)',
+                'default_value': 'hightime.timedelta(seconds=0.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nThe length of time the digitizer waits after detecting a trigger before\nenabling NI-SCOPE to detect another trigger. Refer to\nNISCOPE_ATTR_TRIGGER_HOLDOFF for more information.\n'
@@ -668,10 +668,10 @@ functions = {
                 'name': 'holdoff',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=0.0)',
+                'default_value': 'hightime.timedelta(seconds=0.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nHow long the digitizer waits after receiving the trigger to start\nacquiring data. Refer to NISCOPE_ATTR_TRIGGER_DELAY_TIME for more\ninformation.\n'
@@ -679,7 +679,7 @@ functions = {
                 'name': 'delay',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -742,7 +742,7 @@ functions = {
                 'type': 'ViInt32'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=0.0)',
+                'default_value': 'hightime.timedelta(seconds=0.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nThe length of time the digitizer waits after detecting a trigger before\nenabling NI-SCOPE to detect another trigger. Refer to\nNISCOPE_ATTR_TRIGGER_HOLDOFF for more information.\n'
@@ -750,10 +750,10 @@ functions = {
                 'name': 'holdoff',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=0.0)',
+                'default_value': 'hightime.timedelta(seconds=0.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nHow long the digitizer waits after receiving the trigger to start\nacquiring data. Refer to NISCOPE_ATTR_TRIGGER_DELAY_TIME for more\ninformation.\n'
@@ -761,7 +761,7 @@ functions = {
                 'name': 'delay',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -797,7 +797,7 @@ functions = {
                 'type': 'ViSession'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=0.0)',
+                'default_value': 'hightime.timedelta(seconds=0.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nThe length of time the digitizer waits after detecting a trigger before\nenabling NI-SCOPE to detect another trigger. Refer to\nNISCOPE_ATTR_TRIGGER_HOLDOFF for more information.\n'
@@ -805,10 +805,10 @@ functions = {
                 'name': 'holdoff',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=0.0)',
+                'default_value': 'hightime.timedelta(seconds=0.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nHow long the digitizer waits after receiving the trigger to start\nacquiring data. Refer to NISCOPE_ATTR_TRIGGER_DELAY_TIME for more\ninformation.\n'
@@ -816,7 +816,7 @@ functions = {
                 'name': 'delay',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -898,7 +898,7 @@ functions = {
                 'type': 'ViInt32'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=0.0)',
+                'default_value': 'hightime.timedelta(seconds=0.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nThe length of time the digitizer waits after detecting a trigger before\nenabling NI-SCOPE to detect another trigger. Refer to\nNISCOPE_ATTR_TRIGGER_HOLDOFF for more information.\n'
@@ -906,10 +906,10 @@ functions = {
                 'name': 'holdoff',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=0.0)',
+                'default_value': 'hightime.timedelta(seconds=0.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nHow long the digitizer waits after receiving the trigger to start\nacquiring data. Refer to NISCOPE_ATTR_TRIGGER_DELAY_TIME for more\ninformation.\n'
@@ -917,7 +917,7 @@ functions = {
                 'name': 'delay',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -979,7 +979,7 @@ functions = {
                 'type': 'ViInt32'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=0.0)',
+                'default_value': 'hightime.timedelta(seconds=0.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nThe length of time the digitizer waits after detecting a trigger before\nenabling NI-SCOPE to detect another trigger. Refer to\nNISCOPE_ATTR_TRIGGER_HOLDOFF for more information.\n'
@@ -987,10 +987,10 @@ functions = {
                 'name': 'holdoff',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=0.0)',
+                'default_value': 'hightime.timedelta(seconds=0.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nHow long the digitizer waits after receiving the trigger to start\nacquiring data. Refer to NISCOPE_ATTR_TRIGGER_DELAY_TIME for more\ninformation.\n'
@@ -998,7 +998,7 @@ functions = {
                 'name': 'delay',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -1227,16 +1227,16 @@ functions = {
                 'type': 'ViInt32'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=5.0)',
+                'default_value': 'hightime.timedelta(seconds=5.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': 'The time to wait for data to be acquired; using 0 for this parameter tells NI-SCOPE to fetch whatever is currently available. Using -1 seconds for this parameter implies infinite timeout.'
                 },
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
-                'python_type': 'float or datetime.timedelta',
+                'python_type': 'float or hightime.timedelta',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
                 'direction': 'out',
@@ -1364,16 +1364,16 @@ functions = {
                 'type': 'ViInt32'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=5.0)',
+                'default_value': 'hightime.timedelta(seconds=5.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': 'The time to wait for data to be acquired; using 0 for this parameter tells NI-SCOPE to fetch whatever is currently available. Using -1 seconds for this parameter implies infinite timeout.'
                 },
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
-                'python_type': 'float or datetime.timedelta',
+                'python_type': 'float or hightime.timedelta',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
                 'direction': 'out',
@@ -1426,7 +1426,7 @@ functions = {
                 'type': 'ViConstString'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=5.0)',
+                'default_value': 'hightime.timedelta(seconds=5.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nThe time to wait in seconds for data to be acquired; using 0 for this\nparameter tells NI-SCOPE to fetch whatever is currently available. Using\n-1 for this parameter implies infinite timeout.\n'
@@ -1434,7 +1434,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
                 'direction': 'in',
@@ -1497,7 +1497,7 @@ functions = {
                 'type': 'ViConstString'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=5.0)',
+                'default_value': 'hightime.timedelta(seconds=5.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nThe time to wait in seconds for data to be acquired; using 0 for this\nparameter tells NI-SCOPE to fetch whatever is currently available. Using\n-1 for this parameter implies infinite timeout.\n'
@@ -1505,7 +1505,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
                 'direction': 'in',
@@ -1587,7 +1587,7 @@ functions = {
                 'type': 'ViConstString'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=5.0)',
+                'default_value': 'hightime.timedelta(seconds=5.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nThe time to wait in seconds for data to be acquired; using 0 for this\nparameter tells NI-SCOPE to fetch whatever is currently available. Using\n-1 for this parameter implies infinite timeout.\n'
@@ -1595,7 +1595,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
                 'direction': 'in',
@@ -1665,7 +1665,7 @@ functions = {
                 'type': 'ViConstString'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=5.0)',
+                'default_value': 'hightime.timedelta(seconds=5.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nThe time to wait in seconds for data to be acquired; using 0 for this\nparameter tells NI-SCOPE to fetch whatever is currently available. Using\n-1 for this parameter implies infinite timeout.\n'
@@ -1673,7 +1673,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
                 'direction': 'in',
@@ -1743,7 +1743,7 @@ functions = {
                 'type': 'ViConstString'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=5.0)',
+                'default_value': 'hightime.timedelta(seconds=5.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nThe time to wait in seconds for data to be acquired; using 0 for this\nparameter tells NI-SCOPE to fetch whatever is currently available. Using\n-1 for this parameter implies infinite timeout.\n'
@@ -1751,7 +1751,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
                 'direction': 'in',
@@ -1868,14 +1868,14 @@ functions = {
                 'type': 'ViInt32'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=5.0)',
+                'default_value': 'hightime.timedelta(seconds=5.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': 'The time to wait in seconds for data to be acquired; using 0 for this parameter tells NI-SCOPE to fetch whatever is currently available. Using -1 for this parameter implies infinite timeout.'
                 },
                 'name': 'timeout',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
                 'direction': 'out',
@@ -1916,7 +1916,7 @@ functions = {
                 'type': 'ViConstString'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=5.0)',
+                'default_value': 'hightime.timedelta(seconds=5.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nThe time to wait in seconds for data to be acquired; using 0 for this\nparameter tells NI-SCOPE to fetch whatever is currently available. Using\n-1 for this parameter implies infinite timeout.\n'
@@ -1924,7 +1924,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
                 'direction': 'in',
@@ -1973,7 +1973,7 @@ functions = {
                 'type': 'ViConstString'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=5.0)',
+                'default_value': 'hightime.timedelta(seconds=5.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nThe time to wait in seconds for data to be acquired; using 0 for this\nparameter tells NI-SCOPE to fetch whatever is currently available. Using\n-1 for this parameter implies infinite timeout.\n'
@@ -1981,7 +1981,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
                 'direction': 'in',
@@ -2641,7 +2641,7 @@ functions = {
                 'type': 'ViConstString'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=5.0)',
+                'default_value': 'hightime.timedelta(seconds=5.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nThe time to wait in seconds for data to be acquired; using 0 for this\nparameter tells NI-SCOPE to fetch whatever is currently available. Using\n-1 for this parameter implies infinite timeout.\n'
@@ -2649,7 +2649,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
                 'direction': 'in',
@@ -2710,7 +2710,7 @@ functions = {
                 'type': 'ViConstString'
             },
             {
-                'default_value': 'datetime.timedelta(seconds=5.0)',
+                'default_value': 'hightime.timedelta(seconds=5.0)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nThe time to wait in seconds for data to be acquired; using 0 for this\nparameter tells NI-SCOPE to fetch whatever is currently available. Using\n-1 for this parameter implies infinite timeout.\n'
@@ -2718,7 +2718,7 @@ functions = {
                 'name': 'timeout',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta'
+                'type_in_documentation': 'float in seconds or hightime.timedelta'
             },
             {
                 'direction': 'in',

--- a/src/nise/metadata/functions.py
+++ b/src/nise/metadata/functions.py
@@ -503,7 +503,7 @@ functions = {
                 'name': 'maximumTimeMs',
                 'python_api_converter_name': 'convert_timedelta_to_milliseconds_int32',
                 'type': 'ViInt32',
-                'type_in_documentation': 'int in milliseconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or int in milliseconds'
             }
         ],
         'returns': 'ViStatus'

--- a/src/nise/metadata/functions.py
+++ b/src/nise/metadata/functions.py
@@ -495,7 +495,7 @@ functions = {
                 'type': 'ViSession'
             },
             {
-                'default_value': 'datetime.timedelta(milliseconds=-1)',
+                'default_value': 'hightime.timedelta(milliseconds=-1)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nThe amount of time to wait (in milliseconds) for the debounce to\ncomplete. A value of 0 checks for debouncing once and returns an error\nif the system is not debounced at that time. A value of -1 means to\nblock for an infinite period of time until the system is debounced.\n'
@@ -503,7 +503,7 @@ functions = {
                 'name': 'maximumTimeMs',
                 'python_api_converter_name': 'convert_timedelta_to_milliseconds_int32',
                 'type': 'ViInt32',
-                'type_in_documentation': 'int in milliseconds or datetime.timedelta'
+                'type_in_documentation': 'int in milliseconds or hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'

--- a/src/niswitch/metadata/attributes.py
+++ b/src/niswitch/metadata/attributes.py
@@ -285,7 +285,7 @@ attributes = {
         'name': 'SETTLING_TIME',
         'resettable': False,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or hightime.timedelta'
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
     },
     1250005: {
         'access': 'read only',
@@ -522,7 +522,7 @@ attributes = {
         'name': 'SCAN_DELAY',
         'resettable': False,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or hightime.timedelta'
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
     },
     1250026: {
         'access': 'read-write',

--- a/src/niswitch/metadata/attributes.py
+++ b/src/niswitch/metadata/attributes.py
@@ -285,7 +285,7 @@ attributes = {
         'name': 'SETTLING_TIME',
         'resettable': False,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or datetime.timedelta'
+        'type_in_documentation': 'float in seconds or hightime.timedelta'
     },
     1250005: {
         'access': 'read only',
@@ -522,7 +522,7 @@ attributes = {
         'name': 'SCAN_DELAY',
         'resettable': False,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or datetime.timedelta'
+        'type_in_documentation': 'float in seconds or hightime.timedelta'
     },
     1250026: {
         'access': 'read-write',

--- a/src/niswitch/metadata/functions.py
+++ b/src/niswitch/metadata/functions.py
@@ -1141,7 +1141,7 @@ functions = {
                 'type': 'ViSession'
             },
             {
-                'default_value': 'datetime.timedelta(milliseconds=5000)',
+                'default_value': 'hightime.timedelta(milliseconds=5000)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nSpecifies the maximum length of time to wait for all relays in the\nswitch module to activate or deactivate. If the specified time elapses\nbefore all relays active or deactivate, a timeout error is returned.\nDefault Value:5000 ms\n'
@@ -1149,7 +1149,7 @@ functions = {
                 'name': 'maximumTimeMs',
                 'python_api_converter_name': 'convert_timedelta_to_milliseconds_int32',
                 'type': 'ViInt32',
-                'type_in_documentation': 'int in milliseconds or datetime.timedelta'
+                'type_in_documentation': 'int in milliseconds or hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'
@@ -1168,7 +1168,7 @@ functions = {
                 'type': 'ViSession'
             },
             {
-                'default_value': 'datetime.timedelta(milliseconds=5000)',
+                'default_value': 'hightime.timedelta(milliseconds=5000)',
                 'direction': 'in',
                 'documentation': {
                     'description': '\nSpecifies the maximum length of time to wait for the switch module to\nstop scanning. If the specified time elapses before the scan ends,\nNISWITCH_ERROR_MAX_TIME_EXCEEDED error is returned. Default\nValue:5000 ms\n'
@@ -1176,7 +1176,7 @@ functions = {
                 'name': 'maximumTimeMs',
                 'python_api_converter_name': 'convert_timedelta_to_milliseconds_int32',
                 'type': 'ViInt32',
-                'type_in_documentation': 'int in milliseconds or datetime.timedelta'
+                'type_in_documentation': 'int in milliseconds or hightime.timedelta'
             }
         ],
         'returns': 'ViStatus'

--- a/src/niswitch/metadata/functions.py
+++ b/src/niswitch/metadata/functions.py
@@ -1149,7 +1149,7 @@ functions = {
                 'name': 'maximumTimeMs',
                 'python_api_converter_name': 'convert_timedelta_to_milliseconds_int32',
                 'type': 'ViInt32',
-                'type_in_documentation': 'int in milliseconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or int in milliseconds'
             }
         ],
         'returns': 'ViStatus'
@@ -1176,7 +1176,7 @@ functions = {
                 'name': 'maximumTimeMs',
                 'python_api_converter_name': 'convert_timedelta_to_milliseconds_int32',
                 'type': 'ViInt32',
-                'type_in_documentation': 'int in milliseconds or hightime.timedelta'
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or int in milliseconds'
             }
         ],
         'returns': 'ViStatus'

--- a/src/niswitch/system_tests/test_system_niswitch.py
+++ b/src/niswitch/system_tests/test_system_niswitch.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
-import datetime
 import fasteners
+import hightime
 import niswitch
 import os
 import pytest
@@ -103,7 +103,7 @@ def test_vi_int32_attribute(session):
 
 
 def test_vi_real64_attribute(session):
-    session.settling_time = datetime.timedelta(seconds=0.1)
+    session.settling_time = hightime.timedelta(seconds=0.1)
     assert session.settling_time.total_seconds() == 0.1
 
 

--- a/src/nitclk/metadata/attributes.py
+++ b/src/nitclk/metadata/attributes.py
@@ -121,7 +121,7 @@ attributes = {
         'name': 'SAMPLE_CLOCK_DELAY',
         'resettable': False,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or datetime.timedelta',
+        'type_in_documentation': 'float in seconds or hightime.timedelta',
     },
     13: {
         'access': 'read-write',

--- a/src/nitclk/metadata/attributes.py
+++ b/src/nitclk/metadata/attributes.py
@@ -121,7 +121,7 @@ attributes = {
         'name': 'SAMPLE_CLOCK_DELAY',
         'resettable': False,
         'type': 'ViReal64',
-        'type_in_documentation': 'float in seconds or hightime.timedelta',
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds',
     },
     13: {
         'access': 'read-write',

--- a/src/nitclk/metadata/functions.py
+++ b/src/nitclk/metadata/functions.py
@@ -135,9 +135,9 @@ functions = {
             },
             {
                 'direction': 'in',
-                'default_value': 'datetime.timedelta(seconds=0.0)',
+                'default_value': 'hightime.timedelta(seconds=0.0)',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta',
+                'type_in_documentation': 'float in seconds or hightime.timedelta',
                 'type': 'ViReal64',
                 'documentation': {
                     'description': '\nMinimal period of TClk, expressed in seconds. Supported values are\nbetween 0.0 s and 0.050 s (50 ms). Minimal period for a single\nchassis/PC is 200 ns. If the specified value is less than 200 ns,\nNI-TClk automatically coerces minTime to 200 ns. For multichassis\nsynchronization, adjust this value to account for propagation delays\nthrough the various devices and cables.\n'
@@ -989,9 +989,9 @@ functions = {
             },
             {
                 'direction': 'in',
-                'default_value': 'datetime.timedelta(seconds=0.0)',
+                'default_value': 'hightime.timedelta(seconds=0.0)',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta',
+                'type_in_documentation': 'float in seconds or hightime.timedelta',
                 'documentation': {
                     'description': '\nMinimal period of TClk, expressed in seconds. Supported values are\nbetween 0.0 s and 0.050 s (50 ms). Minimal period for a single\nchassis/PC is 200 ns. If the specified value is less than 200 ns,\nNI-TClk automatically coerces minTime to 200 ns. For multichassis\nsynchronization, adjust this value to account for propagation delays\nthrough the various devices and cables.\n'
                 },
@@ -1034,9 +1034,9 @@ functions = {
                 'documentation': {
                     'description': '\nMinimal period of TClk, expressed in seconds. Supported values are\nbetween 0.0 s and 0.050 s (50 ms). Minimal period for a single\nchassis/PC is 200 ns. If the specified value is less than 200 ns,\nNI-TClk automatically coerces minTime to 200 ns. For multichassis\nsynchronization, adjust this value to account for propagation delays\nthrough the various devices and cables.\n'
                 },
-                'default_value': 'datetime.timedelta(seconds=0.0)',
+                'default_value': 'hightime.timedelta(seconds=0.0)',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta',
+                'type_in_documentation': 'float in seconds or hightime.timedelta',
                 'name': 'minTclkPeriod',
                 'type': 'ViReal64'
             }
@@ -1136,9 +1136,9 @@ functions = {
             },
             {
                 'direction': 'in',
-                'default_value': 'datetime.timedelta(seconds=0.0)',
+                'default_value': 'hightime.timedelta(seconds=0.0)',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta',
+                'type_in_documentation': 'float in seconds or hightime.timedelta',
                 'documentation': {
                     'description': '\nMinimal period of TClk, expressed in seconds. Supported values are\nbetween 0.0 s and 0.050 s (50 ms). Minimal period for a single\nchassis/PC is 200 ns. If the specified value is less than 200 ns,\nNI-TClk automatically coerces minTime to 200 ns. For multichassis\nsynchronization, adjust this value to account for propagation delays\nthrough the various devices and cables.\n'
                 },
@@ -1178,9 +1178,9 @@ functions = {
             },
             {
                 'direction': 'in',
-                'default_value': 'datetime.timedelta(seconds=0.0)',
+                'default_value': 'hightime.timedelta(seconds=0.0)',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
-                'type_in_documentation': 'float in seconds or datetime.timedelta',
+                'type_in_documentation': 'float in seconds or hightime.timedelta',
                 'documentation': {
                     'description': '\nThe amount of time in seconds that niTClk_WaitUntilDone waits for the\nsessions to complete. If timeout is exceeded, niTClk_WaitUntilDone\nreturns an error.\n'
                 },

--- a/src/nitclk/metadata/functions.py
+++ b/src/nitclk/metadata/functions.py
@@ -137,7 +137,7 @@ functions = {
                 'direction': 'in',
                 'default_value': 'hightime.timedelta(seconds=0.0)',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta',
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds',
                 'type': 'ViReal64',
                 'documentation': {
                     'description': '\nMinimal period of TClk, expressed in seconds. Supported values are\nbetween 0.0 s and 0.050 s (50 ms). Minimal period for a single\nchassis/PC is 200 ns. If the specified value is less than 200 ns,\nNI-TClk automatically coerces minTime to 200 ns. For multichassis\nsynchronization, adjust this value to account for propagation delays\nthrough the various devices and cables.\n'
@@ -991,7 +991,7 @@ functions = {
                 'direction': 'in',
                 'default_value': 'hightime.timedelta(seconds=0.0)',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta',
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds',
                 'documentation': {
                     'description': '\nMinimal period of TClk, expressed in seconds. Supported values are\nbetween 0.0 s and 0.050 s (50 ms). Minimal period for a single\nchassis/PC is 200 ns. If the specified value is less than 200 ns,\nNI-TClk automatically coerces minTime to 200 ns. For multichassis\nsynchronization, adjust this value to account for propagation delays\nthrough the various devices and cables.\n'
                 },
@@ -1036,7 +1036,7 @@ functions = {
                 },
                 'default_value': 'hightime.timedelta(seconds=0.0)',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta',
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds',
                 'name': 'minTclkPeriod',
                 'type': 'ViReal64'
             }
@@ -1138,7 +1138,7 @@ functions = {
                 'direction': 'in',
                 'default_value': 'hightime.timedelta(seconds=0.0)',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta',
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds',
                 'documentation': {
                     'description': '\nMinimal period of TClk, expressed in seconds. Supported values are\nbetween 0.0 s and 0.050 s (50 ms). Minimal period for a single\nchassis/PC is 200 ns. If the specified value is less than 200 ns,\nNI-TClk automatically coerces minTime to 200 ns. For multichassis\nsynchronization, adjust this value to account for propagation delays\nthrough the various devices and cables.\n'
                 },
@@ -1180,7 +1180,7 @@ functions = {
                 'direction': 'in',
                 'default_value': 'hightime.timedelta(seconds=0.0)',
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
-                'type_in_documentation': 'float in seconds or hightime.timedelta',
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds',
                 'documentation': {
                     'description': '\nThe amount of time in seconds that niTClk_WaitUntilDone waits for the\nsessions to complete. If timeout is exceeded, niTClk_WaitUntilDone\nreturns an error.\n'
                 },

--- a/src/nitclk/templates/session.py.mako
+++ b/src/nitclk/templates/session.py.mako
@@ -14,7 +14,7 @@
 
 import array
 import ctypes
-import datetime
+import hightime
 import threading
 
 import ${module_name}._attributes as _attributes

--- a/src/nitclk/unit_tests/test_nitclk.py
+++ b/src/nitclk/unit_tests/test_nitclk.py
@@ -1,7 +1,7 @@
 import _matchers
 import _mock_helper
 
-import datetime
+import hightime
 import nitclk
 
 from mock import patch
@@ -88,7 +88,7 @@ class TestNitclkApi(object):
         return
 
     def test_synchronize_timedelta(self):
-        min_time = datetime.timedelta(seconds=0.042)
+        min_time = hightime.timedelta(seconds=0.042)
         self.patched_library.niTClk_Synchronize.side_effect = self.side_effects_helper.niTClk_Synchronize
         nitclk.synchronize(multiple_session_references, min_time)
         self.patched_library.niTClk_Synchronize.assert_called_once_with(_matchers.ViUInt32Matcher(len(multiple_sessions)), _matchers.ViSessionBufferMatcher(multiple_sessions), _matchers.ViReal64Matcher(min_time.total_seconds()))
@@ -197,7 +197,7 @@ class TestNitclkApi(object):
         self.patched_library.niTClk_SetAttributeViReal64.side_effect = self.side_effects_helper.niTClk_SetAttributeViReal64
         attribute_id = 11
         test_number = 4.2
-        session.sample_clock_delay = datetime.timedelta(seconds=test_number)
+        session.sample_clock_delay = hightime.timedelta(seconds=test_number)
         self.patched_library.niTClk_SetAttributeViReal64.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViReal64Matcher(test_number))
 
     def test_get_timedelta(self):

--- a/tox-travis.ini
+++ b/tox-travis.ini
@@ -116,6 +116,7 @@ deps =
     test: mock
     test: mako
     test: numpy
+    test: hightime
     build_test: pytest
     build_test: coverage
     build_test: mako

--- a/tox.ini
+++ b/tox.ini
@@ -116,6 +116,7 @@ deps =
     test: mock
     test: mako
     test: numpy
+    test: hightime
     build_test: pytest
     build_test: coverage
     build_test: mako


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

In all nimi-python modules, change the type of applicable properties and method parameters from `datetime.timedelta` to `hightime.timedelta` and from `datetime.datetime` to `hightime.datetime`.

`hightime` types are drop-in replacements for `datetime` counterparts, with sub-microsecond resolution. See https://github.com/ni/nimi-python/pull/1445#discussion_r424031427 for the rationale behind this change.

- Update code generator to generate code using `hightime` types
- Update applicable attribute and function metadata to use `hightime` types
- Update nifake unit tests to verify usage of `hightime` types

### List issues fixed by this Pull Request below, if any.

* Fix #744
* Fix #1368 
* Fix #1382 
* Fix #1397 

### What testing has been done?

Update unit tests for converter and nifake to verify usage of `hightime` types. CI runs all the tests.