### PR TITLE
Fix scripts used by ATS to run system tests

### DIFF
--- a/tools/prepare_python_system_tests.py
+++ b/tools/prepare_python_system_tests.py
@@ -1,23 +1,19 @@
 import argparse
 import json
-import os
+import pathlib
 import subprocess
 import tempfile
 import time
 import urllib.request
 import zipfile
 
-parser = argparse.ArgumentParser(description='Downloads the latest release artifacts from nimi-python and runs system tests on the specified python package.',
-                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-parser.add_argument('-d', '--driver', required=True, type=str,
-                    help='Python package name.',
-                    choices=os.listdir('src'))
-parser.add_argument('-pv', '--python-version', required=False, type=str,
-                    help='Python version to be run. This is used to invoke the appropriate tox environment.',
-                    choices=['py35', 'py36', 'py37', 'py38', ], default='py38')
-parser.add_argument('-pb', '--python-bitness', required=False, type=str,
-                    help='Python bitness to be run. "32" means pass "--32" to tox, which will force 32 bit. "any" does not pass anything to tox, so it will used whatever bitness is installed, preferring 64 if available',
-                    choices=['32', 'any'], default=None)
+
+parser = argparse.ArgumentParser(
+    description="""
+Prepares the environment for running system tests by downloading the release
+artifacts from latest release on nimi-python.
+""",
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 args = parser.parse_args()
 
 
@@ -25,15 +21,7 @@ print('****Installing tox to Python.****')
 results = subprocess.run(["python", '-m', 'pip', 'install', '--disable-pip-version-check', '--upgrade', 'pip', 'tox'], check=True)
 
 
-print('****Creating temporary directory.****')
-temp_dir = tempfile.gettempdir()
-working_directory = os.path.join(temp_dir, str(time.time()))
-if not os.path.exists(working_directory):
-    os.makedirs(working_directory)
-print(working_directory)
-
-
-print('****Parsing GitHub releases to obtain the latest zip file URL.****')
+print('****Parsing releases on nimi-python GitHub repo to obtain the latest zip file URL.****')
 release_url = 'https://api.github.com/repos/ni/nimi-python/releases'
 with urllib.request.urlopen(release_url) as response:
     html = response.read()
@@ -41,38 +29,21 @@ url_data = json.loads(html.decode('utf-8'))
 zip_url = url_data[0]['zipball_url']
 print(zip_url)
 
+
 print('****Downloading latest zip file from GitHub.****')
 try:
     from urllib.request import urlretrieve
 except ImportError:
     from urllib import urlretrieve
-my_zip_file = os.path.join(working_directory, 'zip.zip')
-urlretrieve(zip_url, my_zip_file)
+working_directory = pathlib.Path.cwd()
+zip_file = pathlib.Path(working_directory).joinpath('system_tests.zip')
+urlretrieve(zip_url, zip_file)
 print('Download complete.')
 
 
 print('****Unzipping Zip file.****')
-zip_folder = os.path.join(working_directory, 'zip_folder')
-zip_ref = zipfile.ZipFile(my_zip_file, 'r')
+zip_folder = pathlib.Path(working_directory).joinpath('system_tests')
+zip_ref = zipfile.ZipFile(zip_file, 'r')
 zip_ref.extractall(zip_folder)
 zip_ref.close()
 print(zip_folder)
-
-drivers_using_other_driver = ['niscope', 'nifgen', 'nidigital', 'nitclk', ]
-other_driver_env = ''
-if args.driver in drivers_using_other_driver:
-    # Creating the wheel for the other required driver only uses Python 3.8
-    other_driver_env = 'py38-{0}-wheel_dep,'.format(args.driver)
-
-print('****Invoking build specific script****')
-tox_dir = os.path.join(zip_folder, os.listdir(zip_folder)[0], 'generated', args.driver)
-os.chdir(tox_dir)
-command = ['python', '../../tools/run_python_system_tests.py', '-d', args.driver]
-command += ['--python-version', args.python_version]
-if args.python_bitness is not None:
-    command += ['--python-bitness', args.python_bitness]
-
-print('Running command:')
-print(command)
-results = subprocess.run(command, check=True)
-

--- a/tools/prepare_python_system_tests.py
+++ b/tools/prepare_python_system_tests.py
@@ -2,8 +2,6 @@ import argparse
 import json
 import pathlib
 import subprocess
-import tempfile
-import time
 import urllib.request
 import zipfile
 

--- a/tools/run_python_system_tests.py
+++ b/tools/run_python_system_tests.py
@@ -1,33 +1,44 @@
 import argparse
 import os
+import pathlib
 import subprocess
 
-parser = argparse.ArgumentParser(description='Runs system tests on the specified driver.',
+
+base_dir = next(pathlib.Path.cwd().glob('system_tests/*nimi-python*'))
+src_dir = base_dir.joinpath('src')
+
+parser = argparse.ArgumentParser(description='Runs system tests for the specified nimi-python module.',
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-parser.add_argument('-d', '--driver', required=True, type=str,
-                    help='Python package name.',
-                    choices=os.listdir('src'))
+parser.add_argument('-m', '--module', required=True, type=str,
+                    help='nimi-python module name.',
+                    choices=[x.name for x in src_dir.iterdir() if x.is_dir()])
 parser.add_argument('-pv', '--python-version', required=False, type=str,
                     help='Python version to be run. This is used to invoke the appropriate tox environment.',
                     choices=['py35', 'py36', 'py37', 'py38', ], default='py38')
 parser.add_argument('-pb', '--python-bitness', required=False, type=str,
-                    help='Python bitness to be run. "32" means pass "--32" to tox, which will force 32 bit. "any" does not pass anything to tox, so it will used whatever bitness is installed, preferring 64 if available',
+                    help="""
+                    Python bitness to be run. "32" means pass "--32" to tox, which
+                    will force 32 bit. "any" does not pass anything to tox, so it
+                    will used whatever bitness is installed, preferring 64 if available""",
                     choices=['32', 'any'], default='any')  # We disallow None and force 'any' to be the default
 args = parser.parse_args()
 
 
+tox_dir = base_dir.joinpath('generated', args.module)
+os.chdir(tox_dir)
 command = ['python', '-m', 'tox']
 if args.python_bitness != 'any':  # This means it must be '32'
     command.append('--32')
 
 drivers_using_other_driver = ['niscope', 'nifgen', 'nidigital', 'nitclk', ]
-if args.driver in drivers_using_other_driver:
-    # Creating the wheel for the other required driver only uses Python 3.8
-    command += ['-e', 'py38-{0}-wheel_dep,'.format(args.driver)]
+if args.module in drivers_using_other_driver:
+    # Creating the wheel for the other required module only uses Python 3.8
+    command += ['-e', 'py38-{0}-wheel_dep,'.format(args.module)]
 
-command += ['-e', '{0}-{1}-system_tests'.format(args.python_version, args.driver)]
+command += ['-e', '{0}-{1}-system_tests'.format(args.python_version, args.module)]
 command += ['-c', 'tox-system_tests.ini']
 
 print('****Running system tests in tox.****')
+print(command)
 results = subprocess.run(command, check=True)
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Fix scripts used by ATS to run system tests. The scripts were broken because the `prepare` script referenced `src` folder which won't be present until `prepare` script is run once successfully.

Refactored the scripts so that `prepare` and `run` are decoupled from each other. The way to run system tests is:
```
mkdir %temp%\nimi-python
chdir %temp%\nimi-python
curl -o prepare_python_system_tests.py https://raw.githubusercontent.com/ni/nimi-python/master/tools/prepare_python_system_tests.py
curl -o run_python_system_tests.py https://raw.githubusercontent.com/ni/nimi-python/master/tools/run_python_system_tests.py
python prepare_python_system_tests
python run_python_system_tests.py --module niscope --python-version py38
```

### List issues fixed by this Pull Request below, if any.

* Fix #1440

### What testing has been done?

Ran the scripts locally