### PR TITLE
Update niscope system tests to use multi-instrument session

### DIFF
--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -35,7 +35,7 @@ def single_instrument_session():
 
 
 @pytest.fixture(scope='function')
-def session():
+def multi_instrument_session():
     with niscope.Session(','.join(instruments), False, True, 'Simulate=1, DriverSetup=Model:5164; BoardType:PXIe') as simulated_session:
         yield simulated_session
 
@@ -55,84 +55,84 @@ def session_5142():
 
 
 # Attribute tests
-def test_vi_boolean_attribute(session):
-    session.allow_more_records_than_memory = False
-    default_option = session.allow_more_records_than_memory
+def test_vi_boolean_attribute(multi_instrument_session):
+    multi_instrument_session.allow_more_records_than_memory = False
+    default_option = multi_instrument_session.allow_more_records_than_memory
     assert default_option is False
 
 
-def test_vi_string_attribute(session):
+def test_vi_string_attribute(multi_instrument_session):
     trigger_source = '/{0}/NISCOPE_VAL_IMMEDIATE'.format(instruments[1])
-    session.acq_arm_source = trigger_source
-    assert trigger_source == session.acq_arm_source
+    multi_instrument_session.acq_arm_source = trigger_source
+    assert trigger_source == multi_instrument_session.acq_arm_source
 
 
 # Basic usability tests
-def test_read(session):
+def test_read(multi_instrument_session):
     test_voltage = 1.0
     test_record_length = 2000
     test_num_channels = 2
     test_num_records = 3
-    session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
-    session.configure_horizontal_timing(50000000, test_record_length, 50.0, test_num_records, True)
-    waveforms = session.channels[test_channels].read(num_samples=test_record_length, num_records=test_num_records)
+    multi_instrument_session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
+    multi_instrument_session.configure_horizontal_timing(50000000, test_record_length, 50.0, test_num_records, True)
+    waveforms = multi_instrument_session.channels[test_channels].read(num_samples=test_record_length, num_records=test_num_records)
     assert len(waveforms) == test_num_channels * test_num_records
     for i in range(len(waveforms)):
         assert len(waveforms[i].samples) == test_record_length
 
 
-def test_fetch(session):
+def test_fetch(multi_instrument_session):
     test_voltage = 1.0
     test_record_length = 2000
     test_num_channels = 2
     test_num_records = 3
-    session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
-    session.configure_horizontal_timing(50000000, test_record_length, 50.0, test_num_records, True)
-    with session.initiate():
-        waveforms = session.channels[test_channels].fetch(num_samples=test_record_length, num_records=test_num_records)
+    multi_instrument_session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
+    multi_instrument_session.configure_horizontal_timing(50000000, test_record_length, 50.0, test_num_records, True)
+    with multi_instrument_session.initiate():
+        waveforms = multi_instrument_session.channels[test_channels].fetch(num_samples=test_record_length, num_records=test_num_records)
     assert len(waveforms) == test_num_channels * test_num_records
     for i in range(len(waveforms)):
         assert len(waveforms[i].samples) == test_record_length
 
 
-def test_fetch_defaults(session):
+def test_fetch_defaults(multi_instrument_session):
     test_voltage = 1.0
     test_record_length = 2000
     test_num_channels = 2
-    session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
-    session.configure_horizontal_timing(50000000, test_record_length, 50.0, 1, True)
-    with session.initiate():
-        waveforms = session.channels[test_channels].fetch()
+    multi_instrument_session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
+    multi_instrument_session.configure_horizontal_timing(50000000, test_record_length, 50.0, 1, True)
+    with multi_instrument_session.initiate():
+        waveforms = multi_instrument_session.channels[test_channels].fetch()
     assert len(waveforms) == test_num_channels
     for i in range(len(waveforms)):
         assert len(waveforms[i].samples) == test_record_length
 
 
-def test_fetch_array_measurement(session):
+def test_fetch_array_measurement(multi_instrument_session):
     test_voltage = 1.0
     test_record_length = 2000
     test_num_channels = 2
     test_num_records = 3
