### PR TITLE
NI-DMM: Make getting the last calibration temp and datetime consistent with other drivers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,14 @@ All notable changes to this project will be documented in this file.
     * #### Removed
 * ### `nidmm` (NI-DMM)
     * #### Added
+        * New methods for getting calibration information. - [#1462](https://github.com/ni/nimi-python/issues/1462)
+            * `get_ext_cal_last_date_and_time`
+            * `get_ext_cal_last_temp`
+            * `get_self_cal_last_date_and_time`
+            * `get_self_cal_last_temp`
     * #### Changed
     * #### Removed
+        * Outdated `get_cal_date_and_time` method removed in favor of more consistent new methods. - [#1462](https://github.com/ni/nimi-python/issues/1462)
 * ### `nifgen` (NI-FGEN)
     * #### Added
     * #### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,6 @@ All notable changes to this project will be documented in this file.
             * `get_self_cal_last_temp`
     * #### Changed
     * #### Removed
-        * Outdated `get_cal_date_and_time` method removed in favor of more consistent new methods. - [#1462](https://github.com/ni/nimi-python/issues/1462)
 * ### `nifgen` (NI-FGEN)
     * #### Added
     * #### Changed

--- a/docs/nidmm/class.rst
+++ b/docs/nidmm/class.rst
@@ -1131,49 +1131,6 @@ fetch_waveform_into
 
 
 
-get_cal_date_and_time
----------------------
-
-    .. py:currentmodule:: nidmm.Session
-
-    .. py:method:: get_cal_date_and_time(cal_type)
-
-            Returns the date and time of the last calibration performed.
-
-            
-
-            .. note:: The NI 4050 and NI 4060 are not supported.
-
-
-
-            :param cal_type:
-
-
-                Specifies the type of calibration performed (external or self-calibration).
-
-                +-----------------------------------------------------+---+----------------------+
-                | :py:data:`~nidmm.NIDMM_VAL_INTERNAL_AREA` (default) | 0 | Self-Calibration     |
-                +-----------------------------------------------------+---+----------------------+
-                | :py:data:`~nidmm.NIDMM_VAL_EXTERNAL_AREA`           | 1 | External Calibration |
-                +-----------------------------------------------------+---+----------------------+
-
-                .. note:: The NI 4065 does not support self-calibration.
-
-                .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
-
-
-            :type cal_type: int
-
-            :rtype: hightime.datetime
-            :return:
-
-
-                    Indicates date and time of the last calibration.
-
-                    
-
-
-
 get_dev_temp
 ------------
 
@@ -1277,50 +1234,6 @@ get_ext_cal_recommended_interval
 
                     Returns the recommended number of **months** between external
                     calibrations.
-
-                    
-
-
-
-get_last_cal_temp
------------------
-
-    .. py:currentmodule:: nidmm.Session
-
-    .. py:method:: get_last_cal_temp(cal_type)
-
-            Returns the **Temperature** during the last calibration procedure.
-
-            
-
-            .. note:: The NI 4050 and NI 4060 are not supported.
-
-
-
-            :param cal_type:
-
-
-                Specifies the type of calibration performed (external or
-                self-calibration).
-
-                +-----------------------------------------------------+---+----------------------+
-                | :py:data:`~nidmm.NIDMM_VAL_INTERNAL_AREA` (default) | 0 | Self-Calibration     |
-                +-----------------------------------------------------+---+----------------------+
-                | :py:data:`~nidmm.NIDMM_VAL_EXTERNAL_AREA`           | 1 | External Calibration |
-                +-----------------------------------------------------+---+----------------------+
-
-                .. note:: The NI 4065 does not support self-calibration.
-
-                .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
-
-
-            :type cal_type: int
-
-            :rtype: float
-            :return:
-
-
-                    Returns the **temperature** during the last calibration.
 
                     
 

--- a/docs/nidmm/class.rst
+++ b/docs/nidmm/class.rst
@@ -1209,6 +1209,52 @@ get_dev_temp
 
 
 
+get_ext_cal_last_date_and_time
+------------------------------
+
+    .. py:currentmodule:: nidmm.Session
+
+    .. py:method:: get_ext_cal_last_date_and_time()
+
+            Returns the date and time of the last external calibration performed.
+
+            
+
+
+
+            :rtype: hightime.datetime
+            :return:
+
+
+                    Indicates date and time of the last external calibration.
+
+                    
+
+
+
+get_ext_cal_last_temp
+---------------------
+
+    .. py:currentmodule:: nidmm.Session
+
+    .. py:method:: get_ext_cal_last_temp()
+
+            Returns the **Temperature** during the last external calibration procedure.
+
+            
+
+
+
+            :rtype: float
+            :return:
+
+
+                    Returns the **temperature** during the last external calibration.
+
+                    
+
+
+
 get_ext_cal_recommended_interval
 --------------------------------
 
@@ -1275,6 +1321,52 @@ get_last_cal_temp
 
 
                     Returns the **temperature** during the last calibration.
+
+                    
+
+
+
+get_self_cal_last_date_and_time
+-------------------------------
+
+    .. py:currentmodule:: nidmm.Session
+
+    .. py:method:: get_self_cal_last_date_and_time()
+
+            Returns the date and time of the last self calibration performed.
+
+            
+
+
+
+            :rtype: hightime.datetime
+            :return:
+
+
+                    Indicates date and time of the last self calibration.
+
+                    
+
+
+
+get_self_cal_last_temp
+----------------------
+
+    .. py:currentmodule:: nidmm.Session
+
+    .. py:method:: get_self_cal_last_temp()
+
+            Returns the **Temperature** during the last self calibration procedure.
+
+            
+
+
+
+            :rtype: float
+            :return:
+
+
+                    Returns the **temperature** during the last self calibration.
 
                     
 

--- a/docs/nidmm/class.rst
+++ b/docs/nidmm/class.rst
@@ -1131,6 +1131,49 @@ fetch_waveform_into
 
 
 
+get_cal_date_and_time
+---------------------
+
+    .. py:currentmodule:: nidmm.Session
+
+    .. py:method:: get_cal_date_and_time(cal_type)
+
+            Returns the date and time of the last calibration performed.
+
+            
+
+            .. note:: The NI 4050 and NI 4060 are not supported.
+
+
+
+            :param cal_type:
+
+
+                Specifies the type of calibration performed (external or self-calibration).
+
+                +-----------------------------------------------------+---+----------------------+
+                | :py:data:`~nidmm.NIDMM_VAL_INTERNAL_AREA` (default) | 0 | Self-Calibration     |
+                +-----------------------------------------------------+---+----------------------+
+                | :py:data:`~nidmm.NIDMM_VAL_EXTERNAL_AREA`           | 1 | External Calibration |
+                +-----------------------------------------------------+---+----------------------+
+
+                .. note:: The NI 4065 does not support self-calibration.
+
+                .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
+
+
+            :type cal_type: int
+
+            :rtype: hightime.datetime
+            :return:
+
+
+                    Indicates date and time of the last calibration.
+
+                    
+
+
+
 get_dev_temp
 ------------
 

--- a/generated/nidmm/nidmm/session.py
+++ b/generated/nidmm/nidmm/session.py
@@ -1792,6 +1792,58 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
+    def get_ext_cal_last_date_and_time(self):
+        '''get_ext_cal_last_date_and_time
+
+        Returns the date and time of the last external calibration performed.
+
+        Returns:
+            last_cal_datetime (hightime.datetime): Indicates date and time of the last external calibration.
+
+        '''
+
+        return self.get_last_cal_temp(1)
+
+    @ivi_synchronized
+    def get_ext_cal_last_temp(self):
+        '''get_ext_cal_last_temp
+
+        Returns the **Temperature** during the last external calibration procedure.
+
+        Returns:
+            temperature (float): Returns the **temperature** during the last external calibration.
+
+        '''
+
+        return self.get_last_cal_temp(1)
+
+    @ivi_synchronized
+    def get_self_cal_last_date_and_time(self):
+        '''get_self_cal_last_date_and_time
+
+        Returns the date and time of the last self calibration performed.
+
+        Returns:
+            last_cal_datetime (hightime.datetime): Indicates date and time of the last self calibration.
+
+        '''
+
+        return self.get_last_cal_temp(0)
+
+    @ivi_synchronized
+    def get_self_cal_last_temp(self):
+        '''get_self_cal_last_temp
+
+        Returns the **Temperature** during the last self calibration procedure.
+
+        Returns:
+            temperature (float): Returns the **temperature** during the last self calibration.
+
+        '''
+
+        return self.get_last_cal_temp(0)
+
+    @ivi_synchronized
     def fetch(self, maximum_time=hightime.timedelta(milliseconds=-1)):
         r'''fetch
 

--- a/generated/nidmm/nidmm/session.py
+++ b/generated/nidmm/nidmm/session.py
@@ -1802,7 +1802,7 @@ class Session(_SessionBase):
 
         '''
 
-        return self.get_last_cal_temp(1)
+        return self.get_cal_date_and_time(1)
 
     @ivi_synchronized
     def get_ext_cal_last_temp(self):
@@ -1828,7 +1828,7 @@ class Session(_SessionBase):
 
         '''
 
-        return self.get_last_cal_temp(0)
+        return self.get_cal_date_and_time(0)
 
     @ivi_synchronized
     def get_self_cal_last_temp(self):

--- a/generated/nidmm/nidmm/session.py
+++ b/generated/nidmm/nidmm/session.py
@@ -2125,6 +2125,36 @@ class Session(_SessionBase):
         return _converters.convert_month_to_timedelta(int(months_ctype.value))
 
     @ivi_synchronized
+    def get_cal_date_and_time(self, cal_type):
+        '''get_cal_date_and_time
+
+        Returns the date and time of the last calibration performed.
+
+        Note: The NI 4050 and NI 4060 are not supported.
+
+        Args:
+            cal_type (int): Specifies the type of calibration performed (external or self-calibration).
+
+                +-----------------------------------+---+----------------------+
+                | NIDMM_VAL_INTERNAL_AREA (default) | 0 | Self-Calibration     |
+                +-----------------------------------+---+----------------------+
+                | NIDMM_VAL_EXTERNAL_AREA           | 1 | External Calibration |
+                +-----------------------------------+---+----------------------+
+
+                Note: The NI 4065 does not support self-calibration.
+
+                Note:
+                One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
+
+
+        Returns:
+            month (hightime.datetime): Indicates date and time of the last calibration.
+
+        '''
+        month, day, year, hour, minute = self._get_cal_date_and_time(cal_type)
+        return hightime.datetime(year, month, day, hour, minute)
+
+    @ivi_synchronized
     def _get_last_cal_temp(self, cal_type):
         r'''_get_last_cal_temp
 

--- a/generated/nidmm/nidmm/session.py
+++ b/generated/nidmm/nidmm/session.py
@@ -1802,7 +1802,8 @@ class Session(_SessionBase):
 
         '''
 
-        return self.get_cal_date_and_time(1)
+        month, day, year, hour, minute = self._get_cal_date_and_time(1)
+        return hightime.datetime(year, month, day, hour, minute)
 
     @ivi_synchronized
     def get_ext_cal_last_temp(self):
@@ -1815,7 +1816,7 @@ class Session(_SessionBase):
 
         '''
 
-        return self.get_last_cal_temp(1)
+        return self._get_last_cal_temp(1)
 
     @ivi_synchronized
     def get_self_cal_last_date_and_time(self):
@@ -1828,7 +1829,8 @@ class Session(_SessionBase):
 
         '''
 
-        return self.get_cal_date_and_time(0)
+        month, day, year, hour, minute = self._get_cal_date_and_time(0)
+        return hightime.datetime(year, month, day, hour, minute)
 
     @ivi_synchronized
     def get_self_cal_last_temp(self):
@@ -1841,7 +1843,7 @@ class Session(_SessionBase):
 
         '''
 
-        return self.get_last_cal_temp(0)
+        return self._get_last_cal_temp(0)
 
     @ivi_synchronized
     def fetch(self, maximum_time=hightime.timedelta(milliseconds=-1)):
@@ -2123,38 +2125,8 @@ class Session(_SessionBase):
         return _converters.convert_month_to_timedelta(int(months_ctype.value))
 
     @ivi_synchronized
-    def get_cal_date_and_time(self, cal_type):
-        '''get_cal_date_and_time
-
-        Returns the date and time of the last calibration performed.
-
-        Note: The NI 4050 and NI 4060 are not supported.
-
-        Args:
-            cal_type (int): Specifies the type of calibration performed (external or self-calibration).
-
-                +-----------------------------------+---+----------------------+
-                | NIDMM_VAL_INTERNAL_AREA (default) | 0 | Self-Calibration     |
-                +-----------------------------------+---+----------------------+
-                | NIDMM_VAL_EXTERNAL_AREA           | 1 | External Calibration |
-                +-----------------------------------+---+----------------------+
-
-                Note: The NI 4065 does not support self-calibration.
-
-                Note:
-                One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
-
-
-        Returns:
-            month (hightime.datetime): Indicates date and time of the last calibration.
-
-        '''
-        month, day, year, hour, minute = self._get_cal_date_and_time(cal_type)
-        return hightime.datetime(year, month, day, hour, minute)
-
-    @ivi_synchronized
-    def get_last_cal_temp(self, cal_type):
-        r'''get_last_cal_temp
+    def _get_last_cal_temp(self, cal_type):
+        r'''_get_last_cal_temp
 
         Returns the **Temperature** during the last calibration procedure.
 

--- a/src/nidmm/metadata/functions.py
+++ b/src/nidmm/metadata/functions.py
@@ -1152,6 +1152,62 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
+    'GetLastCalDateAndTime': {
+        'codegen_method': 'python-only',
+        'documentation': {
+            'description': 'Returns the date and time of the last calibration performed.',
+            'note': 'The NI 4050 and NI 4060 are not supported.'
+        },
+        'method_templates': [
+            {
+                'documentation_filename': 'default_method',
+                'method_python_name_suffix': '',
+                'session_filename': 'datetime_wrappers'
+            }
+        ],
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Identifies a particular instrument session. You obtain the **vi** parameter from niDMM_init or niDMM_InitWithOptions. The default is None.'
+                },
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Specifies the type of calibration performed (external or self-calibration).',
+                    'note': 'The NI 4065 does not support self-calibration.',
+                    'table_body': [
+                        [
+                            'NIDMM_VAL_INTERNAL_AREA (default)',
+                            '0',
+                            'Self-Calibration'
+                        ],
+                        [
+                            'NIDMM_VAL_EXTERNAL_AREA',
+                            '1',
+                            'External Calibration'
+                        ]
+                    ]
+                },
+                'name': 'calType',
+                'type': 'ViInt32'
+            },
+            {
+                'direction': 'out',
+                'documentation': {
+                    'description': 'Indicates date and time of the last calibration.'
+                },
+                'name': 'month',
+                'type': 'hightime.datetime'
+            }
+        ],
+        'python_name': 'get_cal_date_and_time',
+        'real_datetime_call': 'GetCalDateAndTime',
+        'returns': 'ViStatus'
+    },
     'GetLastCalTemp': {
         'codegen_method': 'private',
         'documentation': {

--- a/src/nidmm/metadata/functions.py
+++ b/src/nidmm/metadata/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DMM API metadata version 19.6.0d7
+# This file is generated from NI-DMM API metadata version 20.5.0d5
 functions = {
     'Abort': {
         'documentation': {
@@ -1152,63 +1152,8 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
-    'GetLastCalDateAndTime': {
-        'codegen_method': 'python-only',
-        'documentation': {
-            'description': 'Returns the date and time of the last calibration performed.',
-            'note': 'The NI 4050 and NI 4060 are not supported.'
-        },
-        'method_templates': [
-            {
-                'documentation_filename': 'default_method',
-                'method_python_name_suffix': '',
-                'session_filename': 'datetime_wrappers'
-            }
-        ],
-        'parameters': [
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session. You obtain the **vi** parameter from niDMM_init or niDMM_InitWithOptions. The default is None.'
-                },
-                'name': 'vi',
-                'type': 'ViSession'
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Specifies the type of calibration performed (external or self-calibration).',
-                    'note': 'The NI 4065 does not support self-calibration.',
-                    'table_body': [
-                        [
-                            'NIDMM_VAL_INTERNAL_AREA (default)',
-                            '0',
-                            'Self-Calibration'
-                        ],
-                        [
-                            'NIDMM_VAL_EXTERNAL_AREA',
-                            '1',
-                            'External Calibration'
-                        ]
-                    ]
-                },
-                'name': 'calType',
-                'type': 'ViInt32'
-            },
-            {
-                'direction': 'out',
-                'documentation': {
-                    'description': 'Indicates date and time of the last calibration.'
-                },
-                'name': 'month',
-                'type': 'hightime.datetime'
-            }
-        ],
-        'python_name': 'get_cal_date_and_time',
-        'real_datetime_call': 'GetCalDateAndTime',
-        'returns': 'ViStatus'
-    },
     'GetLastCalTemp': {
+        'codegen_method': 'private',
         'documentation': {
             'description': 'Returns the **Temperature** during the last calibration procedure.',
             'note': 'The NI 4050 and NI 4060 are not supported.'

--- a/src/nidmm/metadata/functions_addon.py
+++ b/src/nidmm/metadata/functions_addon.py
@@ -4,4 +4,146 @@
 functions_override_metadata = {
 }
 
+functions_additional_get_ext_cal_last_temp = {
+    'FancyGetExtCalLastTemp': {
+        'codegen_method': 'python-only',
+        'python_name': 'get_ext_cal_last_temp',
+        'documentation': {
+            'description': 'Returns the **Temperature** during the last external calibration procedure.',
+        },
+        'method_templates': [
+            {
+                'documentation_filename': 'default_method',
+                'method_python_name_suffix': '',
+                'session_filename': 'fancy_get_cal_last_temp'
+            }
+        ],
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': '\nIdentifies a particular instrument session. You obtain the **vi**\nparameter from niDMM_init or niDMM_InitWithOptions. The default is\nNone.\n'
+                },
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'out',
+                'documentation': {
+                    'description': 'Returns the **temperature** during the last external calibration.'
+                },
+                'name': 'temperature',
+                'type': 'ViReal64'
+            }
+        ],
+        'returns': 'ViStatus'
+    }
+}
 
+functions_additional_get_self_cal_last_temp = {
+    'FancyGetSelfCalLastTemp': {
+        'codegen_method': 'python-only',
+        'python_name': 'get_self_cal_last_temp',
+        'documentation': {
+            'description': 'Returns the **Temperature** during the last self calibration procedure.',
+        },
+        'method_templates': [
+            {
+                'documentation_filename': 'default_method',
+                'method_python_name_suffix': '',
+                'session_filename': 'fancy_get_cal_last_temp'
+            }
+        ],
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': '\nIdentifies a particular instrument session. You obtain the **vi**\nparameter from niDMM_init or niDMM_InitWithOptions. The default is\nNone.\n'
+                },
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'out',
+                'documentation': {
+                    'description': 'Returns the **temperature** during the last self calibration.'
+                },
+                'name': 'temperature',
+                'type': 'ViReal64'
+            }
+        ],
+        'returns': 'ViStatus'
+    }
+}
+
+functions_additional_get_ext_cal_last_date_and_time = {
+    'FancyGetExtCalLastDateAndTime': {
+        'codegen_method': 'python-only',
+    	'python_name': 'get_ext_cal_last_date_and_time',
+        'documentation': {
+            'description': 'Returns the date and time of the last external calibration performed.',
+        },
+        'method_templates': [
+            {
+                'documentation_filename': 'default_method',
+                'method_python_name_suffix': '',
+                'session_filename': 'fancy_get_cal_last_date_and_time'
+            }
+        ],
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Identifies a particular instrument session. You obtain the **vi** parameter from niDMM_init or niDMM_InitWithOptions. The default is None.'
+                },
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'out',
+                'documentation': {
+                    'description': 'Indicates date and time of the last external calibration.'
+                },
+                'name': 'last_cal_datetime',
+                'type': 'hightime.datetime'
+            }
+        ],
+        'returns': 'ViStatus'
+    }
+}
+
+functions_additional_get_self_cal_last_date_and_time = {
+    'FancyGetSelfCalLastDateAndTime': {
+        'codegen_method': 'python-only',
+    	'python_name': 'get_self_cal_last_date_and_time',
+        'documentation': {
+            'description': 'Returns the date and time of the last self calibration performed.',
+        },
+        'method_templates': [
+            {
+                'documentation_filename': 'default_method',
+                'method_python_name_suffix': '',
+                'session_filename': 'fancy_get_cal_last_date_and_time'
+            }
+        ],
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Identifies a particular instrument session. You obtain the **vi** parameter from niDMM_init or niDMM_InitWithOptions. The default is None.'
+                },
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'out',
+                'documentation': {
+                    'description': 'Indicates date and time of the last self calibration.'
+                },
+                'name': 'last_cal_datetime',
+                'type': 'hightime.datetime'
+            }
+        ],
+        'returns': 'ViStatus'
+    }
+}

