### PR TITLE
nidcpower API update for NI-DCPower 20.5.0 Runtime changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,17 @@ All notable changes to this project will be documented in this file.
     * #### Removed
 * ### `nidcpower` (NI-DCPower)
     * #### Added
+        * API parity with NI-DCPower 20.5.0 by adding measurement autoranging threshold range support, for which the following properties are added:
+            * `autorange`
+            * `autorange_aperture_time_mode`
+            * `autorange_behavior`
+            * `autorange_minimum_aperture_time`
+            * `autorange_minimum_aperture_time_units`
+            * `autorange_minimum_current_range`
+            * `autorange_minimum_voltage_range`
+            * `autorange_threshold_mode`
     * #### Changed
+        * Fix the documentation of `instrument_manufacturer`, `instrument_model`, and `serial_number` properties to correctly mention that they use `instruments` repeated capability.
     * #### Removed
 * ### `nidigital` (NI-Digital Pattern Driver)
     * #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,6 @@ All notable changes to this project will be documented in this file.
             * `autorange_minimum_voltage_range`
             * `autorange_threshold_mode`
     * #### Changed
-        * Fix the documentation of `instrument_manufacturer`, `instrument_model`, and `serial_number` properties to correctly mention that they use `instruments` repeated capability.
     * #### Removed
 * ### `nidigital` (NI-Digital Pattern Driver)
     * #### Added

--- a/docs/nidcpower/class.rst
+++ b/docs/nidcpower/class.rst
@@ -1993,6 +1993,13 @@ autorange
 
     .. py:attribute:: autorange
 
+        Specifies whether the hardware automatically selects the best range to measure the signal.  Note the highest range the algorithm uses is dependent on the corresponding limit range property. The algorithm the hardware uses can be controlled using the :py:attr:`nidcpower.Session.autorange_aperture_time_mode` property.
+
+
+
+        .. note:: Autoranging begins at module startup and remains active until the module is reconfigured or reset.  This property is not supported by all devices. Refer to Supported Properties by Device topic.
+
+
         .. tip:: This property can use repeated capabilities. If set or get directly on the
             nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
             You can specify a subset of repeated capabilities using the Python index notation on an
@@ -2022,6 +2029,13 @@ autorange_aperture_time_mode
 ----------------------------
 
     .. py:attribute:: autorange_aperture_time_mode
+
+        Specifies whether the aperture time used for the measurement autorange algorithm is determined automatically or customized using the :py:attr:`nidcpower.Session.autorange_minimum_aperture_time` property.
+
+
+
+        .. note:: This property is not supported by all devices. Refer to Supported Properties by Device topic.
+
 
         .. tip:: This property can use repeated capabilities. If set or get directly on the
             nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
@@ -2053,6 +2067,13 @@ autorange_behavior
 
     .. py:attribute:: autorange_behavior
 
+        Specifies the algorithm the hardware uses for measurement autoranging.
+
+
+
+        .. note:: This property is not supported by all devices. Refer to Supported Properties by Device topic.
+
+
         .. tip:: This property can use repeated capabilities. If set or get directly on the
             nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
             You can specify a subset of repeated capabilities using the Python index notation on an
@@ -2082,6 +2103,13 @@ autorange_minimum_aperture_time
 -------------------------------
 
     .. py:attribute:: autorange_minimum_aperture_time
+
+        Specifies the measurement autorange aperture time used for the measurement autorange algorithm.  The aperture time is specified in the units set by the :py:attr:`nidcpower.Session.autorange_minimum_aperture_time_units` property. This value will typically be smaller than the aperture time used for measurements.
+
+
+
+        .. note:: For smaller ranges, the value is scaled up to account for noise. The factor used to scale the value is derived from the module capabilities.  This property is not supported by all devices. Refer to Supported Properties by Device topic.
+
 
         .. tip:: This property can use repeated capabilities. If set or get directly on the
             nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
@@ -2113,6 +2141,13 @@ autorange_minimum_aperture_time_units
 
     .. py:attribute:: autorange_minimum_aperture_time_units
 
+        Specifies the units of the :py:attr:`nidcpower.Session.autorange_minimum_aperture_time` property.
+
+
+
+        .. note:: This property is not supported by all devices. Refer to Supported Properties by Device topic.
+
+
         .. tip:: This property can use repeated capabilities. If set or get directly on the
             nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
             You can specify a subset of repeated capabilities using the Python index notation on an
@@ -2142,6 +2177,13 @@ autorange_minimum_current_range
 -------------------------------
 
     .. py:attribute:: autorange_minimum_current_range
+
+        Specifies the lowest range used during measurement autoranging.  Limiting the lowest range used during autoranging can improve the speed of the autoranging algorithm and minimize frequent and unpredictable range changes for noisy signals.
+
+
+
+        .. note:: The maximum range used is the range that includes the value specified in the compliance limit property, :py:attr:`nidcpower.Session.voltage_limit_range` property or :py:attr:`nidcpower.Session.current_limit_range` property, depending on the selected :py:attr:`nidcpower.Session.output_function`. This property is not supported by all devices. Refer to Supported Properties by Device topic.
+
 
         .. tip:: This property can use repeated capabilities. If set or get directly on the
             nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
@@ -2173,6 +2215,13 @@ autorange_minimum_voltage_range
 
     .. py:attribute:: autorange_minimum_voltage_range
 
+        Specifies the lowest range used during measurement autoranging. The maximum range used is range that includes the value specified in the compliance limit property. Limiting the lowest range used during autoranging can improve the speed of the autoranging algorithm and/or minimize thrashing between ranges for noisy signals.
+
+
+
+        .. note:: The maximum range used is the range that includes the value specified in the compliance limit property, :py:attr:`nidcpower.Session.voltage_limit_range` property or :py:attr:`nidcpower.Session.current_limit_range` property, depending on the selected :py:attr:`nidcpower.Session.output_function`. This property is not supported by all devices. Refer to Supported Properties by Device topic.
+
+
         .. tip:: This property can use repeated capabilities. If set or get directly on the
             nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
             You can specify a subset of repeated capabilities using the Python index notation on an
@@ -2202,6 +2251,13 @@ autorange_threshold_mode
 ------------------------
 
     .. py:attribute:: autorange_threshold_mode
+
+        Specifies thresholds used during autoranging to determine when range changing occurs.
+
+
+
+        .. note:: This property is not supported by all devices. Refer to Supported Properties by Device topic.
+
 
         .. tip:: This property can use repeated capabilities. If set or get directly on the
             nidcpower.Session object, then the set/get will use all repeated capabilities in the session.

