### PR TITLE
Add additional fetch related parameters to `fetch_array_measurement` and `fetch_measurement_stats` methods

### DIFF
--- a/docs/niscope/class.rst
+++ b/docs/niscope/class.rst
@@ -1463,7 +1463,7 @@ fetch_array_measurement
 
     .. py:currentmodule:: niscope.Session
 
-    .. py:method:: fetch_array_measurement(array_meas_function, meas_wfm_size=None, timeout=hightime.timedelta(seconds=5.0))
+    .. py:method:: fetch_array_measurement(array_meas_function, meas_wfm_size=None, relative_to=niscope.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, meas_num_samples=None, timeout=hightime.timedelta(seconds=5.0))
 
             Obtains a waveform from the digitizer and returns the specified
             measurement array. This method may return multiple waveforms depending
@@ -1499,11 +1499,53 @@ fetch_array_measurement
 
                 
 
-                .. note:: Use the property :py:attr:`niscope.Session.fetch_meas_num_samples` to set the
-                    number of samples to fetch when performing a measurement.
-
 
             :type meas_wfm_size: int
+            :param relative_to:
+
+
+                Position to start fetching within one record.
+
+                
+
+
+            :type relative_to: :py:data:`niscope.FetchRelativeTo`
+            :param offset:
+
+
+                Offset in samples to start fetching data within each record. The offset can be positive or negative.
+
+                
+
+
+            :type offset: int
+            :param record_number:
+
+
+                Zero-based index of the first record to fetch.
+
+                
+
+
+            :type record_number: int
+            :param num_records:
+
+
+                Number of records to fetch. Use `None` to fetch all configured records.
+
+                
+
+
+            :type num_records: int
+            :param meas_num_samples:
+
+
+                Number of samples to fetch when performing a measurement. Use `None` to fetch the actual record length.
+
+                
+
+
+            :type meas_num_samples: int
             :param timeout:
 
 
@@ -1677,7 +1719,7 @@ fetch_measurement_stats
 
     .. py:currentmodule:: niscope.Session
 
-    .. py:method:: fetch_measurement_stats(scalar_meas_function, timeout=hightime.timedelta(seconds=5.0))
+    .. py:method:: fetch_measurement_stats(scalar_meas_function, relative_to=niscope.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout=hightime.timedelta(seconds=5.0))
 
             Obtains a waveform measurement and returns the measurement value. This
             method may return multiple statistical results depending on the number
@@ -1720,6 +1762,42 @@ fetch_measurement_stats
 
 
             :type scalar_meas_function: :py:data:`niscope.ScalarMeasurement`
+            :param relative_to:
+
+
+                Position to start fetching within one record.
+
+                
+
+
+            :type relative_to: :py:data:`niscope.FetchRelativeTo`
+            :param offset:
+
+
+                Offset in samples to start fetching data within each record. The offset can be positive or negative.
+
+                
+
+
+            :type offset: int
+            :param record_number:
+
+
+                Zero-based index of the first record to fetch.
+
+                
+
+
+            :type record_number: int
+            :param num_records:
+
+
+                Number of records to fetch. Use `None` to fetch all configured records.
+
+                
+
+
+            :type num_records: int
             :param timeout:
 
 

