### PR TITLE
Add `measWfmSize` param to fetch_array_measurement method in niscope

### DIFF
--- a/docs/niscope/class.rst
+++ b/docs/niscope/class.rst
@@ -208,6 +208,42 @@ acquisition_status
 
 
 
+actual_meas_wfm_size
+--------------------
+
+    .. py:currentmodule:: niscope.Session
+
+    .. py:method:: actual_meas_wfm_size(array_meas_function)
+
+            Returns the total available size of an array measurement acquisition.
+
+            
+
+
+
+            :param array_meas_function:
+
+
+                The `array
+                measurement <REPLACE_DRIVER_SPECIFIC_URL_2(array_measurements_refs)>`__
+                to perform.
+
+                
+
+
+            :type array_meas_function: :py:data:`niscope.ArrayMeasurement`
+
+            :rtype: int
+            :return:
+
+
+                    Returns the size (in number of samples) of the resulting analysis
+                    waveform.
+
+                    
+
+
+
 add_waveform_processing
 -----------------------
 
@@ -1463,7 +1499,7 @@ fetch_array_measurement
 
     .. py:currentmodule:: niscope.Session
 
-    .. py:method:: fetch_array_measurement(array_meas_function, meas_wfm_size, timeout=hightime.timedelta(seconds=5.0))
+    .. py:method:: fetch_array_measurement(array_meas_function, timeout=hightime.timedelta(seconds=5.0), meas_wfm_size=None)
 
             Obtains a waveform from the digitizer and returns the specified
             measurement array. This method may return multiple waveforms depending
@@ -1502,6 +1538,20 @@ fetch_array_measurement
 
 
             :type timeout: hightime.timedelta, datetime.timedelta, or float in seconds
+            :param meas_wfm_size:
+
+
+                The maximum number of samples returned in the measurement waveform array
+                for each waveform measurement. Use :py:meth:`niscope.Session.actual_meas_wfm_size` to
+                determine the number of available samples.
+
+                
+
+                .. note:: Use the property :py:attr:`niscope.Session.fetch_meas_num_samples` to set the
+                    number of samples to fetch when performing a measurement.
+
+
+            :type meas_wfm_size: int
 
             :rtype: list of WaveformInfo
             :return:

--- a/docs/niscope/class.rst
+++ b/docs/niscope/class.rst
@@ -208,42 +208,6 @@ acquisition_status
 
 
 
-actual_meas_wfm_size
---------------------
-
-    .. py:currentmodule:: niscope.Session
-
-    .. py:method:: actual_meas_wfm_size(array_meas_function)
-
-            Returns the total available size of an array measurement acquisition.
-
-            
-
-
-
-            :param array_meas_function:
-
-
-                The `array
-                measurement <REPLACE_DRIVER_SPECIFIC_URL_2(array_measurements_refs)>`__
-                to perform.
-
-                
-
-
-            :type array_meas_function: :py:data:`niscope.ArrayMeasurement`
-
-            :rtype: int
-            :return:
-
-
-                    Returns the size (in number of samples) of the resulting analysis
-                    waveform.
-
-                    
-
-
-
 add_waveform_processing
 -----------------------
 
@@ -1531,8 +1495,7 @@ fetch_array_measurement
 
 
                 The maximum number of samples returned in the measurement waveform array
-                for each waveform measurement. Use :py:meth:`niscope.Session.actual_meas_wfm_size` to determine the number
-                of available samples. Default Value: None (returns all available samples).
+                for each waveform measurement. Default Value: None (returns all available samples).
 
                 
 

--- a/docs/niscope/class.rst
+++ b/docs/niscope/class.rst
@@ -1499,7 +1499,7 @@ fetch_array_measurement
 
     .. py:currentmodule:: niscope.Session
 
-    .. py:method:: fetch_array_measurement(array_meas_function, timeout=hightime.timedelta(seconds=5.0), meas_wfm_size=None)
+    .. py:method:: fetch_array_measurement(array_meas_function, meas_wfm_size=None, timeout=hightime.timedelta(seconds=5.0))
 
             Obtains a waveform from the digitizer and returns the specified
             measurement array. This method may return multiple waveforms depending
@@ -1527,6 +1527,20 @@ fetch_array_measurement
 
 
             :type array_meas_function: :py:data:`niscope.ArrayMeasurement`
+            :param meas_wfm_size:
+
+
+                The maximum number of samples returned in the measurement waveform array
+                for each waveform measurement. Use :py:meth:`niscope.Session.actual_meas_wfm_size` to determine the number
+                of available samples. Default Value: None (returns all available samples).
+
+                
+
+                .. note:: Use the property :py:attr:`niscope.Session.fetch_meas_num_samples` to set the
+                    number of samples to fetch when performing a measurement.
+
+
+            :type meas_wfm_size: int
             :param timeout:
 
 
@@ -1538,20 +1552,6 @@ fetch_array_measurement
 
 
             :type timeout: hightime.timedelta, datetime.timedelta, or float in seconds
-            :param meas_wfm_size:
-
-
-                The maximum number of samples returned in the measurement waveform array
-                for each waveform measurement. Use :py:meth:`niscope.Session.actual_meas_wfm_size` to
-                determine the number of available samples.
-
-                
-
-                .. note:: Use the property :py:attr:`niscope.Session.fetch_meas_num_samples` to set the
-                    number of samples to fetch when performing a measurement.
-
-
-            :type meas_wfm_size: int
 
             :rtype: list of WaveformInfo
             :return:

--- a/generated/niscope/niscope/_library.py
+++ b/generated/niscope/niscope/_library.py
@@ -308,13 +308,13 @@ class Library(object):
                 self.niScope_Fetch_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_Fetch_cfunc(vi, channel_list, timeout, num_samples, waveform, wfm_info)
 