-    session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
-    session.configure_horizontal_timing(50000000, test_record_length, 50.0, test_num_records, True)
-    with session.initiate():
-        waveforms = session.channels[test_channels].fetch_array_measurement(niscope.enums.ArrayMeasurement.ARRAY_GAIN)
+    multi_instrument_session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
+    multi_instrument_session.configure_horizontal_timing(50000000, test_record_length, 50.0, test_num_records, True)
+    with multi_instrument_session.initiate():
+        waveforms = multi_instrument_session.channels[test_channels].fetch_array_measurement(niscope.enums.ArrayMeasurement.ARRAY_GAIN)
     assert len(waveforms) == test_num_channels * test_num_records
     for i in range(len(waveforms)):
         assert len(waveforms[i].samples) == test_record_length
 
 
-def test_fetch_binary8_into(session):
+def test_fetch_binary8_into(multi_instrument_session):
     test_voltage = 1.0
     test_record_length = 2000
     test_num_channels = 2
     waveform = numpy.ndarray(test_num_channels * test_record_length, dtype=numpy.int8)
     # Initialize with NaN so we can later verify all samples were overwritten by the driver.
     waveform.fill(float('nan'))
-    session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
-    session.configure_horizontal_timing(50000000, test_record_length, 50.0, 1, True)
-    with session.initiate():
-        waveforms = session.channels[test_channels].fetch_into(waveform=waveform)
+    multi_instrument_session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
+    multi_instrument_session.configure_horizontal_timing(50000000, test_record_length, 50.0, 1, True)
+    with multi_instrument_session.initiate():
+        waveforms = multi_instrument_session.channels[test_channels].fetch_into(waveform=waveform)
 
     for sample in waveform:
         assert not math.isnan(sample)
@@ -145,17 +145,17 @@ def test_fetch_binary8_into(session):
             assert record_wfm[j] == waveform[i * test_record_length + j]
 
 
-def test_fetch_binary16_into(session):
+def test_fetch_binary16_into(multi_instrument_session):
     test_voltage = 1.0
     test_record_length = 2000
     test_num_channels = 2
     waveform = numpy.ndarray(test_num_channels * test_record_length, dtype=numpy.int16)
     # Initialize with NaN so we can later verify all samples were overwritten by the driver.
     waveform.fill(float('nan'))
-    session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
-    session.configure_horizontal_timing(50000000, test_record_length, 50.0, 1, True)
-    with session.initiate():
-        waveforms = session.channels[test_channels].fetch_into(waveform=waveform)
+    multi_instrument_session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
+    multi_instrument_session.configure_horizontal_timing(50000000, test_record_length, 50.0, 1, True)
+    with multi_instrument_session.initiate():
+        waveforms = multi_instrument_session.channels[test_channels].fetch_into(waveform=waveform)
 
     for sample in waveform:
         assert not math.isnan(sample)
@@ -168,17 +168,17 @@ def test_fetch_binary16_into(session):
             assert record_wfm[j] == waveform[i * test_record_length + j]
 
 
-def test_fetch_binary32_into(session):
+def test_fetch_binary32_into(multi_instrument_session):
     test_voltage = 1.0
     test_record_length = 2000
     test_num_channels = 2
     waveform = numpy.ndarray(test_num_channels * test_record_length, dtype=numpy.int32)
     # Initialize with NaN so we can later verify all samples were overwritten by the driver.
     waveform.fill(float('nan'))
-    session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
-    session.configure_horizontal_timing(50000000, test_record_length, 50.0, 1, True)
-    with session.initiate():
-        waveforms = session.channels[test_channels].fetch_into(waveform=waveform)
+    multi_instrument_session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
+    multi_instrument_session.configure_horizontal_timing(50000000, test_record_length, 50.0, 1, True)
+    with multi_instrument_session.initiate():
+        waveforms = multi_instrument_session.channels[test_channels].fetch_into(waveform=waveform)
 
     for sample in waveform:
         assert not math.isnan(sample)
@@ -191,17 +191,17 @@ def test_fetch_binary32_into(session):
             assert record_wfm[j] == waveform[i * test_record_length + j]
 
 