--- a/src/niscope/metadata/functions_addon.py
+++ b/src/niscope/metadata/functions_addon.py
@@ -50,9 +50,54 @@ functions_additional_fetch_array_measurement = {
                 'direction': 'in',
                 'documentation': {
                     'description': '\nThe maximum number of samples returned in the measurement waveform array\nfor each waveform measurement. Default Value: None (returns all available samples).\n',
-                    'note': '\nUse the attribute NISCOPE_ATTR_FETCH_MEAS_NUM_SAMPLES to set the\nnumber of samples to fetch when performing a measurement.\n'
                 },
                 'name': 'measWfmSize',
+                'type': 'ViInt32'
+            },
+            {
+                'default_value': 'FetchRelativeTo.PRETRIGGER',
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Position to start fetching within one record.'
+                },
+                'enum': 'FetchRelativeTo',
+                'name': 'relativeTo',
+                'type': 'ViInt32'
+            },
+            {
+                'default_value': 0,
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Offset in samples to start fetching data within each record. The offset can be positive or negative.'
+                },
+                'name': 'offset',
+                'type': 'ViInt32'
+            },
+            {
+                'default_value': 0,
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Zero-based index of the first record to fetch.'
+                },
+                'name': 'recordNumber',
+                'type': 'ViInt32'
+            },
+            {
+                'default_value': None,
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Number of records to fetch. Use `None` to fetch all configured records.'
+                },
+                'name': 'numRecords',
+                'type': 'ViInt32'
+            },
+            {
+                'default_value': None,
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Number of samples to fetch when performing a measurement. Use `None` to fetch the actual record length.'
+                },
+                'name': 'measNumSamples',
                 'type': 'ViInt32'
             },
             {
@@ -115,6 +160,52 @@ functions_additional_fetch_array_measurement_stats = {
                 'type': 'ViConstString'
             },
             {
+                'direction': 'in',
+                'documentation': {
+                    'description': '\nThe scalar measurement to be performed on each fetched waveform.\n'
+                },
+                'enum': 'ScalarMeasurement',
+                'name': 'scalarMeasFunction',
+                'type': 'ViInt32'
+            },
+            {
+                'default_value': 'FetchRelativeTo.PRETRIGGER',
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Position to start fetching within one record.'
+                },
+                'enum': 'FetchRelativeTo',
+                'name': 'relativeTo',
+                'type': 'ViInt32'
+            },
+            {
+                'default_value': 0,
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Offset in samples to start fetching data within each record. The offset can be positive or negative.'
+                },
+                'name': 'offset',
+                'type': 'ViInt32'
+            },
+            {
+                'default_value': 0,
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Zero-based index of the first record to fetch.'
+                },
+                'name': 'recordNumber',
+                'type': 'ViInt32'
+            },
+            {
+                'default_value': None,
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Number of records to fetch. Use `None` to fetch all configured records.'
+                },
+                'name': 'numRecords',
+                'type': 'ViInt32'
+            },
+            {
                 'default_value': 'hightime.timedelta(seconds=5.0)',
                 'direction': 'in',
                 'documentation': {
@@ -124,15 +215,6 @@ functions_additional_fetch_array_measurement_stats = {
                 'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
                 'type': 'ViReal64',
                 'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': '\nThe scalar measurement to be performed on each fetched waveform.\n'
-                },
-                'enum': 'ScalarMeasurement',
-                'name': 'scalarMeasFunction',
-                'type': 'ViInt32'
             },
             {
                 'direction': 'out',

--- a/src/niscope/templates/session.py/fancy_fetch_array_measurement.py.mako
+++ b/src/niscope/templates/session.py/fancy_fetch_array_measurement.py.mako
@@ -9,6 +9,14 @@
 
         ${helper.get_function_docstring(f, False, config, indent=8)}
         '''
+        # Set the fetch attributes
+        with _NoChannel(session=self):
+            self._fetch_relative_to = relative_to
+            self._fetch_offset = offset
+            self._fetch_record_number = record_number
+            self._fetch_num_records = -1 if num_records is None else num_records
+            self._fetch_meas_num_samples = -1 if meas_num_samples is None else meas_num_samples
+
         if meas_wfm_size is None:
             meas_wfm_size = self._actual_meas_wfm_size(array_meas_function)
 
@@ -17,8 +25,11 @@
         record_length = int(len(meas_wfm) / len(wfm_info))
         waveform_info._populate_samples_info(wfm_info, meas_wfm, record_length)
 
-        num_records = int(len(wfm_info) / len(self._repeated_capability_list))
-        waveform_info._populate_channel_and_record_info(wfm_info, self._repeated_capability_list, range(num_records))
+        wfm_info_count = len(wfm_info)
+        channel_count = len(self._repeated_capability_list)
+        assert wfm_info_count % channel_count == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(self._repeated_capability_list) == {1}'.format(wfm_info_count, channel_count)
+        actual_num_records = int(wfm_info_count / channel_count)
+        waveform_info._populate_channel_and_record_info(wfm_info, self._repeated_capability_list, range(record_number, record_number + actual_num_records))
 
         return wfm_info
 

--- a/src/niscope/templates/session.py/fancy_fetch_measurement_stats.py.mako
+++ b/src/niscope/templates/session.py/fancy_fetch_measurement_stats.py.mako
@@ -9,6 +9,12 @@
 
         ${helper.get_function_docstring(f, False, config, indent=8)}
         '''
+        # Set the fetch attributes
+        with _NoChannel(session=self):
+            self._fetch_relative_to = relative_to
+            self._fetch_offset = offset
+            self._fetch_record_number = record_number
+            self._fetch_num_records = -1 if num_records is None else num_records
 
         results, means, stdevs, min_vals, max_vals, nums_in_stats = self._${f['python_name']}(scalar_meas_function, timeout)
 
@@ -17,8 +23,11 @@
             measurement_stat = measurement_stats.MeasurementStats(result, mean, stdev, min_val, max_val, num_in_stats)
             output.append(measurement_stat)
 
-        num_records = int(len(results) / len(self._repeated_capability_list))
-        waveform_info._populate_channel_and_record_info(output, self._repeated_capability_list, range(num_records))
+        results_count = len(results)
+        channel_count = len(self._repeated_capability_list)
+        assert results_count % channel_count == 0, 'Number of results should be evenly divisible by the number of channels: len(results) == {0}, len(self._repeated_capability_list) == {1}'.format(results_count, channel_count)
+        actual_num_records = int(results_count / channel_count)
+        waveform_info._populate_channel_and_record_info(output, self._repeated_capability_list, range(record_number, record_number + actual_num_records))
 
         return output
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

Add additional fetch related parameters to `fetch_array_measurement` and `fetch_measurement_stats` methods. This makes these methods be consistent with `fetch`:
https://github.com/ni/nimi-python/blob/028c8a1ed8e977d9d3558ff185d7bf4047929286/generated/niscope/niscope/session.py#L1909

### List issues fixed by this Pull Request below, if any.

* Fix #1501

### What testing has been done?

Performed some dev testing on real h/w. Added/modified system tests to run on simulated h/w