-    def niScope_FetchArrayMeasurement(self, vi, channel_list, timeout, array_meas_function, meas_wfm_size, meas_wfm, wfm_info):  # noqa: N802
+    def niScope_FetchArrayMeasurement(self, vi, channel_list, timeout, array_meas_function, measurement_waveform_size, meas_wfm, wfm_info):  # noqa: N802
         with self._func_lock:
             if self.niScope_FetchArrayMeasurement_cfunc is None:
                 self.niScope_FetchArrayMeasurement_cfunc = self._library.niScope_FetchArrayMeasurement
                 self.niScope_FetchArrayMeasurement_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(waveform_info.struct_niScope_wfmInfo)]  # noqa: F405
                 self.niScope_FetchArrayMeasurement_cfunc.restype = ViStatus  # noqa: F405
-        return self.niScope_FetchArrayMeasurement_cfunc(vi, channel_list, timeout, array_meas_function, meas_wfm_size, meas_wfm, wfm_info)
+        return self.niScope_FetchArrayMeasurement_cfunc(vi, channel_list, timeout, array_meas_function, measurement_waveform_size, meas_wfm, wfm_info)
 
     def niScope_FetchBinary16(self, vi, channel_list, timeout, num_samples, waveform, wfm_info):  # noqa: N802
         with self._func_lock:

--- a/generated/niscope/niscope/_library.py
+++ b/generated/niscope/niscope/_library.py
@@ -308,13 +308,13 @@ class Library(object):
                 self.niScope_Fetch_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_Fetch_cfunc(vi, channel_list, timeout, num_samples, waveform, wfm_info)
 
-    def niScope_FetchArrayMeasurement(self, vi, channel_list, array_meas_function, meas_wfm_size, timeout, meas_wfm, wfm_info):  # noqa: N802
+    def niScope_FetchArrayMeasurement(self, vi, channel_list, timeout, array_meas_function, meas_wfm_size, meas_wfm, wfm_info):  # noqa: N802
         with self._func_lock:
             if self.niScope_FetchArrayMeasurement_cfunc is None:
                 self.niScope_FetchArrayMeasurement_cfunc = self._library.niScope_FetchArrayMeasurement
-                self.niScope_FetchArrayMeasurement_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViInt32, ViReal64, ctypes.POINTER(ViReal64), ctypes.POINTER(waveform_info.struct_niScope_wfmInfo)]  # noqa: F405
+                self.niScope_FetchArrayMeasurement_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(waveform_info.struct_niScope_wfmInfo)]  # noqa: F405
                 self.niScope_FetchArrayMeasurement_cfunc.restype = ViStatus  # noqa: F405
-        return self.niScope_FetchArrayMeasurement_cfunc(vi, channel_list, array_meas_function, meas_wfm_size, timeout, meas_wfm, wfm_info)
+        return self.niScope_FetchArrayMeasurement_cfunc(vi, channel_list, timeout, array_meas_function, meas_wfm_size, meas_wfm, wfm_info)
 
     def niScope_FetchBinary16(self, vi, channel_list, timeout, num_samples, waveform, wfm_info):  # noqa: N802
         with self._func_lock:

--- a/generated/niscope/niscope/_library.py
+++ b/generated/niscope/niscope/_library.py
@@ -308,13 +308,13 @@ class Library(object):
                 self.niScope_Fetch_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_Fetch_cfunc(vi, channel_list, timeout, num_samples, waveform, wfm_info)
 
-    def niScope_FetchArrayMeasurement(self, vi, channel_list, timeout, array_meas_function, meas_wfm_size, meas_wfm, wfm_info):  # noqa: N802
+    def niScope_FetchArrayMeasurement(self, vi, channel_list, array_meas_function, meas_wfm_size, timeout, meas_wfm, wfm_info):  # noqa: N802
         with self._func_lock:
             if self.niScope_FetchArrayMeasurement_cfunc is None:
                 self.niScope_FetchArrayMeasurement_cfunc = self._library.niScope_FetchArrayMeasurement
-                self.niScope_FetchArrayMeasurement_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(waveform_info.struct_niScope_wfmInfo)]  # noqa: F405
+                self.niScope_FetchArrayMeasurement_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViInt32, ViReal64, ctypes.POINTER(ViReal64), ctypes.POINTER(waveform_info.struct_niScope_wfmInfo)]  # noqa: F405
                 self.niScope_FetchArrayMeasurement_cfunc.restype = ViStatus  # noqa: F405
-        return self.niScope_FetchArrayMeasurement_cfunc(vi, channel_list, timeout, array_meas_function, meas_wfm_size, meas_wfm, wfm_info)
+        return self.niScope_FetchArrayMeasurement_cfunc(vi, channel_list, array_meas_function, meas_wfm_size, timeout, meas_wfm, wfm_info)
 
     def niScope_FetchBinary16(self, vi, channel_list, timeout, num_samples, waveform, wfm_info):  # noqa: N802
         with self._func_lock:

--- a/generated/niscope/niscope/session.py
+++ b/generated/niscope/niscope/session.py
@@ -1601,8 +1601,8 @@ class _SessionBase(object):
     ''' These are code-generated '''
 
     @ivi_synchronized
-    def actual_meas_wfm_size(self, array_meas_function):
-        r'''actual_meas_wfm_size
+    def _actual_meas_wfm_size(self, array_meas_function):
+        r'''_actual_meas_wfm_size
 
         Returns the total available size of an array measurement acquisition.
 
@@ -2008,8 +2008,7 @@ class _SessionBase(object):
             array_meas_function (enums.ArrayMeasurement): The array measurement to perform.
 
             meas_wfm_size (int): The maximum number of samples returned in the measurement waveform array
-                for each waveform measurement. Use actual_meas_wfm_size to determine the number
-                of available samples. Default Value: None (returns all available samples).
+                for each waveform measurement. Default Value: None (returns all available samples).
 
                 Note:
                 Use the property fetch_meas_num_samples to set the