-def test_fetch_double_into(session):
+def test_fetch_double_into(multi_instrument_session):
     test_voltage = 1.0
     test_record_length = 2000
     test_num_channels = 2
     waveform = numpy.ndarray(test_num_channels * test_record_length, dtype=numpy.float64)
     # Initialize with NaN so we can later verify all samples were overwritten by the driver.
     waveform.fill(float('nan'))
-    session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
-    session.configure_horizontal_timing(50000000, test_record_length, 50.0, 1, True)
-    with session.initiate():
-        waveforms = session.channels[test_channels].fetch_into(waveform=waveform)
+    multi_instrument_session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
+    multi_instrument_session.configure_horizontal_timing(50000000, test_record_length, 50.0, 1, True)
+    with multi_instrument_session.initiate():
+        waveforms = multi_instrument_session.channels[test_channels].fetch_into(waveform=waveform)
 
     for sample in waveform:
         assert not math.isnan(sample)
@@ -214,32 +214,32 @@ def test_fetch_double_into(session):
             assert record_wfm[j] == waveform[i * test_record_length + j]
 
 
-def test_fetch_measurement_stats(session):
+def test_fetch_measurement_stats(multi_instrument_session):
     test_voltage = 1.0
     test_record_length = 1000
     test_num_channels = 2
     test_num_records = 3
-    session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
-    session.configure_horizontal_timing(50000000, test_record_length, 50.0, test_num_records, True)
-    with session.initiate():
-        measurement_stats = session.channels[test_channels].fetch_measurement_stats(niscope.enums.ScalarMeasurement.NO_MEASUREMENT, 5.0)
+    multi_instrument_session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
+    multi_instrument_session.configure_horizontal_timing(50000000, test_record_length, 50.0, test_num_records, True)
+    with multi_instrument_session.initiate():
+        measurement_stats = multi_instrument_session.channels[test_channels].fetch_measurement_stats(niscope.enums.ScalarMeasurement.NO_MEASUREMENT, 5.0)
 
     assert len(measurement_stats) == test_num_channels * test_num_records
     for stat in measurement_stats:
         assert stat.result == 0.0
 
 
-def test_clear_waveform_measurement_stats(session):
+def test_clear_waveform_measurement_stats(multi_instrument_session):
     test_voltage = 1.0
     test_record_length = 1000
     test_num_records = 1
-    session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
-    session.configure_horizontal_timing(50000000, test_record_length, 50.0, test_num_records, True)
-    with session.initiate():
-        uncleared_stats = session.channels[test_channels].fetch_measurement_stats(niscope.enums.ScalarMeasurement.FREQUENCY, 5.0)
-        uncleared_stats_2 = session.channels[test_channels].fetch_measurement_stats(niscope.enums.ScalarMeasurement.FREQUENCY, 5.0)
-        session.channels[test_channels].clear_waveform_measurement_stats(niscope.enums.ClearableMeasurement.FREQUENCY)
-        cleared_stats = session.channels[test_channels].fetch_measurement_stats(niscope.enums.ScalarMeasurement.FREQUENCY, 5.0)
+    multi_instrument_session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
+    multi_instrument_session.configure_horizontal_timing(50000000, test_record_length, 50.0, test_num_records, True)
+    with multi_instrument_session.initiate():
+        uncleared_stats = multi_instrument_session.channels[test_channels].fetch_measurement_stats(niscope.enums.ScalarMeasurement.FREQUENCY, 5.0)
+        uncleared_stats_2 = multi_instrument_session.channels[test_channels].fetch_measurement_stats(niscope.enums.ScalarMeasurement.FREQUENCY, 5.0)
+        multi_instrument_session.channels[test_channels].clear_waveform_measurement_stats(niscope.enums.ClearableMeasurement.FREQUENCY)
+        cleared_stats = multi_instrument_session.channels[test_channels].fetch_measurement_stats(niscope.enums.ScalarMeasurement.FREQUENCY, 5.0)
 
     # The principle here is using consistent behavior (i.e. if stats are fetched twice on a single record/channel measurement in a row, it will always be the same)
     # to demonstrate that clearing the stats does in fact cause a measurable change.