--- a/src/nidmm/system_tests/test_system_nidmm.py
+++ b/src/nidmm/system_tests/test_system_nidmm.py
@@ -150,6 +150,15 @@ def test_get_auto_range_value(session):
         assert auto_range_value_property == 300   # simulated device auto_range_value to maximum 300
 
 
+def test_get_cal_last_date_time(session):
+    last_cal = session.get_cal_date_and_time(0)
+    assert last_cal.month == 3
+    assert last_cal.day == 1
+    assert last_cal.year == 1940
+    assert last_cal.hour == 0
+    assert last_cal.minute == 0   # cal_date_and_time should be 03/01/1940:00:00 for simulated 408x devices; 407x and 4065 returns 00/00/0000:00:00
+
+
 def test_get_ext_cal_last_date_and_time(session):
     last_cal = session.get_ext_cal_last_date_and_time()
     assert last_cal.month == 3

--- a/src/nidmm/system_tests/test_system_nidmm.py
+++ b/src/nidmm/system_tests/test_system_nidmm.py
@@ -150,8 +150,8 @@ def test_get_auto_range_value(session):
         assert auto_range_value_property == 300   # simulated device auto_range_value to maximum 300
 
 
-def test_get_cal_date_time(session):
-    last_cal = session.get_cal_date_and_time(0)
+def test_get_ext_cal_last_date_and_time(session):
+    last_cal = session.get_ext_cal_last_date_and_time()
     assert last_cal.month == 3
     assert last_cal.day == 1
     assert last_cal.year == 1940
