### PR TITLE
Eliminate code duplication in niscope fancy fetch methods

### DIFF
--- a/generated/niscope/niscope/session.py
+++ b/generated/niscope/niscope/session.py
@@ -1987,16 +1987,18 @@ class _SessionBase(object):
         # Should this raise instead? If this asserts, is it the users fault?
         assert lwfm_i % lrcl == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(self._repeated_capability_list) == {1}'.format(lwfm_i, lrcl)
         actual_num_records = int(lwfm_i / lrcl)
-        i = 0
-        for chan in self._repeated_capability_list:
-            for rec in range(offset, offset + actual_num_records):
-                wfm_info[i].channel = chan
-                wfm_info[i].record = rec
-                i += 1
-
+        self._populate_channel_and_record_info(wfm_info, self._repeated_capability_list, range(offset, offset + actual_num_records))
         return wfm_info
 
     @ivi_synchronized
+    def _populate_channel_and_record_info(self, objects, channels, records):
+        i = 0
+        for channel in channels:
+            for record in records:
+                objects[i].channel = channel
+                objects[i].record = record
+                i += 1
+
     def fetch_array_measurement(self, array_meas_function, timeout=hightime.timedelta(seconds=5.0)):
         r'''fetch_array_measurement
 
@@ -2061,12 +2063,7 @@ class _SessionBase(object):
             wfm_info[i].samples = meas_wfm[start:end]
 
         num_records = int(len(wfm_info) / len(self._repeated_capability_list))
-        i = 0
-        for chan in self._repeated_capability_list:
-            for rec in range(0, num_records):
-                wfm_info[i].channel = chan
-                wfm_info[i].record = rec
-                i += 1
+        self._populate_channel_and_record_info(wfm_info, self._repeated_capability_list, range(num_records))
 
         return wfm_info
 
@@ -2137,13 +2134,8 @@ class _SessionBase(object):
             measurement_stat = measurement_stats.MeasurementStats(result, mean, stdev, min_val, max_val, num_in_stats)
             output.append(measurement_stat)
 
-        i = 0
         num_records = int(len(results) / len(self._repeated_capability_list))
-        for chan in self._repeated_capability_list:
-            for rec in range(0, num_records):
-                output[i].channel = chan
-                output[i].record = rec
-                i += 1
+        self._populate_channel_and_record_info(output, self._repeated_capability_list, range(num_records))
 
         return output
 
@@ -2246,13 +2238,7 @@ class _SessionBase(object):
         # Should this raise instead? If this asserts, is it the users fault?
         assert lwfm_i % lrcl == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(self._repeated_capability_list) == {1}'.format(lwfm_i, lrcl)
         actual_num_records = int(lwfm_i / lrcl)
-        i = 0
-        for chan in self._repeated_capability_list:
-            for rec in range(offset, offset + actual_num_records):
-                wfm_info[i].channel = chan
-                wfm_info[i].record = rec
-                i += 1
-
+        self._populate_channel_and_record_info(wfm_info, self._repeated_capability_list, range(offset, offset + actual_num_records))
         return wfm_info
 
     @ivi_synchronized

--- a/src/niscope/templates/session.py/fancy_fetch.py.mako
+++ b/src/niscope/templates/session.py/fancy_fetch.py.mako
@@ -36,12 +36,6 @@
         # Should this raise instead? If this asserts, is it the users fault?
         assert lwfm_i % lrcl == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(self._repeated_capability_list) == {1}'.format(lwfm_i, lrcl)
         actual_num_records = int(lwfm_i / lrcl)
-        i = 0
-        for chan in self._repeated_capability_list:
-            for rec in range(offset, offset + actual_num_records):
-                wfm_info[i].channel = chan
-                wfm_info[i].record = rec
-                i += 1
-
+        self._populate_channel_and_record_info(wfm_info, self._repeated_capability_list, range(offset, offset + actual_num_records))
         return wfm_info
 

--- a/src/niscope/templates/session.py/fancy_fetch_array_measurement.py.mako
+++ b/src/niscope/templates/session.py/fancy_fetch_array_measurement.py.mako
@@ -4,6 +4,14 @@
     import build.helper as helper
     suffix = method_template['method_python_name_suffix']
 %>\
+    def _populate_channel_and_record_info(self, objects, channels, records):
+        i = 0
+        for channel in channels:
+            for record in records:
+                objects[i].channel = channel
+                objects[i].record = record
+                i += 1
+
     def ${f['python_name']}${suffix}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
         r'''${f['python_name']}
 
@@ -20,12 +28,7 @@
             wfm_info[i].samples = meas_wfm[start:end]
 
         num_records = int(len(wfm_info) / len(self._repeated_capability_list))
-        i = 0
-        for chan in self._repeated_capability_list:
-            for rec in range(0, num_records):
-                wfm_info[i].channel = chan
-                wfm_info[i].record = rec
-                i += 1
+        self._populate_channel_and_record_info(wfm_info, self._repeated_capability_list, range(num_records))
 
         return wfm_info
 

--- a/src/niscope/templates/session.py/fancy_fetch_measurement_stats.py.mako
+++ b/src/niscope/templates/session.py/fancy_fetch_measurement_stats.py.mako
@@ -17,13 +17,8 @@
             measurement_stat = measurement_stats.MeasurementStats(result, mean, stdev, min_val, max_val, num_in_stats)
             output.append(measurement_stat)
 
-        i = 0
         num_records = int(len(results) / len(self._repeated_capability_list))
-        for chan in self._repeated_capability_list:
-            for rec in range(0, num_records):
-                output[i].channel = chan
-                output[i].record = rec
-                i += 1
+        self._populate_channel_and_record_info(output, self._repeated_capability_list, range(num_records))
 
         return output
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Eliminate code duplication in niscope fancy fetch methods by creating a helper method that's called from fancy methods

### List issues fixed by this Pull Request below, if any.

* Fix #1496 

### What testing has been done?

Ran system tests locally