@@ -2048,7 +2047,7 @@ class _SessionBase(object):
 
         '''
         if meas_wfm_size is None:
-            meas_wfm_size = self.actual_meas_wfm_size(array_meas_function)
+            meas_wfm_size = self._actual_meas_wfm_size(array_meas_function)
 
         meas_wfm, wfm_info = self._fetch_array_measurement(array_meas_function, meas_wfm_size, timeout)
 
@@ -2483,8 +2482,7 @@ class _SessionBase(object):
                 to perform.
 
             measurement_waveform_size (int): The maximum number of samples returned in the measurement waveform array
-                for each waveform measurement. Use actual_meas_wfm_size to determine the number
-                of available samples. Default Value: None (returns all available samples).
+                for each waveform measurement. Default Value: None (returns all available samples).
 
                 Note:
                 Use the property fetch_meas_num_samples to set the
@@ -2500,7 +2498,7 @@ class _SessionBase(object):
         Returns:
             meas_wfm (list of float): Returns an array whose length is the number of waveforms times
                 **measurementWaveformSize**; call _actual_num_wfms to determine the number of
-                waveforms; call actual_meas_wfm_size to determine the size of each
+                waveforms; call _actual_meas_wfm_size to determine the size of each
                 waveform.
 
                 NI-SCOPE returns this data sequentially, so all record 0 waveforms are

--- a/generated/niscope/niscope/session.py
+++ b/generated/niscope/niscope/session.py
@@ -2050,7 +2050,7 @@ class _SessionBase(object):
         if meas_wfm_size is None:
             meas_wfm_size = self.actual_meas_wfm_size(array_meas_function)
 
-        meas_wfm, wfm_info = self._fetch_array_measurement(array_meas_function, timeout, meas_wfm_size)
+        meas_wfm, wfm_info = self._fetch_array_measurement(array_meas_function, meas_wfm_size, timeout)
 
         record_length = int(len(meas_wfm) / len(wfm_info))
         waveform_info._populate_samples_info(wfm_info, meas_wfm, record_length)
@@ -2457,7 +2457,7 @@ class _SessionBase(object):
         return [waveform_info.WaveformInfo(wfm_info_ctype[i]) for i in range(self._actual_num_wfms())]
 
     @ivi_synchronized
-    def _fetch_array_measurement(self, array_meas_function, timeout=hightime.timedelta(seconds=5.0), meas_wfm_size=None):
+    def _fetch_array_measurement(self, array_meas_function, measurement_waveform_size, timeout=hightime.timedelta(seconds=5.0)):
         r'''_fetch_array_measurement
 
         Obtains a waveform from the digitizer and returns the specified