@@ -159,8 +159,22 @@ def test_get_cal_date_time(session):
     assert last_cal.minute == 0   # cal_date_and_time should be 03/01/1940:00:00 for simulated 408x devices; 407x and 4065 returns 00/00/0000:00:00
 
 
-def test_get_last_cal_temperature(session):
-    last_cal_temp = session.get_last_cal_temp(0)
+def test_get_self_cal_last_date_and_time(session):
+    last_cal = session.get_self_cal_last_date_and_time()
+    assert last_cal.month == 3
+    assert last_cal.day == 1
+    assert last_cal.year == 1940
+    assert last_cal.hour == 0
+    assert last_cal.minute == 0   # cal_date_and_time should be 03/01/1940:00:00 for simulated 408x devices; 407x and 4065 returns 00/00/0000:00:00
+
+
+def test_get_ext_cal_last_temp(session):
+    last_cal_temp = session.get_ext_cal_last_temp()
+    assert last_cal_temp == 25   # last_cal_temp should be 25 for simulated 408x devices; 407x and 4065 returns 0
+
+
+def test_get_self_cal_last_temp(session):
+    last_cal_temp = session.get_self_cal_last_temp()
     assert last_cal_temp == 25   # last_cal_temp should be 25 for simulated 408x devices; 407x and 4065 returns 0
 
 

