### PR TITLE
Update test_query_max_current_limit in nidcpower to work with 20.0 driver runtime

### DIFF
--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -177,7 +177,7 @@ def test_measure_multiple(session):
 
 def test_query_max_current_limit(single_channel_session):
     max_current_limit = single_channel_session.query_max_current_limit(6)
-    expected_max_current_limit = 0.06  # for a simulated 4162 max current limit should be 0.06 for 6V Voltage level
+    expected_max_current_limit = 0.1  # for a simulated 4162 max current limit should be 0.1 for 6V Voltage level
     max_current_limit_in_range = abs(max_current_limit - expected_max_current_limit) <= max(1e-09 * max(abs(max_current_limit), abs(expected_max_current_limit)), 0.0)  # https://stackoverflow.com/questions/5595425/what-is-the-best-way-to-compare-floats-for-almost-equality-in-python
     assert max_current_limit_in_range is True
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Update test_query_max_current_limit in nidcpower to work with 20.0 driver runtime.
The change is required because nimi-bot was updated to NI-DCPower Runtime 20.0 recently. Due to change in driver runtime behavior, now simulated devices will create a high cooling chassis instance. The default value for max current limit on high cooling chassis should be 0.1A.

### List issues fixed by this Pull Request below, if any.

* Fix #1154 

### What testing has been done?

Ran the test locally and verified it passes. CI will run all tests.