### PR TITLE
Add support for properties of type `str` that represents a repeated capability

### DIFF
--- a/build/templates/_attributes.py.mako
+++ b/build/templates/_attributes.py.mako
@@ -70,6 +70,15 @@ class AttributeViString(Attribute):
         session._set_attribute_vi_string(self._attribute_id, value)
 
 
+class AttributeViStringRepeatedCapability(Attribute):
+
+    def __get__(self, session, session_type):
+        return session._get_attribute_vi_string(self._attribute_id)
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
 class AttributeViBoolean(Attribute):
 
     def __get__(self, session, session_type):

--- a/generated/nidcpower/nidcpower/_attributes.py
+++ b/generated/nidcpower/nidcpower/_attributes.py
@@ -66,6 +66,15 @@ class AttributeViString(Attribute):
         session._set_attribute_vi_string(self._attribute_id, value)
 
 
+class AttributeViStringRepeatedCapability(Attribute):
+
+    def __get__(self, session, session_type):
+        return session._get_attribute_vi_string(self._attribute_id)
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
 class AttributeViBoolean(Attribute):
 
     def __get__(self, session, session_type):

--- a/generated/nidigital/nidigital/_attributes.py
+++ b/generated/nidigital/nidigital/_attributes.py
@@ -66,6 +66,15 @@ class AttributeViString(Attribute):
         session._set_attribute_vi_string(self._attribute_id, value)
 
 
+class AttributeViStringRepeatedCapability(Attribute):
+
+    def __get__(self, session, session_type):
+        return session._get_attribute_vi_string(self._attribute_id)
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
 class AttributeViBoolean(Attribute):
 
     def __get__(self, session, session_type):

--- a/generated/nidmm/nidmm/_attributes.py
+++ b/generated/nidmm/nidmm/_attributes.py
@@ -66,6 +66,15 @@ class AttributeViString(Attribute):
         session._set_attribute_vi_string(self._attribute_id, value)
 
 
+class AttributeViStringRepeatedCapability(Attribute):
+
+    def __get__(self, session, session_type):
+        return session._get_attribute_vi_string(self._attribute_id)
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
 class AttributeViBoolean(Attribute):
 
     def __get__(self, session, session_type):

--- a/generated/nifake/nifake/_attributes.py
+++ b/generated/nifake/nifake/_attributes.py
@@ -66,6 +66,15 @@ class AttributeViString(Attribute):
         session._set_attribute_vi_string(self._attribute_id, value)
 
 
+class AttributeViStringRepeatedCapability(Attribute):
+
+    def __get__(self, session, session_type):
+        return session._get_attribute_vi_string(self._attribute_id)
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
 class AttributeViBoolean(Attribute):
 
     def __get__(self, session, session_type):

--- a/generated/nifake/nifake/session.py
+++ b/generated/nifake/nifake/session.py
@@ -181,6 +181,11 @@ class _SessionBase(object):
 
     A property of type string with read/write access.
     '''
+    read_write_string_repeated_capability = _attributes.AttributeViStringRepeatedCapability(1000010)
+    '''Type: basic sequence types or str or int
+
+    A property of type string with read/write access, that represents a repeated capability
+    '''
 
     def __init__(self, repeated_capability_list, vi, library, encoding, freeze_it=False):
         self._repeated_capability_list = repeated_capability_list

--- a/generated/nifake/nifake/session.py
+++ b/generated/nifake/nifake/session.py
@@ -182,9 +182,14 @@ class _SessionBase(object):
     A property of type string with read/write access.
     '''
     read_write_string_repeated_capability = _attributes.AttributeViStringRepeatedCapability(1000010)
-    '''Type: basic sequence types or str or int
+    '''Type: Any repeated capability type, as defined in nimi-python:
+        - str
+        - str - Comma delimited list
+        - str - Range (using '-' or ':')
+        - int
+        - Basic sequence types (list, tuple, range, slice) of other supported types
 