--- a/src/nidmm/templates/session.py/fancy_get_cal_last_date_and_time.py.mako
+++ b/src/nidmm/templates/session.py/fancy_get_cal_last_date_and_time.py.mako
@@ -1,0 +1,19 @@
+<%page args="f, config, method_template"/>\
+<%
+    '''Forwards to get_cal_date_and_time, with calibration type pre-selected.'''
+    import build.helper as helper
+    SELF = 0
+    EXTERNAL = 1
+    if f['python_name'] == "get_self_cal_last_date_and_time":
+        calibration_type = SELF
+    else: # f['python_name'] == "get_ext_cal_last_date_and_time"
+        calibration_type = EXTERNAL
+%>\
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+        '''${f['python_name']}
+
+        ${helper.get_function_docstring(f, False, config, indent=8)}
+        '''
+
+        return self.get_last_cal_temp(${calibration_type})
+

--- a/src/nidmm/templates/session.py/fancy_get_cal_last_date_and_time.py.mako
+++ b/src/nidmm/templates/session.py/fancy_get_cal_last_date_and_time.py.mako
@@ -15,5 +15,6 @@
         ${helper.get_function_docstring(f, False, config, indent=8)}
         '''
 
-        return self.get_cal_date_and_time(${calibration_type})
+        month, day, year, hour, minute = self._get_cal_date_and_time(${calibration_type})
+        return hightime.datetime(year, month, day, hour, minute)
 

--- a/src/nidmm/templates/session.py/fancy_get_cal_last_date_and_time.py.mako
+++ b/src/nidmm/templates/session.py/fancy_get_cal_last_date_and_time.py.mako
@@ -15,5 +15,5 @@
         ${helper.get_function_docstring(f, False, config, indent=8)}
         '''
 