@@ -252,18 +252,18 @@ def test_clear_waveform_measurement_stats(session):
     assert uncleared_stats[0].num_in_stats != cleared_stats[0].num_in_stats
 
 
-def test_waveform_processing(session):
+def test_waveform_processing(multi_instrument_session):
     test_voltage = 1.0
     test_record_length = 1000
     test_num_channels = 2
     test_num_records = 3
-    session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
-    session.configure_horizontal_timing(50000000, test_record_length, 50.0, test_num_records, True)
-    with session.initiate():
-        session.add_waveform_processing(niscope.enums.ArrayMeasurement.DERIVATIVE)
-        processed_waveforms = session.channels[test_channels].fetch_measurement_stats(niscope.enums.ScalarMeasurement.MID_REF_VOLTS, 5.0)
-        session.clear_waveform_processing()
-        unprocessed_waveforms = session.channels[test_channels].fetch_measurement_stats(niscope.enums.ScalarMeasurement.MID_REF_VOLTS, 5.0)
+    multi_instrument_session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
+    multi_instrument_session.configure_horizontal_timing(50000000, test_record_length, 50.0, test_num_records, True)
+    with multi_instrument_session.initiate():
+        multi_instrument_session.add_waveform_processing(niscope.enums.ArrayMeasurement.DERIVATIVE)
+        processed_waveforms = multi_instrument_session.channels[test_channels].fetch_measurement_stats(niscope.enums.ScalarMeasurement.MID_REF_VOLTS, 5.0)
+        multi_instrument_session.clear_waveform_processing()
+        unprocessed_waveforms = multi_instrument_session.channels[test_channels].fetch_measurement_stats(niscope.enums.ScalarMeasurement.MID_REF_VOLTS, 5.0)
 
     assert len(processed_waveforms) == test_num_channels * test_num_records
     assert len(unprocessed_waveforms) == test_num_channels * test_num_records
@@ -275,14 +275,14 @@ def test_waveform_processing(session):
         assert abs(processed.result) > 1 or processed.result == 0
 
 
-def test_measurement_stats_str(session):
+def test_measurement_stats_str(multi_instrument_session):
     test_voltage = 1.0
     test_record_length = 1000
     test_num_records = 1
-    session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
-    session.configure_horizontal_timing(50000000, test_record_length, 50.0, test_num_records, True)
-    with session.initiate():
-        measurement_stat = session.channels[test_channels].fetch_measurement_stats(niscope.enums.ScalarMeasurement.NO_MEASUREMENT, 5.0)
+    multi_instrument_session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
+    multi_instrument_session.configure_horizontal_timing(50000000, test_record_length, 50.0, test_num_records, True)
+    with multi_instrument_session.initiate():
+        measurement_stat = multi_instrument_session.channels[test_channels].fetch_measurement_stats(niscope.enums.ScalarMeasurement.NO_MEASUREMENT, 5.0)
 
     assert isinstance(measurement_stat[0].__str__(), str)
     assert isinstance(measurement_stat[0].__repr__(), str)
@@ -316,39 +316,39 @@ def test_get_ext_cal_last_temperature(single_instrument_session):
     assert last_cal_temp == 25
 
 
-def test_self_test(session):
+def test_self_test(multi_instrument_session):
     # We should not get an assert if self_test passes
-    session.self_test()
+    multi_instrument_session.self_test()
 
 
-def test_reset(session):
-    deault_fetch_relative_to = session._fetch_relative_to
+def test_reset(multi_instrument_session):
+    deault_fetch_relative_to = multi_instrument_session._fetch_relative_to
     assert deault_fetch_relative_to == niscope.FetchRelativeTo.PRETRIGGER
-    session._fetch_relative_to = niscope.FetchRelativeTo.READ_POINTER
-    non_default_acqusition_type = session._fetch_relative_to
+    multi_instrument_session._fetch_relative_to = niscope.FetchRelativeTo.READ_POINTER
+    non_default_acqusition_type = multi_instrument_session._fetch_relative_to
     assert non_default_acqusition_type == niscope.FetchRelativeTo.READ_POINTER