-    A property of type string with read/write access, that represents a repeated capability
+    A property with read/write access, that represents a repeated capability
     '''
 
     def __init__(self, repeated_capability_list, vi, library, encoding, freeze_it=False):

--- a/generated/nifake/nifake/unit_tests/test_session.py
+++ b/generated/nifake/nifake/unit_tests/test_session.py
@@ -966,6 +966,25 @@ class TestSession(object):
             session.read_write_string = attrib_string
             self.patched_library.niFake_SetAttributeViString.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViStringMatcher('This is test string'))
 
+    def test_get_attribute_string_with_converter(self):
+        self.patched_library.niFake_GetAttributeViString.side_effect = self.side_effects_helper.niFake_GetAttributeViString
+        string = 'not that interesting'
+        self.side_effects_helper['GetAttributeViString']['attributeValue'] = string
+        with nifake.Session('dev1') as session:
+            attr_string = session.read_write_string_repeated_capability
+            assert attr_string == string
+            from mock import call
+            calls = [call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(1000010), _matchers.ViInt32Matcher(0), None), call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(1000010), _matchers.ViInt32Matcher(20), _matchers.ViCharBufferMatcher(len(string)))]
+            self.patched_library.niFake_GetAttributeViString.assert_has_calls(calls)
+            assert self.patched_library.niFake_GetAttributeViString.call_count == 2
+
+    def test_set_attribute_string_with_converter(self):
+        self.patched_library.niFake_SetAttributeViString.side_effect = self.side_effects_helper.niFake_SetAttributeViString
+        attribute_id = 1000010
+        with nifake.Session('dev1') as session:
+            session.read_write_string_repeated_capability = 42
+            self.patched_library.niFake_SetAttributeViString.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViStringMatcher('42'))
+
     def test_get_attribute_boolean(self):
         self.patched_library.niFake_GetAttributeViBoolean.side_effect = self.side_effects_helper.niFake_GetAttributeViBoolean
         self.side_effects_helper['GetAttributeViBoolean']['attributeValue'] = 1

--- a/generated/nifgen/nifgen/_attributes.py
+++ b/generated/nifgen/nifgen/_attributes.py
@@ -66,6 +66,15 @@ class AttributeViString(Attribute):
         session._set_attribute_vi_string(self._attribute_id, value)
 
 
+class AttributeViStringRepeatedCapability(Attribute):
+
+    def __get__(self, session, session_type):
+        return session._get_attribute_vi_string(self._attribute_id)
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
 class AttributeViBoolean(Attribute):
 
     def __get__(self, session, session_type):

--- a/generated/niscope/niscope/_attributes.py
+++ b/generated/niscope/niscope/_attributes.py
@@ -66,6 +66,15 @@ class AttributeViString(Attribute):
         session._set_attribute_vi_string(self._attribute_id, value)
 
 
+class AttributeViStringRepeatedCapability(Attribute):
+
+    def __get__(self, session, session_type):
+        return session._get_attribute_vi_string(self._attribute_id)
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
 class AttributeViBoolean(Attribute):
 
     def __get__(self, session, session_type):

--- a/generated/niswitch/niswitch/_attributes.py
+++ b/generated/niswitch/niswitch/_attributes.py
@@ -66,6 +66,15 @@ class AttributeViString(Attribute):
         session._set_attribute_vi_string(self._attribute_id, value)
 
 
+class AttributeViStringRepeatedCapability(Attribute):
+
+    def __get__(self, session, session_type):
+        return session._get_attribute_vi_string(self._attribute_id)
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
 class AttributeViBoolean(Attribute):
 
     def __get__(self, session, session_type):

--- a/generated/nitclk/nitclk/_attributes.py
+++ b/generated/nitclk/nitclk/_attributes.py
@@ -66,6 +66,15 @@ class AttributeViString(Attribute):
         session._set_attribute_vi_string(self._attribute_id, value)
 
 
+class AttributeViStringRepeatedCapability(Attribute):
+
+    def __get__(self, session, session_type):
+        return session._get_attribute_vi_string(self._attribute_id)
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
 class AttributeViBoolean(Attribute):
 
     def __get__(self, session, session_type):

--- a/src/nifake/metadata/attributes.py
+++ b/src/nifake/metadata/attributes.py
@@ -112,5 +112,18 @@ attributes = {
         'name': 'READ_WRITE_DOUBLE_WITH_REPEATED_CAPABILITY',
         'resettable': False,
         'type': 'ViReal64'
+    },
+    1000010: {
+        'access': 'read-write',
+        'attribute_class': 'AttributeViStringRepeatedCapability',
+        'channel_based': False,
+        'documentation': {
+            'description': 'An attribute of type string with read/write access, that represents a repeated capability'
+        },
+        'lv_property': 'Fake attributes:Read Write String Repeated Capability',
+        'name': 'READ_WRITE_STRING_REPEATED_CAPABILITY',
+        'resettable': False,
+        'type': 'ViString',
+        'type_in_documentation': 'basic sequence types or str or int'
     }
 }

--- a/src/nifake/metadata/attributes.py
+++ b/src/nifake/metadata/attributes.py
@@ -118,12 +118,17 @@ attributes = {
         'attribute_class': 'AttributeViStringRepeatedCapability',
         'channel_based': False,
         'documentation': {
-            'description': 'An attribute of type string with read/write access, that represents a repeated capability'
+            'description': 'An attribute with read/write access, that represents a repeated capability'
         },
         'lv_property': 'Fake attributes:Read Write String Repeated Capability',
         'name': 'READ_WRITE_STRING_REPEATED_CAPABILITY',
         'resettable': False,
         'type': 'ViString',
-        'type_in_documentation': 'basic sequence types or str or int'
+        'type_in_documentation': '''Any repeated capability type, as defined in nimi-python:
+        - str
+        - str - Comma delimited list
+        - str - Range (using '-' or ':')
+        - int
+        - Basic sequence types (list, tuple, range, slice) of other supported types'''
     }
 }

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -966,6 +966,25 @@ class TestSession(object):
             session.read_write_string = attrib_string
             self.patched_library.niFake_SetAttributeViString.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViStringMatcher('This is test string'))
 
+    def test_get_attribute_string_with_converter(self):
+        self.patched_library.niFake_GetAttributeViString.side_effect = self.side_effects_helper.niFake_GetAttributeViString
+        string = 'not that interesting'
+        self.side_effects_helper['GetAttributeViString']['attributeValue'] = string
+        with nifake.Session('dev1') as session:
+            attr_string = session.read_write_string_repeated_capability
+            assert attr_string == string
+            from mock import call
+            calls = [call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(1000010), _matchers.ViInt32Matcher(0), None), call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(1000010), _matchers.ViInt32Matcher(20), _matchers.ViCharBufferMatcher(len(string)))]
+            self.patched_library.niFake_GetAttributeViString.assert_has_calls(calls)
+            assert self.patched_library.niFake_GetAttributeViString.call_count == 2
+
+    def test_set_attribute_string_with_converter(self):
+        self.patched_library.niFake_SetAttributeViString.side_effect = self.side_effects_helper.niFake_SetAttributeViString
+        attribute_id = 1000010
+        with nifake.Session('dev1') as session:
+            session.read_write_string_repeated_capability = 42
+            self.patched_library.niFake_SetAttributeViString.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViStringMatcher('42'))
+
     def test_get_attribute_boolean(self):
         self.patched_library.niFake_GetAttributeViBoolean.side_effect = self.side_effects_helper.niFake_GetAttributeViBoolean
         self.side_effects_helper['GetAttributeViBoolean']['attributeValue'] = 1


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

- Add support for properties of type `str` that represents a repeated capability
- It will be used to fix #1497 


### List issues fixed by this Pull Request below, if any.

Contribute towards fixing #1497 

### What testing has been done?

Added and ran new unit tests in nifake