--- a/docs/nidcpower/class.rst
+++ b/docs/nidcpower/class.rst
@@ -3495,14 +3495,6 @@ instrument_manufacturer
 
         Contains the name of the manufacturer for the device you are currently using.
 
-
-
-
-        .. tip:: This property can use repeated capabilities. If set or get directly on the
-            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
-            You can specify a subset of repeated capabilities using the Python index notation on an
-            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
-
         The following table lists the characteristics of this property.
 
             +----------------+-----------+
@@ -6083,12 +6075,6 @@ self_calibration_persistence
 
         .. note:: This property is not supported by all devices. Refer to Supported Properties by Device for information
 
-
-        .. tip:: This property can use repeated capabilities. If set or get directly on the
-            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
-            You can specify a subset of repeated capabilities using the Python index notation on an
-            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
-
         The following table lists the characteristics of this property.
 
             +----------------+----------------------------------+
@@ -6570,14 +6556,6 @@ serial_number
     .. py:attribute:: serial_number
 
         Contains the serial number for the device you are currently using.
-
-
-
-
-        .. tip:: This property can use repeated capabilities. If set or get directly on the
-            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
-            You can specify a subset of repeated capabilities using the Python index notation on an
-            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
 
         The following table lists the characteristics of this property.
 

--- a/docs/nidcpower/class.rst
+++ b/docs/nidcpower/class.rst
@@ -1988,6 +1988,246 @@ aperture_time_units
                 - LabVIEW Property: **Measurement:Aperture Time Units**
                 - C Attribute: **NIDCPOWER_ATTR_APERTURE_TIME_UNITS**
 
+autorange
+---------
+
+    .. py:attribute:: autorange
+
+        .. tip:: This property can use repeated capabilities. If set or get directly on the
+            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+            You can specify a subset of repeated capabilities using the Python index notation on an
+            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+
+        The following table lists the characteristics of this property.
+
+            +----------------+------------+
+            | Characteristic | Value      |
+            +================+============+
+            | Datatype       | bool       |
+            +----------------+------------+
+            | Permissions    | read-write |
+            +----------------+------------+
+            | Channel Based  | Yes        |
+            +----------------+------------+
+            | Resettable     | No         |
+            +----------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Measurement:Autorange**
+                - C Attribute: **NIDCPOWER_ATTR_AUTORANGE**
+
+autorange_aperture_time_mode
+----------------------------
+
+    .. py:attribute:: autorange_aperture_time_mode
+
+        .. tip:: This property can use repeated capabilities. If set or get directly on the
+            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+            You can specify a subset of repeated capabilities using the Python index notation on an
+            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+
+        The following table lists the characteristics of this property.
+
+            +----------------+---------------------------------+
+            | Characteristic | Value                           |
+            +================+=================================+
+            | Datatype       | enums.AutorangeApertureTimeMode |
+            +----------------+---------------------------------+
+            | Permissions    | read-write                      |
+            +----------------+---------------------------------+
+            | Channel Based  | Yes                             |
+            +----------------+---------------------------------+
+            | Resettable     | No                              |
+            +----------------+---------------------------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Measurement:Advanced:Autorange Aperture Time Mode**
+                - C Attribute: **NIDCPOWER_ATTR_AUTORANGE_APERTURE_TIME_MODE**
+
+autorange_behavior
+------------------
+
+    .. py:attribute:: autorange_behavior
+
+        .. tip:: This property can use repeated capabilities. If set or get directly on the
+            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+            You can specify a subset of repeated capabilities using the Python index notation on an
+            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+
+        The following table lists the characteristics of this property.
+
+            +----------------+-------------------------+
+            | Characteristic | Value                   |
+            +================+=========================+
+            | Datatype       | enums.AutorangeBehavior |
+            +----------------+-------------------------+
+            | Permissions    | read-write              |
+            +----------------+-------------------------+
+            | Channel Based  | Yes                     |
+            +----------------+-------------------------+
+            | Resettable     | No                      |
+            +----------------+-------------------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Measurement:Advanced:Autorange Behavior**
+                - C Attribute: **NIDCPOWER_ATTR_AUTORANGE_BEHAVIOR**
+
+autorange_minimum_aperture_time
+-------------------------------
+
+    .. py:attribute:: autorange_minimum_aperture_time
+
+        .. tip:: This property can use repeated capabilities. If set or get directly on the
+            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+            You can specify a subset of repeated capabilities using the Python index notation on an
+            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+
+        The following table lists the characteristics of this property.
+
+            +----------------+------------+
+            | Characteristic | Value      |
+            +================+============+
+            | Datatype       | float      |
+            +----------------+------------+
+            | Permissions    | read-write |
+            +----------------+------------+
+            | Channel Based  | Yes        |
+            +----------------+------------+
+            | Resettable     | No         |
+            +----------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Measurement:Advanced:Autorange Minimum Aperture Time**
+                - C Attribute: **NIDCPOWER_ATTR_AUTORANGE_MINIMUM_APERTURE_TIME**
+
+autorange_minimum_aperture_time_units
+-------------------------------------
+
+    .. py:attribute:: autorange_minimum_aperture_time_units
+
+        .. tip:: This property can use repeated capabilities. If set or get directly on the
+            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+            You can specify a subset of repeated capabilities using the Python index notation on an
+            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+
+        The following table lists the characteristics of this property.
+
+            +----------------+-------------------------+
+            | Characteristic | Value                   |
+            +================+=========================+
+            | Datatype       | enums.ApertureTimeUnits |
+            +----------------+-------------------------+
+            | Permissions    | read-write              |
+            +----------------+-------------------------+
+            | Channel Based  | Yes                     |
+            +----------------+-------------------------+
+            | Resettable     | No                      |
+            +----------------+-------------------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Measurement:Advanced:Autorange Minimum Aperture Time Units**
+                - C Attribute: **NIDCPOWER_ATTR_AUTORANGE_MINIMUM_APERTURE_TIME_UNITS**
+
+autorange_minimum_current_range
+-------------------------------
+
+    .. py:attribute:: autorange_minimum_current_range
+
+        .. tip:: This property can use repeated capabilities. If set or get directly on the
+            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+            You can specify a subset of repeated capabilities using the Python index notation on an
+            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+
+        The following table lists the characteristics of this property.
+
+            +----------------+------------+
+            | Characteristic | Value      |
+            +================+============+
+            | Datatype       | float      |
+            +----------------+------------+
+            | Permissions    | read-write |
+            +----------------+------------+
+            | Channel Based  | Yes        |
+            +----------------+------------+
+            | Resettable     | No         |
+            +----------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Measurement:Advanced:Autorange Minimum Current Range**
+                - C Attribute: **NIDCPOWER_ATTR_AUTORANGE_MINIMUM_CURRENT_RANGE**
+
+autorange_minimum_voltage_range
+-------------------------------
+
+    .. py:attribute:: autorange_minimum_voltage_range
+
+        .. tip:: This property can use repeated capabilities. If set or get directly on the
+            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+            You can specify a subset of repeated capabilities using the Python index notation on an
+            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+
+        The following table lists the characteristics of this property.
+
+            +----------------+------------+
+            | Characteristic | Value      |
+            +================+============+
+            | Datatype       | float      |
+            +----------------+------------+
+            | Permissions    | read-write |
+            +----------------+------------+
+            | Channel Based  | Yes        |
+            +----------------+------------+
+            | Resettable     | No         |
+            +----------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Measurement:Advanced:Autorange Minimum Voltage Range**
+                - C Attribute: **NIDCPOWER_ATTR_AUTORANGE_MINIMUM_VOLTAGE_RANGE**
+
+autorange_threshold_mode
+------------------------
+
+    .. py:attribute:: autorange_threshold_mode
+
+        .. tip:: This property can use repeated capabilities. If set or get directly on the
+            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+            You can specify a subset of repeated capabilities using the Python index notation on an
+            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+
+        The following table lists the characteristics of this property.
+
+            +----------------+------------------------------+
+            | Characteristic | Value                        |
+            +================+==============================+
+            | Datatype       | enums.AutorangeThresholdMode |
+            +----------------+------------------------------+
+            | Permissions    | read-write                   |
+            +----------------+------------------------------+
+            | Channel Based  | Yes                          |
+            +----------------+------------------------------+
+            | Resettable     | No                           |
+            +----------------+------------------------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Measurement:Advanced:Autorange Threshold Mode**
+                - C Attribute: **NIDCPOWER_ATTR_AUTORANGE_THRESHOLD_MODE**
+
 auto_zero
 ---------
 
