### PR TITLE
Make meas_other_channel in niscope work with channel repeated capability types

### DIFF
--- a/docs/niscope/class.rst
+++ b/docs/niscope/class.rst
@@ -4902,7 +4902,7 @@ meas_other_channel
             +----------------+------------+
             | Characteristic | Value      |
             +================+============+
-            | Datatype       | str        |
+            | Datatype       | str or int |
             +----------------+------------+
             | Permissions    | read-write |
             +----------------+------------+

--- a/generated/niscope/niscope/session.py
+++ b/generated/niscope/niscope/session.py
@@ -899,8 +899,8 @@ class _SessionBase(object):
     '''
     meas_low_ref = _attributes.AttributeViReal64(1250608)
     meas_mid_ref = _attributes.AttributeViReal64(1250609)
-    meas_other_channel = _attributes.AttributeViString(1150018)
-    '''Type: str
+    meas_other_channel = _attributes.AttributeViStringRepeatedCapability(1150018)
+    '''Type: str or int
 
     Specifies the second channel for two-channel measurements, such as ArrayMeasurement.ADD_CHANNELS. If processing steps are registered with this channel, the processing is done before the waveform is used in a two-channel measurement.
     Default: '0'

--- a/src/niscope/metadata/attributes.py
+++ b/src/niscope/metadata/attributes.py
@@ -259,6 +259,7 @@ attributes = {
     },
     1150018: {
         'access': 'read-write',
+        'attribute_class': 'AttributeViStringRepeatedCapability',
         'channel_based': True,
         'codegen_method': 'public',
         'documentation': {
@@ -267,7 +268,8 @@ attributes = {
         'lv_property': 'Waveform Measurement:Other Channel',
         'name': 'MEAS_OTHER_CHANNEL',
         'resettable': True,
-        'type': 'ViString'
+        'type': 'ViString',
+        'type_in_documentation': 'str or int'
     },
     1150019: {
         'access': 'read-write',


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Make meas_other_channel in niscope work with channel repeated capability types. Users can now pass in `str` or `int` or any other type supported by channel repeated capability.

Metadata changes come from internal metadata source.

### List issues fixed by this Pull Request below, if any.

* Fix #1497 

### What testing has been done?

None. The generated code is tested by nifake unit tests.