### PR TITLE
Fix bugs in niscope fetch methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ generated/*/coverage.xml
 nidigitalunittest.xml
 nifakeunittest.xml
 nimodinstunittest.xml
+niscopeunittest.xml
 nitclkunittest.xml
 codegen.xml
 commands.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,8 @@ All notable changes to this project will be documented in this file.
             * `meas_voltage_histogram_low_volts`
             * `meas_voltage_histogram_size`
     * #### Changed
+        * Fix [#1509](https://github.com/ni/nimi-python/issues/1509): `channel` and `record` fields are swapped in `waveform_info` struct returned from niscope fetch methods
+        * Fix [#1510](https://github.com/ni/nimi-python/issues/1510): `record` value in `waveform_info` struct returned from niscope fetch methods is wrong if `record_number` is non-zero
     * #### Removed
 * ### `niswitch` (NI-SWITCH)
     * #### Added

--- a/generated/niscope/niscope/session.py
+++ b/generated/niscope/niscope/session.py
@@ -1981,7 +1981,7 @@ class _SessionBase(object):
         # Should this raise instead? If this asserts, is it the users fault?
         assert lwfm_i % lrcl == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(self._repeated_capability_list) == {1}'.format(lwfm_i, lrcl)
         actual_num_records = int(lwfm_i / lrcl)
-        waveform_info._populate_channel_and_record_info(wfm_info, self._repeated_capability_list, range(offset, offset + actual_num_records))
+        waveform_info._populate_channel_and_record_info(wfm_info, self._repeated_capability_list, range(record_number, record_number + actual_num_records))
 
         return wfm_info
 
@@ -2215,7 +2215,7 @@ class _SessionBase(object):
         # Should this raise instead? If this asserts, is it the users fault?
         assert lwfm_i % lrcl == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(self._repeated_capability_list) == {1}'.format(lwfm_i, lrcl)
         actual_num_records = int(lwfm_i / lrcl)
-        waveform_info._populate_channel_and_record_info(wfm_info, self._repeated_capability_list, range(offset, offset + actual_num_records))
+        waveform_info._populate_channel_and_record_info(wfm_info, self._repeated_capability_list, range(record_number, record_number + actual_num_records))
 
         return wfm_info
 
@@ -3013,7 +3013,7 @@ class _SessionBase(object):
         lrcl = len(self._repeated_capability_list)
         assert lwfm_i % lrcl == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(self._repeated_capability_list) == {1}'.format(lwfm_i, lrcl)
         actual_num_records = int(lwfm_i / lrcl)
-        waveform_info._populate_channel_and_record_info(wfm_info, self._repeated_capability_list, range(offset, offset + actual_num_records))
+        waveform_info._populate_channel_and_record_info(wfm_info, self._repeated_capability_list, range(record_number, record_number + actual_num_records))
 
         return wfm_info
 

--- a/generated/niscope/niscope/unit_tests/test_niscope.py
+++ b/generated/niscope/niscope/unit_tests/test_niscope.py
@@ -1,0 +1,38 @@
+import array
+import niscope.waveform_info
+
+
+def test_populate_samples_info():
+    waveform_infos = []
+    for i in range(1, 4):
+        waveform_infos.append(niscope.waveform_info.WaveformInfo())
+        waveform_infos[-1]._actual_samples = i
+
+    sample_data = array.array('d', [0, 1, 2, 3, 4, 5, 6, 7, 8])
+    niscope.waveform_info._populate_samples_info(waveform_infos, sample_data, 3)
+
+    expected = [
+        array.array('d', [0]),
+        array.array('d', [3, 4]),
+        array.array('d', [6, 7, 8])
+    ]
+    for i in range(len(waveform_infos)):
+        assert waveform_infos[i]._actual_samples is None
+        assert waveform_infos[i].samples == expected[i]
+
+
+def test_populate_channel_and_record_info():
+    waveform_infos = []
+    for i in range(6):
+        waveform_infos.append(niscope.waveform_info.WaveformInfo())
+
+    channels = ["Dev1/4", "Dev2/2"]
+    records = [0, 1, 2]
+    niscope.waveform_info._populate_channel_and_record_info(waveform_infos, channels, records)
+
+    expected_channels = ["Dev1/4", "Dev2/2"] * len(records)
+    expected_records = [0, 0, 1, 1, 2, 2]
+
+    for i in range(len(waveform_infos)):
+        assert waveform_infos[i].channel == expected_channels[i]
+        assert waveform_infos[i].record == expected_records[i]

--- a/generated/niscope/niscope/waveform_info.py
+++ b/generated/niscope/niscope/waveform_info.py
@@ -141,8 +141,8 @@ def _populate_channel_and_record_info(waveform_infos, channels, records):
         records (Iterable of int): Record numbers
     '''
     i = 0
-    for channel in channels:
-        for record in records:
+    for record in records:
+        for channel in channels:
             waveform_infos[i].channel = channel
             waveform_infos[i].record = record
             i += 1

--- a/src/niscope/custom_types/waveform_info.py
+++ b/src/niscope/custom_types/waveform_info.py
@@ -141,8 +141,8 @@ def _populate_channel_and_record_info(waveform_infos, channels, records):
         records (Iterable of int): Record numbers
     '''
     i = 0
-    for channel in channels:
-        for record in records:
+    for record in records:
+        for channel in channels:
             waveform_infos[i].channel = channel
             waveform_infos[i].record = record
             i += 1

--- a/src/niscope/templates/session.py/fancy_fetch.py.mako
+++ b/src/niscope/templates/session.py/fancy_fetch.py.mako
@@ -30,7 +30,7 @@
         # Should this raise instead? If this asserts, is it the users fault?
         assert lwfm_i % lrcl == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(self._repeated_capability_list) == {1}'.format(lwfm_i, lrcl)
         actual_num_records = int(lwfm_i / lrcl)
-        waveform_info._populate_channel_and_record_info(wfm_info, self._repeated_capability_list, range(offset, offset + actual_num_records))
+        waveform_info._populate_channel_and_record_info(wfm_info, self._repeated_capability_list, range(record_number, record_number + actual_num_records))
 
         return wfm_info
 

--- a/src/niscope/templates/session.py/fetch_waveform.py.mako
+++ b/src/niscope/templates/session.py/fetch_waveform.py.mako
@@ -40,7 +40,7 @@
         lrcl = len(self._repeated_capability_list)
         assert lwfm_i % lrcl == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(self._repeated_capability_list) == {1}'.format(lwfm_i, lrcl)
         actual_num_records = int(lwfm_i / lrcl)
-        waveform_info._populate_channel_and_record_info(wfm_info, self._repeated_capability_list, range(offset, offset + actual_num_records))
+        waveform_info._populate_channel_and_record_info(wfm_info, self._repeated_capability_list, range(record_number, record_number + actual_num_records))
 
         return wfm_info
 

--- a/src/niscope/unit_tests/test_niscope.py
+++ b/src/niscope/unit_tests/test_niscope.py
@@ -1,0 +1,38 @@
+import array
+import niscope.waveform_info
+
+
+def test_populate_samples_info():
+    waveform_infos = []
+    for i in range(1, 4):
+        waveform_infos.append(niscope.waveform_info.WaveformInfo())
+        waveform_infos[-1]._actual_samples = i
+
+    sample_data = array.array('d', [0, 1, 2, 3, 4, 5, 6, 7, 8])
+    niscope.waveform_info._populate_samples_info(waveform_infos, sample_data, 3)
+
+    expected = [
+        array.array('d', [0]),
+        array.array('d', [3, 4]),
+        array.array('d', [6, 7, 8])
+    ]
+    for i in range(len(waveform_infos)):
+        assert waveform_infos[i]._actual_samples is None
+        assert waveform_infos[i].samples == expected[i]
+
+
+def test_populate_channel_and_record_info():
+    waveform_infos = []
+    for i in range(6):
+        waveform_infos.append(niscope.waveform_info.WaveformInfo())
+
+    channels = ["Dev1/4", "Dev2/2"]
+    records = [0, 1, 2]
+    niscope.waveform_info._populate_channel_and_record_info(waveform_infos, channels, records)
+
+    expected_channels = ["Dev1/4", "Dev2/2"] * len(records)
+    expected_records = [0, 0, 1, 1, 2, 2]
+
+    for i in range(len(waveform_infos)):
+        assert waveform_infos[i].channel == expected_channels[i]
+        assert waveform_infos[i].record == expected_records[i]

--- a/tools/coverage_unit_tests.rc
+++ b/tools/coverage_unit_tests.rc
@@ -10,6 +10,11 @@ omit =
     */nimodinst/_converters.py
     */nimodinst/_visatype.py
     */nimodinst/errors.py