@@ -3198,6 +3438,14 @@ instrument_manufacturer
     .. py:attribute:: instrument_manufacturer
 
         Contains the name of the manufacturer for the device you are currently using.
+
+
+
+
+        .. tip:: This property can use repeated capabilities. If set or get directly on the
+            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+            You can specify a subset of repeated capabilities using the Python index notation on an
+            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
 
         The following table lists the characteristics of this property.
 
@@ -5779,6 +6027,12 @@ self_calibration_persistence
 
         .. note:: This property is not supported by all devices. Refer to Supported Properties by Device for information
 
+
+        .. tip:: This property can use repeated capabilities. If set or get directly on the
+            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+            You can specify a subset of repeated capabilities using the Python index notation on an
+            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+
         The following table lists the characteristics of this property.
 
             +----------------+----------------------------------+
@@ -6260,6 +6514,14 @@ serial_number
     .. py:attribute:: serial_number
 
         Contains the serial number for the device you are currently using.
+
+
+
+
+        .. tip:: This property can use repeated capabilities. If set or get directly on the
+            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+            You can specify a subset of repeated capabilities using the Python index notation on an
+            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
 
         The following table lists the characteristics of this property.
 

--- a/docs/nidcpower/enums.rst
+++ b/docs/nidcpower/enums.rst
@@ -66,6 +66,61 @@ AutoZero
 
 
 
+AutorangeApertureTimeMode
+-------------------------
+
+.. py:class:: AutorangeApertureTimeMode
+
+    .. py:attribute:: AutorangeApertureTimeMode.AUTO
+
+
+
+    .. py:attribute:: AutorangeApertureTimeMode.CUSTOM
+
+
+
+AutorangeBehavior
+-----------------
+
+.. py:class:: AutorangeBehavior
+
+    .. py:attribute:: AutorangeBehavior.UP_TO_LIMIT_THEN_DOWN
+
+
+
+    .. py:attribute:: AutorangeBehavior.UP
+
+
+
+    .. py:attribute:: AutorangeBehavior.UP_AND_DOWN
+
+
+
+AutorangeThresholdMode
+----------------------
+
+.. py:class:: AutorangeThresholdMode
+
+    .. py:attribute:: AutorangeThresholdMode.NORMAL
+
+
+
+    .. py:attribute:: AutorangeThresholdMode.FAST_STEP
+
+
+
+    .. py:attribute:: AutorangeThresholdMode.HIGH_HYSTERESIS
+
+
+
+    .. py:attribute:: AutorangeThresholdMode.MEDIUM_HYSTERESIS
+
+
+
+    .. py:attribute:: AutorangeThresholdMode.HOLD
+
+
+
 ComplianceLimitSymmetry
 -----------------------
 

--- a/docs/nidcpower/enums.rst
+++ b/docs/nidcpower/enums.rst
@@ -75,7 +75,19 @@ AutorangeApertureTimeMode
 
 
 
+        NI-DCPower optimizes the aperture time for the autorange algorithm based on the module range.
+
+        
+
+
+
     .. py:attribute:: AutorangeApertureTimeMode.CUSTOM
+
+
+
+        The user specifies a minimum aperture time for the algorithm using the :py:attr:`nidcpower.Session.autorange_minimum_aperture_time` property and the corresponding :py:attr:`nidcpower.Session.autorange_minimum_aperture_time_units` property.
+
+        
 
 
 
@@ -88,11 +100,29 @@ AutorangeBehavior
 
 
 
+        Go to limit range then range down as needed until measured value is within thresholds.
+
+        
+
+
+
     .. py:attribute:: AutorangeBehavior.UP
 
 
 
+        go up one range when the upper threshold is reached.
+
+        
+
+
+
     .. py:attribute:: AutorangeBehavior.UP_AND_DOWN
+
+
+
+        go up or down one range when the upper/lower threshold is reached.
+
+        
 
 
 
@@ -105,7 +135,19 @@ AutorangeThresholdMode
 
 
 
+        Thresholds are selected based on a balance between accuracy and hysteresis.
+
+        
+
+
+
     .. py:attribute:: AutorangeThresholdMode.FAST_STEP
+
+
+
+        Optimized for faster changes in the measured signal. Thresholds are configured to be a smaller percentage of the range.
+
+        
 
 
 
@@ -113,11 +155,29 @@ AutorangeThresholdMode
 
 
 
+        Optimized for noisy signals to minimize frequent and unpredictable range changes. Thresholds are configured to be a larger percentage of the range.
+
+        
+
+
+
     .. py:attribute:: AutorangeThresholdMode.MEDIUM_HYSTERESIS
 
 
 