-        return self.get_last_cal_temp(${calibration_type})
+        return self.get_cal_date_and_time(${calibration_type})
 

--- a/src/nidmm/templates/session.py/fancy_get_cal_last_temp.py.mako
+++ b/src/nidmm/templates/session.py/fancy_get_cal_last_temp.py.mako
@@ -15,5 +15,5 @@
         ${helper.get_function_docstring(f, False, config, indent=8)}
         '''
 
-        return self.get_last_cal_temp(${calibration_type})
+        return self._get_last_cal_temp(${calibration_type})
 

--- a/src/nidmm/templates/session.py/fancy_get_cal_last_temp.py.mako
+++ b/src/nidmm/templates/session.py/fancy_get_cal_last_temp.py.mako
@@ -1,0 +1,19 @@
+<%page args="f, config, method_template"/>\
+<%
+    '''Forwards to get_last_cal_temp, with calibration type pre-selected.'''
+    import build.helper as helper
+    SELF = 0
+    EXTERNAL = 1
+    if f['python_name'] == "get_self_cal_last_temp":
+        calibration_type = SELF
+    else: # f['python_name'] == "get_ext_cal_last_temp"
+        calibration_type = EXTERNAL
+%>\
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+        '''${f['python_name']}
+
+        ${helper.get_function_docstring(f, False, config, indent=8)}
+        '''
+
+        return self.get_last_cal_temp(${calibration_type})
+


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

Adds external and self calibration variations of get last cal temp and get last cal date and time, in order to be consistent with other drivers with similar methods. Removes the previously existing get last cal date time method since it was an added function rather than part of base metadata, and is now redundant with the newly added methods.

### List issues fixed by this Pull Request below, if any.

* Fix #1462 

### What testing has been done?

Branch has successfully built and passed all system tests on a local testing machine.