-    session.reset()
-    assert session._fetch_relative_to == niscope.FetchRelativeTo.PRETRIGGER
+    multi_instrument_session.reset()
+    assert multi_instrument_session._fetch_relative_to == niscope.FetchRelativeTo.PRETRIGGER
 
 
-def test_reset_device(session):
-    deault_meas_time_histogram_high_time = session.meas_time_histogram_high_time
+def test_reset_device(multi_instrument_session):
+    deault_meas_time_histogram_high_time = multi_instrument_session.meas_time_histogram_high_time
     assert deault_meas_time_histogram_high_time == hightime.timedelta(microseconds=500)
-    session.meas_time_histogram_high_time = hightime.timedelta(microseconds=1000)
-    non_default_meas_time_histogram_high_time = session.meas_time_histogram_high_time
+    multi_instrument_session.meas_time_histogram_high_time = hightime.timedelta(microseconds=1000)
+    non_default_meas_time_histogram_high_time = multi_instrument_session.meas_time_histogram_high_time
     assert non_default_meas_time_histogram_high_time == hightime.timedelta(microseconds=1000)
-    session.reset_device()
-    assert session.meas_time_histogram_high_time == hightime.timedelta(microseconds=500)
+    multi_instrument_session.reset_device()
+    assert multi_instrument_session.meas_time_histogram_high_time == hightime.timedelta(microseconds=500)
 
 
-def test_reset_with_defaults(session):
-    deault_meas_time_histogram_high_time = session.meas_time_histogram_high_time
+def test_reset_with_defaults(multi_instrument_session):
+    deault_meas_time_histogram_high_time = multi_instrument_session.meas_time_histogram_high_time
     assert deault_meas_time_histogram_high_time == hightime.timedelta(microseconds=500)
-    session.meas_time_histogram_high_time = hightime.timedelta(microseconds=1000)
-    non_default_meas_time_histogram_high_time = session.meas_time_histogram_high_time
+    multi_instrument_session.meas_time_histogram_high_time = hightime.timedelta(microseconds=1000)
+    non_default_meas_time_histogram_high_time = multi_instrument_session.meas_time_histogram_high_time
     assert non_default_meas_time_histogram_high_time == hightime.timedelta(microseconds=1000)
-    session.reset_device()
-    assert session.meas_time_histogram_high_time == hightime.timedelta(microseconds=500)
+    multi_instrument_session.reset_device()
+    assert multi_instrument_session.meas_time_histogram_high_time == hightime.timedelta(microseconds=500)
 
 
 def test_error_message():
@@ -361,42 +361,42 @@ def test_error_message():
         assert e.description.find('Simulation does not support the selected model and board type.') != -1
 
 
-def test_get_error(session):
+def test_get_error(multi_instrument_session):
     try:
-        session.instrument_model = ''
+        multi_instrument_session.instrument_model = ''
         assert False
     except niscope.Error as e:
         assert e.code == -1074135027  # Error : Attribute is read-only.
         assert e.description.find('Attribute is read-only.') != -1
 
 