+        Optimized for noisy signals to minimize frequent and unpredictable range changes. Thresholds are configured to be a medium percentage of the range.
+
+        
+
+
+
     .. py:attribute:: AutorangeThresholdMode.HOLD
+
+
+
+        Attempt to maintain the active range. Thresholds will favor the active range.
+
+        
 
 
 

--- a/generated/nidcpower/nidcpower/enums.py
+++ b/generated/nidcpower/nidcpower/enums.py
@@ -30,6 +30,25 @@ class AutoZero(Enum):
     '''
 
 
+class AutorangeApertureTimeMode(Enum):
+    AUTO = 1110
+    CUSTOM = 1111
+
+
+class AutorangeBehavior(Enum):
+    UP_TO_LIMIT_THEN_DOWN = 1107
+    UP = 1108
+    UP_AND_DOWN = 1109
+
+
+class AutorangeThresholdMode(Enum):
+    NORMAL = 1112
+    FAST_STEP = 1113
+    HIGH_HYSTERESIS = 1114
+    MEDIUM_HYSTERESIS = 1115
+    HOLD = 1116
+
+
 class ComplianceLimitSymmetry(Enum):
     SYMMETRIC = 0
     r'''

--- a/generated/nidcpower/nidcpower/enums.py
+++ b/generated/nidcpower/nidcpower/enums.py
@@ -32,21 +32,51 @@ class AutoZero(Enum):
 
 class AutorangeApertureTimeMode(Enum):
     AUTO = 1110
+    r'''
+    NI-DCPower optimizes the aperture time for the autorange algorithm based on the module range.
+    '''
     CUSTOM = 1111
+    r'''
+    The user specifies a minimum aperture time for the algorithm using the autorange_minimum_aperture_time property and the corresponding autorange_minimum_aperture_time_units property.
+    '''
 
 
 class AutorangeBehavior(Enum):
     UP_TO_LIMIT_THEN_DOWN = 1107
+    r'''
+    Go to limit range then range down as needed until measured value is within thresholds.
+    '''
     UP = 1108
+    r'''
+    go up one range when the upper threshold is reached.
+    '''
     UP_AND_DOWN = 1109
+    r'''
+    go up or down one range when the upper/lower threshold is reached.
+    '''
 
 
 class AutorangeThresholdMode(Enum):
     NORMAL = 1112
+    r'''
+    Thresholds are selected based on a balance between accuracy and hysteresis.
+    '''
     FAST_STEP = 1113
+    r'''
+    Optimized for faster changes in the measured signal. Thresholds are configured to be a smaller percentage of the range.
+    '''
     HIGH_HYSTERESIS = 1114
+    r'''
+    Optimized for noisy signals to minimize frequent and unpredictable range changes. Thresholds are configured to be a larger percentage of the range.
+    '''
     MEDIUM_HYSTERESIS = 1115
+    r'''
+    Optimized for noisy signals to minimize frequent and unpredictable range changes. Thresholds are configured to be a medium percentage of the range.
+    '''
     HOLD = 1116
+    r'''
+    Attempt to maintain the active range. Thresholds will favor the active range.
+    '''
 
 
 class ComplianceLimitSymmetry(Enum):

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -806,12 +806,6 @@ class _SessionBase(object):
     '''Type: str
 
     Contains the name of the manufacturer for the device you are currently using.
-
-    Tip:
-    This property can use repeated capabilities. If set or get directly on the
-    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
-    You can specify a subset of repeated capabilities using the Python index notation on an
-    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
     '''
     instrument_model = _attributes.AttributeViString(1050512)
     '''Type: str
@@ -1953,12 +1947,6 @@ class _SessionBase(object):
     Default Value: SelfCalibrationPersistence.KEEP_IN_MEMORY
 
     Note: This property is not supported by all devices. Refer to Supported Properties by Device for information
-
-    Tip:
-    This property can use repeated capabilities. If set or get directly on the
-    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
-    You can specify a subset of repeated capabilities using the Python index notation on an
-    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
     '''
     sense = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.Sense, 1150013)
     '''Type: enums.Sense
@@ -2139,12 +2127,6 @@ class _SessionBase(object):
     '''Type: str
 
     Contains the serial number for the device you are currently using.
-
-    Tip:
-    This property can use repeated capabilities. If set or get directly on the
-    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
-    You can specify a subset of repeated capabilities using the Python index notation on an
-    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
     '''
     simulate = _attributes.AttributeViBoolean(1050005)
     '''Type: bool

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -201,6 +201,78 @@ class _SessionBase(object):
     You can specify a subset of repeated capabilities using the Python index notation on an
     nidcpower.Session repeated capabilities container, and calling set/get value on the result.
     '''
+    autorange = _attributes.AttributeViInt32(1150244)
+    '''Type: bool
+
+    Tip:
+    This property can use repeated capabilities. If set or get directly on the
+    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+    You can specify a subset of repeated capabilities using the Python index notation on an
+    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+    '''
+    autorange_aperture_time_mode = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.AutorangeApertureTimeMode, 1150246)
+    '''Type: enums.AutorangeApertureTimeMode
+
+    Tip:
+    This property can use repeated capabilities. If set or get directly on the
+    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+    You can specify a subset of repeated capabilities using the Python index notation on an
+    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+    '''
+    autorange_behavior = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.AutorangeBehavior, 1150245)
+    '''Type: enums.AutorangeBehavior
+
+    Tip:
+    This property can use repeated capabilities. If set or get directly on the
+    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+    You can specify a subset of repeated capabilities using the Python index notation on an
+    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+    '''
+    autorange_minimum_aperture_time = _attributes.AttributeViReal64(1150247)
+    '''Type: float
+
+    Tip:
+    This property can use repeated capabilities. If set or get directly on the
+    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+    You can specify a subset of repeated capabilities using the Python index notation on an
+    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+    '''
+    autorange_minimum_aperture_time_units = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.ApertureTimeUnits, 1150248)
+    '''Type: enums.ApertureTimeUnits
+
+    Tip:
+    This property can use repeated capabilities. If set or get directly on the
+    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+    You can specify a subset of repeated capabilities using the Python index notation on an
+    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+    '''
+    autorange_minimum_current_range = _attributes.AttributeViReal64(1150255)
+    '''Type: float
+
+    Tip:
+    This property can use repeated capabilities. If set or get directly on the
+    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+    You can specify a subset of repeated capabilities using the Python index notation on an
+    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+    '''
+    autorange_minimum_voltage_range = _attributes.AttributeViReal64(1150256)
+    '''Type: float
+
+    Tip:
+    This property can use repeated capabilities. If set or get directly on the
+    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+    You can specify a subset of repeated capabilities using the Python index notation on an
+    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+    '''
+    autorange_threshold_mode = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.AutorangeThresholdMode, 1150257)
+    '''Type: enums.AutorangeThresholdMode
+
+    Tip:
+    This property can use repeated capabilities. If set or get directly on the
+    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+    You can specify a subset of repeated capabilities using the Python index notation on an
+    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+    '''
     auto_zero = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.AutoZero, 1150055)
     '''Type: enums.AutoZero
 