+    */niscope/_*
+    */niscope/enums.py
+    */niscope/errors.py
+    */niscope/measurement_stats.py
+    */niscope/session.py
     */nitclk/__init__.py
     */nitclk/_attributes.py
     */nitclk/_converters.py
@@ -19,5 +24,6 @@ include =
     */nifake/*
     */nidigital/session.py
     */nimodinst/session.py
+    */niscope/waveform_info.py
     */nitclk/session.py
     build/*

--- a/tox-travis.ini
+++ b/tox-travis.ini
@@ -65,6 +65,10 @@ commands =
     test: coverage report
     test: coverage xml -o nimodinstunittest.xml
     test: coverage html --directory=generated/htmlcov/unit_tests/nimodinst
+    test: coverage run --rcfile=tools/coverage_unit_tests.rc --source niscope -m py.test generated/niscope/niscope {posargs} -s
+    test: coverage report
+    test: coverage xml -o niscopeunittest.xml
+    test: coverage html --directory=generated/htmlcov/unit_tests/niscope
     test: coverage run --rcfile=tools/coverage_unit_tests.rc --source nitclk -m py.test generated/nitclk/nitclk {posargs} -s
     test: coverage report
     test: coverage xml -o nitclkunittest.xml

--- a/tox.ini
+++ b/tox.ini
@@ -65,6 +65,10 @@ commands =
     test: coverage report
     test: coverage xml -o nimodinstunittest.xml
     test: coverage html --directory=generated/htmlcov/unit_tests/nimodinst
+    test: coverage run --rcfile=tools/coverage_unit_tests.rc --source niscope -m py.test generated/niscope/niscope {posargs} -s
+    test: coverage report
+    test: coverage xml -o niscopeunittest.xml
+    test: coverage html --directory=generated/htmlcov/unit_tests/niscope
     test: coverage run --rcfile=tools/coverage_unit_tests.rc --source nitclk -m py.test generated/nitclk/nitclk {posargs} -s
     test: coverage report
     test: coverage xml -o nitclkunittest.xml


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

- Fix two bugs in niscope fetch methods
-- `channel` and `record` fields are swapped in `waveform_info` struct returned from niscope fetch methods
-- `record` value in `waveform_info` struct returned from niscope fetch methods is wrong if `record_number` is non-zero
- Added unit tests for helper functions in `waveform_info.py`
- Update system test for fetch to verify the `channel` and `record` attributes in returned `WaveformInfo` instances

### List issues fixed by this Pull Request below, if any.

* Fix #1509 
* Fix #1510 

### What testing has been done?

Added new unit and system tests and ran them successfully, locally.