@@ -2482,11 +2482,7 @@ class _SessionBase(object):
                 measurement <REPLACE_DRIVER_SPECIFIC_URL_2(array_measurements_refs)>`__
                 to perform.
 
-            timeout (hightime.timedelta, datetime.timedelta, or float in seconds): The time to wait in seconds for data to be acquired; using 0 for this
-                parameter tells NI-SCOPE to fetch whatever is currently available. Using
-                -1 for this parameter implies infinite timeout.
-
-            meas_wfm_size (int): The maximum number of samples returned in the measurement waveform array
+            measurement_waveform_size (int): The maximum number of samples returned in the measurement waveform array
                 for each waveform measurement. Use actual_meas_wfm_size to determine the number
                 of available samples. Default Value: None (returns all available samples).
 
@@ -2496,10 +2492,14 @@ class _SessionBase(object):
                 information about when to use this property, refer to the `NI
                 KnowledgeBase <javascript:WWW(WWW_KB_MEAS)>`__.
 
+            timeout (hightime.timedelta, datetime.timedelta, or float in seconds): The time to wait in seconds for data to be acquired; using 0 for this
+                parameter tells NI-SCOPE to fetch whatever is currently available. Using
+                -1 for this parameter implies infinite timeout.
+
 
         Returns:
             meas_wfm (list of float): Returns an array whose length is the number of waveforms times
-                **measWfmSize**; call _actual_num_wfms to determine the number of
+                **measurementWaveformSize**; call _actual_num_wfms to determine the number of
                 waveforms; call actual_meas_wfm_size to determine the size of each
                 waveform.
 
@@ -2549,14 +2549,14 @@ class _SessionBase(object):
         channel_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
         timeout_ctype = _converters.convert_timedelta_to_seconds_real64(timeout)  # case S140
         array_meas_function_ctype = _visatype.ViInt32(array_meas_function.value)  # case S130
-        meas_wfm_size_ctype = _visatype.ViInt32(meas_wfm_size)  # case S150
-        meas_wfm_size = (self.actual_meas_wfm_size(array_meas_function) * self._actual_num_wfms())  # case B560
+        measurement_waveform_size_ctype = _visatype.ViInt32(measurement_waveform_size)  # case S150
+        meas_wfm_size = (measurement_waveform_size * self._actual_num_wfms())  # case B560
         meas_wfm_ctype = get_ctypes_pointer_for_buffer(library_type=_visatype.ViReal64, size=meas_wfm_size)  # case B560
         wfm_info_size = self._actual_num_wfms()  # case B560
         wfm_info_ctype = get_ctypes_pointer_for_buffer(library_type=waveform_info.struct_niScope_wfmInfo, size=wfm_info_size)  # case B560
-        error_code = self._library.niScope_FetchArrayMeasurement(vi_ctype, channel_list_ctype, timeout_ctype, array_meas_function_ctype, meas_wfm_size_ctype, meas_wfm_ctype, wfm_info_ctype)
+        error_code = self._library.niScope_FetchArrayMeasurement(vi_ctype, channel_list_ctype, timeout_ctype, array_meas_function_ctype, measurement_waveform_size_ctype, meas_wfm_ctype, wfm_info_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return [float(meas_wfm_ctype[i]) for i in range((self.actual_meas_wfm_size(array_meas_function) * self._actual_num_wfms()))], [waveform_info.WaveformInfo(wfm_info_ctype[i]) for i in range(self._actual_num_wfms())]
+        return [float(meas_wfm_ctype[i]) for i in range((measurement_waveform_size * self._actual_num_wfms()))], [waveform_info.WaveformInfo(wfm_info_ctype[i]) for i in range(self._actual_num_wfms())]
 
     @ivi_synchronized
     def _fetch_binary16_into_numpy(self, num_samples, waveform, timeout=hightime.timedelta(seconds=5.0)):

--- a/generated/niscope/niscope/session.py
+++ b/generated/niscope/niscope/session.py
@@ -1601,8 +1601,8 @@ class _SessionBase(object):
     ''' These are code-generated '''
 
     @ivi_synchronized
-    def _actual_meas_wfm_size(self, array_meas_function):
-        r'''_actual_meas_wfm_size
+    def actual_meas_wfm_size(self, array_meas_function):
+        r'''actual_meas_wfm_size
 
         Returns the total available size of an array measurement acquisition.
 
@@ -1986,7 +1986,7 @@ class _SessionBase(object):
         return wfm_info
 
     @ivi_synchronized
-    def fetch_array_measurement(self, array_meas_function, timeout=hightime.timedelta(seconds=5.0)):
+    def fetch_array_measurement(self, array_meas_function, timeout=hightime.timedelta(seconds=5.0), meas_wfm_size=None):
         r'''fetch_array_measurement
 
         Obtains a waveform from the digitizer and returns the specified
@@ -2010,6 +2010,14 @@ class _SessionBase(object):
             timeout (hightime.timedelta, datetime.timedelta, or float in seconds): The time to wait in seconds for data to be acquired; using 0 for this
                 parameter tells NI-SCOPE to fetch whatever is currently available. Using
                 -1 for this parameter implies infinite timeout.
+
+            meas_wfm_size (int): The maximum number of samples returned in the measurement waveform array
+                for each waveform measurement. Use actual_meas_wfm_size to
+                determine the number of available samples.
+
+                Note:
+                Use the property fetch_meas_num_samples to set the
+                number of samples to fetch when performing a measurement.
 
 
         Returns:
@@ -2039,8 +2047,10 @@ class _SessionBase(object):
                 -  **samples**-floating point array of samples. Length will be of actual samples acquired.
 
         '''
+        if meas_wfm_size is None:
+            meas_wfm_size = self.actual_meas_wfm_size(array_meas_function)
 
-        meas_wfm, wfm_info = self._fetch_array_measurement(array_meas_function, timeout)
+        meas_wfm, wfm_info = self._fetch_array_measurement(array_meas_function, meas_wfm_size, timeout)
 
         record_length = int(len(meas_wfm) / len(wfm_info))
         waveform_info._populate_samples_info(wfm_info, meas_wfm, record_length)
@@ -2447,7 +2457,7 @@ class _SessionBase(object):
         return [waveform_info.WaveformInfo(wfm_info_ctype[i]) for i in range(self._actual_num_wfms())]
 
     @ivi_synchronized
-    def _fetch_array_measurement(self, array_meas_function, timeout=hightime.timedelta(seconds=5.0)):
+    def _fetch_array_measurement(self, array_meas_function, meas_wfm_size, timeout=hightime.timedelta(seconds=5.0)):
         r'''_fetch_array_measurement
 
         Obtains a waveform from the digitizer and returns the specified
@@ -2472,6 +2482,16 @@ class _SessionBase(object):
                 measurement <REPLACE_DRIVER_SPECIFIC_URL_2(array_measurements_refs)>`__
                 to perform.
 
+            meas_wfm_size (int): The maximum number of samples returned in the measurement waveform array
+                for each waveform measurement. Use actual_meas_wfm_size to
+                determine the number of available samples.
+
+                Note:
+                Use the property fetch_meas_num_samples to set the
+                number of samples to fetch when performing a measurement. For more
+                information about when to use this property, refer to the `NI
+                KnowledgeBase <javascript:WWW(WWW_KB_MEAS)>`__.
+
             timeout (hightime.timedelta, datetime.timedelta, or float in seconds): The time to wait in seconds for data to be acquired; using 0 for this
                 parameter tells NI-SCOPE to fetch whatever is currently available. Using
                 -1 for this parameter implies infinite timeout.
@@ -2480,7 +2500,7 @@ class _SessionBase(object):
         Returns:
             meas_wfm (list of float): Returns an array whose length is the number of waveforms times
                 **measWfmSize**; call _actual_num_wfms to determine the number of
-                waveforms; call _actual_meas_wfm_size to determine the size of each
+                waveforms; call actual_meas_wfm_size to determine the size of each
                 waveform.
 
                 NI-SCOPE returns this data sequentially, so all record 0 waveforms are
@@ -2527,16 +2547,16 @@ class _SessionBase(object):
             raise TypeError('Parameter array_meas_function must be of type ' + str(enums.ArrayMeasurement))
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         channel_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
-        timeout_ctype = _converters.convert_timedelta_to_seconds_real64(timeout)  # case S140
         array_meas_function_ctype = _visatype.ViInt32(array_meas_function.value)  # case S130
-        meas_wfm_size_ctype = _visatype.ViInt32(self._actual_meas_wfm_size(array_meas_function))  # case S120
-        meas_wfm_size = (self._actual_meas_wfm_size(array_meas_function) * self._actual_num_wfms())  # case B560
+        meas_wfm_size_ctype = _visatype.ViInt32(meas_wfm_size)  # case S150
+        timeout_ctype = _converters.convert_timedelta_to_seconds_real64(timeout)  # case S140
+        meas_wfm_size = (self.actual_meas_wfm_size(array_meas_function) * self._actual_num_wfms())  # case B560
         meas_wfm_ctype = get_ctypes_pointer_for_buffer(library_type=_visatype.ViReal64, size=meas_wfm_size)  # case B560
         wfm_info_size = self._actual_num_wfms()  # case B560
         wfm_info_ctype = get_ctypes_pointer_for_buffer(library_type=waveform_info.struct_niScope_wfmInfo, size=wfm_info_size)  # case B560