@@ -702,6 +774,12 @@ class _SessionBase(object):
     '''Type: str
 
     Contains the name of the manufacturer for the device you are currently using.
+
+    Tip:
+    This property can use repeated capabilities. If set or get directly on the
+    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+    You can specify a subset of repeated capabilities using the Python index notation on an
+    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
     '''
     instrument_model = _attributes.AttributeViString(1050512)
     '''Type: str
@@ -1843,6 +1921,12 @@ class _SessionBase(object):
     Default Value: SelfCalibrationPersistence.KEEP_IN_MEMORY
 
     Note: This property is not supported by all devices. Refer to Supported Properties by Device for information
+
+    Tip:
+    This property can use repeated capabilities. If set or get directly on the
+    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+    You can specify a subset of repeated capabilities using the Python index notation on an
+    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
     '''
     sense = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.Sense, 1150013)
     '''Type: enums.Sense
@@ -2023,6 +2107,12 @@ class _SessionBase(object):
     '''Type: str
 
     Contains the serial number for the device you are currently using.
+
+    Tip:
+    This property can use repeated capabilities. If set or get directly on the
+    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+    You can specify a subset of repeated capabilities using the Python index notation on an
+    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
     '''
     simulate = _attributes.AttributeViBoolean(1050005)
     '''Type: bool

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -204,6 +204,10 @@ class _SessionBase(object):
     autorange = _attributes.AttributeViInt32(1150244)
     '''Type: bool
 
+    Specifies whether the hardware automatically selects the best range to measure the signal.  Note the highest range the algorithm uses is dependent on the corresponding limit range property. The algorithm the hardware uses can be controlled using the autorange_aperture_time_mode property.
+
+    Note: Autoranging begins at module startup and remains active until the module is reconfigured or reset.  This property is not supported by all devices. Refer to Supported Properties by Device topic.
+
     Tip:
     This property can use repeated capabilities. If set or get directly on the
     nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
@@ -212,6 +216,10 @@ class _SessionBase(object):
     '''
     autorange_aperture_time_mode = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.AutorangeApertureTimeMode, 1150246)
     '''Type: enums.AutorangeApertureTimeMode
+
+    Specifies whether the aperture time used for the measurement autorange algorithm is determined automatically or customized using the autorange_minimum_aperture_time property.
+
+    Note: This property is not supported by all devices. Refer to Supported Properties by Device topic.
 
     Tip:
     This property can use repeated capabilities. If set or get directly on the
@@ -222,6 +230,10 @@ class _SessionBase(object):
     autorange_behavior = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.AutorangeBehavior, 1150245)
     '''Type: enums.AutorangeBehavior
 
+    Specifies the algorithm the hardware uses for measurement autoranging.
+
+    Note: This property is not supported by all devices. Refer to Supported Properties by Device topic.
+
     Tip:
     This property can use repeated capabilities. If set or get directly on the
     nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
@@ -230,6 +242,10 @@ class _SessionBase(object):
     '''
     autorange_minimum_aperture_time = _attributes.AttributeViReal64(1150247)
     '''Type: float
+
+    Specifies the measurement autorange aperture time used for the measurement autorange algorithm.  The aperture time is specified in the units set by the autorange_minimum_aperture_time_units property. This value will typically be smaller than the aperture time used for measurements.
+
+    Note: For smaller ranges, the value is scaled up to account for noise. The factor used to scale the value is derived from the module capabilities.  This property is not supported by all devices. Refer to Supported Properties by Device topic.
 
     Tip:
     This property can use repeated capabilities. If set or get directly on the
@@ -240,6 +256,10 @@ class _SessionBase(object):
     autorange_minimum_aperture_time_units = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.ApertureTimeUnits, 1150248)
     '''Type: enums.ApertureTimeUnits
 
+    Specifies the units of the autorange_minimum_aperture_time property.
+
+    Note: This property is not supported by all devices. Refer to Supported Properties by Device topic.
+
     Tip:
     This property can use repeated capabilities. If set or get directly on the
     nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
@@ -248,6 +268,10 @@ class _SessionBase(object):
     '''
     autorange_minimum_current_range = _attributes.AttributeViReal64(1150255)
     '''Type: float
+
+    Specifies the lowest range used during measurement autoranging.  Limiting the lowest range used during autoranging can improve the speed of the autoranging algorithm and minimize frequent and unpredictable range changes for noisy signals.
+
+    Note: The maximum range used is the range that includes the value specified in the compliance limit property, voltage_limit_range property or current_limit_range property, depending on the selected output_function. This property is not supported by all devices. Refer to Supported Properties by Device topic.
 
     Tip:
     This property can use repeated capabilities. If set or get directly on the
@@ -258,6 +282,10 @@ class _SessionBase(object):
     autorange_minimum_voltage_range = _attributes.AttributeViReal64(1150256)
     '''Type: float
 
+    Specifies the lowest range used during measurement autoranging. The maximum range used is range that includes the value specified in the compliance limit property. Limiting the lowest range used during autoranging can improve the speed of the autoranging algorithm and/or minimize thrashing between ranges for noisy signals.
+
+    Note: The maximum range used is the range that includes the value specified in the compliance limit property, voltage_limit_range property or current_limit_range property, depending on the selected output_function. This property is not supported by all devices. Refer to Supported Properties by Device topic.
+
     Tip:
     This property can use repeated capabilities. If set or get directly on the
     nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
@@ -266,6 +294,10 @@ class _SessionBase(object):
     '''
     autorange_threshold_mode = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.AutorangeThresholdMode, 1150257)
     '''Type: enums.AutorangeThresholdMode
+
+    Specifies thresholds used during autoranging to determine when range changing occurs.
+
+    Note: This property is not supported by all devices. Refer to Supported Properties by Device topic.
 
     Tip:
     This property can use repeated capabilities. If set or get directly on the