-def test_acquisition_status(session):
-    assert session.acquisition_status() == niscope.AcquisitionStatus.COMPLETE
+def test_acquisition_status(multi_instrument_session):
+    assert multi_instrument_session.acquisition_status() == niscope.AcquisitionStatus.COMPLETE
 
 
-def test_self_cal(session):
-    session.self_cal(niscope.Option.SELF_CALIBRATE_ALL_CHANNELS)
+def test_self_cal(multi_instrument_session):
+    multi_instrument_session.self_cal(niscope.Option.SELF_CALIBRATE_ALL_CHANNELS)
 
 
-def test_probe_compensation_signal(session):
-    session.probe_compensation_signal_start()
-    session.probe_compensation_signal_stop()
+def test_probe_compensation_signal(multi_instrument_session):
+    multi_instrument_session.probe_compensation_signal_start()
+    multi_instrument_session.probe_compensation_signal_stop()
 
 
-def test_configure_horizontal_timing(session):
-    session.configure_vertical(5.0, niscope.VerticalCoupling.DC)
-    session.auto_setup()
-    session.configure_horizontal_timing(10000000, 1000, 50.0, 1, True)
-    session.trigger_modifier = niscope.TriggerModifier.AUTO
-    session.configure_trigger_immediate()
-    session.horz_record_length == 1000
-    session.horz_sample_rate == 10000000
+def test_configure_horizontal_timing(multi_instrument_session):
+    multi_instrument_session.configure_vertical(5.0, niscope.VerticalCoupling.DC)
+    multi_instrument_session.auto_setup()
+    multi_instrument_session.configure_horizontal_timing(10000000, 1000, 50.0, 1, True)
+    multi_instrument_session.trigger_modifier = niscope.TriggerModifier.AUTO
+    multi_instrument_session.configure_trigger_immediate()
+    multi_instrument_session.horz_record_length == 1000
+    multi_instrument_session.horz_sample_rate == 10000000
 
 
-def test_configure_chan_characteristics(session):
-    session.vertical_range = 4.0
-    session.configure_chan_characteristics(50, 0)
-    assert 50.0 == session.input_impedance
+def test_configure_chan_characteristics(multi_instrument_session):
+    multi_instrument_session.vertical_range = 4.0
+    multi_instrument_session.configure_chan_characteristics(50, 0)
+    assert 50.0 == multi_instrument_session.input_impedance
 
 
 def test_filter_coefficients(session_5142):
@@ -412,15 +412,15 @@ def test_filter_coefficients(session_5142):
     assert filter_coefficients == session_5142.get_equalization_filter_coefficients()
 
 
-def test_send_software_trigger_edge(session):
-    session.send_software_trigger_edge(niscope.WhichTrigger.ARM_REFERENCE)
+def test_send_software_trigger_edge(multi_instrument_session):
+    multi_instrument_session.send_software_trigger_edge(niscope.WhichTrigger.ARM_REFERENCE)
 
 
-def test_disable(session):
-    assert session.allow_more_records_than_memory is False
-    session.allow_more_records_than_memory = True
-    session.disable()
-    assert session.allow_more_records_than_memory is False
+def test_disable(multi_instrument_session):
+    assert multi_instrument_session.allow_more_records_than_memory is False
+    multi_instrument_session.allow_more_records_than_memory = True
+    multi_instrument_session.disable()
+    assert multi_instrument_session.allow_more_records_than_memory is False
 
 
 # Basic configuration tests
@@ -429,60 +429,60 @@ def test_configure_ref_levels(single_instrument_session):
     assert 90.0 == single_instrument_session.meas_chan_high_ref_level
 
 
-def test_configure_trigger_digital(session):
+def test_configure_trigger_digital(multi_instrument_session):
     trigger_source = '/{0}/VAL_RTSI_0'.format(instruments[1])
-    session.configure_trigger_digital(trigger_source)
-    session.vertical_range = 5
-    assert trigger_source == session.trigger_source
+    multi_instrument_session.configure_trigger_digital(trigger_source)
+    multi_instrument_session.vertical_range = 5
+    assert trigger_source == multi_instrument_session.trigger_source
 
 
-def test_configure_trigger_edge(session):
-    assert niscope.TriggerSlope.POSITIVE == session.trigger_slope
+def test_configure_trigger_edge(multi_instrument_session):
+    assert niscope.TriggerSlope.POSITIVE == multi_instrument_session.trigger_slope
     trigger_source = '{0}/0'.format(instruments[1])
-    session.configure_trigger_edge(trigger_source, 0.0, niscope.TriggerCoupling.DC)
-    session.commit()
-    assert trigger_source == session.trigger_source
-    assert niscope.TriggerCoupling.DC == session.trigger_coupling
+    multi_instrument_session.configure_trigger_edge(trigger_source, 0.0, niscope.TriggerCoupling.DC)
+    multi_instrument_session.commit()
+    assert trigger_source == multi_instrument_session.trigger_source
+    assert niscope.TriggerCoupling.DC == multi_instrument_session.trigger_coupling
 
 
-def test_configure_trigger_hysteresis(session):
+def test_configure_trigger_hysteresis(multi_instrument_session):
     trigger_source = '{0}/1'.format(instruments[1])