-        error_code = self._library.niScope_FetchArrayMeasurement(vi_ctype, channel_list_ctype, timeout_ctype, array_meas_function_ctype, meas_wfm_size_ctype, meas_wfm_ctype, wfm_info_ctype)
+        error_code = self._library.niScope_FetchArrayMeasurement(vi_ctype, channel_list_ctype, array_meas_function_ctype, meas_wfm_size_ctype, timeout_ctype, meas_wfm_ctype, wfm_info_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return [float(meas_wfm_ctype[i]) for i in range((self._actual_meas_wfm_size(array_meas_function) * self._actual_num_wfms()))], [waveform_info.WaveformInfo(wfm_info_ctype[i]) for i in range(self._actual_num_wfms())]
+        return [float(meas_wfm_ctype[i]) for i in range((self.actual_meas_wfm_size(array_meas_function) * self._actual_num_wfms()))], [waveform_info.WaveformInfo(wfm_info_ctype[i]) for i in range(self._actual_num_wfms())]
 
     @ivi_synchronized
     def _fetch_binary16_into_numpy(self, num_samples, waveform, timeout=hightime.timedelta(seconds=5.0)):

--- a/generated/niscope/niscope/unit_tests/_mock_helper.py
+++ b/generated/niscope/niscope/unit_tests/_mock_helper.py
@@ -392,7 +392,7 @@ class SideEffectsHelper(object):
             wfm_info_ref[i] = test_value[i]
         return self._defaults['Fetch']['return']
 
-    def niScope_FetchArrayMeasurement(self, vi, channel_list, timeout, array_meas_function, meas_wfm_size, meas_wfm, wfm_info):  # noqa: N802
+    def niScope_FetchArrayMeasurement(self, vi, channel_list, array_meas_function, meas_wfm_size, timeout, meas_wfm, wfm_info):  # noqa: N802
         if self._defaults['FetchArrayMeasurement']['return'] != 0:
             return self._defaults['FetchArrayMeasurement']['return']
         # meas_wfm

--- a/generated/niscope/niscope/unit_tests/_mock_helper.py
+++ b/generated/niscope/niscope/unit_tests/_mock_helper.py
@@ -392,7 +392,7 @@ class SideEffectsHelper(object):
             wfm_info_ref[i] = test_value[i]
         return self._defaults['Fetch']['return']
 
-    def niScope_FetchArrayMeasurement(self, vi, channel_list, array_meas_function, meas_wfm_size, timeout, meas_wfm, wfm_info):  # noqa: N802
+    def niScope_FetchArrayMeasurement(self, vi, channel_list, timeout, array_meas_function, meas_wfm_size, meas_wfm, wfm_info):  # noqa: N802
         if self._defaults['FetchArrayMeasurement']['return'] != 0:
             return self._defaults['FetchArrayMeasurement']['return']
         # meas_wfm

--- a/generated/niscope/niscope/unit_tests/_mock_helper.py
+++ b/generated/niscope/niscope/unit_tests/_mock_helper.py
@@ -392,7 +392,7 @@ class SideEffectsHelper(object):
             wfm_info_ref[i] = test_value[i]
         return self._defaults['Fetch']['return']
 
-    def niScope_FetchArrayMeasurement(self, vi, channel_list, timeout, array_meas_function, meas_wfm_size, meas_wfm, wfm_info):  # noqa: N802
+    def niScope_FetchArrayMeasurement(self, vi, channel_list, timeout, array_meas_function, measurement_waveform_size, meas_wfm, wfm_info):  # noqa: N802
         if self._defaults['FetchArrayMeasurement']['return'] != 0:
             return self._defaults['FetchArrayMeasurement']['return']
         # meas_wfm

--- a/src/niscope/metadata/functions.py
+++ b/src/niscope/metadata/functions.py
@@ -1691,24 +1691,6 @@ functions = {
                 'type': 'ViConstString'
             },
             {
-                'direction': 'in',
-                'documentation': {
-                    'description': '\nThe `array\nmeasurement <REPLACE_DRIVER_SPECIFIC_URL_2(array_measurements_refs)>`__\nto perform.\n'
-                },
-                'enum': 'ArrayMeasurement',
-                'name': 'arrayMeasFunction',
-                'type': 'ViInt32'
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': '\nThe maximum number of samples returned in the measurement waveform array\nfor each waveform measurement. Use niScope_ActualMeasWfmSize to\ndetermine the number of available samples.\n',
-                    'note': '\nUse the attribute NISCOPE_ATTR_FETCH_MEAS_NUM_SAMPLES to set the\nnumber of samples to fetch when performing a measurement. For more\ninformation about when to use this attribute, refer to the `NI\nKnowledgeBase <javascript:WWW(WWW_KB_MEAS)>`__.\n'
-                },
-                'name': 'measWfmSize',
-                'type': 'ViInt32'
-            },
-            {
                 'default_value': 'hightime.timedelta(seconds=5.0)',
                 'direction': 'in',
                 'documentation': {
@@ -1718,6 +1700,25 @@ functions = {
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
                 'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': '\nThe `array\nmeasurement <REPLACE_DRIVER_SPECIFIC_URL_2(array_measurements_refs)>`__\nto perform.\n'
+                },
+                'enum': 'ArrayMeasurement',
+                'name': 'arrayMeasFunction',
+                'type': 'ViInt32'
+            },
+            {
+                'default_value': None,
+                'direction': 'in',
+                'documentation': {
+                    'description': '\nThe maximum number of samples returned in the measurement waveform array\nfor each waveform measurement. Use niScope_ActualMeasWfmSize to determine the number\nof available samples. Default Value: None (returns all available samples).\n',
+                    'note': '\nUse the attribute NISCOPE_ATTR_FETCH_MEAS_NUM_SAMPLES to set the\nnumber of samples to fetch when performing a measurement. For more\ninformation about when to use this attribute, refer to the `NI\nKnowledgeBase <javascript:WWW(WWW_KB_MEAS)>`__.\n'
+                },
+                'name': 'measWfmSize',
+                'type': 'ViInt32'
             },
             {
                 'direction': 'out',

--- a/src/niscope/metadata/functions.py
+++ b/src/niscope/metadata/functions.py
@@ -1711,24 +1711,23 @@ functions = {
                 'type': 'ViInt32'
             },
             {
-                'default_value': None,
                 'direction': 'in',
                 'documentation': {
                     'description': '\nThe maximum number of samples returned in the measurement waveform array\nfor each waveform measurement. Use niScope_ActualMeasWfmSize to determine the number\nof available samples. Default Value: None (returns all available samples).\n',
                     'note': '\nUse the attribute NISCOPE_ATTR_FETCH_MEAS_NUM_SAMPLES to set the\nnumber of samples to fetch when performing a measurement. For more\ninformation about when to use this attribute, refer to the `NI\nKnowledgeBase <javascript:WWW(WWW_KB_MEAS)>`__.\n'
                 },
-                'name': 'measWfmSize',
+                'name': 'measurementWaveformSize',
                 'type': 'ViInt32'
             },
             {
                 'direction': 'out',
                 'documentation': {
-                    'description': '\nReturns an array whose length is the number of waveforms times\n**measWfmSize**; call niScope_ActualNumWfms to determine the number of\nwaveforms; call niScope_ActualMeasWfmSize to determine the size of each\nwaveform.\n\nNI-SCOPE returns this data sequentially, so all record 0 waveforms are\nfirst. For example, with channel list of 0, 1, you would have the\nfollowing index values:\n\nindex 0 = record 0, channel 0\n\nindex *x* = record 0, channel 1\n\nindex 2\\ *x* = record 1, channel 0\n\nindex 3\\ *x* = record 1, channel 1\n\nWhere *x* = the record length\n'
+                    'description': '\nReturns an array whose length is the number of waveforms times\n**measurementWaveformSize**; call niScope_ActualNumWfms to determine the number of\nwaveforms; call niScope_ActualMeasWfmSize to determine the size of each\nwaveform.\n\nNI-SCOPE returns this data sequentially, so all record 0 waveforms are\nfirst. For example, with channel list of 0, 1, you would have the\nfollowing index values:\n\nindex 0 = record 0, channel 0\n\nindex *x* = record 0, channel 1\n\nindex 2\\ *x* = record 1, channel 0\n\nindex 3\\ *x* = record 1, channel 1\n\nWhere *x* = the record length\n'
                 },
                 'name': 'measWfm',
                 'size': {
                     'mechanism': 'python-code',
-                    'value': '(self.actual_meas_wfm_size(array_meas_function) * self._actual_num_wfms())'
+                    'value': '(measurement_waveform_size * self._actual_num_wfms())'
                 },
                 'type': 'ViReal64[]'
             },

--- a/src/niscope/metadata/functions.py
+++ b/src/niscope/metadata/functions.py
@@ -43,6 +43,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'ActualMeasWfmSize': {
+        'codegen_method': 'private',
         'documentation': {
             'description': 'Returns the total available size of an array measurement acquisition.'
         },
@@ -1713,7 +1714,7 @@ functions = {
             {
                 'direction': 'in',
                 'documentation': {
-                    'description': '\nThe maximum number of samples returned in the measurement waveform array\nfor each waveform measurement. Use niScope_ActualMeasWfmSize to determine the number\nof available samples. Default Value: None (returns all available samples).\n',
+                    'description': '\nThe maximum number of samples returned in the measurement waveform array\nfor each waveform measurement. Default Value: None (returns all available samples).\n',
                     'note': '\nUse the attribute NISCOPE_ATTR_FETCH_MEAS_NUM_SAMPLES to set the\nnumber of samples to fetch when performing a measurement. For more\ninformation about when to use this attribute, refer to the `NI\nKnowledgeBase <javascript:WWW(WWW_KB_MEAS)>`__.\n'
                 },
                 'name': 'measurementWaveformSize',

--- a/src/niscope/metadata/functions.py
+++ b/src/niscope/metadata/functions.py
@@ -43,7 +43,6 @@ functions = {
         'returns': 'ViStatus'
     },
     'ActualMeasWfmSize': {
-        'codegen_method': 'private',
         'documentation': {
             'description': 'Returns the total available size of an array measurement acquisition.'
         },
@@ -1692,17 +1691,6 @@ functions = {
                 'type': 'ViConstString'
             },
             {
-                'default_value': 'hightime.timedelta(seconds=5.0)',
-                'direction': 'in',
-                'documentation': {
-                    'description': '\nThe time to wait in seconds for data to be acquired; using 0 for this\nparameter tells NI-SCOPE to fetch whatever is currently available. Using\n-1 for this parameter implies infinite timeout.\n'
-                },
-                'name': 'timeout',
-                'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
-                'type': 'ViReal64',
-                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
-            },
-            {
                 'direction': 'in',
                 'documentation': {
                     'description': '\nThe `array\nmeasurement <REPLACE_DRIVER_SPECIFIC_URL_2(array_measurements_refs)>`__\nto perform.\n'
@@ -1718,11 +1706,18 @@ functions = {
                     'note': '\nUse the attribute NISCOPE_ATTR_FETCH_MEAS_NUM_SAMPLES to set the\nnumber of samples to fetch when performing a measurement. For more\ninformation about when to use this attribute, refer to the `NI\nKnowledgeBase <javascript:WWW(WWW_KB_MEAS)>`__.\n'
                 },
                 'name': 'measWfmSize',
-                'size': {
-                    'mechanism': 'python-code',
-                    'value': 'self._actual_meas_wfm_size(array_meas_function)'
-                },
                 'type': 'ViInt32'
+            },
+            {
+                'default_value': 'hightime.timedelta(seconds=5.0)',
+                'direction': 'in',
+                'documentation': {
+                    'description': '\nThe time to wait in seconds for data to be acquired; using 0 for this\nparameter tells NI-SCOPE to fetch whatever is currently available. Using\n-1 for this parameter implies infinite timeout.\n'
+                },
+                'name': 'timeout',
+                'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
+                'type': 'ViReal64',
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'out',
@@ -1732,7 +1727,7 @@ functions = {
                 'name': 'measWfm',
                 'size': {
                     'mechanism': 'python-code',
-                    'value': '(self._actual_meas_wfm_size(array_meas_function) * self._actual_num_wfms())'
+                    'value': '(self.actual_meas_wfm_size(array_meas_function) * self._actual_num_wfms())'
                 },
                 'type': 'ViReal64[]'
             },

--- a/src/niscope/metadata/functions_addon.py
+++ b/src/niscope/metadata/functions_addon.py
@@ -57,16 +57,13 @@ functions_additional_fetch_array_measurement = {
                 'type': 'ViInt32'
             },
             {
+                'default_value': None,
                 'direction': 'in',
                 'documentation': {
                     'description': '\nThe maximum number of samples returned in the measurement waveform array\nfor each waveform measurement. Use niScope_ActualMeasWfmSize to\ndetermine the number of available samples.\n',
                     'note': '\nUse the attribute NISCOPE_ATTR_FETCH_MEAS_NUM_SAMPLES to set the\nnumber of samples to fetch when performing a measurement.\n'
                 },
                 'name': 'measWfmSize',
-                'size': {
-                    'mechanism': 'python-code',
-                    'value': 'self._actual_meas_wfm_size(array_meas_function)'
-                },
                 'type': 'ViInt32'
             },
             {

--- a/src/niscope/metadata/functions_addon.py
+++ b/src/niscope/metadata/functions_addon.py
@@ -37,17 +37,6 @@ functions_additional_fetch_array_measurement = {
                 'type': 'ViConstString'
             },
             {
-                'default_value': 'hightime.timedelta(seconds=5.0)',
-                'direction': 'in',
-                'documentation': {
-                    'description': '\nThe time to wait in seconds for data to be acquired; using 0 for this\nparameter tells NI-SCOPE to fetch whatever is currently available. Using\n-1 for this parameter implies infinite timeout.\n'
-                },
-                'name': 'timeout',
-                'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
-                'type': 'ViReal64',
-                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
-            },
-            {
                 'direction': 'in',
                 'documentation': {
                     'description': '\nThe array measurement to perform.\n'
@@ -60,11 +49,22 @@ functions_additional_fetch_array_measurement = {
                 'default_value': None,
                 'direction': 'in',
                 'documentation': {
-                    'description': '\nThe maximum number of samples returned in the measurement waveform array\nfor each waveform measurement. Use niScope_ActualMeasWfmSize to\ndetermine the number of available samples.\n',
+                    'description': '\nThe maximum number of samples returned in the measurement waveform array\nfor each waveform measurement. Use niScope_ActualMeasWfmSize to determine the number\nof available samples. Default Value: None (returns all available samples).\n',
                     'note': '\nUse the attribute NISCOPE_ATTR_FETCH_MEAS_NUM_SAMPLES to set the\nnumber of samples to fetch when performing a measurement.\n'
                 },
                 'name': 'measWfmSize',
                 'type': 'ViInt32'
+            },
+            {
+                'default_value': 'hightime.timedelta(seconds=5.0)',
+                'direction': 'in',
+                'documentation': {
+                    'description': '\nThe time to wait in seconds for data to be acquired; using 0 for this\nparameter tells NI-SCOPE to fetch whatever is currently available. Using\n-1 for this parameter implies infinite timeout.\n'
+                },
+                'name': 'timeout',
+                'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
+                'type': 'ViReal64',
+                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             },
             {
                 'direction': 'out',

--- a/src/niscope/metadata/functions_addon.py
+++ b/src/niscope/metadata/functions_addon.py
@@ -49,7 +49,7 @@ functions_additional_fetch_array_measurement = {
                 'default_value': None,
                 'direction': 'in',
                 'documentation': {
-                    'description': '\nThe maximum number of samples returned in the measurement waveform array\nfor each waveform measurement. Use niScope_ActualMeasWfmSize to determine the number\nof available samples. Default Value: None (returns all available samples).\n',
+                    'description': '\nThe maximum number of samples returned in the measurement waveform array\nfor each waveform measurement. Default Value: None (returns all available samples).\n',
                     'note': '\nUse the attribute NISCOPE_ATTR_FETCH_MEAS_NUM_SAMPLES to set the\nnumber of samples to fetch when performing a measurement.\n'
                 },
                 'name': 'measWfmSize',

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -130,13 +130,18 @@ def test_fetch_array_measurement(multi_instrument_session, measurement_wfm_lengt
     test_num_channels = 2
     test_num_records = 3
     test_meas_wfm_length = measurement_wfm_length.passed_in
+    test_array_meas_function = niscope.ArrayMeasurement.ARRAY_GAIN
+
     multi_instrument_session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
     multi_instrument_session.configure_horizontal_timing(50000000, test_record_length, 50.0, test_num_records, True)
+
     with multi_instrument_session.initiate():
+        assert multi_instrument_session.actual_meas_wfm_size(test_array_meas_function) == 2000
         waveforms = multi_instrument_session.channels[test_channels].fetch_array_measurement(
-            array_meas_function=niscope.enums.ArrayMeasurement.ARRAY_GAIN,
+            array_meas_function=test_array_meas_function,
             meas_wfm_size=test_meas_wfm_length,
             timeout=hightime.timedelta(seconds=4))
+
     assert len(waveforms) == test_num_channels * test_num_records
     for i in range(len(waveforms)):
         assert len(waveforms[i].samples) == measurement_wfm_length.expected

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -136,7 +136,6 @@ def test_fetch_array_measurement(multi_instrument_session, measurement_wfm_lengt
     multi_instrument_session.configure_horizontal_timing(50000000, test_record_length, 50.0, test_num_records, True)
 
     with multi_instrument_session.initiate():
-        assert multi_instrument_session.actual_meas_wfm_size(test_array_meas_function) == 2000
         waveforms = multi_instrument_session.channels[test_channels].fetch_array_measurement(
             array_meas_function=test_array_meas_function,
             meas_wfm_size=test_meas_wfm_length,

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -1,3 +1,4 @@
+import collections
 import fasteners
 import hightime
 import math
@@ -117,18 +118,28 @@ def test_fetch_defaults(multi_instrument_session):
         assert len(waveforms[i].samples) == test_record_length
 
 
-def test_fetch_array_measurement(multi_instrument_session):
+@pytest.fixture(params=[(1000, 1000), (2000, 2000), (3000, 2000)], ids=["less_than_actual", "equal_to_actual", "greater_than_actual"])
+def measurement_wfm_length(request):
+    MeasWfmLength = collections.namedtuple('MeasurementWaveformLength', ['passed_in', 'expected'])
+    return MeasWfmLength(passed_in=request.param[0], expected=request.param[1])
+
+
+def test_fetch_array_measurement(multi_instrument_session, measurement_wfm_length):
     test_voltage = 1.0
     test_record_length = 2000
     test_num_channels = 2
     test_num_records = 3
+    test_meas_wfm_length = measurement_wfm_length.passed_in
     multi_instrument_session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
     multi_instrument_session.configure_horizontal_timing(50000000, test_record_length, 50.0, test_num_records, True)
     with multi_instrument_session.initiate():
-        waveforms = multi_instrument_session.channels[test_channels].fetch_array_measurement(niscope.enums.ArrayMeasurement.ARRAY_GAIN)
+        waveforms = multi_instrument_session.channels[test_channels].fetch_array_measurement(
+            array_meas_function=niscope.enums.ArrayMeasurement.ARRAY_GAIN,
+            meas_wfm_size=test_meas_wfm_length,
+            timeout=hightime.timedelta(seconds=4))
     assert len(waveforms) == test_num_channels * test_num_records
     for i in range(len(waveforms)):
-        assert len(waveforms[i].samples) == test_record_length
+        assert len(waveforms[i].samples) == measurement_wfm_length.expected
 
 
 @pytest.fixture(params=[numpy.int8, numpy.int16, numpy.int32, numpy.float64])

--- a/src/niscope/templates/session.py/fancy_fetch_array_measurement.py.mako
+++ b/src/niscope/templates/session.py/fancy_fetch_array_measurement.py.mako
@@ -10,7 +10,7 @@
         ${helper.get_function_docstring(f, False, config, indent=8)}
         '''
         if meas_wfm_size is None:
-            meas_wfm_size = self.actual_meas_wfm_size(array_meas_function)
+            meas_wfm_size = self._actual_meas_wfm_size(array_meas_function)
 
         meas_wfm, wfm_info = self._${f['python_name']}(array_meas_function, meas_wfm_size, timeout)
 

--- a/src/niscope/templates/session.py/fancy_fetch_array_measurement.py.mako
+++ b/src/niscope/templates/session.py/fancy_fetch_array_measurement.py.mako
@@ -12,7 +12,7 @@
         if meas_wfm_size is None:
             meas_wfm_size = self.actual_meas_wfm_size(array_meas_function)
 
-        meas_wfm, wfm_info = self._${f['python_name']}(array_meas_function, timeout, meas_wfm_size)
+        meas_wfm, wfm_info = self._${f['python_name']}(array_meas_function, meas_wfm_size, timeout)
 
         record_length = int(len(meas_wfm) / len(wfm_info))
         waveform_info._populate_samples_info(wfm_info, meas_wfm, record_length)

--- a/src/niscope/templates/session.py/fancy_fetch_array_measurement.py.mako
+++ b/src/niscope/templates/session.py/fancy_fetch_array_measurement.py.mako
@@ -9,8 +9,10 @@
 
         ${helper.get_function_docstring(f, False, config, indent=8)}
         '''
+        if meas_wfm_size is None:
+            meas_wfm_size = self.actual_meas_wfm_size(array_meas_function)
 
-        meas_wfm, wfm_info = self._${f['python_name']}(array_meas_function, timeout)
+        meas_wfm, wfm_info = self._${f['python_name']}(array_meas_function, meas_wfm_size, timeout)
 
         record_length = int(len(meas_wfm) / len(wfm_info))
         waveform_info._populate_samples_info(wfm_info, meas_wfm, record_length)

--- a/src/niscope/templates/session.py/fancy_fetch_array_measurement.py.mako
+++ b/src/niscope/templates/session.py/fancy_fetch_array_measurement.py.mako
@@ -12,7 +12,7 @@
         if meas_wfm_size is None:
             meas_wfm_size = self.actual_meas_wfm_size(array_meas_function)
 
-        meas_wfm, wfm_info = self._${f['python_name']}(array_meas_function, meas_wfm_size, timeout)
+        meas_wfm, wfm_info = self._${f['python_name']}(array_meas_function, timeout, meas_wfm_size)
 
         record_length = int(len(meas_wfm) / len(wfm_info))
         waveform_info._populate_samples_info(wfm_info, meas_wfm, record_length)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

Add `measWfmSize` param to `fetch_array_measurement` method in niscope, to be consistent with the corresponding VI in LabVIEW ADE.

### List issues fixed by this Pull Request below, if any.

Partial fix for #1501 

### What testing has been done?

Updated system test