### PR TITLE
Specify minimum version for `hightime` dependency in `setup.py`

### DIFF
--- a/build/templates/setup.py.mako
+++ b/build/templates/setup.py.mako
@@ -50,7 +50,7 @@ setup(
     install_requires=[
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
-        'hightime',
+        'hightime>=0.2.0',
         % if config['uses_nitclk']:
         'nitclk',
         % endif

--- a/generated/nidcpower/setup.py
+++ b/generated/nidcpower/setup.py
@@ -45,7 +45,7 @@ setup(
     install_requires=[
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
-        'hightime',
+        'hightime>=0.2.0',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/nidigital/setup.py
+++ b/generated/nidigital/setup.py
@@ -45,7 +45,7 @@ setup(
     install_requires=[
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
-        'hightime',
+        'hightime>=0.2.0',
         'nitclk',
     ],
     setup_requires=['pytest-runner', ],

--- a/generated/nidmm/setup.py
+++ b/generated/nidmm/setup.py
@@ -45,7 +45,7 @@ setup(
     install_requires=[
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
-        'hightime',
+        'hightime>=0.2.0',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/nifake/setup.py
+++ b/generated/nifake/setup.py
@@ -45,7 +45,7 @@ setup(
     install_requires=[
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
-        'hightime',
+        'hightime>=0.2.0',
         'nitclk',
     ],
     setup_requires=['pytest-runner', ],

--- a/generated/nifgen/setup.py
+++ b/generated/nifgen/setup.py
@@ -45,7 +45,7 @@ setup(
     install_requires=[
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
-        'hightime',
+        'hightime>=0.2.0',
         'nitclk',
     ],
     setup_requires=['pytest-runner', ],

--- a/generated/nimodinst/setup.py
+++ b/generated/nimodinst/setup.py
@@ -45,7 +45,7 @@ setup(
     install_requires=[
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
-        'hightime',
+        'hightime>=0.2.0',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/niscope/setup.py
+++ b/generated/niscope/setup.py
@@ -45,7 +45,7 @@ setup(
     install_requires=[
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
-        'hightime',
+        'hightime>=0.2.0',
         'nitclk',
     ],
     setup_requires=['pytest-runner', ],

--- a/generated/nise/setup.py
+++ b/generated/nise/setup.py
@@ -45,7 +45,7 @@ setup(
     install_requires=[
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
-        'hightime',
+        'hightime>=0.2.0',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/niswitch/setup.py
+++ b/generated/niswitch/setup.py
@@ -45,7 +45,7 @@ setup(
     install_requires=[
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
-        'hightime',
+        'hightime>=0.2.0',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/nitclk/setup.py
+++ b/generated/nitclk/setup.py
@@ -45,7 +45,7 @@ setup(
     install_requires=[
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
-        'hightime',
+        'hightime>=0.2.0',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Specify minimum version for `hightime` dependency in `setup.py`. `hightime` was heavily refactored in 0.2.0 and nimi-python modules rely on `hightime` version being 0.2.0 or later.

### List issues fixed by this Pull Request below, if any.

* Fix #1474 

### What testing has been done?

Performed a manual test to ensure `hightime` version is bumped up to 0.2.0 when nimi-python module is pip installed.