### PR TITLE
Fix intermittent failure in import_attribute_configuration_buffer()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 * ### ALL
     * #### Added
     * #### Changed
+        * Fix [#1491](https://github.com/ni/nimi-python/issues/1491): import_attribute_configuration_buffer() fails intermittently when `list` or `array.array` is passed in.
     * #### Removed
 * ### `nidcpower` (NI-DCPower)
     * #### Added

--- a/build/helper/codegen_helper.py
+++ b/build/helper/codegen_helper.py
@@ -381,7 +381,9 @@ def _get_ctype_variable_definition_snippet_for_buffers(parameter, parameters, iv
                 definitions.append(array_declaration)
                 definition = 'get_ctypes_pointer_for_buffer(value={0}_array, library_type={1}.{2})  # case B520'.format(parameter['python_name'], module_name, parameter['ctypes_type'])
             elif parameter['use_list']:
-                definition = 'get_ctypes_pointer_for_buffer(value=_converters.{3}({0}), library_type={1}.{2})  # case B520'.format(parameter['python_name'], module_name, parameter['ctypes_type'], parameter['python_api_converter_name'])
+                conversion_declaration = 'converted_{0} = _converters.{1}({0})  # case B520'.format(parameter['python_name'], parameter['python_api_converter_name'])
+                definitions.append(conversion_declaration)
+                definition = 'get_ctypes_pointer_for_buffer(value=converted_{0}, library_type={1}.{2})  # case B520'.format(parameter['python_name'], module_name, parameter['ctypes_type'])
             else:
                 assert False, "Expected either 'use_array' or 'use_list' to be True. Both False."
     elif parameter['direction'] == 'in':
@@ -1514,8 +1516,14 @@ def test_get_ctype_variable_declaration_snippet_case_b520_array():
 
 
 def test_get_ctype_variable_declaration_snippet_case_b520_list():
-    snippet = get_ctype_variable_declaration_snippet(parameters_for_testing[29], parameters_for_testing, IviDanceStep.NOT_APPLICABLE, config_for_testing, use_numpy_array=False)
-    assert snippet == ["input_array_2_ctype = get_ctypes_pointer_for_buffer(value=_converters.convert_to_nitclk_session_num_list(input_array_2), library_type=_visatype.ViReal64)  # case B520"]
+    actual = get_ctype_variable_declaration_snippet(parameters_for_testing[29], parameters_for_testing, IviDanceStep.NOT_APPLICABLE, config_for_testing, use_numpy_array=False)
+    expected = [
+        'converted_input_array_2 = _converters.convert_to_nitclk_session_num_list(input_array_2)  # case B520',
+        'input_array_2_ctype = get_ctypes_pointer_for_buffer(value=converted_input_array_2, library_type=_visatype.ViReal64)  # case B520',
+    ]
+    assert len(actual) == len(expected)
+    for i in range(max(len(actual), len(expected))):
+        assert actual[i] == expected[i]
 
 
 def test_get_ctype_variable_declaration_snippet_case_b520_custom_type():

--- a/build/helper/codegen_helper.py
+++ b/build/helper/codegen_helper.py
@@ -381,9 +381,9 @@ def _get_ctype_variable_definition_snippet_for_buffers(parameter, parameters, iv
                 definitions.append(array_declaration)
                 definition = 'get_ctypes_pointer_for_buffer(value={0}_array, library_type={1}.{2})  # case B520'.format(parameter['python_name'], module_name, parameter['ctypes_type'])
             elif parameter['use_list']:
-                conversion_declaration = 'converted_{0} = _converters.{1}({0})  # case B520'.format(parameter['python_name'], parameter['python_api_converter_name'])
+                conversion_declaration = '{0}_converted = _converters.{1}({0})  # case B520'.format(parameter['python_name'], parameter['python_api_converter_name'])
                 definitions.append(conversion_declaration)
-                definition = 'get_ctypes_pointer_for_buffer(value=converted_{0}, library_type={1}.{2})  # case B520'.format(parameter['python_name'], module_name, parameter['ctypes_type'])
+                definition = 'get_ctypes_pointer_for_buffer(value={0}_converted, library_type={1}.{2})  # case B520'.format(parameter['python_name'], module_name, parameter['ctypes_type'])
             else:
                 assert False, "Expected either 'use_array' or 'use_list' to be True. Both False."
     elif parameter['direction'] == 'in':
@@ -1518,8 +1518,8 @@ def test_get_ctype_variable_declaration_snippet_case_b520_array():
 def test_get_ctype_variable_declaration_snippet_case_b520_list():
     actual = get_ctype_variable_declaration_snippet(parameters_for_testing[29], parameters_for_testing, IviDanceStep.NOT_APPLICABLE, config_for_testing, use_numpy_array=False)
     expected = [
-        'converted_input_array_2 = _converters.convert_to_nitclk_session_num_list(input_array_2)  # case B520',
-        'input_array_2_ctype = get_ctypes_pointer_for_buffer(value=converted_input_array_2, library_type=_visatype.ViReal64)  # case B520',
+        'input_array_2_converted = _converters.convert_to_nitclk_session_num_list(input_array_2)  # case B520',
+        'input_array_2_ctype = get_ctypes_pointer_for_buffer(value=input_array_2_converted, library_type=_visatype.ViReal64)  # case B520',
     ]
     assert len(actual) == len(expected)
     for i in range(max(len(actual), len(expected))):

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -4778,8 +4778,8 @@ class Session(_SessionBase):
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         size_ctype = _visatype.ViInt32(0 if configuration is None else len(configuration))  # case S160
-        converted_configuration = _converters.convert_to_bytes(configuration)  # case B520
-        configuration_ctype = get_ctypes_pointer_for_buffer(value=converted_configuration, library_type=_visatype.ViInt8)  # case B520
+        configuration_converted = _converters.convert_to_bytes(configuration)  # case B520
+        configuration_ctype = get_ctypes_pointer_for_buffer(value=configuration_converted, library_type=_visatype.ViInt8)  # case B520
         error_code = self._library.niDCPower_ImportAttributeConfigurationBuffer(vi_ctype, size_ctype, configuration_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -4778,7 +4778,8 @@ class Session(_SessionBase):
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         size_ctype = _visatype.ViInt32(0 if configuration is None else len(configuration))  # case S160
-        configuration_ctype = get_ctypes_pointer_for_buffer(value=_converters.convert_to_bytes(configuration), library_type=_visatype.ViInt8)  # case B520
+        converted_configuration = _converters.convert_to_bytes(configuration)  # case B520
+        configuration_ctype = get_ctypes_pointer_for_buffer(value=converted_configuration, library_type=_visatype.ViInt8)  # case B520
         error_code = self._library.niDCPower_ImportAttributeConfigurationBuffer(vi_ctype, size_ctype, configuration_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -622,8 +622,8 @@ class _SessionBase(object):
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         channel_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         num_offsets_ctype = _visatype.ViInt32(0 if offsets is None else len(offsets))  # case S160
-        converted_offsets = _converters.convert_timedeltas_to_seconds_real64(offsets)  # case B520
-        offsets_ctype = get_ctypes_pointer_for_buffer(value=converted_offsets, library_type=_visatype.ViReal64)  # case B520
+        offsets_converted = _converters.convert_timedeltas_to_seconds_real64(offsets)  # case B520
+        offsets_ctype = get_ctypes_pointer_for_buffer(value=offsets_converted, library_type=_visatype.ViReal64)  # case B520
         error_code = self._library.niDigital_ApplyTDROffsets(vi_ctype, channel_list_ctype, num_offsets_ctype, offsets_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -622,7 +622,8 @@ class _SessionBase(object):
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         channel_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         num_offsets_ctype = _visatype.ViInt32(0 if offsets is None else len(offsets))  # case S160
-        offsets_ctype = get_ctypes_pointer_for_buffer(value=_converters.convert_timedeltas_to_seconds_real64(offsets), library_type=_visatype.ViReal64)  # case B520
+        converted_offsets = _converters.convert_timedeltas_to_seconds_real64(offsets)  # case B520
+        offsets_ctype = get_ctypes_pointer_for_buffer(value=converted_offsets, library_type=_visatype.ViReal64)  # case B520
         error_code = self._library.niDigital_ApplyTDROffsets(vi_ctype, channel_list_ctype, num_offsets_ctype, offsets_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return

--- a/generated/nidmm/nidmm/session.py
+++ b/generated/nidmm/nidmm/session.py
@@ -2202,8 +2202,8 @@ class Session(_SessionBase):
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         size_ctype = _visatype.ViInt32(0 if configuration is None else len(configuration))  # case S160
-        converted_configuration = _converters.convert_to_bytes(configuration)  # case B520
-        configuration_ctype = get_ctypes_pointer_for_buffer(value=converted_configuration, library_type=_visatype.ViInt8)  # case B520
+        configuration_converted = _converters.convert_to_bytes(configuration)  # case B520
+        configuration_ctype = get_ctypes_pointer_for_buffer(value=configuration_converted, library_type=_visatype.ViInt8)  # case B520
         error_code = self._library.niDMM_ImportAttributeConfigurationBuffer(vi_ctype, size_ctype, configuration_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return

--- a/generated/nidmm/nidmm/session.py
+++ b/generated/nidmm/nidmm/session.py
@@ -2202,7 +2202,8 @@ class Session(_SessionBase):
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         size_ctype = _visatype.ViInt32(0 if configuration is None else len(configuration))  # case S160
-        configuration_ctype = get_ctypes_pointer_for_buffer(value=_converters.convert_to_bytes(configuration), library_type=_visatype.ViInt8)  # case B520
+        converted_configuration = _converters.convert_to_bytes(configuration)  # case B520
+        configuration_ctype = get_ctypes_pointer_for_buffer(value=converted_configuration, library_type=_visatype.ViInt8)  # case B520
         error_code = self._library.niDMM_ImportAttributeConfigurationBuffer(vi_ctype, size_ctype, configuration_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return

--- a/generated/nifake/nifake/session.py
+++ b/generated/nifake/nifake/session.py
@@ -777,7 +777,8 @@ class Session(_SessionBase):
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         count_ctype = _visatype.ViInt32(0 if delays is None else len(delays))  # case S160
-        delays_ctype = get_ctypes_pointer_for_buffer(value=_converters.convert_timedeltas_to_seconds_real64(delays), library_type=_visatype.ViReal64)  # case B520
+        converted_delays = _converters.convert_timedeltas_to_seconds_real64(delays)  # case B520
+        delays_ctype = get_ctypes_pointer_for_buffer(value=converted_delays, library_type=_visatype.ViReal64)  # case B520
         error_code = self._library.niFake_AcceptListOfDurationsInSeconds(vi_ctype, count_ctype, delays_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
@@ -816,7 +817,8 @@ class Session(_SessionBase):
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         number_count_ctype = _visatype.ViInt32(0 if numbers is None else len(numbers))  # case S160
-        numbers_ctype = get_ctypes_pointer_for_buffer(value=_converters.convert_double_each_element(numbers), library_type=_visatype.ViReal64)  # case B520
+        converted_numbers = _converters.convert_double_each_element(numbers)  # case B520
+        numbers_ctype = get_ctypes_pointer_for_buffer(value=converted_numbers, library_type=_visatype.ViReal64)  # case B520
         error_code = self._library.niFake_DoubleAllTheNums(vi_ctype, number_count_ctype, numbers_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
@@ -1295,7 +1297,8 @@ class Session(_SessionBase):
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         size_in_bytes_ctype = _visatype.ViInt32(0 if configuration is None else len(configuration))  # case S160
-        configuration_ctype = get_ctypes_pointer_for_buffer(value=_converters.convert_to_bytes(configuration), library_type=_visatype.ViInt8)  # case B520
+        converted_configuration = _converters.convert_to_bytes(configuration)  # case B520
+        configuration_ctype = get_ctypes_pointer_for_buffer(value=converted_configuration, library_type=_visatype.ViInt8)  # case B520
         error_code = self._library.niFake_ImportAttributeConfigurationBuffer(vi_ctype, size_in_bytes_ctype, configuration_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return

--- a/generated/nifake/nifake/session.py
+++ b/generated/nifake/nifake/session.py
@@ -777,8 +777,8 @@ class Session(_SessionBase):
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         count_ctype = _visatype.ViInt32(0 if delays is None else len(delays))  # case S160
-        converted_delays = _converters.convert_timedeltas_to_seconds_real64(delays)  # case B520
-        delays_ctype = get_ctypes_pointer_for_buffer(value=converted_delays, library_type=_visatype.ViReal64)  # case B520
+        delays_converted = _converters.convert_timedeltas_to_seconds_real64(delays)  # case B520
+        delays_ctype = get_ctypes_pointer_for_buffer(value=delays_converted, library_type=_visatype.ViReal64)  # case B520
         error_code = self._library.niFake_AcceptListOfDurationsInSeconds(vi_ctype, count_ctype, delays_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
@@ -817,8 +817,8 @@ class Session(_SessionBase):
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         number_count_ctype = _visatype.ViInt32(0 if numbers is None else len(numbers))  # case S160
-        converted_numbers = _converters.convert_double_each_element(numbers)  # case B520
-        numbers_ctype = get_ctypes_pointer_for_buffer(value=converted_numbers, library_type=_visatype.ViReal64)  # case B520
+        numbers_converted = _converters.convert_double_each_element(numbers)  # case B520
+        numbers_ctype = get_ctypes_pointer_for_buffer(value=numbers_converted, library_type=_visatype.ViReal64)  # case B520
         error_code = self._library.niFake_DoubleAllTheNums(vi_ctype, number_count_ctype, numbers_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
@@ -1297,8 +1297,8 @@ class Session(_SessionBase):
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         size_in_bytes_ctype = _visatype.ViInt32(0 if configuration is None else len(configuration))  # case S160
-        converted_configuration = _converters.convert_to_bytes(configuration)  # case B520
-        configuration_ctype = get_ctypes_pointer_for_buffer(value=converted_configuration, library_type=_visatype.ViInt8)  # case B520
+        configuration_converted = _converters.convert_to_bytes(configuration)  # case B520
+        configuration_ctype = get_ctypes_pointer_for_buffer(value=configuration_converted, library_type=_visatype.ViInt8)  # case B520
         error_code = self._library.niFake_ImportAttributeConfigurationBuffer(vi_ctype, size_in_bytes_ctype, configuration_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return

--- a/generated/nifgen/nifgen/session.py
+++ b/generated/nifgen/nifgen/session.py
@@ -3918,7 +3918,8 @@ class Session(_SessionBase):
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         size_in_bytes_ctype = _visatype.ViInt32(0 if configuration is None else len(configuration))  # case S160
-        configuration_ctype = get_ctypes_pointer_for_buffer(value=_converters.convert_to_bytes(configuration), library_type=_visatype.ViInt8)  # case B520
+        converted_configuration = _converters.convert_to_bytes(configuration)  # case B520
+        configuration_ctype = get_ctypes_pointer_for_buffer(value=converted_configuration, library_type=_visatype.ViInt8)  # case B520
         error_code = self._library.niFgen_ImportAttributeConfigurationBuffer(vi_ctype, size_in_bytes_ctype, configuration_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return

--- a/generated/nifgen/nifgen/session.py
+++ b/generated/nifgen/nifgen/session.py
@@ -3918,8 +3918,8 @@ class Session(_SessionBase):
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         size_in_bytes_ctype = _visatype.ViInt32(0 if configuration is None else len(configuration))  # case S160
-        converted_configuration = _converters.convert_to_bytes(configuration)  # case B520
-        configuration_ctype = get_ctypes_pointer_for_buffer(value=converted_configuration, library_type=_visatype.ViInt8)  # case B520
+        configuration_converted = _converters.convert_to_bytes(configuration)  # case B520
+        configuration_ctype = get_ctypes_pointer_for_buffer(value=configuration_converted, library_type=_visatype.ViInt8)  # case B520
         error_code = self._library.niFgen_ImportAttributeConfigurationBuffer(vi_ctype, size_in_bytes_ctype, configuration_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return

--- a/generated/niscope/niscope/session.py
+++ b/generated/niscope/niscope/session.py
@@ -4867,7 +4867,8 @@ class Session(_SessionBase):
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         size_in_bytes_ctype = _visatype.ViInt32(0 if configuration is None else len(configuration))  # case S160
-        configuration_ctype = get_ctypes_pointer_for_buffer(value=_converters.convert_to_bytes(configuration), library_type=_visatype.ViInt8)  # case B520
+        converted_configuration = _converters.convert_to_bytes(configuration)  # case B520
+        configuration_ctype = get_ctypes_pointer_for_buffer(value=converted_configuration, library_type=_visatype.ViInt8)  # case B520
         error_code = self._library.niScope_ImportAttributeConfigurationBuffer(vi_ctype, size_in_bytes_ctype, configuration_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return

--- a/generated/niscope/niscope/session.py
+++ b/generated/niscope/niscope/session.py
@@ -4867,8 +4867,8 @@ class Session(_SessionBase):
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         size_in_bytes_ctype = _visatype.ViInt32(0 if configuration is None else len(configuration))  # case S160
-        converted_configuration = _converters.convert_to_bytes(configuration)  # case B520
-        configuration_ctype = get_ctypes_pointer_for_buffer(value=converted_configuration, library_type=_visatype.ViInt8)  # case B520
+        configuration_converted = _converters.convert_to_bytes(configuration)  # case B520
+        configuration_ctype = get_ctypes_pointer_for_buffer(value=configuration_converted, library_type=_visatype.ViInt8)  # case B520
         error_code = self._library.niScope_ImportAttributeConfigurationBuffer(vi_ctype, size_in_bytes_ctype, configuration_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return

--- a/generated/nitclk/nitclk/session.py
+++ b/generated/nitclk/nitclk/session.py
@@ -591,7 +591,8 @@ class _Session(object):
 
         '''
         session_count_ctype = _visatype.ViUInt32(0 if sessions is None else len(sessions))  # case S160
-        sessions_ctype = get_ctypes_pointer_for_buffer(value=_converters.convert_to_nitclk_session_number_list(sessions), library_type=_visatype.ViSession)  # case B520
+        converted_sessions = _converters.convert_to_nitclk_session_number_list(sessions)  # case B520
+        sessions_ctype = get_ctypes_pointer_for_buffer(value=converted_sessions, library_type=_visatype.ViSession)  # case B520
         error_code = self._library.niTClk_ConfigureForHomogeneousTriggers(session_count_ctype, sessions_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
@@ -613,7 +614,8 @@ class _Session(object):
 
         '''
         session_count_ctype = _visatype.ViUInt32(0 if sessions is None else len(sessions))  # case S160
-        sessions_ctype = get_ctypes_pointer_for_buffer(value=_converters.convert_to_nitclk_session_number_list(sessions), library_type=_visatype.ViSession)  # case B520
+        converted_sessions = _converters.convert_to_nitclk_session_number_list(sessions)  # case B520
+        sessions_ctype = get_ctypes_pointer_for_buffer(value=converted_sessions, library_type=_visatype.ViSession)  # case B520
         min_time_ctype = _converters.convert_timedelta_to_seconds_real64(min_time)  # case S140
         error_code = self._library.niTClk_FinishSyncPulseSenderSynchronize(session_count_ctype, sessions_ctype, min_time_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
@@ -659,7 +661,8 @@ class _Session(object):
 
         '''
         session_count_ctype = _visatype.ViUInt32(0 if sessions is None else len(sessions))  # case S160
-        sessions_ctype = get_ctypes_pointer_for_buffer(value=_converters.convert_to_nitclk_session_number_list(sessions), library_type=_visatype.ViSession)  # case B520
+        converted_sessions = _converters.convert_to_nitclk_session_number_list(sessions)  # case B520
+        sessions_ctype = get_ctypes_pointer_for_buffer(value=converted_sessions, library_type=_visatype.ViSession)  # case B520
         error_code = self._library.niTClk_Initiate(session_count_ctype, sessions_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
@@ -681,7 +684,8 @@ class _Session(object):
 
         '''
         session_count_ctype = _visatype.ViUInt32(0 if sessions is None else len(sessions))  # case S160
-        sessions_ctype = get_ctypes_pointer_for_buffer(value=_converters.convert_to_nitclk_session_number_list(sessions), library_type=_visatype.ViSession)  # case B520
+        converted_sessions = _converters.convert_to_nitclk_session_number_list(sessions)  # case B520
+        sessions_ctype = get_ctypes_pointer_for_buffer(value=converted_sessions, library_type=_visatype.ViSession)  # case B520
         done_ctype = _visatype.ViBoolean()  # case S220
         error_code = self._library.niTClk_IsDone(session_count_ctype, sessions_ctype, None if done_ctype is None else (ctypes.pointer(done_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
@@ -704,7 +708,8 @@ class _Session(object):
 
         '''
         session_count_ctype = _visatype.ViUInt32(0 if sessions is None else len(sessions))  # case S160
-        sessions_ctype = get_ctypes_pointer_for_buffer(value=_converters.convert_to_nitclk_session_number_list(sessions), library_type=_visatype.ViSession)  # case B520
+        converted_sessions = _converters.convert_to_nitclk_session_number_list(sessions)  # case B520
+        sessions_ctype = get_ctypes_pointer_for_buffer(value=converted_sessions, library_type=_visatype.ViSession)  # case B520
         min_time_ctype = _converters.convert_timedelta_to_seconds_real64(min_time)  # case S140
         error_code = self._library.niTClk_SetupForSyncPulseSenderSynchronize(session_count_ctype, sessions_ctype, min_time_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
@@ -732,7 +737,8 @@ class _Session(object):
 
         '''
         session_count_ctype = _visatype.ViUInt32(0 if sessions is None else len(sessions))  # case S160
-        sessions_ctype = get_ctypes_pointer_for_buffer(value=_converters.convert_to_nitclk_session_number_list(sessions), library_type=_visatype.ViSession)  # case B520
+        converted_sessions = _converters.convert_to_nitclk_session_number_list(sessions)  # case B520
+        sessions_ctype = get_ctypes_pointer_for_buffer(value=converted_sessions, library_type=_visatype.ViSession)  # case B520
         min_tclk_period_ctype = _converters.convert_timedelta_to_seconds_real64(min_tclk_period)  # case S140
         error_code = self._library.niTClk_Synchronize(session_count_ctype, sessions_ctype, min_tclk_period_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
@@ -755,7 +761,8 @@ class _Session(object):
 
         '''
         session_count_ctype = _visatype.ViUInt32(0 if sessions is None else len(sessions))  # case S160
-        sessions_ctype = get_ctypes_pointer_for_buffer(value=_converters.convert_to_nitclk_session_number_list(sessions), library_type=_visatype.ViSession)  # case B520
+        converted_sessions = _converters.convert_to_nitclk_session_number_list(sessions)  # case B520
+        sessions_ctype = get_ctypes_pointer_for_buffer(value=converted_sessions, library_type=_visatype.ViSession)  # case B520
         min_time_ctype = _converters.convert_timedelta_to_seconds_real64(min_time)  # case S140
         error_code = self._library.niTClk_SynchronizeToSyncPulseSender(session_count_ctype, sessions_ctype, min_time_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
@@ -782,7 +789,8 @@ class _Session(object):
 
         '''
         session_count_ctype = _visatype.ViUInt32(0 if sessions is None else len(sessions))  # case S160
-        sessions_ctype = get_ctypes_pointer_for_buffer(value=_converters.convert_to_nitclk_session_number_list(sessions), library_type=_visatype.ViSession)  # case B520
+        converted_sessions = _converters.convert_to_nitclk_session_number_list(sessions)  # case B520
+        sessions_ctype = get_ctypes_pointer_for_buffer(value=converted_sessions, library_type=_visatype.ViSession)  # case B520
         timeout_ctype = _converters.convert_timedelta_to_seconds_real64(timeout)  # case S140
         error_code = self._library.niTClk_WaitUntilDone(session_count_ctype, sessions_ctype, timeout_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)

--- a/generated/nitclk/nitclk/session.py
+++ b/generated/nitclk/nitclk/session.py
@@ -591,8 +591,8 @@ class _Session(object):
 
         '''
         session_count_ctype = _visatype.ViUInt32(0 if sessions is None else len(sessions))  # case S160
-        converted_sessions = _converters.convert_to_nitclk_session_number_list(sessions)  # case B520
-        sessions_ctype = get_ctypes_pointer_for_buffer(value=converted_sessions, library_type=_visatype.ViSession)  # case B520
+        sessions_converted = _converters.convert_to_nitclk_session_number_list(sessions)  # case B520
+        sessions_ctype = get_ctypes_pointer_for_buffer(value=sessions_converted, library_type=_visatype.ViSession)  # case B520
         error_code = self._library.niTClk_ConfigureForHomogeneousTriggers(session_count_ctype, sessions_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
@@ -614,8 +614,8 @@ class _Session(object):
 
         '''
         session_count_ctype = _visatype.ViUInt32(0 if sessions is None else len(sessions))  # case S160
-        converted_sessions = _converters.convert_to_nitclk_session_number_list(sessions)  # case B520
-        sessions_ctype = get_ctypes_pointer_for_buffer(value=converted_sessions, library_type=_visatype.ViSession)  # case B520
+        sessions_converted = _converters.convert_to_nitclk_session_number_list(sessions)  # case B520
+        sessions_ctype = get_ctypes_pointer_for_buffer(value=sessions_converted, library_type=_visatype.ViSession)  # case B520
         min_time_ctype = _converters.convert_timedelta_to_seconds_real64(min_time)  # case S140
         error_code = self._library.niTClk_FinishSyncPulseSenderSynchronize(session_count_ctype, sessions_ctype, min_time_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
@@ -661,8 +661,8 @@ class _Session(object):
 
         '''
         session_count_ctype = _visatype.ViUInt32(0 if sessions is None else len(sessions))  # case S160
-        converted_sessions = _converters.convert_to_nitclk_session_number_list(sessions)  # case B520
-        sessions_ctype = get_ctypes_pointer_for_buffer(value=converted_sessions, library_type=_visatype.ViSession)  # case B520
+        sessions_converted = _converters.convert_to_nitclk_session_number_list(sessions)  # case B520
+        sessions_ctype = get_ctypes_pointer_for_buffer(value=sessions_converted, library_type=_visatype.ViSession)  # case B520
         error_code = self._library.niTClk_Initiate(session_count_ctype, sessions_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
@@ -684,8 +684,8 @@ class _Session(object):
 
         '''
         session_count_ctype = _visatype.ViUInt32(0 if sessions is None else len(sessions))  # case S160
-        converted_sessions = _converters.convert_to_nitclk_session_number_list(sessions)  # case B520
-        sessions_ctype = get_ctypes_pointer_for_buffer(value=converted_sessions, library_type=_visatype.ViSession)  # case B520
+        sessions_converted = _converters.convert_to_nitclk_session_number_list(sessions)  # case B520
+        sessions_ctype = get_ctypes_pointer_for_buffer(value=sessions_converted, library_type=_visatype.ViSession)  # case B520
         done_ctype = _visatype.ViBoolean()  # case S220
         error_code = self._library.niTClk_IsDone(session_count_ctype, sessions_ctype, None if done_ctype is None else (ctypes.pointer(done_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
@@ -708,8 +708,8 @@ class _Session(object):
 
         '''
         session_count_ctype = _visatype.ViUInt32(0 if sessions is None else len(sessions))  # case S160
-        converted_sessions = _converters.convert_to_nitclk_session_number_list(sessions)  # case B520
-        sessions_ctype = get_ctypes_pointer_for_buffer(value=converted_sessions, library_type=_visatype.ViSession)  # case B520
+        sessions_converted = _converters.convert_to_nitclk_session_number_list(sessions)  # case B520
+        sessions_ctype = get_ctypes_pointer_for_buffer(value=sessions_converted, library_type=_visatype.ViSession)  # case B520
         min_time_ctype = _converters.convert_timedelta_to_seconds_real64(min_time)  # case S140
         error_code = self._library.niTClk_SetupForSyncPulseSenderSynchronize(session_count_ctype, sessions_ctype, min_time_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
@@ -737,8 +737,8 @@ class _Session(object):
 
         '''
         session_count_ctype = _visatype.ViUInt32(0 if sessions is None else len(sessions))  # case S160
-        converted_sessions = _converters.convert_to_nitclk_session_number_list(sessions)  # case B520
-        sessions_ctype = get_ctypes_pointer_for_buffer(value=converted_sessions, library_type=_visatype.ViSession)  # case B520
+        sessions_converted = _converters.convert_to_nitclk_session_number_list(sessions)  # case B520
+        sessions_ctype = get_ctypes_pointer_for_buffer(value=sessions_converted, library_type=_visatype.ViSession)  # case B520
         min_tclk_period_ctype = _converters.convert_timedelta_to_seconds_real64(min_tclk_period)  # case S140
         error_code = self._library.niTClk_Synchronize(session_count_ctype, sessions_ctype, min_tclk_period_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
@@ -761,8 +761,8 @@ class _Session(object):
 
         '''
         session_count_ctype = _visatype.ViUInt32(0 if sessions is None else len(sessions))  # case S160
-        converted_sessions = _converters.convert_to_nitclk_session_number_list(sessions)  # case B520
-        sessions_ctype = get_ctypes_pointer_for_buffer(value=converted_sessions, library_type=_visatype.ViSession)  # case B520
+        sessions_converted = _converters.convert_to_nitclk_session_number_list(sessions)  # case B520
+        sessions_ctype = get_ctypes_pointer_for_buffer(value=sessions_converted, library_type=_visatype.ViSession)  # case B520
         min_time_ctype = _converters.convert_timedelta_to_seconds_real64(min_time)  # case S140
         error_code = self._library.niTClk_SynchronizeToSyncPulseSender(session_count_ctype, sessions_ctype, min_time_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
@@ -789,8 +789,8 @@ class _Session(object):
 
         '''
         session_count_ctype = _visatype.ViUInt32(0 if sessions is None else len(sessions))  # case S160
-        converted_sessions = _converters.convert_to_nitclk_session_number_list(sessions)  # case B520
-        sessions_ctype = get_ctypes_pointer_for_buffer(value=converted_sessions, library_type=_visatype.ViSession)  # case B520
+        sessions_converted = _converters.convert_to_nitclk_session_number_list(sessions)  # case B520
+        sessions_ctype = get_ctypes_pointer_for_buffer(value=sessions_converted, library_type=_visatype.ViSession)  # case B520
         timeout_ctype = _converters.convert_timedelta_to_seconds_real64(timeout)  # case S140
         error_code = self._library.niTClk_WaitUntilDone(session_count_ctype, sessions_ctype, timeout_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Fix intermittent failure in import_attribute_configuration_buffer() by updating code generator to pass non-temporary object to `get_ctypes_pointer_for_buffer()`.

### List issues fixed by this Pull Request below, if any.

* Fix #1491 

### What testing has been done?

Created a test that calls `import_attribute_configuration_buffer()` by passing in `list` of `int`, in a loop. The test failed pretty consistently on my setup without the fix. With the fix, it ran for 1 million iterations without failure.