--- a/src/nidcpower/metadata/attributes.py
+++ b/src/nidcpower/metadata/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 20.6.0d4
+# This file is generated from NI-DCPower API metadata version 20.6.0d7
 attributes = {
     1050003: {
         'access': 'read-write',
@@ -1556,6 +1556,10 @@ attributes = {
     1150244: {
         'access': 'read-write',
         'channel_based': True,
+        'documentation': {
+            'description': '\nSpecifies whether the hardware automatically selects the best range to measure the signal.  Note the highest range the algorithm uses is dependent on the corresponding limit range property. The algorithm the hardware uses can be controlled using the NIDCPOWER_ATTR_AUTORANGE_APERTURE_TIME_MODE property.\n',
+            'note': 'Autoranging begins at module startup and remains active until the module is reconfigured or reset.  This attribute is not supported by all devices. Refer to Supported Attributes by Device topic.'
+        },
         'lv_property': 'Measurement:Autorange',
         'name': 'AUTORANGE',
         'python_type': 'bool',
@@ -1565,6 +1569,10 @@ attributes = {
     1150245: {
         'access': 'read-write',
         'channel_based': True,
+        'documentation': {
+            'description': '\nSpecifies the algorithm the hardware uses for measurement autoranging.\n',
+            'note': 'This attribute is not supported by all devices. Refer to Supported Attributes by Device topic.'
+        },
         'enum': 'AutorangeBehavior',
         'lv_property': 'Measurement:Advanced:Autorange Behavior',
         'name': 'AUTORANGE_BEHAVIOR',
@@ -1574,6 +1582,10 @@ attributes = {
     1150246: {
         'access': 'read-write',
         'channel_based': True,
+        'documentation': {
+            'description': '\nSpecifies whether the aperture time used for the measurement autorange algorithm is determined automatically or customized using the NIDCPOWER_ATTR_AUTORANGE_MINIMUM_APERTURE_TIME property.\n',
+            'note': 'This attribute is not supported by all devices. Refer to Supported Attributes by Device topic.'
+        },
         'enum': 'AutorangeApertureTimeMode',
         'lv_property': 'Measurement:Advanced:Autorange Aperture Time Mode',
         'name': 'AUTORANGE_APERTURE_TIME_MODE',
@@ -1583,6 +1595,10 @@ attributes = {
     1150247: {
         'access': 'read-write',
         'channel_based': True,
+        'documentation': {
+            'description': '\nSpecifies the measurement autorange aperture time used for the measurement autorange algorithm.  The aperture time is specified in the units set by the NIDCPOWER_ATTR_AUTORANGE_MINIMUM_APERTURE_TIME_UNITS property. This value will typically be smaller than the aperture time used for measurements.\n',
+            'note': 'For smaller ranges, the value is scaled up to account for noise. The factor used to scale the value is derived from the module capabilities.  This attribute is not supported by all devices. Refer to Supported Attributes by Device topic.'
+        },
         'lv_property': 'Measurement:Advanced:Autorange Minimum Aperture Time',
         'name': 'AUTORANGE_MINIMUM_APERTURE_TIME',
         'resettable': False,
@@ -1591,6 +1607,10 @@ attributes = {
     1150248: {
         'access': 'read-write',
         'channel_based': True,
+        'documentation': {
+            'description': '\nSpecifies the units of the NIDCPOWER_ATTR_AUTORANGE_MINIMUM_APERTURE_TIME property.\n',
+            'note': 'This attribute is not supported by all devices. Refer to Supported Attributes by Device topic.'
+        },
         'enum': 'ApertureTimeUnits',
         'lv_property': 'Measurement:Advanced:Autorange Minimum Aperture Time Units',
         'name': 'AUTORANGE_MINIMUM_APERTURE_TIME_UNITS',
@@ -1600,6 +1620,10 @@ attributes = {
     1150255: {
         'access': 'read-write',
         'channel_based': True,
+        'documentation': {
+            'description': '\nSpecifies the lowest range used during measurement autoranging.  Limiting the lowest range used during autoranging can improve the speed of the autoranging algorithm and minimize frequent and unpredictable range changes for noisy signals.\n',
+            'note': 'The maximum range used is the range that includes the value specified in the compliance limit property, NIDCPOWER_ATTR_VOLTAGE_LIMIT_RANGE property or NIDCPOWER_ATTR_CURRENT_LIMIT_RANGE property, depending on the selected NIDCPOWER_ATTR_OUTPUT_FUNCTION. This attribute is not supported by all devices. Refer to Supported Attributes by Device topic.'
+        },
         'lv_property': 'Measurement:Advanced:Autorange Minimum Current Range',
         'name': 'AUTORANGE_MINIMUM_CURRENT_RANGE',
         'resettable': False,
@@ -1608,6 +1632,10 @@ attributes = {
     1150256: {
         'access': 'read-write',
         'channel_based': True,
+        'documentation': {
+            'description': '\nSpecifies the lowest range used during measurement autoranging. The maximum range used is range that includes the value specified in the compliance limit property. Limiting the lowest range used during autoranging can improve the speed of the autoranging algorithm and/or minimize thrashing between ranges for noisy signals.\n',
+            'note': 'The maximum range used is the range that includes the value specified in the compliance limit property, NIDCPOWER_ATTR_VOLTAGE_LIMIT_RANGE property or NIDCPOWER_ATTR_CURRENT_LIMIT_RANGE property, depending on the selected NIDCPOWER_ATTR_OUTPUT_FUNCTION. This attribute is not supported by all devices. Refer to Supported Attributes by Device topic.'
+        },
         'lv_property': 'Measurement:Advanced:Autorange Minimum Voltage Range',
         'name': 'AUTORANGE_MINIMUM_VOLTAGE_RANGE',
         'resettable': False,
@@ -1616,6 +1644,10 @@ attributes = {
     1150257: {
         'access': 'read-write',
         'channel_based': True,
+        'documentation': {
+            'description': '\nSpecifies thresholds used during autoranging to determine when range changing occurs.\n',
+            'note': 'This attribute is not supported by all devices. Refer to Supported Attributes by Device topic.'
+        },
         'enum': 'AutorangeThresholdMode',
         'lv_property': 'Measurement:Advanced:Autorange Threshold Mode',
         'name': 'AUTORANGE_THRESHOLD_MODE',

--- a/src/nidcpower/metadata/attributes.py
+++ b/src/nidcpower/metadata/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 20.2.0d22
+# This file is generated from NI-DCPower API metadata version 20.6.0d4
 attributes = {
     1050003: {
         'access': 'read-write',
@@ -108,6 +108,7 @@ attributes = {
         },
         'lv_property': 'Inherent IVI Attributes:Instrument Identification:Manufacturer',
         'name': 'INSTRUMENT_MANUFACTURER',
+        'repeated_capability_type': 'instruments',
         'resettable': False,
         'type': 'ViString'
     },
@@ -973,6 +974,7 @@ attributes = {
         'enum': 'SelfCalibrationPersistence',
         'lv_property': 'Advanced:Self-Calibration Persistence',
         'name': 'SELF_CALIBRATION_PERSISTENCE',
+        'repeated_capability_type': 'instruments',
         'resettable': False,
         'type': 'ViInt32'
     },
@@ -1339,6 +1341,7 @@ attributes = {
         },
         'lv_property': 'Inherent IVI Attributes:Instrument Identification:Serial Number',
         'name': 'SERIAL_NUMBER',
+        'repeated_capability_type': 'instruments',
         'resettable': False,
         'type': 'ViString'
     },
@@ -1547,6 +1550,75 @@ attributes = {
         'enum': 'PowerAllocationMode',
         'lv_property': 'Source:Advanced:Power Allocation Mode',
         'name': 'POWER_ALLOCATION_MODE',
+        'resettable': False,
+        'type': 'ViInt32'
+    },
+    1150244: {
+        'access': 'read-write',
+        'channel_based': True,
+        'lv_property': 'Measurement:Autorange',
+        'name': 'AUTORANGE',
+        'python_type': 'bool',
+        'resettable': False,
+        'type': 'ViInt32'
+    },
+    1150245: {
+        'access': 'read-write',
+        'channel_based': True,
+        'enum': 'AutorangeBehavior',
+        'lv_property': 'Measurement:Advanced:Autorange Behavior',
+        'name': 'AUTORANGE_BEHAVIOR',
+        'resettable': False,
+        'type': 'ViInt32'
+    },
+    1150246: {
+        'access': 'read-write',
+        'channel_based': True,
+        'enum': 'AutorangeApertureTimeMode',
+        'lv_property': 'Measurement:Advanced:Autorange Aperture Time Mode',
+        'name': 'AUTORANGE_APERTURE_TIME_MODE',
+        'resettable': False,
+        'type': 'ViInt32'
+    },
+    1150247: {
+        'access': 'read-write',
+        'channel_based': True,
+        'lv_property': 'Measurement:Advanced:Autorange Minimum Aperture Time',
+        'name': 'AUTORANGE_MINIMUM_APERTURE_TIME',
+        'resettable': False,
+        'type': 'ViReal64'
+    },
+    1150248: {
+        'access': 'read-write',
+        'channel_based': True,
+        'enum': 'ApertureTimeUnits',
+        'lv_property': 'Measurement:Advanced:Autorange Minimum Aperture Time Units',
+        'name': 'AUTORANGE_MINIMUM_APERTURE_TIME_UNITS',
+        'resettable': False,
+        'type': 'ViInt32'
+    },
+    1150255: {
+        'access': 'read-write',
+        'channel_based': True,
+        'lv_property': 'Measurement:Advanced:Autorange Minimum Current Range',
+        'name': 'AUTORANGE_MINIMUM_CURRENT_RANGE',
+        'resettable': False,
+        'type': 'ViReal64'
+    },
+    1150256: {
+        'access': 'read-write',
+        'channel_based': True,
+        'lv_property': 'Measurement:Advanced:Autorange Minimum Voltage Range',
+        'name': 'AUTORANGE_MINIMUM_VOLTAGE_RANGE',
+        'resettable': False,
+        'type': 'ViReal64'
+    },
+    1150257: {
+        'access': 'read-write',
+        'channel_based': True,
+        'enum': 'AutorangeThresholdMode',
+        'lv_property': 'Measurement:Advanced:Autorange Threshold Mode',
+        'name': 'AUTORANGE_THRESHOLD_MODE',
         'resettable': False,
         'type': 'ViInt32'
     },

--- a/src/nidcpower/metadata/attributes.py
+++ b/src/nidcpower/metadata/attributes.py
@@ -108,7 +108,6 @@ attributes = {
         },
         'lv_property': 'Inherent IVI Attributes:Instrument Identification:Manufacturer',
         'name': 'INSTRUMENT_MANUFACTURER',
-        'repeated_capability_type': 'instruments',
         'resettable': False,
         'type': 'ViString'
     },
@@ -974,7 +973,6 @@ attributes = {
         'enum': 'SelfCalibrationPersistence',
         'lv_property': 'Advanced:Self-Calibration Persistence',
         'name': 'SELF_CALIBRATION_PERSISTENCE',
-        'repeated_capability_type': 'instruments',
         'resettable': False,
         'type': 'ViInt32'
     },
@@ -1341,7 +1339,6 @@ attributes = {
         },
         'lv_property': 'Inherent IVI Attributes:Instrument Identification:Serial Number',
         'name': 'SERIAL_NUMBER',
-        'repeated_capability_type': 'instruments',
         'resettable': False,
         'type': 'ViString'
     },

--- a/src/nidcpower/metadata/config.py
+++ b/src/nidcpower/metadata/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 20.2.0d22
+# This file is generated from NI-DCPower API metadata version 20.6.0d4
 config = {
-    'api_version': '20.2.0d22',
+    'api_version': '20.6.0d4',
     'c_function_prefix': 'niDCPower_',
     'close_function': 'close',
     'context_manager_name': {
@@ -45,5 +45,5 @@ config = {
     ],
     'session_class_description': 'An NI-DCPower session to a National Instruments Programmable Power Supply or Source Measure Unit.',
     'session_handle_parameter_name': 'vi',
-    'uses_nitclk': False,
+    'uses_nitclk': False
 }

--- a/src/nidcpower/metadata/config.py
+++ b/src/nidcpower/metadata/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 20.6.0d4
+# This file is generated from NI-DCPower API metadata version 20.6.0d7
 config = {
-    'api_version': '20.6.0d4',
+    'api_version': '20.6.0d7',
     'c_function_prefix': 'niDCPower_',
     'close_function': 'close',
     'context_manager_name': {

--- a/src/nidcpower/metadata/enums.py
+++ b/src/nidcpower/metadata/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 20.2.0d22
+# This file is generated from NI-DCPower API metadata version 20.6.0d4
 enums = {
     'ApertureTimeUnits': {
         'values': [
@@ -41,6 +41,58 @@ enums = {
                 },
                 'name': 'NIDCPOWER_VAL_ONCE',
                 'value': 1024
+            }
+        ]
+    },
+    'AutorangeApertureTimeMode': {
+        'values': [
+            {
+                'name': 'NIDCPOWER_VAL_APERTURE_TIME_AUTO',
+                'value': 1110
+            },
+            {
+                'name': 'NIDCPOWER_VAL_APERTURE_TIME_CUSTOM',
+                'value': 1111
+            }
+        ]
+    },
+    'AutorangeBehavior': {
+        'values': [
+            {
+                'name': 'NIDCPOWER_VAL_RANGE_UP_TO_LIMIT_THEN_DOWN',
+                'value': 1107
+            },
+            {
+                'name': 'NIDCPOWER_VAL_RANGE_UP',
+                'value': 1108
+            },
+            {
+                'name': 'NIDCPOWER_VAL_RANGE_UP_AND_DOWN',
+                'value': 1109
+            }
+        ]
+    },
+    'AutorangeThresholdMode': {
+        'values': [
+            {
+                'name': 'NIDCPOWER_VAL_THRESHOLD_MODE_NORMAL',
+                'value': 1112
+            },
+            {
+                'name': 'NIDCPOWER_VAL_THRESHOLD_MODE_FAST_STEP',
+                'value': 1113
+            },
+            {
+                'name': 'NIDCPOWER_VAL_THRESHOLD_MODE_HIGH_HYSTERESIS',
+                'value': 1114
+            },
+            {
+                'name': 'NIDCPOWER_VAL_THRESHOLD_MODE_MEDIUM_HYSTERESIS',
+                'value': 1115
+            },
+            {
+                'name': 'NIDCPOWER_VAL_THRESHOLD_MODE_HOLD',
+                'value': 1116
             }
         ]
     },

--- a/src/nidcpower/metadata/enums.py
+++ b/src/nidcpower/metadata/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 20.6.0d4
+# This file is generated from NI-DCPower API metadata version 20.6.0d7
 enums = {
     'ApertureTimeUnits': {
         'values': [
@@ -47,10 +47,16 @@ enums = {
     'AutorangeApertureTimeMode': {
         'values': [
             {
+                'documentation': {
+                    'description': 'NI-DCPower optimizes the aperture time for the autorange algorithm based on the module range.'
+                },
                 'name': 'NIDCPOWER_VAL_APERTURE_TIME_AUTO',
                 'value': 1110
             },
             {
+                'documentation': {
+                    'description': 'The user specifies a minimum aperture time for the algorithm using the NIDCPOWER_ATTR_AUTORANGE_MINIMUM_APERTURE_TIME property and the corresponding NIDCPOWER_ATTR_AUTORANGE_MINIMUM_APERTURE_TIME_UNITS property.'
+                },
                 'name': 'NIDCPOWER_VAL_APERTURE_TIME_CUSTOM',
                 'value': 1111
             }
@@ -59,14 +65,23 @@ enums = {
     'AutorangeBehavior': {
         'values': [
             {
+                'documentation': {
+                    'description': 'Go to limit range then range down as needed until measured value is within thresholds.'
+                },
                 'name': 'NIDCPOWER_VAL_RANGE_UP_TO_LIMIT_THEN_DOWN',
                 'value': 1107
             },
             {
+                'documentation': {
+                    'description': 'go up one range when the upper threshold is reached.'
+                },
                 'name': 'NIDCPOWER_VAL_RANGE_UP',
                 'value': 1108
             },
             {
+                'documentation': {
+                    'description': 'go up or down one range when the upper/lower threshold is reached.'
+                },
                 'name': 'NIDCPOWER_VAL_RANGE_UP_AND_DOWN',
                 'value': 1109
             }
@@ -75,22 +90,37 @@ enums = {
     'AutorangeThresholdMode': {
         'values': [
             {
+                'documentation': {
+                    'description': 'Thresholds are selected based on a balance between accuracy and hysteresis.'
+                },
                 'name': 'NIDCPOWER_VAL_THRESHOLD_MODE_NORMAL',
                 'value': 1112
             },
             {
+                'documentation': {
+                    'description': 'Optimized for faster changes in the measured signal. Thresholds are configured to be a smaller percentage of the range.'
+                },
                 'name': 'NIDCPOWER_VAL_THRESHOLD_MODE_FAST_STEP',
                 'value': 1113
             },
             {
+                'documentation': {
+                    'description': 'Optimized for noisy signals to minimize frequent and unpredictable range changes. Thresholds are configured to be a larger percentage of the range.'
+                },
                 'name': 'NIDCPOWER_VAL_THRESHOLD_MODE_HIGH_HYSTERESIS',
                 'value': 1114
             },
             {
+                'documentation': {
+                    'description': 'Optimized for noisy signals to minimize frequent and unpredictable range changes. Thresholds are configured to be a medium percentage of the range.'
+                },
                 'name': 'NIDCPOWER_VAL_THRESHOLD_MODE_MEDIUM_HYSTERESIS',
                 'value': 1115
             },
             {
+                'documentation': {
+                    'description': 'Attempt to maintain the active range. Thresholds will favor the active range.'
+                },
                 'name': 'NIDCPOWER_VAL_THRESHOLD_MODE_HOLD',
                 'value': 1116
             }

--- a/src/nidcpower/metadata/functions.py
+++ b/src/nidcpower/metadata/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 20.6.0d4
+# This file is generated from NI-DCPower API metadata version 20.6.0d7
 functions = {
     'Abort': {
         'documentation': {

--- a/src/nidcpower/metadata/functions.py
+++ b/src/nidcpower/metadata/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 20.2.0d22
+# This file is generated from NI-DCPower API metadata version 20.6.0d4
 functions = {
     'Abort': {
         'documentation': {
@@ -847,12 +847,12 @@ functions = {
                 },
                 'name': 'configuration',
                 'python_api_converter_name': 'convert_to_bytes',
-                'type_in_documentation': 'bytes',
                 'size': {
                     'mechanism': 'ivi-dance',
                     'value': 'size'
                 },
                 'type': 'ViInt8[]',
+                'type_in_documentation': 'bytes',
                 'use_array': True
             }
         ],
@@ -1689,12 +1689,12 @@ functions = {
                 },
                 'name': 'configuration',
                 'python_api_converter_name': 'convert_to_bytes',
-                'type_in_documentation': 'bytes',
                 'size': {
                     'mechanism': 'len',
                     'value': 'size'
                 },
-                'type': 'ViInt8[]'
+                'type': 'ViInt8[]',
+                'type_in_documentation': 'bytes'
             }
         ],
         'returns': 'ViStatus'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

- API parity with NI-DCPower 20.5.0 by adding measurement autoranging threshold range support.
- Fix the documentation of `instrument_manufacturer`, `instrument_model`, and `serial_number` properties to correctly mention that they use `instruments` repeated capability.

### List issues fixed by this Pull Request below, if any.

N/a

### What testing has been done?

System tests will be run by nimi-bot