### PR TITLE
Fix tox env ordering issue

### DIFF
--- a/tox-travis.ini
+++ b/tox-travis.ini
@@ -140,8 +140,11 @@ deps =
 
 depends =
     codegen: py38-clean
-    test: py38-codegen
     installers: py38-codegen
+    flake8: py38-codegen
+    docs: py38-codegen
+    test: py38-installers
+    pkg: py38-installers
 
 whitelist_externals =
     build_test: mv

--- a/tox.ini
+++ b/tox.ini
@@ -140,8 +140,11 @@ deps =
 
 depends =
     codegen: py38-clean
-    test: py38-codegen
     installers: py38-codegen
+    flake8: py38-codegen
+    docs: py38-codegen
+    test: py38-installers
+    pkg: py38-installers
 
 whitelist_externals =
     build_test: mv


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Fix tox env ordering issue:
- flake8 and docs depend on codegen
- test depends on installers (for `install_local_wheel.py --driver nitclk`), not codegen
- pkg depends on installers

### List issues fixed by this Pull Request below, if any.

None

### What testing has been done?

Ran `tox` in serial and parallel modes and verified the ordering is correct.