-    session.configure_trigger_hysteresis(trigger_source, 0.0, 0.05, niscope.TriggerCoupling.DC)
-    assert trigger_source == session.trigger_source
-    assert niscope.TriggerCoupling.DC == session.trigger_coupling
+    multi_instrument_session.configure_trigger_hysteresis(trigger_source, 0.0, 0.05, niscope.TriggerCoupling.DC)
+    assert trigger_source == multi_instrument_session.trigger_source
+    assert niscope.TriggerCoupling.DC == multi_instrument_session.trigger_coupling
 
 
-def test_import_export_buffer(session):
+def test_import_export_buffer(multi_instrument_session):
     test_value_1 = 1
     test_value_2 = 5
-    session.vertical_range = test_value_1
-    assert session.vertical_range == test_value_1
-    buffer = session.export_attribute_configuration_buffer()
-    session.vertical_range = test_value_2
-    assert session.vertical_range == test_value_2
-    session.import_attribute_configuration_buffer(buffer)
-    assert session.vertical_range == test_value_1
+    multi_instrument_session.vertical_range = test_value_1
+    assert multi_instrument_session.vertical_range == test_value_1
+    buffer = multi_instrument_session.export_attribute_configuration_buffer()
+    multi_instrument_session.vertical_range = test_value_2
+    assert multi_instrument_session.vertical_range == test_value_2
+    multi_instrument_session.import_attribute_configuration_buffer(buffer)
+    assert multi_instrument_session.vertical_range == test_value_1
 
 
-def test_import_export_file(session):
+def test_import_export_file(multi_instrument_session):
     test_value_1 = 1
     test_value_2 = 5
     temp_file = tempfile.NamedTemporaryFile(suffix='.txt', delete=False)
     # NamedTemporaryFile() returns the file already opened, so we need to close it before we can use it
     temp_file.close()
     path = temp_file.name
-    session.vertical_range = test_value_1
-    assert session.vertical_range == test_value_1
-    session.export_attribute_configuration_file(path)
-    session.vertical_range = test_value_2
-    assert session.vertical_range == test_value_2
-    session.import_attribute_configuration_file(path)
-    assert session.vertical_range == test_value_1
+    multi_instrument_session.vertical_range = test_value_1
+    assert multi_instrument_session.vertical_range == test_value_1
+    multi_instrument_session.export_attribute_configuration_file(path)
+    multi_instrument_session.vertical_range = test_value_2
+    assert multi_instrument_session.vertical_range == test_value_2
+    multi_instrument_session.import_attribute_configuration_file(path)
+    assert multi_instrument_session.vertical_range == test_value_1
     os.remove(path)
 
 
-def test_configure_trigger_software(session):
-    session.configure_trigger_software()
+def test_configure_trigger_software(multi_instrument_session):
+    multi_instrument_session.configure_trigger_software()
 
 
 def test_configure_trigger_video(session_5124):
@@ -493,10 +493,8 @@ def test_configure_trigger_video(session_5124):
     assert niscope.TriggerCoupling.DC == session_5124.trigger_coupling
 
 
-def test_configure_trigger_window(session):
+def test_configure_trigger_window(multi_instrument_session):
     trigger_source = '{0}/1'.format(instruments[1])
-    session.configure_trigger_window(trigger_source, 0, 5, niscope.TriggerWindowMode.ENTERING, niscope.TriggerCoupling.DC)
-    assert trigger_source == session.trigger_source
-    assert niscope.TriggerWindowMode.ENTERING == session.trigger_window_mode
-
-
+    multi_instrument_session.configure_trigger_window(trigger_source, 0, 5, niscope.TriggerWindowMode.ENTERING, niscope.TriggerCoupling.DC)
+    assert trigger_source == multi_instrument_session.trigger_source
+    assert niscope.TriggerWindowMode.ENTERING == multi_instrument_session.trigger_window_mode


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

- Update niscope system tests to use multi-instrument session, wherever possible 
- Setup the test code such that when a new test is added, by default multi-instrument session gets used. Tests can opt to use `single_instrument_session`, if required.

### List issues fixed by this Pull Request below, if any.

* Fix #1503 

### What testing has been done?

Ran the system tests locally