### PR TITLE
Add type hints in the public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 * ### ALL
     * #### Added
+        * Type hints for all public methods
     * #### Changed
     * #### Removed
 * ### `nidcpower` (NI-DCPower)

--- a/build/helper/__init__.py
+++ b/build/helper/__init__.py
@@ -2,6 +2,7 @@ from build.helper.codegen_helper import get_ctype_variable_declaration_snippet  
 from build.helper.codegen_helper import get_dictionary_snippet  # noqa: F401
 from build.helper.codegen_helper import get_enum_type_check_snippet  # noqa: F401
 from build.helper.codegen_helper import get_method_return_snippet  # noqa: F401
+from build.helper.codegen_helper import get_method_return_type_hint  # noqa: F401
 from build.helper.codegen_helper import get_params_snippet  # noqa: F401
 from build.helper.codegen_helper import IviDanceStep  # noqa: F401
 

--- a/build/helper/codegen_helper.py
+++ b/build/helper/codegen_helper.py
@@ -141,6 +141,25 @@ def get_method_return_snippet(parameters, config, use_numpy_array=False):
     return ('return ' + ', '.join(snippets)).strip()
 
 
+def get_method_return_type_hint(parameters, config, use_numpy_array=False):
+    '''Add the type hint for the return value(s)'''
+    snippets = []
+    for x in parameters:
+        if x['direction'] == 'out' or x['size']['mechanism'] == 'ivi-dance':
+            if x['numpy'] is False or use_numpy_array is False:
+                if x['use_in_python_api']:
+                    snippets.append(x['type_hint'])
+
+    if len(snippets) == 0:
+        type_hint = 'None'
+    elif len(snippets) == 1:
+        type_hint = snippets[0]
+    else:
+        type_hint = 'typing.Tuple[' + ', '.join(snippets) + ']'
+
+    return type_hint
+
+
 def get_enum_type_check_snippet(parameter, indent):
     '''Returns python snippet to check that the type of a parameter is what is expected'''
     assert parameter['enum'] is not None, pp.pformat(parameter)

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -22,10 +22,12 @@ ${template_parameters['encoding_tag']}
 %>\
 import array  # noqa: F401
 import ctypes
+import datetime
 % if config['use_locking']:
 # Used by @ivi_synchronized
 from functools import wraps
 % endif
+import typing
 
 % if attributes:
 import ${module_name}._attributes as _attributes

--- a/build/templates/session.py/datetime_wrappers.py.mako
+++ b/build/templates/session.py/datetime_wrappers.py.mako
@@ -13,7 +13,7 @@
 
     output_params = ', '.join(output_params_list)
 %>\
-    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}) -> ${helper.get_method_return_type_hint(f['parameters'], config)}:
         '''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}

--- a/build/templates/session.py/default_method.py.mako
+++ b/build/templates/session.py/default_method.py.mako
@@ -15,7 +15,7 @@
     len_size_parameter = helper.find_size_parameter(len_parameters, parameters)
     assert ivi_dance_size_parameter is None or len_size_parameter is None
 %>\
-    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}) -> ${helper.get_method_return_type_hint(f['parameters'], config)}:
         r'''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}

--- a/build/templates/session.py/fancy_self_test.py.mako
+++ b/build/templates/session.py/fancy_self_test.py.mako
@@ -3,7 +3,7 @@
     '''Call self-test and throw if there is a failure'''
     import build.helper as helper
 %>\
-    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}) -> ${helper.get_method_return_type_hint(f['parameters'], config)}:
         '''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}

--- a/build/templates/session.py/lock.py.mako
+++ b/build/templates/session.py/lock.py.mako
@@ -4,7 +4,7 @@
 
     c_function_prefix = config['c_function_prefix']
 %>\
-    def ${f['python_name']}(self):
+    def ${f['python_name']}(self) -> ${helper.get_method_return_type_hint(f['parameters'], config)}:
         '''${f['python_name']}
 
         Obtains a multithread lock on the device session. Before doing so, the
@@ -39,7 +39,7 @@
         # that will handle the unlock for them
         return _Lock(self)
 
-    def _lock_session(self):
+    def _lock_session(self) -> None:
         '''_lock_session
 
         Actual call to driver

--- a/build/templates/session.py/numpy_read_method.py.mako
+++ b/build/templates/session.py/numpy_read_method.py.mako
@@ -9,7 +9,7 @@
     enum_input_parameters = helper.filter_parameters(f, helper.ParameterUsageOptions.INPUT_ENUM_PARAMETERS)
     suffix = method_template['method_python_name_suffix']
 %>\
-    def ${f['python_name']}${suffix}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_NUMPY_INTO_METHOD_DECLARATION)}):
+    def ${f['python_name']}${suffix}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_NUMPY_INTO_METHOD_DECLARATION)}) -> ${helper.get_method_return_type_hint(f['parameters'], config, use_numpy_array=True)}:
         r'''${f['python_name']}
 
         ${helper.get_function_docstring(f, True, config, indent=8)}

--- a/build/templates/session.py/numpy_write_method.py.mako
+++ b/build/templates/session.py/numpy_write_method.py.mako
@@ -9,7 +9,7 @@
     enum_input_parameters = helper.filter_parameters(f, helper.ParameterUsageOptions.INPUT_ENUM_PARAMETERS)
     suffix = method_template['method_python_name_suffix']
 %>\
-    def ${f['python_name']}${suffix}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+    def ${f['python_name']}${suffix}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}) -> ${helper.get_method_return_type_hint(f['parameters'], config, use_numpy_array=True)}:
         r'''${f['python_name']}
 
         ${helper.get_function_docstring(f, True, config, indent=8)}

--- a/build/templates/session.py/unlock.py.mako
+++ b/build/templates/session.py/unlock.py.mako
@@ -4,7 +4,7 @@
 
     c_function_prefix = config['c_function_prefix']
 %>\
-    def ${f['python_name']}(self):
+    def ${f['python_name']}(self) -> ${helper.get_method_return_type_hint(f['parameters'], config)}:
         '''${f['python_name']}
 
         Releases a lock that you acquired on an device session using

--- a/build/templates/setup.py.mako
+++ b/build/templates/setup.py.mako
@@ -54,6 +54,7 @@ setup(
         % if config['uses_nitclk']:
         'nitclk',
         % endif
+        'typing',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/docs/nidcpower/class.rst
+++ b/docs/nidcpower/class.rst
@@ -3,7 +3,7 @@
 Session
 =======
 
-.. py:class:: Session(self, resource_name, channels=None, reset=False, options={})
+.. py:class:: Session(self, resource_name: str, channels: typing.Union[str, 'list', 'range', 'tuple'] = None, reset: 'bool' = False, options={})
 
     
 

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -3,7 +3,7 @@
 Session
 =======
 
-.. py:class:: Session(self, resource_name, id_query=False, reset_device=False, options={})
+.. py:class:: Session(self, resource_name: str, id_query: 'bool' = False, reset_device: 'bool' = False, options={})
 
     
 

--- a/docs/nidmm/class.rst
+++ b/docs/nidmm/class.rst
@@ -3,7 +3,7 @@
 Session
 =======
 
-.. py:class:: Session(self, resource_name, id_query=False, reset_device=False, options={})
+.. py:class:: Session(self, resource_name: str, id_query: 'bool' = False, reset_device: 'bool' = False, options={})
 
     
 

--- a/docs/nifgen/class.rst
+++ b/docs/nifgen/class.rst
@@ -3,7 +3,7 @@
 Session
 =======
 
-.. py:class:: Session(self, resource_name, channel_name=None, reset_device=False, options={})
+.. py:class:: Session(self, resource_name: str, channel_name: typing.Union[str, 'list', 'range', 'tuple'] = None, reset_device: 'bool' = False, options={})
 
     
 

--- a/docs/nimodinst/class.rst
+++ b/docs/nimodinst/class.rst
@@ -3,7 +3,7 @@
 Session
 =======
 
-.. py:class:: Session(self, driver)
+.. py:class:: Session(self, driver: str)
 
     
 

--- a/docs/niscope/class.rst
+++ b/docs/niscope/class.rst
@@ -3,7 +3,7 @@
 Session
 =======
 
-.. py:class:: Session(self, resource_name, id_query=False, reset_device=False, options={})
+.. py:class:: Session(self, resource_name: str, id_query: 'bool' = False, reset_device: 'bool' = False, options={})
 
     
 

--- a/docs/nise/class.rst
+++ b/docs/nise/class.rst
@@ -3,7 +3,7 @@
 Session
 =======
 
-.. py:class:: Session(self, virtual_device_name, options={})
+.. py:class:: Session(self, virtual_device_name: str, options={})
 
     
 

--- a/docs/niswitch/class.rst
+++ b/docs/niswitch/class.rst
@@ -3,7 +3,7 @@
 Session
 =======
 
-.. py:class:: Session(self, resource_name, topology="Configured Topology", simulate=False, reset_device=False)
+.. py:class:: Session(self, resource_name: str, topology: str = "Configured Topology", simulate: 'bool' = False, reset_device: 'bool' = False)
 
     
 

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -2,8 +2,10 @@
 # This file was generated
 import array  # noqa: F401
 import ctypes
+import datetime
 # Used by @ivi_synchronized
 from functools import wraps
+import typing
 
 import nidcpower._attributes as _attributes
 import nidcpower._converters as _converters
@@ -2556,7 +2558,7 @@ class _SessionBase(object):
     ''' These are code-generated '''
 
     @ivi_synchronized
-    def self_cal(self):
+    def self_cal(self) -> None:
         r'''self_cal
 
         Performs a self-calibration upon the specified channel(s).
@@ -2600,7 +2602,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def configure_aperture_time(self, aperture_time, units=enums.ApertureTimeUnits.SECONDS):
+    def configure_aperture_time(self, aperture_time: float, units: 'enums.ApertureTimeUnits' = enums.ApertureTimeUnits.SECONDS) -> None:
         r'''configure_aperture_time
 
         Configures the aperture time on the specified channel(s).
@@ -2656,7 +2658,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def fetch_multiple(self, count, timeout=hightime.timedelta(seconds=1.0)):
+    def fetch_multiple(self, count: int, timeout: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=1.0)) -> typing.List[typing.NamedTuple[float, float, bool]]:
         '''fetch_multiple
 
         Returns a list of named tuples (Measurement) that were
@@ -2695,15 +2697,14 @@ class _SessionBase(object):
                 - **in_compliance** (bool)
 
         '''
-        import collections
-        Measurement = collections.namedtuple('Measurement', ['voltage', 'current', 'in_compliance'])
+        measurement = typing.NamedTuple('Measurement', [('voltage', 'float'), ('current', 'float'), ('in_compliance', 'bool')])
 
         voltage_measurements, current_measurements, in_compliance = self._fetch_multiple(timeout, count)
 
-        return [Measurement(voltage=voltage_measurements[i], current=current_measurements[i], in_compliance=in_compliance[i]) for i in range(count)]
+        return [measurement(voltage=voltage_measurements[i], current=current_measurements[i], in_compliance=in_compliance[i]) for i in range(count)]
 
     @ivi_synchronized
-    def measure_multiple(self):
+    def measure_multiple(self) -> typing.List[typing.NamedTuple[float, float, bool]]:
         '''measure_multiple
 
         Returns a list of named tuples (Measurement) containing the measured voltage
@@ -2734,15 +2735,14 @@ class _SessionBase(object):
                 - **in_compliance** (bool) - Always None
 
         '''
-        import collections
-        Measurement = collections.namedtuple('Measurement', ['voltage', 'current', 'in_compliance'])
+        measurement = typing.NamedTuple('Measurement', [('voltage', 'float'), ('current', 'float'), ('in_compliance', 'bool')])
 
         voltage_measurements, current_measurements = self._measure_multiple()
 
-        return [Measurement(voltage=voltage_measurements[i], current=current_measurements[i], in_compliance=None) for i in range(self._parse_channel_count())]
+        return [measurement(voltage=voltage_measurements[i], current=current_measurements[i], in_compliance=None) for i in range(self._parse_channel_count())]
 
     @ivi_synchronized
-    def _fetch_multiple(self, timeout, count):
+    def _fetch_multiple(self, timeout: typing.Union['hightime.timedelta', 'datetime.timedelta', float], count: int) -> typing.Tuple[typing.Iterable[float], typing.Iterable[float], typing.Iterable['bool']]:
         r'''_fetch_multiple
 
         Returns an array of voltage measurements, an array of current
@@ -2816,7 +2816,7 @@ class _SessionBase(object):
         return voltage_measurements_array, current_measurements_array, [bool(in_compliance_ctype[i]) for i in range(count_ctype.value)]
 
     @ivi_synchronized
-    def _get_attribute_vi_boolean(self, attribute_id):
+    def _get_attribute_vi_boolean(self, attribute_id: int) -> 'bool':
         r'''_get_attribute_vi_boolean
 
         | Queries the value of a ViBoolean property.
@@ -2869,7 +2869,7 @@ class _SessionBase(object):
         return bool(attribute_value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_int32(self, attribute_id):
+    def _get_attribute_vi_int32(self, attribute_id: int) -> int:
         r'''_get_attribute_vi_int32
 
         | Queries the value of a ViInt32 property.
@@ -2922,7 +2922,7 @@ class _SessionBase(object):
         return int(attribute_value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_int64(self, attribute_id):
+    def _get_attribute_vi_int64(self, attribute_id: int) -> int:
         r'''_get_attribute_vi_int64
 
         | Queries the value of a ViInt64 property.
@@ -2975,7 +2975,7 @@ class _SessionBase(object):
         return int(attribute_value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_real64(self, attribute_id):
+    def _get_attribute_vi_real64(self, attribute_id: int) -> float:
         r'''_get_attribute_vi_real64
 
         | Queries the value of a ViReal64 property.
@@ -3028,7 +3028,7 @@ class _SessionBase(object):
         return float(attribute_value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_string(self, attribute_id):
+    def _get_attribute_vi_string(self, attribute_id: int) -> str:
         r'''_get_attribute_vi_string
 
         | Queries the value of a ViString property.
@@ -3095,7 +3095,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return attribute_value_ctype.value.decode(self._encoding)
 
-    def _get_error(self):
+    def _get_error(self) -> typing.Tuple[int, str]:
         r'''_get_error
 
         | Retrieves and then clears the IVI error information for the session or
@@ -3145,7 +3145,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return int(code_ctype.value), description_ctype.value.decode(self._encoding)
 
-    def lock(self):
+    def lock(self) -> 'bool':
         '''lock
 
         Obtains a multithread lock on the device session. Before doing so, the
@@ -3180,7 +3180,7 @@ class _SessionBase(object):
         # that will handle the unlock for them
         return _Lock(self)
 
-    def _lock_session(self):
+    def _lock_session(self) -> None:
         '''_lock_session
 
         Actual call to driver
@@ -3191,7 +3191,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def measure(self, measurement_type):
+    def measure(self, measurement_type: 'enums.MeasurementTypes') -> float:
         r'''measure
 
         Returns the measured value of either the voltage or current on the
@@ -3233,7 +3233,7 @@ class _SessionBase(object):
         return float(measurement_ctype.value)
 
     @ivi_synchronized
-    def _measure_multiple(self):
+    def _measure_multiple(self) -> typing.Tuple[typing.Iterable[float], typing.Iterable[float]]:
         r'''_measure_multiple
 
         Returns arrays of the measured voltage and current values on the
@@ -3273,7 +3273,7 @@ class _SessionBase(object):
         return voltage_measurements_array, current_measurements_array
 
     @ivi_synchronized
-    def _parse_channel_count(self):
+    def _parse_channel_count(self) -> int:
         r'''_parse_channel_count
 
         Returns the number of channels.
@@ -3296,7 +3296,7 @@ class _SessionBase(object):
         return int(number_of_channels_ctype.value)
 
     @ivi_synchronized
-    def query_in_compliance(self):
+    def query_in_compliance(self) -> 'bool':
         r'''query_in_compliance
 
         Queries the specified output device to determine if it is operating at
@@ -3341,7 +3341,7 @@ class _SessionBase(object):
         return bool(in_compliance_ctype.value)
 
     @ivi_synchronized
-    def query_max_current_limit(self, voltage_level):
+    def query_max_current_limit(self, voltage_level: float) -> float:
         r'''query_max_current_limit
 
         Queries the maximum current limit on an output channel if the output
@@ -3372,7 +3372,7 @@ class _SessionBase(object):
         return float(max_current_limit_ctype.value)
 
     @ivi_synchronized
-    def query_max_voltage_level(self, current_limit):
+    def query_max_voltage_level(self, current_limit: float) -> float:
         r'''query_max_voltage_level
 
         Queries the maximum voltage level on an output channel if the output
@@ -3403,7 +3403,7 @@ class _SessionBase(object):
         return float(max_voltage_level_ctype.value)
 
     @ivi_synchronized
-    def query_min_current_limit(self, voltage_level):
+    def query_min_current_limit(self, voltage_level: float) -> float:
         r'''query_min_current_limit
 
         Queries the minimum current limit on an output channel if the output
@@ -3434,7 +3434,7 @@ class _SessionBase(object):
         return float(min_current_limit_ctype.value)
 
     @ivi_synchronized
-    def query_output_state(self, output_state):
+    def query_output_state(self, output_state: 'enums.OutputStates') -> 'bool':
         r'''query_output_state
 
         Queries the specified output channel to determine if the output channel
@@ -3477,7 +3477,7 @@ class _SessionBase(object):
         return bool(in_state_ctype.value)
 
     @ivi_synchronized
-    def _set_attribute_vi_boolean(self, attribute_id, attribute_value):
+    def _set_attribute_vi_boolean(self, attribute_id: int, attribute_value: 'bool') -> None:
         r'''_set_attribute_vi_boolean
 
         | Sets the value of a ViBoolean property.
@@ -3533,7 +3533,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_int32(self, attribute_id, attribute_value):
+    def _set_attribute_vi_int32(self, attribute_id: int, attribute_value: int) -> None:
         r'''_set_attribute_vi_int32
 
         | Sets the value of a ViInt32 property.
@@ -3589,7 +3589,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_int64(self, attribute_id, attribute_value):
+    def _set_attribute_vi_int64(self, attribute_id: int, attribute_value: int) -> None:
         r'''_set_attribute_vi_int64
 
         | Sets the value of a ViInt64 property.
@@ -3645,7 +3645,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_real64(self, attribute_id, attribute_value):
+    def _set_attribute_vi_real64(self, attribute_id: int, attribute_value: float) -> None:
         r'''_set_attribute_vi_real64
 
         | Sets the value of a ViReal64 property.
@@ -3701,7 +3701,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_string(self, attribute_id, attribute_value):
+    def _set_attribute_vi_string(self, attribute_id: int, attribute_value: str) -> None:
         r'''_set_attribute_vi_string
 
         | Sets the value of a ViString property.
@@ -3757,7 +3757,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def set_sequence(self, values, source_delays):
+    def set_sequence(self, values: typing.Iterable[float], source_delays: typing.Iterable[float]) -> None:
         r'''set_sequence
 
         Configures a series of voltage or current outputs and corresponding
@@ -3813,7 +3813,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def unlock(self):
+    def unlock(self) -> 'bool':
         '''unlock
 
         Releases a lock that you acquired on an device session using
@@ -3825,7 +3825,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return
 
-    def _error_message(self, error_code):
+    def _error_message(self, error_code: int) -> str:
         r'''_error_message
 
         Converts a status code returned by an instrument driver method into a
@@ -3853,7 +3853,7 @@ class _SessionBase(object):
 class Session(_SessionBase):
     '''An NI-DCPower session to a National Instruments Programmable Power Supply or Source Measure Unit.'''
 
-    def __init__(self, resource_name, channels=None, reset=False, options={}):
+    def __init__(self, resource_name: str, channels: typing.Union[str, 'list', 'range', 'tuple'] = None, reset: 'bool' = False, options={}):
         r'''An NI-DCPower session to a National Instruments Programmable Power Supply or Source Measure Unit.
 
         Creates and returns a new NI-DCPower session to the power supply or SMU
@@ -4016,7 +4016,7 @@ class Session(_SessionBase):
     ''' These are code-generated '''
 
     @ivi_synchronized
-    def abort(self):
+    def abort(self) -> None:
         r'''abort
 
         Transitions the NI-DCPower session from the Running state to the
@@ -4049,7 +4049,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def commit(self):
+    def commit(self) -> None:
         r'''commit
 
         Applies previously configured settings to the device. Calling this
@@ -4073,7 +4073,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def _create_advanced_sequence(self, sequence_name, attribute_ids, set_as_active_sequence):
+    def _create_advanced_sequence(self, sequence_name: str, attribute_ids: typing.Iterable[int], set_as_active_sequence: 'bool') -> None:
         r'''_create_advanced_sequence
 
         Creates an empty advanced sequence. Call the
@@ -4242,7 +4242,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def create_advanced_sequence_step(self, set_as_active_step=True):
+    def create_advanced_sequence_step(self, set_as_active_step: 'bool' = True) -> None:
         r'''create_advanced_sequence_step
 
         Creates a new advanced sequence step in the advanced sequence specified
@@ -4285,7 +4285,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def delete_advanced_sequence(self, sequence_name):
+    def delete_advanced_sequence(self, sequence_name: str) -> None:
         r'''delete_advanced_sequence
 
         Deletes a previously created advanced sequence and all the advanced
@@ -4323,7 +4323,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def disable(self):
+    def disable(self) -> None:
         r'''disable
 
         This method performs the same actions as the reset
@@ -4339,7 +4339,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def export_attribute_configuration_buffer(self):
+    def export_attribute_configuration_buffer(self) -> typing.Iterable['bytes']:
         r'''export_attribute_configuration_buffer
 
         Exports the property configuration of the session to the specified
@@ -4404,7 +4404,7 @@ class Session(_SessionBase):
         return _converters.convert_to_bytes(configuration_array)
 
     @ivi_synchronized
-    def export_attribute_configuration_file(self, file_path):
+    def export_attribute_configuration_file(self, file_path: str) -> None:
         r'''export_attribute_configuration_file
 
         Exports the property configuration of the session to the specified
@@ -4464,7 +4464,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def create_advanced_sequence(self, sequence_name, property_names, set_as_active_sequence=True):
+    def create_advanced_sequence(self, sequence_name: str, property_names: typing.Iterable[str], set_as_active_sequence: 'bool' = True) -> None:
         '''create_advanced_sequence
 
         Creates an empty advanced sequence. Call the
@@ -4632,7 +4632,7 @@ class Session(_SessionBase):
         self._create_advanced_sequence(sequence_name, list(attribute_ids_used), set_as_active_sequence)
 
     @ivi_synchronized
-    def get_channel_name(self, index):
+    def get_channel_name(self, index: int) -> str:
         r'''get_channel_name
 
         Retrieves the output **channelName** that corresponds to the requested
@@ -4661,7 +4661,7 @@ class Session(_SessionBase):
         return channel_name_ctype.value.decode(self._encoding)
 
     @ivi_synchronized
-    def _get_ext_cal_last_date_and_time(self):
+    def _get_ext_cal_last_date_and_time(self) -> typing.Tuple[int, int, int, int, int]:
         r'''_get_ext_cal_last_date_and_time
 
         Returns the date and time of the last successful calibration. The time
@@ -4693,7 +4693,7 @@ class Session(_SessionBase):
         return int(year_ctype.value), int(month_ctype.value), int(day_ctype.value), int(hour_ctype.value), int(minute_ctype.value)
 
     @ivi_synchronized
-    def get_ext_cal_last_temp(self):
+    def get_ext_cal_last_temp(self) -> float:
         r'''get_ext_cal_last_temp
 
         Returns the onboard **temperature** of the device, in degrees Celsius,
@@ -4711,7 +4711,7 @@ class Session(_SessionBase):
         return float(temperature_ctype.value)
 
     @ivi_synchronized
-    def get_ext_cal_recommended_interval(self):
+    def get_ext_cal_recommended_interval(self) -> 'hightime.timedelta':
         r'''get_ext_cal_recommended_interval
 
         Returns the recommended maximum interval, in **months**, between
@@ -4729,7 +4729,7 @@ class Session(_SessionBase):
         return _converters.convert_month_to_timedelta(int(months_ctype.value))
 
     @ivi_synchronized
-    def get_ext_cal_last_date_and_time(self):
+    def get_ext_cal_last_date_and_time(self) -> 'hightime.datetime':
         '''get_ext_cal_last_date_and_time
 
         Returns the date and time of the last successful calibration.
@@ -4742,7 +4742,7 @@ class Session(_SessionBase):
         return hightime.datetime(year, month, day, hour, minute)
 
     @ivi_synchronized
-    def get_self_cal_last_date_and_time(self):
+    def get_self_cal_last_date_and_time(self) -> 'hightime.datetime':
         '''get_self_cal_last_date_and_time
 
         Returns the date and time of the oldest successful self-calibration from among the channels in the session.
@@ -4757,7 +4757,7 @@ class Session(_SessionBase):
         return hightime.datetime(year, month, day, hour, minute)
 
     @ivi_synchronized
-    def _get_self_cal_last_date_and_time(self):
+    def _get_self_cal_last_date_and_time(self) -> typing.Tuple[int, int, int, int, int]:
         r'''_get_self_cal_last_date_and_time
 
         Returns the date and time of the oldest successful self-calibration from
@@ -4799,7 +4799,7 @@ class Session(_SessionBase):
         return int(year_ctype.value), int(month_ctype.value), int(day_ctype.value), int(hour_ctype.value), int(minute_ctype.value)
 
     @ivi_synchronized
-    def get_self_cal_last_temp(self):
+    def get_self_cal_last_temp(self) -> float:
         r'''get_self_cal_last_temp
 
         Returns the onboard temperature of the device, in degrees Celsius,
@@ -4830,7 +4830,7 @@ class Session(_SessionBase):
         return float(temperature_ctype.value)
 
     @ivi_synchronized
-    def import_attribute_configuration_buffer(self, configuration):
+    def import_attribute_configuration_buffer(self, configuration: typing.Iterable['bytes']) -> None:
         r'''import_attribute_configuration_buffer
 
         Imports a property configuration to the session from the specified
@@ -4889,7 +4889,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def import_attribute_configuration_file(self, file_path):
+    def import_attribute_configuration_file(self, file_path: str) -> None:
         r'''import_attribute_configuration_file
 
         Imports a property configuration to the session from the specified
@@ -4947,7 +4947,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def _initialize_with_channels(self, resource_name, channels=None, reset=False, option_string=""):
+    def _initialize_with_channels(self, resource_name: str, channels: typing.Union[str, 'list', 'range', 'tuple'] = None, reset: 'bool' = False, option_string: 'dict' = "") -> int:
         r'''_initialize_with_channels
 
         Creates and returns a new NI-DCPower session to the power supply or SMU
@@ -5027,7 +5027,7 @@ class Session(_SessionBase):
         return int(vi_ctype.value)
 
     @ivi_synchronized
-    def _initiate(self):
+    def _initiate(self) -> None:
         r'''_initiate
 
         Starts generation or acquisition, causing the NI-DCPower session to
@@ -5049,7 +5049,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def read_current_temperature(self):
+    def read_current_temperature(self) -> float:
         r'''read_current_temperature
 
         Returns the current onboard **temperature**, in degrees Celsius, of the
@@ -5066,7 +5066,7 @@ class Session(_SessionBase):
         return float(temperature_ctype.value)
 
     @ivi_synchronized
-    def reset_device(self):
+    def reset_device(self) -> None:
         r'''reset_device
 
         Resets the device to a known state. The method disables power
@@ -5089,7 +5089,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def reset_with_defaults(self):
+    def reset_with_defaults(self) -> None:
         r'''reset_with_defaults
 
         Resets the device to a known state. This method disables power
@@ -5106,7 +5106,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def send_software_edge_trigger(self, trigger):
+    def send_software_edge_trigger(self, trigger: 'enums.SendSoftwareEdgeTriggerType') -> None:
         r'''send_software_edge_trigger
 
         Asserts the specified trigger. This method can override an external
@@ -5151,7 +5151,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def wait_for_event(self, event_id, timeout=hightime.timedelta(seconds=10.0)):
+    def wait_for_event(self, event_id: 'enums.Event', timeout: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=10.0)) -> None:
         r'''wait_for_event
 
         Waits until the device has generated the specified event.
@@ -5207,7 +5207,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def _close(self):
+    def _close(self) -> None:
         r'''_close
 
         Closes the session specified in **vi** and deallocates the resources
@@ -5231,7 +5231,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def self_test(self):
+    def self_test(self) -> None:
         '''self_test
 
         Performs the device self-test routine and returns the test result(s).
@@ -5261,7 +5261,7 @@ class Session(_SessionBase):
         return None
 
     @ivi_synchronized
-    def reset(self):
+    def reset(self) -> None:
         r'''reset
 
         Resets the device to a known state. This method disables power
@@ -5277,7 +5277,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def _self_test(self):
+    def _self_test(self) -> typing.Tuple[int, str]:
         r'''_self_test
 
         Performs the device self-test routine and returns the test result(s).

--- a/generated/nidcpower/setup.py
+++ b/generated/nidcpower/setup.py
@@ -46,6 +46,7 @@ setup(
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
         'hightime>=0.2.0',
+        'typing',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -2,8 +2,10 @@
 # This file was generated
 import array  # noqa: F401
 import ctypes
+import datetime
 # Used by @ivi_synchronized
 from functools import wraps
+import typing
 
 import nidigital._attributes as _attributes
 import nidigital._converters as _converters
@@ -569,7 +571,7 @@ class _SessionBase(object):
     ''' These are code-generated '''
 
     @ivi_synchronized
-    def apply_levels_and_timing(self, levels_sheet, timing_sheet, initial_state_high_pins=None, initial_state_low_pins=None, initial_state_tristate_pins=None):
+    def apply_levels_and_timing(self, levels_sheet: str, timing_sheet: str, initial_state_high_pins: typing.Union[typing.Iterable[int], str] = None, initial_state_low_pins: typing.Union[typing.Iterable[int], str] = None, initial_state_tristate_pins: typing.Union[typing.Iterable[int], str] = None) -> None:
         r'''apply_levels_and_timing
 
         TBD
@@ -604,7 +606,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def apply_tdr_offsets(self, offsets):
+    def apply_tdr_offsets(self, offsets: typing.Iterable[typing.Union['hightime.timedelta', 'datetime.timedelta', float]]) -> None:
         r'''apply_tdr_offsets
 
         TBD
@@ -629,7 +631,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _burst_pattern(self, start_label, select_digital_function=True, wait_until_done=True, timeout=hightime.timedelta(seconds=10.0)):
+    def _burst_pattern(self, start_label: str, select_digital_function: 'bool' = True, wait_until_done: 'bool' = True, timeout: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=10.0)) -> None:
         r'''_burst_pattern
 
         TBD
@@ -661,7 +663,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def clock_generator_abort(self):
+    def clock_generator_abort(self) -> None:
         r'''clock_generator_abort
 
         TBD
@@ -679,7 +681,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def clock_generator_generate_clock(self, frequency, select_digital_function=True):
+    def clock_generator_generate_clock(self, frequency: float, select_digital_function: 'bool' = True) -> None:
         r'''clock_generator_generate_clock
 
         TBD
@@ -705,7 +707,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def configure_active_load_levels(self, iol, ioh, vcom):
+    def configure_active_load_levels(self, iol: float, ioh: float, vcom: float) -> None:
         r'''configure_active_load_levels
 
         TBD
@@ -734,7 +736,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def configure_pattern_burst_sites(self):
+    def configure_pattern_burst_sites(self) -> None:
         r'''configure_pattern_burst_sites
 
         TBD
@@ -752,7 +754,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def configure_time_set_compare_edges_strobe(self, time_set_name, strobe_edge):
+    def configure_time_set_compare_edges_strobe(self, time_set_name: str, strobe_edge: typing.Union['hightime.timedelta', 'datetime.timedelta', float]) -> None:
         r'''configure_time_set_compare_edges_strobe
 
         TBD
@@ -778,7 +780,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def configure_time_set_compare_edges_strobe2x(self, time_set_name, strobe_edge, strobe2_edge):
+    def configure_time_set_compare_edges_strobe2x(self, time_set_name: str, strobe_edge: typing.Union['hightime.timedelta', 'datetime.timedelta', float], strobe2_edge: typing.Union['hightime.timedelta', 'datetime.timedelta', float]) -> None:
         r'''configure_time_set_compare_edges_strobe2x
 
         TBD
@@ -807,7 +809,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def configure_time_set_drive_edges(self, time_set_name, format, drive_on_edge, drive_data_edge, drive_return_edge, drive_off_edge):
+    def configure_time_set_drive_edges(self, time_set_name: str, format: 'enums.DriveFormat', drive_on_edge: typing.Union['hightime.timedelta', 'datetime.timedelta', float], drive_data_edge: typing.Union['hightime.timedelta', 'datetime.timedelta', float], drive_return_edge: typing.Union['hightime.timedelta', 'datetime.timedelta', float], drive_off_edge: typing.Union['hightime.timedelta', 'datetime.timedelta', float]) -> None:
         r'''configure_time_set_drive_edges
 
         TBD
@@ -847,7 +849,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def configure_time_set_drive_edges2x(self, time_set_name, format, drive_on_edge, drive_data_edge, drive_return_edge, drive_off_edge, drive_data2_edge, drive_return2_edge):
+    def configure_time_set_drive_edges2x(self, time_set_name: str, format: 'enums.DriveFormat', drive_on_edge: typing.Union['hightime.timedelta', 'datetime.timedelta', float], drive_data_edge: typing.Union['hightime.timedelta', 'datetime.timedelta', float], drive_return_edge: typing.Union['hightime.timedelta', 'datetime.timedelta', float], drive_off_edge: typing.Union['hightime.timedelta', 'datetime.timedelta', float], drive_data2_edge: typing.Union['hightime.timedelta', 'datetime.timedelta', float], drive_return2_edge: typing.Union['hightime.timedelta', 'datetime.timedelta', float]) -> None:
         r'''configure_time_set_drive_edges2x
 
         TBD
@@ -893,7 +895,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def configure_time_set_drive_format(self, time_set_name, drive_format):
+    def configure_time_set_drive_format(self, time_set_name: str, drive_format: 'enums.DriveFormat') -> None:
         r'''configure_time_set_drive_format
 
         TBD
@@ -921,7 +923,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def configure_time_set_edge(self, time_set_name, edge, time):
+    def configure_time_set_edge(self, time_set_name: str, edge: 'enums.TimeSetEdgeType', time: typing.Union['hightime.timedelta', 'datetime.timedelta', float]) -> None:
         r'''configure_time_set_edge
 
         TBD
@@ -952,7 +954,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def configure_time_set_edge_multiplier(self, time_set_name, edge_multiplier):
+    def configure_time_set_edge_multiplier(self, time_set_name: str, edge_multiplier: int) -> None:
         r'''configure_time_set_edge_multiplier
 
         TBD
@@ -978,7 +980,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def configure_voltage_levels(self, vil, vih, vol, voh, vterm):
+    def configure_voltage_levels(self, vil: float, vih: float, vol: float, voh: float, vterm: float) -> None:
         r'''configure_voltage_levels
 
         TBD
@@ -1013,7 +1015,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def create_capture_waveform_parallel(self, waveform_name):
+    def create_capture_waveform_parallel(self, waveform_name: str) -> None:
         r'''create_capture_waveform_parallel
 
         TBD
@@ -1036,7 +1038,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def create_capture_waveform_serial(self, waveform_name, sample_width, bit_order):
+    def create_capture_waveform_serial(self, waveform_name: str, sample_width: int, bit_order: 'enums.BitOrder') -> None:
         r'''create_capture_waveform_serial
 
         TBD
@@ -1067,7 +1069,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def create_source_waveform_parallel(self, waveform_name, data_mapping):
+    def create_source_waveform_parallel(self, waveform_name: str, data_mapping: 'enums.SourceDataMapping') -> None:
         r'''create_source_waveform_parallel
 
         TBD
@@ -1095,7 +1097,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def create_source_waveform_serial(self, waveform_name, data_mapping, sample_width, bit_order):
+    def create_source_waveform_serial(self, waveform_name: str, data_mapping: 'enums.SourceDataMapping', sample_width: int, bit_order: 'enums.BitOrder') -> None:
         r'''create_source_waveform_serial
 
         TBD
@@ -1131,7 +1133,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def disable_sites(self):
+    def disable_sites(self) -> None:
         r'''disable_sites
 
         TBD
@@ -1149,7 +1151,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def enable_sites(self):
+    def enable_sites(self) -> None:
         r'''enable_sites
 
         TBD
@@ -1167,7 +1169,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def burst_pattern(self, start_label, select_digital_function=True, wait_until_done=True, timeout=hightime.timedelta(seconds=10.0)):
+    def burst_pattern(self, start_label: str, select_digital_function: 'bool' = True, wait_until_done: 'bool' = True, timeout: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=10.0)) -> typing.Optional[typing.Dict[int, bool]]:
         '''burst_pattern
 
         Uses the start_label you specify to burst the pattern on the sites you specify. If you
@@ -1205,7 +1207,7 @@ class _SessionBase(object):
             return None
 
     @ivi_synchronized
-    def fetch_capture_waveform(self, waveform_name, samples_to_read, timeout=hightime.timedelta(seconds=10.0)):
+    def fetch_capture_waveform(self, waveform_name: str, samples_to_read: int, timeout: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=10.0)) -> typing.Dict[int, memoryview]:
         '''fetch_capture_waveform
 
         Returns dictionary where each key is a site number and value is a collection of digital states representing capture waveform data
@@ -1271,7 +1273,7 @@ class _SessionBase(object):
         return data_array, actual_num_waveforms_ctype.value, actual_samples_per_waveform_ctype.value  # (modified)
 
     @ivi_synchronized
-    def fetch_history_ram_cycle_information(self, position, samples_to_read):
+    def fetch_history_ram_cycle_information(self, position: int, samples_to_read: int) -> typing.List[history_ram_cycle_information.HistoryRAMCycleInformation]:
         '''fetch_history_ram_cycle_information
 
         Returns the pattern information acquired for the specified cycles.
@@ -1437,7 +1439,7 @@ class _SessionBase(object):
         return cycle_infos
 
     @ivi_synchronized
-    def get_pin_results_pin_information(self):
+    def get_pin_results_pin_information(self) -> typing.List[typing.Any]:
         '''get_pin_results_pin_information
 
         Returns a list of named tuples (PinInfo) that <FILL IN THE BLANK HERE>
@@ -1462,8 +1464,7 @@ class _SessionBase(object):
                 - **channel_name** (str)
 
         '''
-        import collections
-        PinInfo = collections.namedtuple('PinInformation', ['pin_name', 'site_number', 'channel_name'])
+        pininfo = typing.NamedTuple('PinInformation', [('pin_name', 'str'), ('site_number', 'int'), ('channel_name', 'str')])
 
         pin_indexes, site_numbers, channel_indexes = self._get_pin_results_pin_information()
         assert len(pin_indexes) == len(site_numbers), "length of returned arrays don't match"
@@ -1474,12 +1475,12 @@ class _SessionBase(object):
             pin_name = "" if pin_indexes[i] == -1 else self._get_pin_name(pin_indexes[i])
             channel_names = self.get_channel_names(channel_indexes[i] - 1)  # channel_indexes are 1-based
             assert 1 == len(channel_names)
-            pin_infos.append(PinInfo(pin_name=pin_name, site_number=site_numbers[i], channel_name=channel_names[0]))
+            pin_infos.append(pininfo(pin_name=pin_name, site_number=site_numbers[i], channel_name=channel_names[0]))
 
         return pin_infos
 
     @ivi_synchronized
-    def get_site_pass_fail(self):
+    def get_site_pass_fail(self) -> typing.Dict[int, bool]:
         '''get_site_pass_fail
 
         Returns dictionary where each key is a site number and value is pass/fail
@@ -1502,7 +1503,7 @@ class _SessionBase(object):
         return dict(zip(site_list, result_list))
 
     @ivi_synchronized
-    def _fetch_history_ram_cycle_information(self, sample_index):
+    def _fetch_history_ram_cycle_information(self, sample_index: int) -> typing.Tuple[int, int, int, int, int]:
         r'''_fetch_history_ram_cycle_information
 
         TBD
@@ -1542,7 +1543,7 @@ class _SessionBase(object):
         return int(pattern_index_ctype.value), int(time_set_index_ctype.value), int(vector_number_ctype.value), int(cycle_number_ctype.value), int(num_dut_cycles_ctype.value)
 
     @ivi_synchronized
-    def _fetch_history_ram_cycle_pin_data(self, pin_list, sample_index, dut_cycle_index):
+    def _fetch_history_ram_cycle_pin_data(self, pin_list: str, sample_index: int, dut_cycle_index: int) -> typing.Tuple[typing.Iterable['enums.PinState'], typing.Iterable['enums.PinState'], typing.Iterable['bool']]:
         r'''_fetch_history_ram_cycle_pin_data
 
         TBD
@@ -1593,7 +1594,7 @@ class _SessionBase(object):
         return [enums.PinState(expected_pin_states_ctype[i]) for i in range(pin_data_buffer_size_ctype.value)], [enums.PinState(actual_pin_states_ctype[i]) for i in range(pin_data_buffer_size_ctype.value)], [bool(per_pin_pass_fail_ctype[i]) for i in range(pin_data_buffer_size_ctype.value)]
 
     @ivi_synchronized
-    def _fetch_history_ram_scan_cycle_number(self, sample_index):
+    def _fetch_history_ram_scan_cycle_number(self, sample_index: int) -> int:
         r'''_fetch_history_ram_scan_cycle_number
 
         TBD
@@ -1621,7 +1622,7 @@ class _SessionBase(object):
         return int(scan_cycle_number_ctype.value)
 
     @ivi_synchronized
-    def frequency_counter_measure_frequency(self):
+    def frequency_counter_measure_frequency(self) -> typing.Iterable[float]:
         r'''frequency_counter_measure_frequency
 
         TBD
@@ -1651,7 +1652,7 @@ class _SessionBase(object):
         return [float(frequencies_ctype[i]) for i in range(frequencies_buffer_size_ctype.value)]
 
     @ivi_synchronized
-    def _get_attribute_vi_boolean(self, attribute):
+    def _get_attribute_vi_boolean(self, attribute: int) -> 'bool':
         r'''_get_attribute_vi_boolean
 
         TBD
@@ -1679,7 +1680,7 @@ class _SessionBase(object):
         return bool(value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_int32(self, attribute):
+    def _get_attribute_vi_int32(self, attribute: int) -> int:
         r'''_get_attribute_vi_int32
 
         TBD
@@ -1707,7 +1708,7 @@ class _SessionBase(object):
         return int(value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_int64(self, attribute):
+    def _get_attribute_vi_int64(self, attribute: int) -> int:
         r'''_get_attribute_vi_int64
 
         TBD
@@ -1735,7 +1736,7 @@ class _SessionBase(object):
         return int(value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_real64(self, attribute):
+    def _get_attribute_vi_real64(self, attribute: int) -> float:
         r'''_get_attribute_vi_real64
 
         TBD
@@ -1763,7 +1764,7 @@ class _SessionBase(object):
         return float(value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_string(self, attribute):
+    def _get_attribute_vi_string(self, attribute: int) -> str:
         r'''_get_attribute_vi_string
 
         TBD
@@ -1796,7 +1797,7 @@ class _SessionBase(object):
         return value_ctype.value.decode(self._encoding)
 
     @ivi_synchronized
-    def get_channel_names(self, indices):
+    def get_channel_names(self, indices: typing.Union[typing.Iterable[int], str], int) -> str:
         r'''get_channel_names
 
         Returns a list of channel names for given channel indices.
@@ -1833,7 +1834,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return _converters.convert_comma_separated_string_to_list(names_ctype.value.decode(self._encoding))
 
-    def _get_error(self):
+    def _get_error(self) -> typing.Tuple[int, str]:
         r'''_get_error
 
         TBD
@@ -1857,7 +1858,7 @@ class _SessionBase(object):
         return int(error_code_ctype.value), error_description_ctype.value.decode(self._encoding)
 
     @ivi_synchronized
-    def get_fail_count(self):
+    def get_fail_count(self) -> typing.Iterable[int]:
         r'''get_fail_count
 
         TBD
@@ -1887,7 +1888,7 @@ class _SessionBase(object):
         return [int(failure_count_ctype[i]) for i in range(buffer_size_ctype.value)]
 
     @ivi_synchronized
-    def get_history_ram_sample_count(self):
+    def get_history_ram_sample_count(self) -> int:
         r'''get_history_ram_sample_count
 
         Returns the number of samples History RAM acquired on the last pattern burst.
@@ -1935,7 +1936,7 @@ class _SessionBase(object):
         return int(sample_count_ctype.value)
 
     @ivi_synchronized
-    def get_pattern_name(self, pattern_index):
+    def get_pattern_name(self, pattern_index: int) -> str:
         r'''get_pattern_name
 
         TBD
@@ -1961,7 +1962,7 @@ class _SessionBase(object):
         return name_ctype.value.decode(self._encoding)
 
     @ivi_synchronized
-    def _get_pin_name(self, pin_index):
+    def _get_pin_name(self, pin_index: int) -> str:
         r'''_get_pin_name
 
         TBD
@@ -1987,7 +1988,7 @@ class _SessionBase(object):
         return name_ctype.value.decode(self._encoding)
 
     @ivi_synchronized
-    def _get_pin_results_pin_information(self):
+    def _get_pin_results_pin_information(self) -> typing.Tuple[typing.Iterable[int], typing.Iterable[int], typing.Iterable[int]]:
         r'''_get_pin_results_pin_information
 
         TBD
@@ -2027,7 +2028,7 @@ class _SessionBase(object):
         return [int(pin_indexes_ctype[i]) for i in range(buffer_size_ctype.value)], [int(site_numbers_ctype[i]) for i in range(buffer_size_ctype.value)], [int(channel_indexes_ctype[i]) for i in range(buffer_size_ctype.value)]
 
     @ivi_synchronized
-    def _get_site_pass_fail(self):
+    def _get_site_pass_fail(self) -> typing.Iterable['bool']:
         r'''_get_site_pass_fail
 
         TBD
@@ -2057,7 +2058,7 @@ class _SessionBase(object):
         return [bool(pass_fail_ctype[i]) for i in range(pass_fail_buffer_size_ctype.value)]
 
     @ivi_synchronized
-    def _get_site_results_site_numbers(self, site_result_type):
+    def _get_site_results_site_numbers(self, site_result_type: 'enums.SiteResultType') -> typing.Iterable[int]:
         r'''_get_site_results_site_numbers
 
         TBD
@@ -2094,7 +2095,7 @@ class _SessionBase(object):
         return [int(site_numbers_ctype[i]) for i in range(site_numbers_buffer_size_ctype.value)]
 
     @ivi_synchronized
-    def get_time_set_drive_format(self, time_set_name):
+    def get_time_set_drive_format(self, time_set_name: str) -> 'enums.DriveFormat':
         r'''get_time_set_drive_format
 
         TBD
@@ -2122,7 +2123,7 @@ class _SessionBase(object):
         return enums.DriveFormat(format_ctype.value)
 
     @ivi_synchronized
-    def get_time_set_edge(self, time_set_name, edge):
+    def get_time_set_edge(self, time_set_name: str, edge: 'enums.TimeSetEdgeType') -> 'hightime.timedelta':
         r'''get_time_set_edge
 
         TBD
@@ -2155,7 +2156,7 @@ class _SessionBase(object):
         return _converters.convert_seconds_real64_to_timedelta(float(time_ctype.value))
 
     @ivi_synchronized
-    def get_time_set_edge_multiplier(self, time_set_name):
+    def get_time_set_edge_multiplier(self, time_set_name: str) -> int:
         r'''get_time_set_edge_multiplier
 
         TBD
@@ -2183,7 +2184,7 @@ class _SessionBase(object):
         return int(edge_multiplier_ctype.value)
 
     @ivi_synchronized
-    def get_time_set_name(self, time_set_index):
+    def get_time_set_name(self, time_set_index: int) -> str:
         r'''get_time_set_name
 
         TBD
@@ -2209,7 +2210,7 @@ class _SessionBase(object):
         return name_ctype.value.decode(self._encoding)
 
     @ivi_synchronized
-    def is_site_enabled(self):
+    def is_site_enabled(self) -> 'bool':
         r'''is_site_enabled
 
         TBD
@@ -2231,7 +2232,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return bool(enable_ctype.value)
 
-    def lock(self):
+    def lock(self) -> 'bool':
         '''lock
 
         Obtains a multithread lock on the device session. Before doing so, the
@@ -2266,7 +2267,7 @@ class _SessionBase(object):
         # that will handle the unlock for them
         return _Lock(self)
 
-    def _lock_session(self):
+    def _lock_session(self) -> None:
         '''_lock_session
 
         Actual call to driver
@@ -2277,7 +2278,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def ppmu_measure(self, measurement_type):
+    def ppmu_measure(self, measurement_type: 'enums.PPMUMeasurementType') -> typing.Iterable[float]:
         r'''ppmu_measure
 
         TBD
@@ -2314,7 +2315,7 @@ class _SessionBase(object):
         return [float(measurements_ctype[i]) for i in range(buffer_size_ctype.value)]
 
     @ivi_synchronized
-    def ppmu_source(self):
+    def ppmu_source(self) -> None:
         r'''ppmu_source
 
         TBD
@@ -2332,7 +2333,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def read_static(self):
+    def read_static(self) -> typing.Iterable['enums.PinState']:
         r'''read_static
 
         TBD
@@ -2362,7 +2363,7 @@ class _SessionBase(object):
         return [enums.PinState(data_ctype[i]) for i in range(buffer_size_ctype.value)]
 
     @ivi_synchronized
-    def _set_attribute_vi_boolean(self, attribute, value):
+    def _set_attribute_vi_boolean(self, attribute: int, value: 'bool') -> None:
         r'''_set_attribute_vi_boolean
 
         TBD
@@ -2388,7 +2389,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_int32(self, attribute, value):
+    def _set_attribute_vi_int32(self, attribute: int, value: int) -> None:
         r'''_set_attribute_vi_int32
 
         TBD
@@ -2414,7 +2415,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_int64(self, attribute, value):
+    def _set_attribute_vi_int64(self, attribute: int, value: int) -> None:
         r'''_set_attribute_vi_int64
 
         TBD
@@ -2440,7 +2441,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_real64(self, attribute, value):
+    def _set_attribute_vi_real64(self, attribute: int, value: float) -> None:
         r'''_set_attribute_vi_real64
 
         TBD
@@ -2466,7 +2467,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_string(self, attribute, value):
+    def _set_attribute_vi_string(self, attribute: int, value: str) -> None:
         r'''_set_attribute_vi_string
 
         TBD
@@ -2492,7 +2493,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def tdr(self, apply_offsets=True):
+    def tdr(self, apply_offsets: 'bool' = True) -> typing.Iterable['hightime.timedelta']:
         r'''tdr
 
         TBD
@@ -2526,7 +2527,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return _converters.convert_seconds_real64_to_timedeltas([float(offsets_ctype[i]) for i in range(offsets_buffer_size_ctype.value)])
 
-    def unlock(self):
+    def unlock(self) -> 'bool':
         '''unlock
 
         Releases a lock that you acquired on an device session using
@@ -2539,7 +2540,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _write_source_waveform_site_unique_u32(self, waveform_name, num_waveforms, samples_per_waveform, waveform_data):
+    def _write_source_waveform_site_unique_u32(self, waveform_name: str, num_waveforms: int, samples_per_waveform: int, waveform_data: typing.Iterable[int]) -> None:
         r'''_write_source_waveform_site_unique_u32
 
         TBD
@@ -2572,7 +2573,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def write_static(self, state):
+    def write_static(self, state: 'enums.WriteStaticPinState') -> None:
         r'''write_static
 
         TBD
@@ -2596,7 +2597,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def _error_message(self, error_code):
+    def _error_message(self, error_code: int) -> str:
         r'''_error_message
 
         TBD
@@ -2620,7 +2621,7 @@ class _SessionBase(object):
 class Session(_SessionBase):
     '''An NI-Digital Pattern Driver session'''
 
-    def __init__(self, resource_name, id_query=False, reset_device=False, options={}):
+    def __init__(self, resource_name: str, id_query: 'bool' = False, reset_device: 'bool' = False, options={}):
         r'''An NI-Digital Pattern Driver session
 
         TBD
@@ -2719,7 +2720,7 @@ class Session(_SessionBase):
     ''' These are code-generated '''
 
     @ivi_synchronized
-    def abort(self):
+    def abort(self) -> None:
         r'''abort
 
         TBD
@@ -2730,7 +2731,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def abort_keep_alive(self):
+    def abort_keep_alive(self) -> None:
         r'''abort_keep_alive
 
         TBD
@@ -2741,7 +2742,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def commit(self):
+    def commit(self) -> None:
         r'''commit
 
         TBD
@@ -2752,7 +2753,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_time_set_period(self, time_set_name, period):
+    def configure_time_set_period(self, time_set_name: str, period: typing.Union['hightime.timedelta', 'datetime.timedelta', float]) -> None:
         r'''configure_time_set_period
 
         TBD
@@ -2771,7 +2772,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def create_capture_waveform_from_file_digicapture(self, waveform_name, waveform_file_path):
+    def create_capture_waveform_from_file_digicapture(self, waveform_name: str, waveform_file_path: str) -> None:
         r'''create_capture_waveform_from_file_digicapture
 
         TBD
@@ -2790,7 +2791,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def create_source_waveform_from_file_tdms(self, waveform_name, waveform_file_path, write_waveform_data=True):
+    def create_source_waveform_from_file_tdms(self, waveform_name: str, waveform_file_path: str, write_waveform_data: 'bool' = True) -> None:
         r'''create_source_waveform_from_file_tdms
 
         TBD
@@ -2812,7 +2813,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def create_time_set(self, name):
+    def create_time_set(self, name: str) -> None:
         r'''create_time_set
 
         TBD
@@ -2828,7 +2829,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def delete_all_time_sets(self):
+    def delete_all_time_sets(self) -> None:
         r'''delete_all_time_sets
 
         TBD
@@ -2839,7 +2840,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def load_specifications_levels_and_timing(self, specifications_file_paths=None, levels_file_paths=None, timing_file_paths=None):
+    def load_specifications_levels_and_timing(self, specifications_file_paths: typing.Union[str, typing.Iterable[str]] = None, levels_file_paths: typing.Union[str, typing.Iterable[str]] = None, timing_file_paths: typing.Union[str, typing.Iterable[str]] = None) -> None:
         '''load_specifications_levels_and_timing
 
         Loads settings in specifications, levels, and timing sheets. These settings are not
@@ -2870,7 +2871,7 @@ class Session(_SessionBase):
             method(f)
 
     @ivi_synchronized
-    def self_test(self):
+    def self_test(self) -> None:
         '''self_test
 
         TBD
@@ -2881,7 +2882,7 @@ class Session(_SessionBase):
         return None
 
     @ivi_synchronized
-    def unload_specifications(self, file_paths):
+    def unload_specifications(self, file_paths: typing.Union[str, typing.Iterable[str]]) -> None:
         '''unload_specifications
 
         Unloads the given specifications sheets present in the previously loaded
@@ -2898,7 +2899,7 @@ class Session(_SessionBase):
         self._call_method_with_iterable(self._unload_specifications, file_paths)
 
     @ivi_synchronized
-    def write_source_waveform_site_unique(self, waveform_name, waveform_data):
+    def write_source_waveform_site_unique(self, waveform_name: str, waveform_data: typing.Dict[int, typing.Iterable[int]]) -> None:
         '''write_source_waveform_site_unique
 
         TBD
@@ -2954,7 +2955,7 @@ class Session(_SessionBase):
         self.sites[site_list]._write_source_waveform_site_unique_u32(waveform_name, len(waveform_data), actual_samples_per_waveform, data)
 
     @ivi_synchronized
-    def get_pattern_pin_names(self, start_label):
+    def get_pattern_pin_names(self, start_label: str) -> str:
         r'''get_pattern_pin_names
 
         TBD
@@ -2980,7 +2981,7 @@ class Session(_SessionBase):
         return _converters.convert_comma_separated_string_to_list(pin_list_ctype.value.decode(self._encoding))
 
     @ivi_synchronized
-    def get_time_set_period(self, time_set_name):
+    def get_time_set_period(self, time_set_name: str) -> 'hightime.timedelta':
         r'''get_time_set_period
 
         TBD
@@ -3000,7 +3001,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return _converters.convert_seconds_real64_to_timedelta(float(period_ctype.value))
 
-    def _init_with_options(self, resource_name, id_query=False, reset_device=False, option_string=""):
+    def _init_with_options(self, resource_name: str, id_query: 'bool' = False, reset_device: 'bool' = False, option_string: 'dict' = "") -> int:
         r'''_init_with_options
 
         TBD
@@ -3029,7 +3030,7 @@ class Session(_SessionBase):
         return int(new_vi_ctype.value)
 
     @ivi_synchronized
-    def _initiate(self):
+    def _initiate(self) -> None:
         r'''_initiate
 
         TBD
@@ -3040,7 +3041,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def is_done(self):
+    def is_done(self) -> 'bool':
         r'''is_done
 
         TBD
@@ -3056,7 +3057,7 @@ class Session(_SessionBase):
         return bool(done_ctype.value)
 
     @ivi_synchronized
-    def _load_levels(self, file_path):
+    def _load_levels(self, file_path: str) -> None:
         r'''_load_levels
 
         TBD
@@ -3072,7 +3073,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def load_pattern(self, file_path):
+    def load_pattern(self, file_path: str) -> None:
         r'''load_pattern
 
         TBD
@@ -3088,7 +3089,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def load_pin_map(self, file_path):
+    def load_pin_map(self, file_path: str) -> None:
         r'''load_pin_map
 
         TBD
@@ -3104,7 +3105,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def _load_specifications(self, file_path):
+    def _load_specifications(self, file_path: str) -> None:
         r'''_load_specifications
 
         TBD
@@ -3120,7 +3121,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def _load_timing(self, file_path):
+    def _load_timing(self, file_path: str) -> None:
         r'''_load_timing
 
         TBD
@@ -3136,7 +3137,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def read_sequencer_flag(self, flag):
+    def read_sequencer_flag(self, flag: 'enums.SequencerFlag') -> 'bool':
         r'''read_sequencer_flag
 
         TBD
@@ -3159,7 +3160,7 @@ class Session(_SessionBase):
         return bool(value_ctype.value)
 
     @ivi_synchronized
-    def read_sequencer_register(self, reg):
+    def read_sequencer_register(self, reg: 'enums.SequencerRegister') -> int:
         r'''read_sequencer_register
 
         TBD
@@ -3182,7 +3183,7 @@ class Session(_SessionBase):
         return int(value_ctype.value)
 
     @ivi_synchronized
-    def reset_device(self):
+    def reset_device(self) -> None:
         r'''reset_device
 
         TBD
@@ -3193,7 +3194,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def self_calibrate(self):
+    def self_calibrate(self) -> None:
         r'''self_calibrate
 
         TBD
@@ -3204,7 +3205,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def send_software_edge_trigger(self, trigger, trigger_identifier):
+    def send_software_edge_trigger(self, trigger: 'enums.SoftwareTrigger', trigger_identifier: str) -> None:
         r'''send_software_edge_trigger
 
         Forces a particular edge-based trigger to occur regardless of how the
@@ -3243,7 +3244,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def unload_all_patterns(self, unload_keep_alive_pattern=False):
+    def unload_all_patterns(self, unload_keep_alive_pattern: 'bool' = False) -> None:
         r'''unload_all_patterns
 
         TBD
@@ -3259,7 +3260,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def _unload_specifications(self, file_path):
+    def _unload_specifications(self, file_path: str) -> None:
         r'''_unload_specifications
 
         TBD
@@ -3275,7 +3276,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def wait_until_done(self, timeout=hightime.timedelta(seconds=10.0)):
+    def wait_until_done(self, timeout: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=10.0)) -> None:
         r'''wait_until_done
 
         TBD
@@ -3291,7 +3292,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def write_sequencer_flag(self, flag, value):
+    def write_sequencer_flag(self, flag: 'enums.SequencerFlag', value: 'bool') -> None:
         r'''write_sequencer_flag
 
         TBD
@@ -3312,7 +3313,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def write_sequencer_register(self, reg, value):
+    def write_sequencer_register(self, reg: 'enums.SequencerRegister', value: int) -> None:
         r'''write_sequencer_register
 
         TBD
@@ -3333,7 +3334,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def write_source_waveform_broadcast(self, waveform_name, waveform_data):
+    def write_source_waveform_broadcast(self, waveform_name: str, waveform_data: typing.Iterable[int]) -> None:
         r'''write_source_waveform_broadcast
 
         TBD
@@ -3353,7 +3354,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def write_source_waveform_data_from_file_tdms(self, waveform_name, waveform_file_path):
+    def write_source_waveform_data_from_file_tdms(self, waveform_name: str, waveform_file_path: str) -> None:
         r'''write_source_waveform_data_from_file_tdms
 
         TBD
@@ -3371,7 +3372,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def _close(self):
+    def _close(self) -> None:
         r'''_close
 
         TBD
@@ -3382,7 +3383,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def reset(self):
+    def reset(self) -> None:
         r'''reset
 
         TBD
@@ -3393,7 +3394,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def _self_test(self):
+    def _self_test(self) -> typing.Tuple[int, str]:
         r'''_self_test
 
         TBD

--- a/generated/nidigital/setup.py
+++ b/generated/nidigital/setup.py
@@ -47,6 +47,7 @@ setup(
         'singledispatch;python_version<"3.4"',
         'hightime>=0.2.0',
         'nitclk',
+        'typing',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/nidmm/nidmm/session.py
+++ b/generated/nidmm/nidmm/session.py
@@ -2,8 +2,10 @@
 # This file was generated
 import array  # noqa: F401
 import ctypes
+import datetime
 # Used by @ivi_synchronized
 from functools import wraps
+import typing
 
 import nidmm._attributes as _attributes
 import nidmm._converters as _converters
@@ -565,7 +567,7 @@ class _SessionBase(object):
     ''' These are code-generated '''
 
     @ivi_synchronized
-    def _get_attribute_vi_boolean(self, attribute_id):
+    def _get_attribute_vi_boolean(self, attribute_id: int) -> 'bool':
         r'''_get_attribute_vi_boolean
 
         Queries the value of a ViBoolean property. You can use this method to
@@ -603,7 +605,7 @@ class _SessionBase(object):
         return bool(attribute_value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_int32(self, attribute_id):
+    def _get_attribute_vi_int32(self, attribute_id: int) -> int:
         r'''_get_attribute_vi_int32
 
         Queries the value of a ViInt32 property. You can use this method to
@@ -641,7 +643,7 @@ class _SessionBase(object):
         return int(attribute_value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_real64(self, attribute_id):
+    def _get_attribute_vi_real64(self, attribute_id: int) -> float:
         r'''_get_attribute_vi_real64
 
         Queries the value of a ViReal64 property. You can use this method to
@@ -679,7 +681,7 @@ class _SessionBase(object):
         return float(attribute_value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_string(self, attribute_id):
+    def _get_attribute_vi_string(self, attribute_id: int) -> str:
         r'''_get_attribute_vi_string
 
         Queries the value of a ViString property. You can use this method to
@@ -728,7 +730,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return attribute_value_ctype.value.decode(self._encoding)
 
-    def _get_error(self):
+    def _get_error(self) -> typing.Tuple[int, str]:
         r'''_get_error
 
         Returns the error information associated with the
@@ -761,7 +763,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return int(error_code_ctype.value), description_ctype.value.decode(self._encoding)
 
-    def lock(self):
+    def lock(self) -> 'bool':
         '''lock
 
         Obtains a multithread lock on the device session. Before doing so, the
@@ -796,7 +798,7 @@ class _SessionBase(object):
         # that will handle the unlock for them
         return _Lock(self)
 
-    def _lock_session(self):
+    def _lock_session(self) -> None:
         '''_lock_session
 
         Actual call to driver
@@ -807,7 +809,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_boolean(self, attribute_id, attribute_value):
+    def _set_attribute_vi_boolean(self, attribute_id: int, attribute_value: 'bool') -> None:
         r'''_set_attribute_vi_boolean
 
         This method sets the value of a ViBoolean property.
@@ -857,7 +859,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_int32(self, attribute_id, attribute_value):
+    def _set_attribute_vi_int32(self, attribute_id: int, attribute_value: int) -> None:
         r'''_set_attribute_vi_int32
 
         This method sets the value of a ViInt32 property.
@@ -907,7 +909,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_real64(self, attribute_id, attribute_value):
+    def _set_attribute_vi_real64(self, attribute_id: int, attribute_value: float) -> None:
         r'''_set_attribute_vi_real64
 
         This method sets the value of a ViReal64 property.
@@ -957,7 +959,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_string(self, attribute_id, attribute_value):
+    def _set_attribute_vi_string(self, attribute_id: int, attribute_value: str) -> None:
         r'''_set_attribute_vi_string
 
         This method sets the value of a ViString property.
@@ -1006,7 +1008,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def unlock(self):
+    def unlock(self) -> 'bool':
         '''unlock
 
         Releases a lock that you acquired on an device session using
@@ -1018,7 +1020,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return
 
-    def _error_message(self, error_code):
+    def _error_message(self, error_code: int) -> str:
         r'''_error_message
 
         Takes the **Error_Code** returned by the instrument driver methods,
@@ -1044,7 +1046,7 @@ class _SessionBase(object):
 class Session(_SessionBase):
     '''An NI-DMM session to a National Instruments Digital Multimeter'''
 
-    def __init__(self, resource_name, id_query=False, reset_device=False, options={}):
+    def __init__(self, resource_name: str, id_query: 'bool' = False, reset_device: 'bool' = False, options={}):
         r'''An NI-DMM session to a National Instruments Digital Multimeter
 
         This method completes the following tasks:
@@ -1200,7 +1202,7 @@ class Session(_SessionBase):
     ''' These are code-generated '''
 
     @ivi_synchronized
-    def abort(self):
+    def abort(self) -> None:
         r'''abort
 
         Aborts a previously initiated measurement and returns the DMM to the
@@ -1212,7 +1214,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_measurement_absolute(self, measurement_function, range, resolution_absolute):
+    def configure_measurement_absolute(self, measurement_function: 'enums.Function', range: float, resolution_absolute: float) -> None:
         r'''configure_measurement_absolute
 
         Configures the common properties of the measurement. These properties
@@ -1279,7 +1281,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_measurement_digits(self, measurement_function, range, resolution_digits):
+    def configure_measurement_digits(self, measurement_function: 'enums.Function', range: float, resolution_digits: float) -> None:
         r'''configure_measurement_digits
 
         Configures the common properties of the measurement. These properties
@@ -1347,7 +1349,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_multi_point(self, trigger_count, sample_count, sample_trigger=enums.SampleTrigger.IMMEDIATE, sample_interval=hightime.timedelta(seconds=-1)):
+    def configure_multi_point(self, trigger_count: int, sample_count: int, sample_trigger: 'enums.SampleTrigger' = enums.SampleTrigger.IMMEDIATE, sample_interval: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=-1)) -> None:
         r'''configure_multi_point
 
         Configures the properties for multipoint measurements. These properties
@@ -1407,7 +1409,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_rtd_custom(self, rtd_a, rtd_b, rtd_c):
+    def configure_rtd_custom(self, rtd_a: float, rtd_b: float, rtd_c: float) -> None:
         r'''configure_rtd_custom
 
         Configures the A, B, and C parameters for a custom RTD.
@@ -1435,7 +1437,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_rtd_type(self, rtd_type, rtd_resistance):
+    def configure_rtd_type(self, rtd_type: 'enums.RTDType', rtd_resistance: float) -> None:
         r'''configure_rtd_type
 
         Configures the RTD Type and RTD Resistance parameters for an RTD.
@@ -1479,7 +1481,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_thermistor_custom(self, thermistor_a, thermistor_b, thermistor_c):
+    def configure_thermistor_custom(self, thermistor_a: float, thermistor_b: float, thermistor_c: float) -> None:
         r'''configure_thermistor_custom
 
         Configures the A, B, and C parameters for a custom thermistor.
@@ -1516,7 +1518,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_thermocouple(self, thermocouple_type, reference_junction_type=enums.ThermocoupleReferenceJunctionType.FIXED):
+    def configure_thermocouple(self, thermocouple_type: 'enums.ThermocoupleType', reference_junction_type: 'enums.ThermocoupleReferenceJunctionType' = enums.ThermocoupleReferenceJunctionType.FIXED) -> None:
         r'''configure_thermocouple
 
         Configures the thermocouple type and reference junction type for a
@@ -1566,7 +1568,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_trigger(self, trigger_source, trigger_delay=hightime.timedelta(seconds=-1)):
+    def configure_trigger(self, trigger_source: 'enums.TriggerSource', trigger_delay: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=-1)) -> None:
         r'''configure_trigger
 
         Configures the DMM **Trigger_Source** and **Trigger_Delay**. Refer to
@@ -1612,7 +1614,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_waveform_acquisition(self, measurement_function, range, rate, waveform_points):
+    def configure_waveform_acquisition(self, measurement_function: 'enums.Function', range: float, rate: float, waveform_points: int) -> None:
         r'''configure_waveform_acquisition
 
         Configures the DMM for waveform acquisitions. This feature is supported
@@ -1668,7 +1670,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def disable(self):
+    def disable(self) -> None:
         r'''disable
 
         Places the instrument in a quiescent state where it has minimal or no
@@ -1681,7 +1683,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def export_attribute_configuration_buffer(self):
+    def export_attribute_configuration_buffer(self) -> typing.Iterable['bytes']:
         r'''export_attribute_configuration_buffer
 
         Exports the property configuration of the session to the specified
@@ -1739,7 +1741,7 @@ class Session(_SessionBase):
         return _converters.convert_to_bytes(configuration_array)
 
     @ivi_synchronized
-    def export_attribute_configuration_file(self, file_path):
+    def export_attribute_configuration_file(self, file_path: str) -> None:
         r'''export_attribute_configuration_file
 
         Exports the property configuration of the session to the specified
@@ -1792,7 +1794,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def fetch(self, maximum_time=hightime.timedelta(milliseconds=-1)):
+    def fetch(self, maximum_time: typing.Union['hightime.timedelta', 'datetime.timedelta', int] = hightime.timedelta(milliseconds=-1)) -> float:
         r'''fetch
 
         Returns the value from a previously initiated measurement. You must call
@@ -1826,7 +1828,7 @@ class Session(_SessionBase):
         return float(reading_ctype.value)
 
     @ivi_synchronized
-    def fetch_multi_point(self, array_size, maximum_time=hightime.timedelta(milliseconds=-1)):
+    def fetch_multi_point(self, array_size: int, maximum_time: typing.Union['hightime.timedelta', 'datetime.timedelta', int] = hightime.timedelta(milliseconds=-1)) -> typing.Iterable[float]:
         r'''fetch_multi_point
 
         Returns an array of values from a previously initiated multipoint
@@ -1881,7 +1883,7 @@ class Session(_SessionBase):
         return reading_array_array
 
     @ivi_synchronized
-    def fetch_waveform(self, array_size, maximum_time=hightime.timedelta(milliseconds=-1)):
+    def fetch_waveform(self, array_size: int, maximum_time: typing.Union['hightime.timedelta', 'datetime.timedelta', int] = hightime.timedelta(milliseconds=-1)) -> typing.Iterable[float]:
         r'''fetch_waveform
 
         For the NI 4080/4081/4082 and the NI 4070/4071/4072, returns an array of
@@ -1928,7 +1930,7 @@ class Session(_SessionBase):
         return waveform_array_array
 
     @ivi_synchronized
-    def fetch_waveform_into(self, waveform_array, maximum_time=hightime.timedelta(milliseconds=-1)):
+    def fetch_waveform_into(self, waveform_array: typing.Iterable[float], maximum_time: typing.Union['hightime.timedelta', 'datetime.timedelta', int] = hightime.timedelta(milliseconds=-1)) -> None:
         r'''fetch_waveform
 
         For the NI 4080/4081/4082 and the NI 4070/4071/4072, returns an array of
@@ -1981,7 +1983,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def _get_cal_date_and_time(self, cal_type):
+    def _get_cal_date_and_time(self, cal_type: int) -> typing.Tuple[int, int, int, int, int]:
         r'''_get_cal_date_and_time
 
         Returns the date and time of the last calibration performed.
@@ -2028,7 +2030,7 @@ class Session(_SessionBase):
         return int(month_ctype.value), int(day_ctype.value), int(year_ctype.value), int(hour_ctype.value), int(minute_ctype.value)
 
     @ivi_synchronized
-    def get_dev_temp(self, options=""):
+    def get_dev_temp(self, options: str = "") -> float:
         r'''get_dev_temp
 
         Returns the current **Temperature** of the device.
@@ -2051,7 +2053,7 @@ class Session(_SessionBase):
         return float(temperature_ctype.value)
 
     @ivi_synchronized
-    def get_ext_cal_recommended_interval(self):
+    def get_ext_cal_recommended_interval(self) -> 'hightime.timedelta':
         r'''get_ext_cal_recommended_interval
 
         Returns the recommended interval between external recalibration in
@@ -2071,7 +2073,7 @@ class Session(_SessionBase):
         return _converters.convert_month_to_timedelta(int(months_ctype.value))
 
     @ivi_synchronized
-    def get_cal_date_and_time(self, cal_type):
+    def get_cal_date_and_time(self, cal_type: int) -> 'hightime.datetime':
         '''get_cal_date_and_time
 
         Returns the date and time of the last calibration performed.
@@ -2101,7 +2103,7 @@ class Session(_SessionBase):
         return hightime.datetime(year, month, day, hour, minute)
 
     @ivi_synchronized
-    def get_last_cal_temp(self, cal_type):
+    def get_last_cal_temp(self, cal_type: int) -> float:
         r'''get_last_cal_temp
 
         Returns the **Temperature** during the last calibration procedure.
@@ -2136,7 +2138,7 @@ class Session(_SessionBase):
         return float(temperature_ctype.value)
 
     @ivi_synchronized
-    def get_self_cal_supported(self):
+    def get_self_cal_supported(self) -> 'bool':
         r'''get_self_cal_supported
 
         Returns a Boolean value that expresses whether or not the DMM that you
@@ -2160,7 +2162,7 @@ class Session(_SessionBase):
         return bool(self_cal_supported_ctype.value)
 
     @ivi_synchronized
-    def import_attribute_configuration_buffer(self, configuration):
+    def import_attribute_configuration_buffer(self, configuration: typing.Iterable['bytes']) -> None:
         r'''import_attribute_configuration_buffer
 
         Imports a property configuration to the session from the specified
@@ -2209,7 +2211,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def import_attribute_configuration_file(self, file_path):
+    def import_attribute_configuration_file(self, file_path: str) -> None:
         r'''import_attribute_configuration_file
 
         Imports a property configuration to the session from the specified
@@ -2257,7 +2259,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def _init_with_options(self, resource_name, id_query=False, reset_device=False, option_string=""):
+    def _init_with_options(self, resource_name: str, id_query: 'bool' = False, reset_device: 'bool' = False, option_string: 'dict' = "") -> int:
         r'''_init_with_options
 
         This method completes the following tasks:
@@ -2374,7 +2376,7 @@ class Session(_SessionBase):
         return int(vi_ctype.value)
 
     @ivi_synchronized
-    def _initiate(self):
+    def _initiate(self) -> None:
         r'''_initiate
 
         Initiates an acquisition. After you call this method, the DMM leaves
@@ -2389,7 +2391,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def perform_open_cable_comp(self):
+    def perform_open_cable_comp(self) -> typing.Tuple[float, float]:
         r'''perform_open_cable_comp
 
         For the NI 4082 and NI 4072 only, performs the open cable compensation
@@ -2421,7 +2423,7 @@ class Session(_SessionBase):
         return float(conductance_ctype.value), float(susceptance_ctype.value)
 
     @ivi_synchronized
-    def perform_short_cable_comp(self):
+    def perform_short_cable_comp(self) -> typing.Tuple[float, float]:
         r'''perform_short_cable_comp
 
         Performs the short cable compensation measurements for the current
@@ -2452,7 +2454,7 @@ class Session(_SessionBase):
         return float(resistance_ctype.value), float(reactance_ctype.value)
 
     @ivi_synchronized
-    def read(self, maximum_time=hightime.timedelta(milliseconds=-1)):
+    def read(self, maximum_time: typing.Union['hightime.timedelta', 'datetime.timedelta', int] = hightime.timedelta(milliseconds=-1)) -> float:
         r'''read
 
         Acquires a single measurement and returns the measured value.
@@ -2485,7 +2487,7 @@ class Session(_SessionBase):
         return float(reading_ctype.value)
 
     @ivi_synchronized
-    def read_multi_point(self, array_size, maximum_time=hightime.timedelta(milliseconds=-1)):
+    def read_multi_point(self, array_size: int, maximum_time: typing.Union['hightime.timedelta', 'datetime.timedelta', int] = hightime.timedelta(milliseconds=-1)) -> typing.Iterable[float]:
         r'''read_multi_point
 
         Acquires multiple measurements and returns an array of measured values.
@@ -2539,7 +2541,7 @@ class Session(_SessionBase):
         return reading_array_array
 
     @ivi_synchronized
-    def read_status(self):
+    def read_status(self) -> typing.Tuple[int, 'enums.AcquisitionStatus']:
         r'''read_status
 
         Returns measurement backlog and acquisition status. Use this method to
@@ -2584,7 +2586,7 @@ class Session(_SessionBase):
         return int(acquisition_backlog_ctype.value), enums.AcquisitionStatus(acquisition_status_ctype.value)
 
     @ivi_synchronized
-    def read_waveform(self, array_size, maximum_time=hightime.timedelta(milliseconds=-1)):
+    def read_waveform(self, array_size: int, maximum_time: typing.Union['hightime.timedelta', 'datetime.timedelta', int] = hightime.timedelta(milliseconds=-1)) -> typing.Iterable[float]:
         r'''read_waveform
 
         For the NI 4080/4081/4082 and the NI 4070/4071/4072, acquires a waveform
@@ -2636,7 +2638,7 @@ class Session(_SessionBase):
         return waveform_array_array
 
     @ivi_synchronized
-    def reset_with_defaults(self):
+    def reset_with_defaults(self) -> None:
         r'''reset_with_defaults
 
         Resets the instrument to a known state and sends initialization commands
@@ -2650,7 +2652,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def self_cal(self):
+    def self_cal(self) -> None:
         r'''self_cal
 
         For the NI 4080/4081/4082 and the NI 4070/4071/4072, executes the
@@ -2667,7 +2669,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def send_software_trigger(self):
+    def send_software_trigger(self) -> None:
         r'''send_software_trigger
 
         Sends a command to trigger the DMM. Call this method if you have
@@ -2686,7 +2688,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def _close(self):
+    def _close(self) -> None:
         r'''_close
 
         Closes the specified session and deallocates resources that it reserved.
@@ -2697,7 +2699,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def self_test(self):
+    def self_test(self) -> None:
         '''self_test
 
         Performs a self-test on the DMM to ensure that the DMM is functioning
@@ -2722,7 +2724,7 @@ class Session(_SessionBase):
         return None
 
     @ivi_synchronized
-    def reset(self):
+    def reset(self) -> None:
         r'''reset
 
         Resets the instrument to a known state and sends initialization commands
@@ -2735,7 +2737,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def _self_test(self):
+    def _self_test(self) -> typing.Tuple[int, str]:
         r'''_self_test
 
         Performs a self-test on the DMM to ensure that the DMM is functioning

--- a/generated/nidmm/setup.py
+++ b/generated/nidmm/setup.py
@@ -46,6 +46,7 @@ setup(
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
         'hightime>=0.2.0',
+        'typing',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/nifake/nifake/session.py
+++ b/generated/nifake/nifake/session.py
@@ -2,8 +2,10 @@
 # This file was generated
 import array  # noqa: F401
 import ctypes
+import datetime
 # Used by @ivi_synchronized
 from functools import wraps
+import typing
 
 import nifake._attributes as _attributes
 import nifake._converters as _converters
@@ -246,7 +248,7 @@ class _SessionBase(object):
     ''' These are code-generated '''
 
     @ivi_synchronized
-    def _get_attribute_vi_boolean(self, attribute_id):
+    def _get_attribute_vi_boolean(self, attribute_id: int) -> 'bool':
         r'''_get_attribute_vi_boolean
 
         Queries the value of a ViBoolean property.
@@ -274,7 +276,7 @@ class _SessionBase(object):
         return bool(attribute_value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_int32(self, attribute_id):
+    def _get_attribute_vi_int32(self, attribute_id: int) -> int:
         r'''_get_attribute_vi_int32
 
         Queries the value of a ViInt32 property.
@@ -302,7 +304,7 @@ class _SessionBase(object):
         return int(attribute_value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_int64(self, attribute_id):
+    def _get_attribute_vi_int64(self, attribute_id: int) -> int:
         r'''_get_attribute_vi_int64
 
         Queries the value of a ViInt64 property.
@@ -330,7 +332,7 @@ class _SessionBase(object):
         return int(attribute_value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_real64(self, attribute_id):
+    def _get_attribute_vi_real64(self, attribute_id: int) -> float:
         r'''_get_attribute_vi_real64
 
         Queries the value of a ViReal property.
@@ -358,7 +360,7 @@ class _SessionBase(object):
         return float(attribute_value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_string(self, attribute_id):
+    def _get_attribute_vi_string(self, attribute_id: int) -> str:
         r'''_get_attribute_vi_string
 
         Queries the value of a ViBoolean property.
@@ -390,7 +392,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return attribute_value_ctype.value.decode(self._encoding)
 
-    def _get_error(self):
+    def _get_error(self) -> typing.Tuple[int, str]:
         r'''_get_error
 
         Returns the error information associated with the session.
@@ -413,7 +415,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return int(error_code_ctype.value), description_ctype.value.decode(self._encoding)
 
-    def lock(self):
+    def lock(self) -> 'bool':
         '''lock
 
         Obtains a multithread lock on the device session. Before doing so, the
@@ -448,7 +450,7 @@ class _SessionBase(object):
         # that will handle the unlock for them
         return _Lock(self)
 
-    def _lock_session(self):
+    def _lock_session(self) -> None:
         '''_lock_session
 
         Actual call to driver
@@ -459,7 +461,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def read_from_channel(self, maximum_time):
+    def read_from_channel(self, maximum_time: 'hightime.timedelta') -> float:
         r'''read_from_channel
 
         Acquires a single measurement and returns the measured value.
@@ -487,7 +489,7 @@ class _SessionBase(object):
         return float(reading_ctype.value)
 
     @ivi_synchronized
-    def _set_attribute_vi_boolean(self, attribute_id, attribute_value):
+    def _set_attribute_vi_boolean(self, attribute_id: int, attribute_value: 'bool') -> None:
         r'''_set_attribute_vi_boolean
 
         This method sets the value of a ViBoolean property.
@@ -513,7 +515,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_int32(self, attribute_id, attribute_value):
+    def _set_attribute_vi_int32(self, attribute_id: int, attribute_value: int) -> None:
         r'''_set_attribute_vi_int32
 
         This method sets the value of a ViInt32 property.
@@ -539,7 +541,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_int64(self, attribute_id, attribute_value):
+    def _set_attribute_vi_int64(self, attribute_id: int, attribute_value: int) -> None:
         r'''_set_attribute_vi_int64
 
         This method sets the value of a ViInt64 property.
@@ -565,7 +567,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_real64(self, attribute_id, attribute_value):
+    def _set_attribute_vi_real64(self, attribute_id: int, attribute_value: float) -> None:
         r'''_set_attribute_vi_real64
 
         This method sets the value of a ViReal64 property.
@@ -591,7 +593,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_string(self, attribute_id, attribute_value):
+    def _set_attribute_vi_string(self, attribute_id: int, attribute_value: str) -> None:
         r'''_set_attribute_vi_string
 
         This method sets the value of a ViString property.
@@ -616,7 +618,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def unlock(self):
+    def unlock(self) -> 'bool':
         '''unlock
 
         Releases a lock that you acquired on an device session using
@@ -628,7 +630,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return
 
-    def _error_message(self, error_code):
+    def _error_message(self, error_code: int) -> str:
         r'''_error_message
 
         Takes the errorCode returned by a functiona and returns it as a user-readable string.
@@ -652,7 +654,7 @@ class _SessionBase(object):
 class Session(_SessionBase):
     '''An NI-FAKE session to a fake MI driver whose sole purpose is to test nimi-python code generation'''
 
-    def __init__(self, resource_name, options={}, id_query=False, reset_device=False):
+    def __init__(self, resource_name: str, options={}, id_query: 'bool' = False, reset_device: 'bool' = False):
         r'''An NI-FAKE session to a fake MI driver whose sole purpose is to test nimi-python code generation
 
         Creates a new IVI instrument driver session.
@@ -765,7 +767,7 @@ class Session(_SessionBase):
     ''' These are code-generated '''
 
     @ivi_synchronized
-    def abort(self):
+    def abort(self) -> None:
         r'''abort
 
         Aborts a previously initiated thingie.
@@ -776,7 +778,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def accept_list_of_durations_in_seconds(self, delays):
+    def accept_list_of_durations_in_seconds(self, delays: typing.Union[typing.Iterable['hightime.timedelta'], typing.Iterable['datetime.timedelta'], typing.Iterable[float]]) -> None:
         r'''accept_list_of_durations_in_seconds
 
         Accepts list of floats or hightime.timedelta instances representing time delays.
@@ -794,7 +796,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def bool_array_output_function(self, number_of_elements):
+    def bool_array_output_function(self, number_of_elements: int) -> typing.Iterable['bool']:
         r'''bool_array_output_function
 
         This method returns an array of booleans.
@@ -816,7 +818,7 @@ class Session(_SessionBase):
         return [bool(an_array_ctype[i]) for i in range(number_of_elements_ctype.value)]
 
     @ivi_synchronized
-    def double_all_the_nums(self, numbers):
+    def double_all_the_nums(self, numbers: typing.Iterable[float]) -> None:
         r'''double_all_the_nums
 
         Test for buffer with converter
@@ -834,7 +836,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def enum_array_output_function(self, number_of_elements):
+    def enum_array_output_function(self, number_of_elements: int) -> typing.Iterable['enums.Turtle']:
         r'''enum_array_output_function
 
         This method returns an array of enums, stored as 16 bit integers under the hood.
@@ -856,7 +858,7 @@ class Session(_SessionBase):
         return [enums.Turtle(an_array_ctype[i]) for i in range(number_of_elements_ctype.value)]
 
     @ivi_synchronized
-    def enum_input_function_with_defaults(self, a_turtle=enums.Turtle.LEONARDO):
+    def enum_input_function_with_defaults(self, a_turtle: 'enums.Turtle' = enums.Turtle.LEONARDO) -> None:
         r'''enum_input_function_with_defaults
 
         This method takes one parameter other than the session, which happens to be an enum and has a default value.
@@ -884,7 +886,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def export_attribute_configuration_buffer(self):
+    def export_attribute_configuration_buffer(self) -> typing.Iterable['bytes']:
         r'''export_attribute_configuration_buffer
 
         Export configuration buffer.
@@ -907,7 +909,7 @@ class Session(_SessionBase):
         return _converters.convert_to_bytes(configuration_array)
 
     @ivi_synchronized
-    def fetch_waveform(self, number_of_samples):
+    def fetch_waveform(self, number_of_samples: int) -> typing.Iterable[float]:
         r'''fetch_waveform
 
         Returns waveform data.
@@ -933,7 +935,7 @@ class Session(_SessionBase):
         return waveform_data_array
 
     @ivi_synchronized
-    def fetch_waveform_into(self, waveform_data):
+    def fetch_waveform_into(self, waveform_data: typing.Iterable[float]) -> None:
         r'''fetch_waveform
 
         Returns waveform data.
@@ -967,7 +969,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def get_a_boolean(self):
+    def get_a_boolean(self) -> 'bool':
         r'''get_a_boolean
 
         Returns a boolean.
@@ -985,7 +987,7 @@ class Session(_SessionBase):
         return bool(a_boolean_ctype.value)
 
     @ivi_synchronized
-    def get_a_number(self):
+    def get_a_number(self) -> int:
         r'''get_a_number
 
         Returns a number.
@@ -1003,7 +1005,7 @@ class Session(_SessionBase):
         return int(a_number_ctype.value)
 
     @ivi_synchronized
-    def get_a_string_of_fixed_maximum_size(self):
+    def get_a_string_of_fixed_maximum_size(self) -> str:
         r'''get_a_string_of_fixed_maximum_size
 
         Illustrates returning a string of fixed size.
@@ -1019,7 +1021,7 @@ class Session(_SessionBase):
         return a_string_ctype.value.decode(self._encoding)
 
     @ivi_synchronized
-    def get_a_string_using_python_code(self, a_number):
+    def get_a_string_using_python_code(self, a_number: int) -> str:
         r'''get_a_string_using_python_code
 
         Returns a number and a string.
@@ -1042,7 +1044,7 @@ class Session(_SessionBase):
         return a_string_ctype.value.decode(self._encoding)
 
     @ivi_synchronized
-    def get_an_ivi_dance_string(self):
+    def get_an_ivi_dance_string(self) -> str:
         r'''get_an_ivi_dance_string
 
         Returns a string using the IVI dance.
@@ -1063,7 +1065,7 @@ class Session(_SessionBase):
         return a_string_ctype.value.decode(self._encoding)
 
     @ivi_synchronized
-    def get_an_ivi_dance_with_a_twist_string(self):
+    def get_an_ivi_dance_with_a_twist_string(self) -> str:
         r'''get_an_ivi_dance_with_a_twist_string
 
         TBD
@@ -1085,7 +1087,7 @@ class Session(_SessionBase):
         return a_string_ctype.value.decode(self._encoding)
 
     @ivi_synchronized
-    def get_array_for_python_code_custom_type(self):
+    def get_array_for_python_code_custom_type(self) -> typing.Iterable['custom_struct.CustomStruct']:
         r'''get_array_for_python_code_custom_type
 
         This method returns an array for use in python-code size mechanism.
@@ -1103,7 +1105,7 @@ class Session(_SessionBase):
         return [custom_struct.CustomStruct(array_out_ctype[i]) for i in range(self.get_array_size_for_python_code())]
 
     @ivi_synchronized
-    def get_array_for_python_code_double(self):
+    def get_array_for_python_code_double(self) -> typing.Iterable[float]:
         r'''get_array_for_python_code_double
 
         This method returns an array for use in python-code size mechanism.
@@ -1121,7 +1123,7 @@ class Session(_SessionBase):
         return [float(array_out_ctype[i]) for i in range(self.get_array_size_for_python_code())]
 
     @ivi_synchronized
-    def get_array_size_for_python_code(self):
+    def get_array_size_for_python_code(self) -> int:
         r'''get_array_size_for_python_code
 
         This method returns the size of the array for use in python-code size mechanism.
@@ -1137,7 +1139,7 @@ class Session(_SessionBase):
         return int(size_out_ctype.value)
 
     @ivi_synchronized
-    def get_array_using_ivi_dance(self):
+    def get_array_using_ivi_dance(self) -> typing.Iterable[float]:
         r'''get_array_using_ivi_dance
 
         This method returns an array of float whose size is determined with the IVI dance.
@@ -1159,7 +1161,7 @@ class Session(_SessionBase):
         return [float(array_out_ctype[i]) for i in range(array_size_ctype.value)]
 
     @ivi_synchronized
-    def _get_cal_date_and_time(self, cal_type):
+    def _get_cal_date_and_time(self, cal_type: int) -> typing.Tuple[int, int, int, int, int]:
         r'''_get_cal_date_and_time
 
         Returns the date and time of the last calibration performed.
@@ -1192,7 +1194,7 @@ class Session(_SessionBase):
         return int(month_ctype.value), int(day_ctype.value), int(year_ctype.value), int(hour_ctype.value), int(minute_ctype.value)
 
     @ivi_synchronized
-    def get_cal_interval(self):
+    def get_cal_interval(self) -> 'hightime.timedelta':
         r'''get_cal_interval
 
         Returns the recommended maximum interval, in **months**, between external calibrations.
@@ -1208,7 +1210,7 @@ class Session(_SessionBase):
         return _converters.convert_month_to_timedelta(int(months_ctype.value))
 
     @ivi_synchronized
-    def get_custom_type(self):
+    def get_custom_type(self) -> 'custom_struct.CustomStruct':
         r'''get_custom_type
 
         This method returns a custom type.
@@ -1224,7 +1226,7 @@ class Session(_SessionBase):
         return custom_struct.CustomStruct(cs_ctype)
 
     @ivi_synchronized
-    def get_custom_type_array(self, number_of_elements):
+    def get_custom_type_array(self, number_of_elements: int) -> typing.Iterable['custom_struct.CustomStruct']:
         r'''get_custom_type_array
 
         This method returns a custom type.
@@ -1246,7 +1248,7 @@ class Session(_SessionBase):
         return [custom_struct.CustomStruct(cs_ctype[i]) for i in range(number_of_elements_ctype.value)]
 
     @ivi_synchronized
-    def get_enum_value(self):
+    def get_enum_value(self) -> typing.Tuple[int, 'enums.Turtle']:
         r'''get_enum_value
 
         Returns an enum value
@@ -1279,7 +1281,7 @@ class Session(_SessionBase):
         return int(a_quantity_ctype.value), enums.Turtle(a_turtle_ctype.value)
 
     @ivi_synchronized
-    def get_cal_date_and_time(self, cal_type):
+    def get_cal_date_and_time(self, cal_type: int) -> 'hightime.datetime':
         '''get_cal_date_and_time
 
         Returns the date and time of the last calibration performed.
@@ -1296,7 +1298,7 @@ class Session(_SessionBase):
         return hightime.datetime(year, month, day, hour, minute)
 
     @ivi_synchronized
-    def import_attribute_configuration_buffer(self, configuration):
+    def import_attribute_configuration_buffer(self, configuration: typing.Iterable['bytes']) -> None:
         r'''import_attribute_configuration_buffer
 
         Import configuration buffer.
@@ -1313,7 +1315,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def _init_with_options(self, resource_name, option_string, id_query=False, reset_device=False):
+    def _init_with_options(self, resource_name: str, option_string: 'dict', id_query: 'bool' = False, reset_device: 'bool' = False) -> int:
         r'''_init_with_options
 
         Creates a new IVI instrument driver session.
@@ -1356,7 +1358,7 @@ class Session(_SessionBase):
         return int(vi_ctype.value)
 
     @ivi_synchronized
-    def _initiate(self):
+    def _initiate(self) -> None:
         r'''_initiate
 
         Initiates a thingie.
@@ -1367,7 +1369,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def multiple_array_types(self, output_array_size, input_array_of_floats, input_array_of_integers=None):
+    def multiple_array_types(self, output_array_size: int, input_array_of_floats: typing.Iterable[float], input_array_of_integers: typing.Iterable[int] = None) -> typing.Tuple[typing.Iterable[float], typing.Iterable[float]]:
         r'''multiple_array_types
 
         Receives and returns multiple types of arrays.
@@ -1404,7 +1406,7 @@ class Session(_SessionBase):
         return [float(output_array_ctype[i]) for i in range(output_array_size_ctype.value)], [float(output_array_of_fixed_length_ctype[i]) for i in range(3)]
 
     @ivi_synchronized
-    def multiple_arrays_same_size(self, values1, values2, values3, values4):
+    def multiple_arrays_same_size(self, values1: typing.Iterable[float], values2: typing.Iterable[float], values3: typing.Iterable[float], values4: typing.Iterable[float]) -> None:
         r'''multiple_arrays_same_size
 
         Method to test multiple arrays that use the same size
@@ -1436,7 +1438,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def one_input_function(self, a_number):
+    def one_input_function(self, a_number: int) -> None:
         r'''one_input_function
 
         This method takes one parameter other than the session.
@@ -1452,7 +1454,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def parameters_are_multiple_types(self, a_boolean, an_int32, an_int64, an_int_enum, a_float, a_float_enum, a_string):
+    def parameters_are_multiple_types(self, a_boolean: 'bool', an_int32: int, an_int64: int, an_int_enum: 'enums.Turtle', a_float: float, a_float_enum: 'enums.FloatEnum', a_string: str) -> None:
         r'''parameters_are_multiple_types
 
         Has parameters of multiple types.
@@ -1501,7 +1503,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def simple_function(self):
+    def simple_function(self) -> None:
         r'''simple_function
 
         This method takes no parameters other than the session.
@@ -1512,7 +1514,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def read(self, maximum_time):
+    def read(self, maximum_time: 'hightime.timedelta') -> float:
         r'''read
 
         Acquires a single measurement and returns the measured value.
@@ -1533,7 +1535,7 @@ class Session(_SessionBase):
         return float(reading_ctype.value)
 
     @ivi_synchronized
-    def return_a_number_and_a_string(self):
+    def return_a_number_and_a_string(self) -> typing.Tuple[int, str]:
         r'''return_a_number_and_a_string
 
         Returns a number and a string.
@@ -1554,7 +1556,7 @@ class Session(_SessionBase):
         return int(a_number_ctype.value), a_string_ctype.value.decode(self._encoding)
 
     @ivi_synchronized
-    def return_duration_in_seconds(self):
+    def return_duration_in_seconds(self) -> 'hightime.timedelta':
         r'''return_duration_in_seconds
 
         Returns a hightime.timedelta instance.
@@ -1570,7 +1572,7 @@ class Session(_SessionBase):
         return _converters.convert_seconds_real64_to_timedelta(float(timedelta_ctype.value))
 
     @ivi_synchronized
-    def return_list_of_durations_in_seconds(self, number_of_elements):
+    def return_list_of_durations_in_seconds(self, number_of_elements: int) -> typing.Iterable['hightime.timedelta']:
         r'''return_list_of_durations_in_seconds
 
         Returns a list of hightime.timedelta instances.
@@ -1592,7 +1594,7 @@ class Session(_SessionBase):
         return _converters.convert_seconds_real64_to_timedeltas([float(timedeltas_ctype[i]) for i in range(number_of_elements_ctype.value)])
 
     @ivi_synchronized
-    def return_multiple_types(self, array_size):
+    def return_multiple_types(self, array_size: int) -> typing.Tuple['bool', int, int, 'enums.Turtle', float, 'enums.FloatEnum', typing.Iterable[float], str]:
         r'''return_multiple_types
 
         Returns multiple types.
@@ -1652,7 +1654,7 @@ class Session(_SessionBase):
         return bool(a_boolean_ctype.value), int(an_int32_ctype.value), int(an_int64_ctype.value), enums.Turtle(an_int_enum_ctype.value), float(a_float_ctype.value), enums.FloatEnum(a_float_enum_ctype.value), [float(an_array_ctype[i]) for i in range(array_size_ctype.value)], a_string_ctype.value.decode(self._encoding)
 
     @ivi_synchronized
-    def set_custom_type(self, cs):
+    def set_custom_type(self, cs: 'custom_struct.CustomStruct') -> None:
         r'''set_custom_type
 
         This method takes a custom type.
@@ -1668,7 +1670,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def set_custom_type_array(self, cs):
+    def set_custom_type_array(self, cs: typing.Iterable['custom_struct.CustomStruct']) -> None:
         r'''set_custom_type_array
 
         This method takes an array of custom types.
@@ -1685,7 +1687,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def string_valued_enum_input_function_with_defaults(self, a_mobile_os_name=enums.MobileOSNames.ANDROID):
+    def string_valued_enum_input_function_with_defaults(self, a_mobile_os_name: 'enums.MobileOSNames' = enums.MobileOSNames.ANDROID) -> None:
         r'''string_valued_enum_input_function_with_defaults
 
         This method takes one parameter other than the session, which happens to be a string-valued enum and has a default value.
@@ -1711,7 +1713,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def two_input_function(self, a_number, a_string):
+    def two_input_function(self, a_number: float, a_string: str) -> None:
         r'''two_input_function
 
         This method takes two parameters other than the session.
@@ -1730,7 +1732,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def use64_bit_number(self, input):
+    def use64_bit_number(self, input: int) -> int:
         r'''use64_bit_number
 
         Returns a number and a string.
@@ -1753,7 +1755,7 @@ class Session(_SessionBase):
         return int(output_ctype.value)
 
     @ivi_synchronized
-    def write_waveform(self, waveform):
+    def write_waveform(self, waveform: typing.Iterable[float]) -> None:
         r'''write_waveform
 
         Writes waveform to the driver
@@ -1771,7 +1773,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def write_waveform_numpy(self, waveform):
+    def write_waveform_numpy(self, waveform: typing.Iterable[float]) -> None:
         r'''write_waveform
 
         Writes waveform to the driver
@@ -1795,7 +1797,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def _close(self):
+    def _close(self) -> None:
         r'''_close
 
         Closes the specified session and deallocates resources that it reserved.
@@ -1806,7 +1808,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def self_test(self):
+    def self_test(self) -> None:
         '''self_test
 
         Performs a self-test
@@ -1817,7 +1819,7 @@ class Session(_SessionBase):
         return None
 
     @ivi_synchronized
-    def _self_test(self):
+    def _self_test(self) -> typing.Tuple[int, str]:
         r'''_self_test
 
         Performs a self-test.

--- a/generated/nifake/setup.py
+++ b/generated/nifake/setup.py
@@ -47,6 +47,7 @@ setup(
         'singledispatch;python_version<"3.4"',
         'hightime>=0.2.0',
         'nitclk',
+        'typing',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/nifgen/nifgen/session.py
+++ b/generated/nifgen/nifgen/session.py
@@ -2,8 +2,10 @@
 # This file was generated
 import array  # noqa: F401
 import ctypes
+import datetime
 # Used by @ivi_synchronized
 from functools import wraps
+import typing
 
 import nifgen._attributes as _attributes
 import nifgen._converters as _converters
@@ -966,7 +968,7 @@ class _SessionBase(object):
     ''' These are code-generated '''
 
     @ivi_synchronized
-    def allocate_named_waveform(self, waveform_name, waveform_size):
+    def allocate_named_waveform(self, waveform_name: str, waveform_size: int) -> None:
         r'''allocate_named_waveform
 
         Specifies the size of a named waveform up front so that it can be
@@ -997,7 +999,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def allocate_waveform(self, waveform_size):
+    def allocate_waveform(self, waveform_size: int) -> int:
         r'''allocate_waveform
 
         Specifies the size of a waveform so that it can be allocated in onboard
@@ -1032,7 +1034,7 @@ class _SessionBase(object):
         return int(waveform_handle_ctype.value)
 
     @ivi_synchronized
-    def clear_user_standard_waveform(self):
+    def clear_user_standard_waveform(self) -> None:
         r'''clear_user_standard_waveform
 
         Clears the user-defined waveform created by the
@@ -1051,7 +1053,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def configure_arb_sequence(self, sequence_handle, gain, offset):
+    def configure_arb_sequence(self, sequence_handle: int, gain: float, offset: float) -> None:
         r'''configure_arb_sequence
 
         Configures the signal generator properties that affect arbitrary
@@ -1115,7 +1117,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def configure_arb_waveform(self, waveform_handle, gain, offset):
+    def configure_arb_waveform(self, waveform_handle: int, gain: float, offset: float) -> None:
         r'''configure_arb_waveform
 
         Configures the properties of the signal generator that affect arbitrary
@@ -1189,7 +1191,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def configure_freq_list(self, frequency_list_handle, amplitude, dc_offset=0.0, start_phase=0.0):
+    def configure_freq_list(self, frequency_list_handle: int, amplitude: float, dc_offset: float = 0.0, start_phase: float = 0.0) -> None:
         r'''configure_freq_list
 
         Configures the properties of the signal generator that affect frequency
@@ -1272,7 +1274,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def configure_standard_waveform(self, waveform, amplitude, frequency, dc_offset=0.0, start_phase=0.0):
+    def configure_standard_waveform(self, waveform: 'enums.Waveform', amplitude: float, frequency: float, dc_offset: float = 0.0, start_phase: float = 0.0) -> None:
         r'''configure_standard_waveform
 
         Configures the following properties of the signal generator that affect
@@ -1398,7 +1400,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def create_waveform(self, waveform_data_array):
+    def create_waveform(self, waveform_data_array: typing.Union[float, int]) -> int:
         '''create_waveform
 
         Creates an onboard waveform for use in Arbitrary Waveform output mode or Arbitrary Sequence output mode.
@@ -1439,7 +1441,7 @@ class _SessionBase(object):
         return self._create_waveform_f64(waveform_data_array)
 
     @ivi_synchronized
-    def _create_waveform_f64(self, waveform_data_array):
+    def _create_waveform_f64(self, waveform_data_array: typing.Iterable[float]) -> int:
         r'''_create_waveform_f64
 
         Creates an onboard waveform from binary F64 (floating point double) data
@@ -1486,7 +1488,7 @@ class _SessionBase(object):
         return int(waveform_handle_ctype.value)
 
     @ivi_synchronized
-    def _create_waveform_f64_numpy(self, waveform_data_array):
+    def _create_waveform_f64_numpy(self, waveform_data_array: typing.Iterable[float]) -> int:
         r'''_create_waveform_f64
 
         Creates an onboard waveform from binary F64 (floating point double) data
@@ -1540,7 +1542,7 @@ class _SessionBase(object):
         return int(waveform_handle_ctype.value)
 
     @ivi_synchronized
-    def create_waveform_from_file_f64(self, file_name, byte_order):
+    def create_waveform_from_file_f64(self, file_name: str, byte_order: 'enums.ByteOrder') -> int:
         r'''create_waveform_from_file_f64
 
         This method takes the floating point double (F64) data from the
@@ -1602,7 +1604,7 @@ class _SessionBase(object):
         return int(waveform_handle_ctype.value)
 
     @ivi_synchronized
-    def create_waveform_from_file_i16(self, file_name, byte_order):
+    def create_waveform_from_file_i16(self, file_name: str, byte_order: 'enums.ByteOrder') -> int:
         r'''create_waveform_from_file_i16
 
         Takes the binary 16-bit signed integer (I16) data from the specified
@@ -1664,7 +1666,7 @@ class _SessionBase(object):
         return int(waveform_handle_ctype.value)
 
     @ivi_synchronized
-    def _create_waveform_i16_numpy(self, waveform_data_array):
+    def _create_waveform_i16_numpy(self, waveform_data_array: typing.Iterable[int]) -> int:
         r'''_create_waveform_i16
 
         Creates an onboard waveform from binary 16-bit signed integer (I16) data
@@ -1716,7 +1718,7 @@ class _SessionBase(object):
         return int(waveform_handle_ctype.value)
 
     @ivi_synchronized
-    def define_user_standard_waveform(self, waveform_data_array):
+    def define_user_standard_waveform(self, waveform_data_array: typing.Iterable[float]) -> None:
         r'''define_user_standard_waveform
 
         Defines a user waveform for use in either Standard Method or Frequency
@@ -1761,7 +1763,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _delete_named_waveform(self, waveform_name):
+    def _delete_named_waveform(self, waveform_name: str) -> None:
         r'''_delete_named_waveform
 
         Removes a previously created arbitrary waveform from the signal
@@ -1789,7 +1791,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def delete_script(self, script_name):
+    def delete_script(self, script_name: str) -> None:
         r'''delete_script
 
         Deletes the specified script from onboard memory.
@@ -1813,7 +1815,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def delete_waveform(self, waveform_name_or_handle):
+    def delete_waveform(self, waveform_name_or_handle: typing.Union[str, int]) -> None:
         '''delete_waveform
 
         Removes a previously created arbitrary waveform from the signal generator memory.
@@ -1836,7 +1838,7 @@ class _SessionBase(object):
             return self._clear_arb_waveform(waveform_name_or_handle)
 
     @ivi_synchronized
-    def _get_attribute_vi_boolean(self, attribute_id):
+    def _get_attribute_vi_boolean(self, attribute_id: int) -> 'bool':
         r'''_get_attribute_vi_boolean
 
         Queries the value of a ViBoolean property.
@@ -1874,7 +1876,7 @@ class _SessionBase(object):
         return bool(attribute_value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_int32(self, attribute_id):
+    def _get_attribute_vi_int32(self, attribute_id: int) -> int:
         r'''_get_attribute_vi_int32
 
         Queries the value of a ViInt32 property. You can use this method to
@@ -1910,7 +1912,7 @@ class _SessionBase(object):
         return int(attribute_value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_real64(self, attribute_id):
+    def _get_attribute_vi_real64(self, attribute_id: int) -> float:
         r'''_get_attribute_vi_real64
 
         Queries the value of a ViReal64 property.
@@ -1948,7 +1950,7 @@ class _SessionBase(object):
         return float(attribute_value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_string(self, attribute_id):
+    def _get_attribute_vi_string(self, attribute_id: int) -> str:
         r'''_get_attribute_vi_string
 
         Queries the value of a ViString property.
@@ -2020,7 +2022,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return attribute_value_ctype.value.decode(self._encoding)
 
-    def _get_error(self):
+    def _get_error(self) -> typing.Tuple[int, str]:
         r'''_get_error
 
         Returns the error information associated with an IVI session or with the
@@ -2068,7 +2070,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return int(error_code_ctype.value), error_description_ctype.value.decode(self._encoding)
 
-    def lock(self):
+    def lock(self) -> 'bool':
         '''lock
 
         Obtains a multithread lock on the device session. Before doing so, the
@@ -2103,7 +2105,7 @@ class _SessionBase(object):
         # that will handle the unlock for them
         return _Lock(self)
 
-    def _lock_session(self):
+    def _lock_session(self) -> None:
         '''_lock_session
 
         Actual call to driver
@@ -2114,7 +2116,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def send_software_edge_trigger(self, trigger=None, trigger_id=None):
+    def send_software_edge_trigger(self, trigger=None, trigger_id=None) -> None:
         '''send_software_edge_trigger
 
         Sends a command to trigger the signal generator. This VI can act as an
@@ -2169,7 +2171,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_boolean(self, attribute_id, attribute_value):
+    def _set_attribute_vi_boolean(self, attribute_id: int, attribute_value: 'bool') -> None:
         r'''_set_attribute_vi_boolean
 
         Sets the value of a ViBoolean property.
@@ -2223,7 +2225,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_int32(self, attribute_id, attribute_value):
+    def _set_attribute_vi_int32(self, attribute_id: int, attribute_value: int) -> None:
         r'''_set_attribute_vi_int32
 
         Sets the value of a ViInt32 property.
@@ -2277,7 +2279,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_real64(self, attribute_id, attribute_value):
+    def _set_attribute_vi_real64(self, attribute_id: int, attribute_value: float) -> None:
         r'''_set_attribute_vi_real64
 
         Sets the value of a ViReal64 property.
@@ -2331,7 +2333,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_string(self, attribute_id, attribute_value):
+    def _set_attribute_vi_string(self, attribute_id: int, attribute_value: str) -> None:
         r'''_set_attribute_vi_string
 
         Sets the value of a ViString property.
@@ -2385,7 +2387,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_named_waveform_next_write_position(self, waveform_name, relative_to, offset):
+    def _set_named_waveform_next_write_position(self, waveform_name: str, relative_to: 'enums.RelativeTo', offset: int) -> None:
         r'''_set_named_waveform_next_write_position
 
         Sets the position in the waveform to which data is written at the next
@@ -2440,7 +2442,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def set_next_write_position(self, waveform_name_or_handle, relative_to, offset):
+    def set_next_write_position(self, waveform_name_or_handle: typing.Union[str, int], relative_to: 'enums.RelativeTo', offset: int) -> None:
         '''set_next_write_position
 
         Sets the position in the waveform at which the next waveform data is
@@ -2483,7 +2485,7 @@ class _SessionBase(object):
             return self._set_waveform_next_write_position(waveform_name_or_handle, relative_to, offset)
 
     @ivi_synchronized
-    def _set_waveform_next_write_position(self, waveform_handle, relative_to, offset):
+    def _set_waveform_next_write_position(self, waveform_handle: int, relative_to: 'enums.RelativeTo', offset: int) -> None:
         r'''_set_waveform_next_write_position
 
         Sets the position in the waveform at which the next waveform data is
@@ -2538,7 +2540,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def unlock(self):
+    def unlock(self) -> 'bool':
         '''unlock
 
         Releases a lock that you acquired on an device session using
@@ -2551,7 +2553,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _write_binary16_waveform_numpy(self, waveform_handle, data):
+    def _write_binary16_waveform_numpy(self, waveform_handle: int, data: typing.Iterable[int]) -> None:
         r'''_write_binary16_waveform
 
         Writes binary data to the waveform in onboard memory. The waveform
@@ -2600,7 +2602,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _write_named_waveform_f64(self, waveform_name, data):
+    def _write_named_waveform_f64(self, waveform_name: str, data: typing.Iterable[float]) -> None:
         r'''_write_named_waveform_f64
 
         Writes floating-point data to the waveform in onboard memory. The
@@ -2647,7 +2649,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _write_named_waveform_f64_numpy(self, waveform_name, data):
+    def _write_named_waveform_f64_numpy(self, waveform_name: str, data: typing.Iterable[float]) -> None:
         r'''_write_named_waveform_f64
 
         Writes floating-point data to the waveform in onboard memory. The
@@ -2701,7 +2703,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _write_named_waveform_i16_numpy(self, waveform_name, data):
+    def _write_named_waveform_i16_numpy(self, waveform_name: str, data: typing.Iterable[int]) -> None:
         r'''_write_named_waveform_i16
 
         Writes binary data to the named waveform in onboard memory.
@@ -2746,7 +2748,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def write_script(self, script):
+    def write_script(self, script: str) -> None:
         r'''write_script
 
         Writes a string containing one or more scripts that govern the
@@ -2773,7 +2775,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _write_waveform(self, waveform_handle, data):
+    def _write_waveform(self, waveform_handle: int, data: typing.Iterable[float]) -> None:
         r'''_write_waveform
 
         Writes floating-point data to the waveform in onboard memory. The
@@ -2821,7 +2823,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _write_waveform_numpy(self, waveform_handle, data):
+    def _write_waveform_numpy(self, waveform_handle: int, data: typing.Iterable[float]) -> None:
         r'''_write_waveform
 
         Writes floating-point data to the waveform in onboard memory. The
@@ -2876,7 +2878,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def write_waveform(self, waveform_name_or_handle, data):
+    def write_waveform(self, waveform_name_or_handle: typing.Union[str, int], data: typing.Iterable[float]) -> None:
         '''write_waveform
 
         Writes data to the waveform in onboard memory.
@@ -2918,7 +2920,7 @@ class _SessionBase(object):
 
         return self._write_named_waveform_f64(waveform_name_or_handle, data) if use_named else self._write_waveform(waveform_name_or_handle, data)
 
-    def _error_message(self, error_code):
+    def _error_message(self, error_code: int) -> str:
         r'''_error_message
 
         Converts a status code returned by an NI-FGEN method into a
@@ -2949,7 +2951,7 @@ class _SessionBase(object):
 class Session(_SessionBase):
     '''An NI-FGEN session to a National Instruments Signal Generator.'''
 
-    def __init__(self, resource_name, channel_name=None, reset_device=False, options={}):
+    def __init__(self, resource_name: str, channel_name: typing.Union[str, 'list', 'range', 'tuple'] = None, reset_device: 'bool' = False, options={}):
         r'''An NI-FGEN session to a National Instruments Signal Generator.
 
         Creates and returns a new NI-FGEN session to the specified channel of a
@@ -3136,7 +3138,7 @@ class Session(_SessionBase):
     ''' These are code-generated '''
 
     @ivi_synchronized
-    def abort(self):
+    def abort(self) -> None:
         r'''abort
 
         Aborts any previously initiated signal generation. Call the
@@ -3149,7 +3151,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def clear_arb_memory(self):
+    def clear_arb_memory(self) -> None:
         r'''clear_arb_memory
 
         Removes all previously created arbitrary waveforms, sequences, and
@@ -3166,7 +3168,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def clear_arb_sequence(self, sequence_handle):
+    def clear_arb_sequence(self, sequence_handle: int) -> None:
         r'''clear_arb_sequence
 
         Removes a previously created arbitrary sequence from the signal
@@ -3199,7 +3201,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def _clear_arb_waveform(self, waveform_handle):
+    def _clear_arb_waveform(self, waveform_handle: int) -> None:
         r'''_clear_arb_waveform
 
         Removes a previously created arbitrary waveform from the signal
@@ -3243,7 +3245,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def clear_freq_list(self, frequency_list_handle):
+    def clear_freq_list(self, frequency_list_handle: int) -> None:
         r'''clear_freq_list
 
         Removes a previously created frequency list from the signal generator
@@ -3278,7 +3280,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def commit(self):
+    def commit(self) -> None:
         r'''commit
 
         Causes a transition to the Committed state. This method verifies
@@ -3308,7 +3310,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def create_advanced_arb_sequence(self, waveform_handles_array, loop_counts_array, sample_counts_array=None, marker_location_array=None):
+    def create_advanced_arb_sequence(self, waveform_handles_array: typing.Iterable[int], loop_counts_array: typing.Iterable[int], sample_counts_array: typing.Iterable[int] = None, marker_location_array: typing.Iterable[int] = None) -> typing.Tuple[typing.Iterable[int], int]:
         r'''create_advanced_arb_sequence
 
         Creates an arbitrary sequence from an array of waveform handles and an
@@ -3428,7 +3430,7 @@ class Session(_SessionBase):
         return [int(coerced_markers_array_ctype[i]) for i in range((0 if marker_location_array is None else len(marker_location_array)))], int(sequence_handle_ctype.value)
 
     @ivi_synchronized
-    def create_arb_sequence(self, waveform_handles_array, loop_counts_array):
+    def create_arb_sequence(self, waveform_handles_array: typing.Iterable[int], loop_counts_array: typing.Iterable[int]) -> int:
         r'''create_arb_sequence
 
         Creates an arbitrary sequence from an array of waveform handles and an
@@ -3496,7 +3498,7 @@ class Session(_SessionBase):
         return int(sequence_handle_ctype.value)
 
     @ivi_synchronized
-    def create_freq_list(self, waveform, frequency_array, duration_array):
+    def create_freq_list(self, waveform: 'enums.Waveform', frequency_array: typing.Iterable[float], duration_array: typing.Iterable[float]) -> int:
         r'''create_freq_list
 
         Creates a frequency list from an array of frequencies
@@ -3585,7 +3587,7 @@ class Session(_SessionBase):
         return int(frequency_list_handle_ctype.value)
 
     @ivi_synchronized
-    def disable(self):
+    def disable(self) -> None:
         r'''disable
 
         Places the instrument in a quiescent state where it has minimal or no
@@ -3598,7 +3600,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def export_attribute_configuration_buffer(self):
+    def export_attribute_configuration_buffer(self) -> typing.Iterable['bytes']:
         r'''export_attribute_configuration_buffer
 
         Exports the property configuration of the session to a configuration
@@ -3631,7 +3633,7 @@ class Session(_SessionBase):
         return _converters.convert_to_bytes(configuration_array)
 
     @ivi_synchronized
-    def export_attribute_configuration_file(self, file_path):
+    def export_attribute_configuration_file(self, file_path: str) -> None:
         r'''export_attribute_configuration_file
 
         Exports the property configuration of the session to the specified
@@ -3659,7 +3661,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def get_channel_name(self, index):
+    def get_channel_name(self, index: int) -> str:
         r'''get_channel_name
 
         Returns the channel string that is in the channel table at an index you
@@ -3691,7 +3693,7 @@ class Session(_SessionBase):
         return channel_string_ctype.value.decode(self._encoding)
 
     @ivi_synchronized
-    def _get_ext_cal_last_date_and_time(self):
+    def _get_ext_cal_last_date_and_time(self) -> typing.Tuple[int, int, int, int, int]:
         r'''_get_ext_cal_last_date_and_time
 
         Returns the date and time of the last successful external calibration.
@@ -3722,7 +3724,7 @@ class Session(_SessionBase):
         return int(year_ctype.value), int(month_ctype.value), int(day_ctype.value), int(hour_ctype.value), int(minute_ctype.value)
 
     @ivi_synchronized
-    def get_ext_cal_last_temp(self):
+    def get_ext_cal_last_temp(self) -> float:
         r'''get_ext_cal_last_temp
 
         Returns the temperature at the last successful external calibration. The
@@ -3740,7 +3742,7 @@ class Session(_SessionBase):
         return float(temperature_ctype.value)
 
     @ivi_synchronized
-    def get_ext_cal_recommended_interval(self):
+    def get_ext_cal_recommended_interval(self) -> 'hightime.timedelta':
         r'''get_ext_cal_recommended_interval
 
         Returns the recommended interval between external calibrations in
@@ -3758,7 +3760,7 @@ class Session(_SessionBase):
         return _converters.convert_month_to_timedelta(int(months_ctype.value))
 
     @ivi_synchronized
-    def get_hardware_state(self):
+    def get_hardware_state(self) -> 'enums.HardwareState':
         r'''get_hardware_state
 
         Returns the current hardware state of the device and, if the device is
@@ -3791,7 +3793,7 @@ class Session(_SessionBase):
         return enums.HardwareState(state_ctype.value)
 
     @ivi_synchronized
-    def get_ext_cal_last_date_and_time(self):
+    def get_ext_cal_last_date_and_time(self) -> 'hightime.datetime':
         '''get_ext_cal_last_date_and_time
 
         Returns the date and time of the last successful external calibration. The time returned is 24-hour (military) local time; for example, if the device was calibrated at 2:30 PM, this method returns 14 for the **hour** parameter and 30 for the **minute** parameter.
@@ -3804,7 +3806,7 @@ class Session(_SessionBase):
         return hightime.datetime(year, month, day, hour, minute)
 
     @ivi_synchronized
-    def get_self_cal_last_date_and_time(self):
+    def get_self_cal_last_date_and_time(self) -> 'hightime.datetime':
         '''get_self_cal_last_date_and_time
 
         Returns the date and time of the last successful self-calibration.
@@ -3817,7 +3819,7 @@ class Session(_SessionBase):
         return hightime.datetime(year, month, day, hour, minute)
 
     @ivi_synchronized
-    def _get_self_cal_last_date_and_time(self):
+    def _get_self_cal_last_date_and_time(self) -> typing.Tuple[int, int, int, int, int]:
         r'''_get_self_cal_last_date_and_time
 
         Returns the date and time of the last successful self-calibration.
@@ -3855,7 +3857,7 @@ class Session(_SessionBase):
         return int(year_ctype.value), int(month_ctype.value), int(day_ctype.value), int(hour_ctype.value), int(minute_ctype.value)
 
     @ivi_synchronized
-    def get_self_cal_last_temp(self):
+    def get_self_cal_last_temp(self) -> float:
         r'''get_self_cal_last_temp
 
         Returns the temperature at the last successful self-calibration. The
@@ -3873,7 +3875,7 @@ class Session(_SessionBase):
         return float(temperature_ctype.value)
 
     @ivi_synchronized
-    def get_self_cal_supported(self):
+    def get_self_cal_supported(self) -> 'bool':
         r'''get_self_cal_supported
 
         Returns whether the device supports self–calibration.
@@ -3897,7 +3899,7 @@ class Session(_SessionBase):
         return bool(self_cal_supported_ctype.value)
 
     @ivi_synchronized
-    def import_attribute_configuration_buffer(self, configuration):
+    def import_attribute_configuration_buffer(self, configuration: typing.Iterable['bytes']) -> None:
         r'''import_attribute_configuration_buffer
 
         Imports a property configuration to the session from the specified
@@ -3925,7 +3927,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def import_attribute_configuration_file(self, file_path):
+    def import_attribute_configuration_file(self, file_path: str) -> None:
         r'''import_attribute_configuration_file
 
         Imports a property configuration to the session from the specified
@@ -3952,7 +3954,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def _initialize_with_channels(self, resource_name, channel_name=None, reset_device=False, option_string=""):
+    def _initialize_with_channels(self, resource_name: str, channel_name: typing.Union[str, 'list', 'range', 'tuple'] = None, reset_device: 'bool' = False, option_string: 'dict' = "") -> int:
         r'''_initialize_with_channels
 
         Creates and returns a new NI-FGEN session to the specified channel of a
@@ -4093,7 +4095,7 @@ class Session(_SessionBase):
         return int(vi_ctype.value)
 
     @ivi_synchronized
-    def _initiate_generation(self):
+    def _initiate_generation(self) -> None:
         r'''_initiate_generation
 
         Initiates signal generation. If you want to abort signal generation,
@@ -4107,7 +4109,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def is_done(self):
+    def is_done(self) -> 'bool':
         r'''is_done
 
         Determines whether the current generation is complete. This method
@@ -4137,7 +4139,7 @@ class Session(_SessionBase):
         return bool(done_ctype.value)
 
     @ivi_synchronized
-    def query_arb_seq_capabilities(self):
+    def query_arb_seq_capabilities(self) -> typing.Tuple[int, int, int, int]:
         r'''query_arb_seq_capabilities
 
         Returns the properties of the signal generator that are related to
@@ -4174,7 +4176,7 @@ class Session(_SessionBase):
         return int(maximum_number_of_sequences_ctype.value), int(minimum_sequence_length_ctype.value), int(maximum_sequence_length_ctype.value), int(maximum_loop_count_ctype.value)
 
     @ivi_synchronized
-    def query_arb_wfm_capabilities(self):
+    def query_arb_wfm_capabilities(self) -> typing.Tuple[int, int, int, int]:
         r'''query_arb_wfm_capabilities
 
         Returns the properties of the signal generator that are related to
@@ -4218,7 +4220,7 @@ class Session(_SessionBase):
         return int(maximum_number_of_waveforms_ctype.value), int(waveform_quantum_ctype.value), int(minimum_waveform_size_ctype.value), int(maximum_waveform_size_ctype.value)
 
     @ivi_synchronized
-    def query_freq_list_capabilities(self):
+    def query_freq_list_capabilities(self) -> typing.Tuple[int, int, int, float, float, float]:
         r'''query_freq_list_capabilities
 
         Returns the properties of the signal generator that are related to
@@ -4268,7 +4270,7 @@ class Session(_SessionBase):
         return int(maximum_number_of_freq_lists_ctype.value), int(minimum_frequency_list_length_ctype.value), int(maximum_frequency_list_length_ctype.value), float(minimum_frequency_list_duration_ctype.value), float(maximum_frequency_list_duration_ctype.value), float(frequency_list_duration_quantum_ctype.value)
 
     @ivi_synchronized
-    def read_current_temperature(self):
+    def read_current_temperature(self) -> float:
         r'''read_current_temperature
 
         Reads the current onboard temperature of the device. The temperature is
@@ -4286,7 +4288,7 @@ class Session(_SessionBase):
         return float(temperature_ctype.value)
 
     @ivi_synchronized
-    def reset_device(self):
+    def reset_device(self) -> None:
         r'''reset_device
 
         Performs a hard reset on the device. Generation is stopped, all routes
@@ -4300,7 +4302,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def reset_with_defaults(self):
+    def reset_with_defaults(self) -> None:
         r'''reset_with_defaults
 
         Resets the instrument and reapplies initial user–specified settings from
@@ -4314,7 +4316,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def self_cal(self):
+    def self_cal(self) -> None:
         r'''self_cal
 
         Performs a full internal self-calibration on the device. If the
@@ -4327,7 +4329,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def wait_until_done(self, max_time=hightime.timedelta(seconds=10.0)):
+    def wait_until_done(self, max_time: typing.Union['hightime.timedelta', 'datetime.timedelta', int] = hightime.timedelta(seconds=10.0)) -> None:
         r'''wait_until_done
 
         Waits until the device is done generating or until the maximum time has
@@ -4343,7 +4345,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def _close(self):
+    def _close(self) -> None:
         r'''_close
 
         Performs the following operations:
@@ -4375,7 +4377,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def self_test(self):
+    def self_test(self) -> None:
         '''self_test
 
         Runs the instrument self-test routine and returns the test result(s).
@@ -4405,7 +4407,7 @@ class Session(_SessionBase):
         return None
 
     @ivi_synchronized
-    def reset(self):
+    def reset(self) -> None:
         r'''reset
 
         Resets the instrument to a known state. This method aborts the
@@ -4423,7 +4425,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def _self_test(self):
+    def _self_test(self) -> typing.Tuple[int, str]:
         r'''_self_test
 
         Runs the instrument self-test routine and returns the test result(s).

--- a/generated/nifgen/setup.py
+++ b/generated/nifgen/setup.py
@@ -47,6 +47,7 @@ setup(
         'singledispatch;python_version<"3.4"',
         'hightime>=0.2.0',
         'nitclk',
+        'typing',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/nimodinst/nimodinst/session.py
+++ b/generated/nimodinst/nimodinst/session.py
@@ -1,6 +1,7 @@
 # This file was generated
 
 import ctypes
+import typing
 
 import nimodinst._library_singleton as _library_singleton
 import nimodinst._visatype as _visatype
@@ -216,7 +217,7 @@ class Session(object):
         self._handle = 0
 
     ''' These are code-generated '''
-    def _close_installed_devices_session(self):
+    def _close_installed_devices_session(self) -> None:
         r'''_close_installed_devices_session
 
         Cleans up the NI-ModInst session created by a call to
@@ -228,7 +229,7 @@ class Session(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def _get_extended_error_info(self):
+    def _get_extended_error_info(self) -> str:
         r'''_get_extended_error_info
 
         Returns detailed information about the last error that occurred in the
@@ -260,7 +261,7 @@ class Session(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return error_info_ctype.value.decode(self._encoding)
 
-    def _get_installed_device_attribute_vi_int32(self, index, attribute_id):
+    def _get_installed_device_attribute_vi_int32(self, index: int, attribute_id: int) -> int:
         r'''_get_installed_device_attribute_vi_int32
 
         Returns an integer property specified by the attributeID parameter for
@@ -303,7 +304,7 @@ class Session(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(attribute_value_ctype.value)
 
-    def _get_installed_device_attribute_vi_string(self, index, attribute_id):
+    def _get_installed_device_attribute_vi_string(self, index: int, attribute_id: int) -> str:
         r'''_get_installed_device_attribute_vi_string
 
         Returns a string property specified by the attributeID parameter for a
@@ -350,7 +351,7 @@ class Session(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return attribute_value_ctype.value.decode(self._encoding)
 
-    def _open_installed_devices_session(self, driver):
+    def _open_installed_devices_session(self, driver: str) -> typing.Tuple[int, int]:
         r'''_open_installed_devices_session
 
         Creates a handle to a list of installed devices supported by the

--- a/generated/nimodinst/setup.py
+++ b/generated/nimodinst/setup.py
@@ -46,6 +46,7 @@ setup(
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
         'hightime>=0.2.0',
+        'typing',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/niscope/niscope/session.py
+++ b/generated/niscope/niscope/session.py
@@ -2,8 +2,10 @@
 # This file was generated
 import array  # noqa: F401
 import ctypes
+import datetime
 # Used by @ivi_synchronized
 from functools import wraps
+import typing
 
 import niscope._attributes as _attributes
 import niscope._converters as _converters
@@ -1601,7 +1603,7 @@ class _SessionBase(object):
     ''' These are code-generated '''
 
     @ivi_synchronized
-    def _actual_meas_wfm_size(self, array_meas_function):
+    def _actual_meas_wfm_size(self, array_meas_function: 'enums.ArrayMeasurement') -> int:
         r'''_actual_meas_wfm_size
 
         Returns the total available size of an array measurement acquisition.
@@ -1627,7 +1629,7 @@ class _SessionBase(object):
         return int(meas_waveform_size_ctype.value)
 
     @ivi_synchronized
-    def _actual_num_wfms(self):
+    def _actual_num_wfms(self) -> int:
         r'''_actual_num_wfms
 
         Helps you to declare appropriately sized waveforms. NI-SCOPE handles the
@@ -1653,7 +1655,7 @@ class _SessionBase(object):
         return int(num_wfms_ctype.value)
 
     @ivi_synchronized
-    def add_waveform_processing(self, meas_function):
+    def add_waveform_processing(self, meas_function: 'enums.ArrayMeasurement') -> None:
         r'''add_waveform_processing
 
         Adds one measurement to the list of processing steps that are completed
@@ -1688,7 +1690,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def self_cal(self, option=enums.Option.SELF_CALIBRATE_ALL_CHANNELS):
+    def self_cal(self, option: 'enums.Option' = enums.Option.SELF_CALIBRATE_ALL_CHANNELS) -> None:
         r'''self_cal
 
         Self-calibrates most NI digitizers, including all SMC-based devices and
@@ -1736,7 +1738,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def clear_waveform_measurement_stats(self, clearable_measurement_function=enums.ClearableMeasurement.ALL_MEASUREMENTS):
+    def clear_waveform_measurement_stats(self, clearable_measurement_function: 'enums.ClearableMeasurement' = enums.ClearableMeasurement.ALL_MEASUREMENTS) -> None:
         r'''clear_waveform_measurement_stats
 
         Clears the waveform stats on the channel and measurement you specify. If
@@ -1774,7 +1776,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def clear_waveform_processing(self):
+    def clear_waveform_processing(self) -> None:
         r'''clear_waveform_processing
 
         Clears the list of processing steps assigned to the given channel. The
@@ -1797,7 +1799,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def configure_chan_characteristics(self, input_impedance, max_input_frequency):
+    def configure_chan_characteristics(self, input_impedance: float, max_input_frequency: float) -> None:
         r'''configure_chan_characteristics
 
         Configures the properties that control the electrical characteristics of
@@ -1828,7 +1830,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def configure_equalization_filter_coefficients(self, coefficients):
+    def configure_equalization_filter_coefficients(self, coefficients: typing.Iterable[float]) -> None:
         r'''configure_equalization_filter_coefficients
 
         Configures the custom coefficients for the equalization FIR filter on
@@ -1862,7 +1864,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def configure_vertical(self, range, coupling, offset=0.0, probe_attenuation=1.0, enabled=True):
+    def configure_vertical(self, range: float, coupling: 'enums.VerticalCoupling', offset: float = 0.0, probe_attenuation: float = 1.0, enabled: 'bool' = True) -> None:
         r'''configure_vertical
 
         Configures the most commonly configured properties of the digitizer
@@ -1906,7 +1908,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def fetch(self, num_samples=None, relative_to=enums.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout=hightime.timedelta(seconds=5.0)):
+    def fetch(self, num_samples: int = None, relative_to: 'enums.FetchRelativeTo' = enums.FetchRelativeTo.PRETRIGGER, offset: int = 0, record_number: int = 0, num_records: int = None, timeout: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=5.0)) -> typing.Iterable['waveform_info.WaveformInfo']:
         '''fetch
 
         Returns the waveform from a previously initiated acquisition that the
@@ -1986,7 +1988,7 @@ class _SessionBase(object):
         return wfm_info
 
     @ivi_synchronized
-    def fetch_array_measurement(self, array_meas_function, meas_wfm_size=None, relative_to=enums.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, meas_num_samples=None, timeout=hightime.timedelta(seconds=5.0)):
+    def fetch_array_measurement(self, array_meas_function: 'enums.ArrayMeasurement', meas_wfm_size: int = None, relative_to: 'enums.FetchRelativeTo' = enums.FetchRelativeTo.PRETRIGGER, offset: int = 0, record_number: int = 0, num_records: int = None, meas_num_samples: int = None, timeout: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=5.0)) -> typing.Iterable['waveform_info.WaveformInfo']:
         r'''fetch_array_measurement
 
         Obtains a waveform from the digitizer and returns the specified
@@ -2077,7 +2079,7 @@ class _SessionBase(object):
         return wfm_info
 
     @ivi_synchronized
-    def fetch_measurement_stats(self, scalar_meas_function, relative_to=enums.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout=hightime.timedelta(seconds=5.0)):
+    def fetch_measurement_stats(self, scalar_meas_function: 'enums.ScalarMeasurement', relative_to: 'enums.FetchRelativeTo' = enums.FetchRelativeTo.PRETRIGGER, offset: int = 0, record_number: int = 0, num_records: int = None, timeout: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=5.0)) -> typing.List[measurement_stats.MeasurementStats]:
         r'''fetch_measurement_stats
 
         Obtains a waveform measurement and returns the measurement value. This
@@ -2166,7 +2168,7 @@ class _SessionBase(object):
         return output
 
     @ivi_synchronized
-    def get_equalization_filter_coefficients(self):
+    def get_equalization_filter_coefficients(self) -> typing.Iterable[float]:
         '''get_equalization_filter_coefficients
 
         Retrieves the custom coefficients for the equalization FIR filter on the device. This filter is designed to compensate the input signal for artifacts introduced to the signal outside of the digitizer. Because this filter is a generic FIR filter, any coefficients are valid. Coefficient values should be between +1 and –1.
@@ -2180,7 +2182,7 @@ class _SessionBase(object):
         return self._get_equalization_filter_coefficients(self.equalization_num_coefficients)
 
     @ivi_synchronized
-    def read(self, num_samples=None, relative_to=enums.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout=hightime.timedelta(seconds=5.0)):
+    def read(self, num_samples: int = None, relative_to: 'enums.FetchRelativeTo' = enums.FetchRelativeTo.PRETRIGGER, offset: int = 0, record_number: int = 0, num_records: int = None, timeout: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=5.0)) -> typing.Iterable['waveform_info.WaveformInfo']:
         '''read
 
         Initiates an acquisition, waits for it to complete, and retrieves the
@@ -2263,7 +2265,7 @@ class _SessionBase(object):
         return wfm_info
 
     @ivi_synchronized
-    def _fetch(self, num_samples, timeout=hightime.timedelta(seconds=5.0)):
+    def _fetch(self, num_samples: int, timeout: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=5.0)) -> typing.Tuple[typing.Iterable[float], typing.Iterable['waveform_info.WaveformInfo']]:
         r'''_fetch
 
         Returns the waveform from a previously initiated acquisition that the
@@ -2363,7 +2365,7 @@ class _SessionBase(object):
         return waveform_array, [waveform_info.WaveformInfo(wfm_info_ctype[i]) for i in range(self._actual_num_wfms())]
 
     @ivi_synchronized
-    def _fetch_into_numpy(self, num_samples, waveform, timeout=hightime.timedelta(seconds=5.0)):
+    def _fetch_into_numpy(self, num_samples: int, waveform: typing.Iterable[float], timeout: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=5.0)) -> typing.Iterable['waveform_info.WaveformInfo']:
         r'''_fetch
 
         Returns the waveform from a previously initiated acquisition that the
@@ -2490,7 +2492,7 @@ class _SessionBase(object):
         return [waveform_info.WaveformInfo(wfm_info_ctype[i]) for i in range(self._actual_num_wfms())]
 
     @ivi_synchronized
-    def _fetch_array_measurement(self, array_meas_function, measurement_waveform_size, timeout=hightime.timedelta(seconds=5.0)):
+    def _fetch_array_measurement(self, array_meas_function: 'enums.ArrayMeasurement', measurement_waveform_size: int, timeout: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=5.0)) -> typing.Tuple[typing.Iterable[float], typing.Iterable['waveform_info.WaveformInfo']]:
         r'''_fetch_array_measurement
 
         Obtains a waveform from the digitizer and returns the specified
@@ -2591,7 +2593,7 @@ class _SessionBase(object):
         return [float(meas_wfm_ctype[i]) for i in range((measurement_waveform_size * self._actual_num_wfms()))], [waveform_info.WaveformInfo(wfm_info_ctype[i]) for i in range(self._actual_num_wfms())]
 
     @ivi_synchronized
-    def _fetch_binary16_into_numpy(self, num_samples, waveform, timeout=hightime.timedelta(seconds=5.0)):
+    def _fetch_binary16_into_numpy(self, num_samples: int, waveform: typing.Iterable[int], timeout: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=5.0)) -> typing.Iterable['waveform_info.WaveformInfo']:
         r'''_fetch_binary16
 
         Retrieves data from a previously initiated acquisition and returns
@@ -2716,7 +2718,7 @@ class _SessionBase(object):
         return [waveform_info.WaveformInfo(wfm_info_ctype[i]) for i in range(self._actual_num_wfms())]
 
     @ivi_synchronized
-    def _fetch_binary32_into_numpy(self, num_samples, waveform, timeout=hightime.timedelta(seconds=5.0)):
+    def _fetch_binary32_into_numpy(self, num_samples: int, waveform: typing.Iterable[int], timeout: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=5.0)) -> typing.Iterable['waveform_info.WaveformInfo']:
         r'''_fetch_binary32
 
         Retrieves data from a previously initiated acquisition and returns
@@ -2841,7 +2843,7 @@ class _SessionBase(object):
         return [waveform_info.WaveformInfo(wfm_info_ctype[i]) for i in range(self._actual_num_wfms())]
 
     @ivi_synchronized
-    def _fetch_binary8_into_numpy(self, num_samples, waveform, timeout=hightime.timedelta(seconds=5.0)):
+    def _fetch_binary8_into_numpy(self, num_samples: int, waveform: typing.Iterable[int], timeout: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=5.0)) -> typing.Iterable['waveform_info.WaveformInfo']:
         r'''_fetch_binary8
 
         Retrieves data from a previously initiated acquisition and returns
@@ -2966,7 +2968,7 @@ class _SessionBase(object):
         return [waveform_info.WaveformInfo(wfm_info_ctype[i]) for i in range(self._actual_num_wfms())]
 
     @ivi_synchronized
-    def fetch_into(self, waveform, relative_to=enums.FetchRelativeTo.PRETRIGGER, offset=0, record_number=0, num_records=None, timeout=hightime.timedelta(seconds=5.0)):
+    def fetch_into(self, waveform: typing.Iterable[float], relative_to: 'enums.FetchRelativeTo' = enums.FetchRelativeTo.PRETRIGGER, offset: int = 0, record_number: int = 0, num_records: int = None, timeout: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=5.0)) -> typing.Iterable['waveform_info.WaveformInfo']:
         '''fetch
 
         Returns the waveform from a previously initiated acquisition that the
@@ -3070,7 +3072,7 @@ class _SessionBase(object):
         return wfm_info
 
     @ivi_synchronized
-    def _fetch_measurement_stats(self, scalar_meas_function, timeout=hightime.timedelta(seconds=5.0)):
+    def _fetch_measurement_stats(self, scalar_meas_function: 'enums.ScalarMeasurement', timeout: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=5.0)) -> typing.Tuple[typing.Iterable[float], typing.Iterable[float], typing.Iterable[float], typing.Iterable[float], typing.Iterable[float], typing.Iterable[int]]:
         r'''_fetch_measurement_stats
 
         Obtains a waveform measurement and returns the measurement value. This
@@ -3156,7 +3158,7 @@ class _SessionBase(object):
         return [float(result_ctype[i]) for i in range(self._actual_num_wfms())], [float(mean_ctype[i]) for i in range(self._actual_num_wfms())], [float(stdev_ctype[i]) for i in range(self._actual_num_wfms())], [float(min_ctype[i]) for i in range(self._actual_num_wfms())], [float(max_ctype[i]) for i in range(self._actual_num_wfms())], [int(num_in_stats_ctype[i]) for i in range(self._actual_num_wfms())]
 
     @ivi_synchronized
-    def _get_attribute_vi_boolean(self, attribute_id):
+    def _get_attribute_vi_boolean(self, attribute_id: int) -> 'bool':
         r'''_get_attribute_vi_boolean
 
         Queries the value of a ViBoolean property. You can use this method to
@@ -3192,7 +3194,7 @@ class _SessionBase(object):
         return bool(value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_int32(self, attribute_id):
+    def _get_attribute_vi_int32(self, attribute_id: int) -> int:
         r'''_get_attribute_vi_int32
 
         Queries the value of a ViInt32 property. You can use this method to
@@ -3227,7 +3229,7 @@ class _SessionBase(object):
         return int(value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_int64(self, attribute_id):
+    def _get_attribute_vi_int64(self, attribute_id: int) -> int:
         r'''_get_attribute_vi_int64
 
         Queries the value of a ViInt64 property. You can use this method to
@@ -3262,7 +3264,7 @@ class _SessionBase(object):
         return int(value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_real64(self, attribute_id):
+    def _get_attribute_vi_real64(self, attribute_id: int) -> float:
         r'''_get_attribute_vi_real64
 
         Queries the value of a ViReal64 property. You can use this method to
@@ -3298,7 +3300,7 @@ class _SessionBase(object):
         return float(value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_string(self, attribute_id):
+    def _get_attribute_vi_string(self, attribute_id: int) -> str:
         r'''_get_attribute_vi_string
 
         Queries the value of a ViString property. You can use this method to
@@ -3351,7 +3353,7 @@ class _SessionBase(object):
         return value_ctype.value.decode(self._encoding)
 
     @ivi_synchronized
-    def _get_equalization_filter_coefficients(self, number_of_coefficients):
+    def _get_equalization_filter_coefficients(self, number_of_coefficients: int) -> typing.Iterable[float]:
         r'''_get_equalization_filter_coefficients
 
         Retrieves the custom coefficients for the equalization FIR filter on the
@@ -3387,7 +3389,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return [float(coefficients_ctype[i]) for i in range(number_of_coefficients_ctype.value)]
 
-    def _get_error(self):
+    def _get_error(self) -> typing.Tuple[int, str]:
         r'''_get_error
 
         Reads an error code and message from the error queue. National
@@ -3436,7 +3438,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return int(error_code_ctype.value), description_ctype.value.decode(self._encoding)
 
-    def lock(self):
+    def lock(self) -> 'bool':
         '''lock
 
         Obtains a multithread lock on the device session. Before doing so, the
@@ -3471,7 +3473,7 @@ class _SessionBase(object):
         # that will handle the unlock for them
         return _Lock(self)
 
-    def _lock_session(self):
+    def _lock_session(self) -> None:
         '''_lock_session
 
         Actual call to driver
@@ -3482,7 +3484,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _read(self, num_samples, timeout=hightime.timedelta(seconds=5.0)):
+    def _read(self, num_samples: int, timeout: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=5.0)) -> typing.Tuple[typing.Iterable[float], typing.Iterable['waveform_info.WaveformInfo']]:
         r'''_read
 
         Initiates an acquisition, waits for it to complete, and retrieves the
@@ -3581,7 +3583,7 @@ class _SessionBase(object):
         return waveform_array, [waveform_info.WaveformInfo(wfm_info_ctype[i]) for i in range(self._actual_num_wfms())]
 
     @ivi_synchronized
-    def _set_attribute_vi_boolean(self, attribute_id, value):
+    def _set_attribute_vi_boolean(self, attribute_id: int, value: 'bool') -> None:
         r'''_set_attribute_vi_boolean
 
         Sets the value of a ViBoolean property. This is a low-level method
@@ -3629,7 +3631,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_int32(self, attribute_id, value):
+    def _set_attribute_vi_int32(self, attribute_id: int, value: int) -> None:
         r'''_set_attribute_vi_int32
 
         Sets the value of a ViInt32 property. This is a low-level method that
@@ -3677,7 +3679,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_int64(self, attribute_id, value):
+    def _set_attribute_vi_int64(self, attribute_id: int, value: int) -> None:
         r'''_set_attribute_vi_int64
 
         Sets the value of a ViInt64 property. This is a low-level method that
@@ -3725,7 +3727,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_real64(self, attribute_id, value):
+    def _set_attribute_vi_real64(self, attribute_id: int, value: float) -> None:
         r'''_set_attribute_vi_real64
 
         Sets the value of a ViReal64 property. This is a low-level method
@@ -3773,7 +3775,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_string(self, attribute_id, value):
+    def _set_attribute_vi_string(self, attribute_id: int, value: str) -> None:
         r'''_set_attribute_vi_string
 
         Sets the value of a ViString property.
@@ -3822,7 +3824,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def unlock(self):
+    def unlock(self) -> 'bool':
         '''unlock
 
         Releases a lock that you acquired on an device session using
@@ -3834,7 +3836,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return
 
-    def _error_message(self, error_code):
+    def _error_message(self, error_code: int) -> str:
         r'''_error_message
 
         Takes the **Error_Code** returned by the instrument driver methods, interprets it, and returns it as a user-readable string.
@@ -3858,7 +3860,7 @@ class _SessionBase(object):
 class Session(_SessionBase):
     '''An NI-SCOPE session to a National Instruments Digitizer.'''
 
-    def __init__(self, resource_name, id_query=False, reset_device=False, options={}):
+    def __init__(self, resource_name: str, id_query: 'bool' = False, reset_device: 'bool' = False, options={}):
         r'''An NI-SCOPE session to a National Instruments Digitizer.
 
         Performs the following initialization actions:
@@ -4052,7 +4054,7 @@ class Session(_SessionBase):
     ''' These are code-generated '''
 
     @ivi_synchronized
-    def abort(self):
+    def abort(self) -> None:
         r'''abort
 
         Aborts an acquisition and returns the digitizer to the Idle state. Call
@@ -4064,7 +4066,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def acquisition_status(self):
+    def acquisition_status(self) -> 'enums.AcquisitionStatus':
         r'''acquisition_status
 
         Returns status information about the acquisition to the **status**
@@ -4089,7 +4091,7 @@ class Session(_SessionBase):
         return enums.AcquisitionStatus(acquisition_status_ctype.value)
 
     @ivi_synchronized
-    def auto_setup(self):
+    def auto_setup(self) -> None:
         r'''auto_setup
 
         Automatically configures the instrument. When you call this method,
@@ -4165,7 +4167,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def _cal_fetch_date(self, which_one):
+    def _cal_fetch_date(self, which_one: 'enums.CalibrationTypes') -> typing.Tuple[int, int, int]:
         r'''_cal_fetch_date
 
         TBD
@@ -4194,7 +4196,7 @@ class Session(_SessionBase):
         return int(year_ctype.value), int(month_ctype.value), int(day_ctype.value)
 
     @ivi_synchronized
-    def _cal_fetch_temperature(self, which_one):
+    def _cal_fetch_temperature(self, which_one: int) -> float:
         r'''_cal_fetch_temperature
 
         TBD
@@ -4215,7 +4217,7 @@ class Session(_SessionBase):
         return float(temperature_ctype.value)
 
     @ivi_synchronized
-    def commit(self):
+    def commit(self) -> None:
         r'''commit
 
         Commits to hardware all the parameter settings associated with the task.
@@ -4229,7 +4231,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_horizontal_timing(self, min_sample_rate, min_num_pts, ref_position, num_records, enforce_realtime):
+    def configure_horizontal_timing(self, min_sample_rate: float, min_num_pts: int, ref_position: float, num_records: int, enforce_realtime: 'bool') -> None:
         r'''configure_horizontal_timing
 
         Configures the common properties of the horizontal subsystem for a
@@ -4279,7 +4281,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def _configure_ref_levels(self, low=10.0, mid=50.0, high=90.0):
+    def _configure_ref_levels(self, low: float = 10.0, mid: float = 50.0, high: float = 90.0) -> None:
         r'''_configure_ref_levels
 
         This method is included for compliance with the IviScope Class
@@ -4340,7 +4342,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_trigger_digital(self, trigger_source, slope=enums.TriggerSlope.POSITIVE, holdoff=hightime.timedelta(seconds=0.0), delay=hightime.timedelta(seconds=0.0)):
+    def configure_trigger_digital(self, trigger_source: str, slope: 'enums.TriggerSlope' = enums.TriggerSlope.POSITIVE, holdoff: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=0.0), delay: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=0.0)) -> None:
         r'''configure_trigger_digital
 
         Configures the common properties of a digital trigger.
@@ -4402,7 +4404,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_trigger_edge(self, trigger_source, level, trigger_coupling, slope=enums.TriggerSlope.POSITIVE, holdoff=hightime.timedelta(seconds=0.0), delay=hightime.timedelta(seconds=0.0)):
+    def configure_trigger_edge(self, trigger_source: str, level: float, trigger_coupling: 'enums.TriggerCoupling', slope: 'enums.TriggerSlope' = enums.TriggerSlope.POSITIVE, holdoff: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=0.0), delay: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=0.0)) -> None:
         r'''configure_trigger_edge
 
         Configures common properties for analog edge triggering.
@@ -4464,7 +4466,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_trigger_hysteresis(self, trigger_source, level, hysteresis, trigger_coupling, slope=enums.TriggerSlope.POSITIVE, holdoff=hightime.timedelta(seconds=0.0), delay=hightime.timedelta(seconds=0.0)):
+    def configure_trigger_hysteresis(self, trigger_source: str, level: float, hysteresis: float, trigger_coupling: 'enums.TriggerCoupling', slope: 'enums.TriggerSlope' = enums.TriggerSlope.POSITIVE, holdoff: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=0.0), delay: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=0.0)) -> None:
         r'''configure_trigger_hysteresis
 
         Configures common properties for analog hysteresis triggering. This kind
@@ -4537,7 +4539,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_trigger_immediate(self):
+    def configure_trigger_immediate(self) -> None:
         r'''configure_trigger_immediate
 
         Configures common properties for immediate triggering. Immediate
@@ -4553,7 +4555,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_trigger_software(self, holdoff=hightime.timedelta(seconds=0.0), delay=hightime.timedelta(seconds=0.0)):
+    def configure_trigger_software(self, holdoff: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=0.0), delay: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=0.0)) -> None:
         r'''configure_trigger_software
 
         Configures common properties for software triggering.
@@ -4596,7 +4598,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_trigger_video(self, trigger_source, signal_format, event, polarity, trigger_coupling, enable_dc_restore=False, line_number=1, holdoff=hightime.timedelta(seconds=0.0), delay=hightime.timedelta(seconds=0.0)):
+    def configure_trigger_video(self, trigger_source: str, signal_format: 'enums.VideoSignalFormat', event: 'enums.VideoTriggerEvent', polarity: 'enums.VideoPolarity', trigger_coupling: 'enums.TriggerCoupling', enable_dc_restore: 'bool' = False, line_number: int = 1, holdoff: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=0.0), delay: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=0.0)) -> None:
         r'''configure_trigger_video
 
         Configures the common properties for video triggering, including the
@@ -4682,7 +4684,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def configure_trigger_window(self, trigger_source, low_level, high_level, window_mode, trigger_coupling, holdoff=hightime.timedelta(seconds=0.0), delay=hightime.timedelta(seconds=0.0)):
+    def configure_trigger_window(self, trigger_source: str, low_level: float, high_level: float, window_mode: 'enums.TriggerWindowMode', trigger_coupling: 'enums.TriggerCoupling', holdoff: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=0.0), delay: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=0.0)) -> None:
         r'''configure_trigger_window
 
         Configures common properties for analog window triggering. A window
@@ -4747,7 +4749,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def disable(self):
+    def disable(self) -> None:
         r'''disable
 
         Aborts any current operation, opens data channel relays, and releases
@@ -4759,7 +4761,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def export_attribute_configuration_buffer(self):
+    def export_attribute_configuration_buffer(self) -> typing.Iterable['bytes']:
         r'''export_attribute_configuration_buffer
 
         Exports the property configuration of the session to a configuration
@@ -4800,7 +4802,7 @@ class Session(_SessionBase):
         return _converters.convert_to_bytes(configuration_array)
 
     @ivi_synchronized
-    def export_attribute_configuration_file(self, file_path):
+    def export_attribute_configuration_file(self, file_path: str) -> None:
         r'''export_attribute_configuration_file
 
         Exports the property configuration of the session to the specified
@@ -4836,7 +4838,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def get_ext_cal_last_date_and_time(self):
+    def get_ext_cal_last_date_and_time(self) -> hightime.datetime:
         '''get_ext_cal_last_date_and_time
 
         Returns the date and time of the last external calibration performed.
@@ -4850,7 +4852,7 @@ class Session(_SessionBase):
         return hightime.datetime(year, month, day)
 
     @ivi_synchronized
-    def get_ext_cal_last_temp(self):
+    def get_ext_cal_last_temp(self) -> float:
         '''get_ext_cal_last_temp
 
         Returns the onboard temperature, in degrees Celsius, of an oscilloscope at the time of the last successful external calibration.
@@ -4865,7 +4867,7 @@ class Session(_SessionBase):
         return self._cal_fetch_temperature(enums._CalibrationTypes.EXTERNAL.value)
 
     @ivi_synchronized
-    def get_self_cal_last_date_and_time(self):
+    def get_self_cal_last_date_and_time(self) -> hightime.datetime:
         '''get_self_cal_last_date_and_time
 
         Returns the date and time of the last self calibration performed.
@@ -4879,7 +4881,7 @@ class Session(_SessionBase):
         return hightime.datetime(year, month, day)
 
     @ivi_synchronized
-    def get_self_cal_last_temp(self):
+    def get_self_cal_last_temp(self) -> float:
         '''get_self_cal_last_temp
 
         Returns the onboard temperature, in degrees Celsius, of an oscilloscope at the time of the last successful self calibration.
@@ -4894,7 +4896,7 @@ class Session(_SessionBase):
         return self._cal_fetch_temperature(enums._CalibrationTypes.SELF.value)
 
     @ivi_synchronized
-    def import_attribute_configuration_buffer(self, configuration):
+    def import_attribute_configuration_buffer(self, configuration: typing.Iterable['bytes']) -> None:
         r'''import_attribute_configuration_buffer
 
         Imports a property configuration to the session from the specified
@@ -4930,7 +4932,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def import_attribute_configuration_file(self, file_path):
+    def import_attribute_configuration_file(self, file_path: str) -> None:
         r'''import_attribute_configuration_file
 
         Imports a property configuration to the session from the specified
@@ -4965,7 +4967,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def _init_with_options(self, resource_name, id_query=False, reset_device=False, option_string=""):
+    def _init_with_options(self, resource_name: str, id_query: 'bool' = False, reset_device: 'bool' = False, option_string: 'dict' = "") -> int:
         r'''_init_with_options
 
         Performs the following initialization actions:
@@ -5101,7 +5103,7 @@ class Session(_SessionBase):
         return int(vi_ctype.value)
 
     @ivi_synchronized
-    def _initiate_acquisition(self):
+    def _initiate_acquisition(self) -> None:
         r'''_initiate_acquisition
 
         Initiates a waveform acquisition.
@@ -5116,7 +5118,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def probe_compensation_signal_start(self):
+    def probe_compensation_signal_start(self) -> None:
         r'''probe_compensation_signal_start
 
         Starts the 1 kHz square wave output on PFI 1 for probe compensation.
@@ -5127,7 +5129,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def probe_compensation_signal_stop(self):
+    def probe_compensation_signal_stop(self) -> None:
         r'''probe_compensation_signal_stop
 
         Stops the 1 kHz square wave output on PFI 1 for probe compensation.
@@ -5138,7 +5140,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def reset_device(self):
+    def reset_device(self) -> None:
         r'''reset_device
 
         Performs a hard reset of the device. Acquisition stops, all routes are
@@ -5154,7 +5156,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def reset_with_defaults(self):
+    def reset_with_defaults(self) -> None:
         r'''reset_with_defaults
 
         Performs a software reset of the device, returning it to the default
@@ -5167,7 +5169,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def send_software_trigger_edge(self, which_trigger):
+    def send_software_trigger_edge(self, which_trigger: 'enums.WhichTrigger') -> None:
         r'''send_software_trigger_edge
 
         Sends the selected trigger to the digitizer. Call this method if you
@@ -5197,7 +5199,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def _close(self):
+    def _close(self) -> None:
         r'''_close
 
         When you are finished using an instrument driver session, you must call
@@ -5213,7 +5215,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def self_test(self):
+    def self_test(self) -> None:
         '''self_test
 
         Runs the instrument self-test routine and returns the test result(s). Refer to the
@@ -5238,7 +5240,7 @@ class Session(_SessionBase):
         return None
 
     @ivi_synchronized
-    def reset(self):
+    def reset(self) -> None:
         r'''reset
 
         Stops the acquisition, releases routes, and all session properties are
@@ -5251,7 +5253,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def _self_test(self):
+    def _self_test(self) -> typing.Tuple[int, str]:
         r'''_self_test
 
         Runs the instrument self-test routine and returns the test result(s).

--- a/generated/niscope/setup.py
+++ b/generated/niscope/setup.py
@@ -47,6 +47,7 @@ setup(
         'singledispatch;python_version<"3.4"',
         'hightime>=0.2.0',
         'nitclk',
+        'typing',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/nise/nise/session.py
+++ b/generated/nise/nise/session.py
@@ -2,6 +2,8 @@
 # This file was generated
 import array  # noqa: F401
 import ctypes
+import datetime
+import typing
 
 import nise._converters as _converters
 import nise._library_singleton as _library_singleton
@@ -104,7 +106,7 @@ class _SessionBase(object):
 
     ''' These are code-generated '''
 
-    def _get_error(self, error_description_size=[1024]):
+    def _get_error(self, error_description_size: typing.Iterable[int] = [1024]) -> typing.Tuple[int, str]:
         r'''_get_error
 
         Get error information of the first error that occurred. If a valid
@@ -174,7 +176,7 @@ class _SessionBase(object):
 class Session(_SessionBase):
     '''An NI Switch Executive session'''
 
-    def __init__(self, virtual_device_name, options={}):
+    def __init__(self, virtual_device_name: str, options={}):
         r'''An NI Switch Executive session
 
         Opens a session to a specified NI Switch Executive virtual device. Opens
@@ -272,7 +274,7 @@ class Session(_SessionBase):
 
     ''' These are code-generated '''
 
-    def _close_session(self):
+    def _close_session(self) -> None:
         r'''_close_session
 
         Reduces the reference count of open sessions by one. If the reference
@@ -286,7 +288,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def connect(self, connect_spec, multiconnect_mode=enums.MulticonnectMode.DEFAULT, wait_for_debounce=True):
+    def connect(self, connect_spec: str, multiconnect_mode: 'enums.MulticonnectMode' = enums.MulticonnectMode.DEFAULT, wait_for_debounce: 'bool' = True) -> None:
         r'''connect
 
         Connects the routes specified by the connection specification. When
@@ -346,7 +348,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def connect_and_disconnect(self, connect_spec, disconnect_spec, multiconnect_mode=enums.MulticonnectMode.DEFAULT, operation_order=enums.OperationOrder.AFTER, wait_for_debounce=True):
+    def connect_and_disconnect(self, connect_spec: str, disconnect_spec: str, multiconnect_mode: 'enums.MulticonnectMode' = enums.MulticonnectMode.DEFAULT, operation_order: 'enums.OperationOrder' = enums.OperationOrder.AFTER, wait_for_debounce: 'bool' = True) -> None:
         r'''connect_and_disconnect
 
         Connects routes and disconnects routes in a similar fashion to
@@ -441,7 +443,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def disconnect(self, disconnect_spec):
+    def disconnect(self, disconnect_spec: str) -> None:
         r'''disconnect
 
         Disconnects the routes specified in the Disconnection Specification. If
@@ -470,7 +472,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def disconnect_all(self):
+    def disconnect_all(self) -> None:
         r'''disconnect_all
 
         Disconnects all connections on every IVI switch device managed by the
@@ -483,7 +485,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def expand_route_spec(self, route_spec, expand_action=enums.ExpandAction.ROUTES, expanded_route_spec_size=[1024]):
+    def expand_route_spec(self, route_spec: str, expand_action: 'enums.ExpandAction' = enums.ExpandAction.ROUTES, expanded_route_spec_size: typing.Iterable[int] = [1024]) -> str:
         r'''expand_route_spec
 
         Expands a route spec string to yield more information about the routes
@@ -549,7 +551,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return expanded_route_spec_ctype.value.decode(self._encoding)
 
-    def find_route(self, channel1, channel2, route_spec_size=[1024]):
+    def find_route(self, channel1: str, channel2: str, route_spec_size: typing.Iterable[int] = [1024]) -> typing.Tuple[str, 'enums.PathCapability']:
         r'''find_route
 
         Finds an existing or potential route between channel 1 and channel 2.
@@ -630,7 +632,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return route_spec_ctype.value.decode(self._encoding), enums.PathCapability(path_capability_ctype.value)
 
-    def get_all_connections(self, route_spec_size=[1024]):
+    def get_all_connections(self, route_spec_size: typing.Iterable[int] = [1024]) -> str:
         r'''get_all_connections
 
         Returns the top-level connected routes and route groups. The route
@@ -677,7 +679,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return route_spec_ctype.value.decode(self._encoding)
 
-    def is_connected(self, route_spec):
+    def is_connected(self, route_spec: str) -> 'bool':
         r'''is_connected
 
         Checks whether the specified routes and routes groups are connected. It
@@ -706,7 +708,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return bool(is_connected_ctype.value)
 
-    def is_debounced(self):
+    def is_debounced(self) -> 'bool':
         r'''is_debounced
 
         Checks to see if the switching system is debounced or not. This method
@@ -725,7 +727,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return bool(is_debounced_ctype.value)
 
-    def _open_session(self, virtual_device_name, option_string=""):
+    def _open_session(self, virtual_device_name: str, option_string: 'dict' = "") -> int:
         r'''_open_session
 
         Opens a session to a specified NI Switch Executive virtual device. Opens
@@ -763,7 +765,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(vi_ctype.value)
 
-    def wait_for_debounce(self, maximum_time_ms=hightime.timedelta(milliseconds=-1)):
+    def wait_for_debounce(self, maximum_time_ms: typing.Union['hightime.timedelta', 'datetime.timedelta', int] = hightime.timedelta(milliseconds=-1)) -> None:
         r'''wait_for_debounce
 
         Waits for all of the switches in the NI Switch Executive virtual device

--- a/generated/nise/setup.py
+++ b/generated/nise/setup.py
@@ -46,6 +46,7 @@ setup(
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
         'hightime>=0.2.0',
+        'typing',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/niswitch/niswitch/session.py
+++ b/generated/niswitch/niswitch/session.py
@@ -2,8 +2,10 @@
 # This file was generated
 import array  # noqa: F401
 import ctypes
+import datetime
 # Used by @ivi_synchronized
 from functools import wraps
+import typing
 
 import niswitch._attributes as _attributes
 import niswitch._converters as _converters
@@ -569,7 +571,7 @@ class _SessionBase(object):
     ''' These are code-generated '''
 
     @ivi_synchronized
-    def _get_attribute_vi_boolean(self, attribute_id):
+    def _get_attribute_vi_boolean(self, attribute_id: int) -> 'bool':
         r'''_get_attribute_vi_boolean
 
         This method queries the value of a ViBoolean property. You can use
@@ -623,7 +625,7 @@ class _SessionBase(object):
         return bool(attribute_value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_int32(self, attribute_id):
+    def _get_attribute_vi_int32(self, attribute_id: int) -> int:
         r'''_get_attribute_vi_int32
 
         This method queries the value of a ViInt32 property. You can use this
@@ -677,7 +679,7 @@ class _SessionBase(object):
         return int(attribute_value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_real64(self, attribute_id):
+    def _get_attribute_vi_real64(self, attribute_id: int) -> float:
         r'''_get_attribute_vi_real64
 
         This method queries the value of a ViReal64 property. You can use
@@ -731,7 +733,7 @@ class _SessionBase(object):
         return float(attribute_value_ctype.value)
 
     @ivi_synchronized
-    def _get_attribute_vi_string(self, attribute_id):
+    def _get_attribute_vi_string(self, attribute_id: int) -> str:
         r'''_get_attribute_vi_string
 
         This method queries the value of a ViString property. You can use
@@ -810,7 +812,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return attribute_value_ctype.value.decode(self._encoding)
 
-    def _get_error(self):
+    def _get_error(self) -> typing.Tuple[int, str]:
         r'''_get_error
 
         This method retrieves and then clears the IVI error information for
@@ -860,7 +862,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return int(code_ctype.value), description_ctype.value.decode(self._encoding)
 
-    def lock(self):
+    def lock(self) -> 'bool':
         '''lock
 
         Obtains a multithread lock on the device session. Before doing so, the
@@ -895,7 +897,7 @@ class _SessionBase(object):
         # that will handle the unlock for them
         return _Lock(self)
 
-    def _lock_session(self):
+    def _lock_session(self) -> None:
         '''_lock_session
 
         Actual call to driver
@@ -906,7 +908,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_boolean(self, attribute_id, attribute_value):
+    def _set_attribute_vi_boolean(self, attribute_id: int, attribute_value: 'bool') -> None:
         r'''_set_attribute_vi_boolean
 
         This method sets the value of a ViBoolean property. This is a
@@ -972,7 +974,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_int32(self, attribute_id, attribute_value):
+    def _set_attribute_vi_int32(self, attribute_id: int, attribute_value: int) -> None:
         r'''_set_attribute_vi_int32
 
         This method sets the value of a ViInt32 property. This is a low-level
@@ -1038,7 +1040,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_real64(self, attribute_id, attribute_value):
+    def _set_attribute_vi_real64(self, attribute_id: int, attribute_value: float) -> None:
         r'''_set_attribute_vi_real64
 
         This method sets the value of a ViReal64 property. This is a
@@ -1104,7 +1106,7 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
-    def _set_attribute_vi_string(self, attribute_id, attribute_value):
+    def _set_attribute_vi_string(self, attribute_id: int, attribute_value: str) -> None:
         r'''_set_attribute_vi_string
 
         This method sets the value of a ViString property. This is a
@@ -1169,7 +1171,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def unlock(self):
+    def unlock(self) -> 'bool':
         '''unlock
 
         Releases a lock that you acquired on an device session using
@@ -1181,7 +1183,7 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return
 
-    def _error_message(self, error_code):
+    def _error_message(self, error_code: int) -> str:
         r'''_error_message
 
         Converts an error code returned by NI-SWITCH into a user-readable
@@ -1210,7 +1212,7 @@ class _SessionBase(object):
 class Session(_SessionBase):
     '''An NI-SWITCH session to a National Instruments Switch Module'''
 
-    def __init__(self, resource_name, topology="Configured Topology", simulate=False, reset_device=False):
+    def __init__(self, resource_name: str, topology: str = "Configured Topology", simulate: 'bool' = False, reset_device: 'bool' = False):
         r'''An NI-SWITCH session to a National Instruments Switch Module
 
         Returns a session handle used to identify the switch in all subsequent
@@ -1511,7 +1513,7 @@ class Session(_SessionBase):
     ''' These are code-generated '''
 
     @ivi_synchronized
-    def abort(self):
+    def abort(self) -> None:
         r'''abort
 
         Aborts the scan in progress. Initiate a scan with
@@ -1524,7 +1526,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def can_connect(self, channel1, channel2):
+    def can_connect(self, channel1: str, channel2: str) -> 'enums.PathCapability':
         r'''can_connect
 
         Verifies that a path between channel 1 and channel 2 can be created. If
@@ -1581,7 +1583,7 @@ class Session(_SessionBase):
         return enums.PathCapability(path_capability_ctype.value)
 
     @ivi_synchronized
-    def commit(self):
+    def commit(self) -> None:
         r'''commit
 
         Downloads the configured scan list and trigger settings to hardware.
@@ -1595,7 +1597,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def connect(self, channel1, channel2):
+    def connect(self, channel1: str, channel2: str) -> None:
         r'''connect
 
         Creates a path between channel 1 and channel 2. The driver calculates
@@ -1637,7 +1639,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def connect_multiple(self, connection_list):
+    def connect_multiple(self, connection_list: str) -> None:
         r'''connect_multiple
 
         Creates the connections between channels specified in Connection List.
@@ -1678,7 +1680,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def disable(self):
+    def disable(self) -> None:
         r'''disable
 
         Places the switch module in a quiescent state where it has minimal or no
@@ -1691,7 +1693,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def disconnect(self, channel1, channel2):
+    def disconnect(self, channel1: str, channel2: str) -> None:
         r'''disconnect
 
         This method destroys the path between two channels that you create
@@ -1719,7 +1721,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def disconnect_all(self):
+    def disconnect_all(self) -> None:
         r'''disconnect_all
 
         Breaks all existing paths. If the switch module cannot break all paths,
@@ -1731,7 +1733,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def disconnect_multiple(self, disconnection_list):
+    def disconnect_multiple(self, disconnection_list: str) -> None:
         r'''disconnect_multiple
 
         Breaks the connections between channels specified in Disconnection List.
@@ -1757,7 +1759,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def get_channel_name(self, index):
+    def get_channel_name(self, index: int) -> str:
         r'''get_channel_name
 
         Returns the channel string that is in the channel table at the specified
@@ -1788,7 +1790,7 @@ class Session(_SessionBase):
         return channel_name_buffer_ctype.value.decode(self._encoding)
 
     @ivi_synchronized
-    def get_path(self, channel1, channel2):
+    def get_path(self, channel1: str, channel2: str) -> str:
         r'''get_path
 
         Returns a string that identifies the explicit path created with
@@ -1836,7 +1838,7 @@ class Session(_SessionBase):
         return path_ctype.value.decode(self._encoding)
 
     @ivi_synchronized
-    def get_relay_count(self, relay_name):
+    def get_relay_count(self, relay_name: str) -> int:
         r'''get_relay_count
 
         Returns the number of times the relay has changed from Closed to Open.
@@ -1863,7 +1865,7 @@ class Session(_SessionBase):
         return int(relay_count_ctype.value)
 
     @ivi_synchronized
-    def get_relay_name(self, index):
+    def get_relay_name(self, index: int) -> str:
         r'''get_relay_name
 
         Returns the relay name string that is in the relay list at the specified
@@ -1893,7 +1895,7 @@ class Session(_SessionBase):
         return relay_name_buffer_ctype.value.decode(self._encoding)
 
     @ivi_synchronized
-    def get_relay_position(self, relay_name):
+    def get_relay_position(self, relay_name: str) -> 'enums.RelayPosition':
         r'''get_relay_position
 
         Returns the relay position for the relay specified in the Relay Name
@@ -1917,7 +1919,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return enums.RelayPosition(relay_position_ctype.value)
 
-    def _init_with_topology(self, resource_name, topology="Configured Topology", simulate=False, reset_device=False):
+    def _init_with_topology(self, resource_name: str, topology: str = "Configured Topology", simulate: 'bool' = False, reset_device: 'bool' = False) -> int:
         r'''_init_with_topology
 
         Returns a session handle used to identify the switch in all subsequent
@@ -2167,7 +2169,7 @@ class Session(_SessionBase):
         return int(vi_ctype.value)
 
     @ivi_synchronized
-    def _initiate_scan(self):
+    def _initiate_scan(self) -> None:
         r'''_initiate_scan
 
         Commits the configured scan list and trigger settings to hardware and
@@ -2185,7 +2187,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def relay_control(self, relay_name, relay_action):
+    def relay_control(self, relay_name: str, relay_action: 'enums.RelayAction') -> None:
         r'''relay_control
 
         Controls individual relays of the switch. When controlling individual
@@ -2215,7 +2217,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def reset_with_defaults(self):
+    def reset_with_defaults(self) -> None:
         r'''reset_with_defaults
 
         Resets the switch module and applies initial user specified settings
@@ -2229,7 +2231,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def route_scan_advanced_output(self, scan_advanced_output_connector, scan_advanced_output_bus_line, invert=False):
+    def route_scan_advanced_output(self, scan_advanced_output_connector: 'enums.ScanAdvancedOutput', scan_advanced_output_bus_line: 'enums.ScanAdvancedOutput', invert: 'bool' = False) -> None:
         r'''route_scan_advanced_output
 
         Routes the scan advanced output trigger from a trigger bus line (TTLx)
@@ -2270,7 +2272,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def route_trigger_input(self, trigger_input_connector, trigger_input_bus_line, invert=False):
+    def route_trigger_input(self, trigger_input_connector: 'enums.TriggerInput', trigger_input_bus_line: 'enums.TriggerInput', invert: 'bool' = False) -> None:
         r'''route_trigger_input
 
         Routes the input trigger from the front or rear connector to a trigger
@@ -2312,7 +2314,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def send_software_trigger(self):
+    def send_software_trigger(self) -> None:
         r'''send_software_trigger
 
         Sends a software trigger to the switch module specified in the NI-SWITCH
@@ -2331,7 +2333,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def set_path(self, path_list):
+    def set_path(self, path_list: str) -> None:
         r'''set_path
 
         Connects two channels by specifying an explicit path in the path list
@@ -2355,7 +2357,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def wait_for_debounce(self, maximum_time_ms=hightime.timedelta(milliseconds=5000)):
+    def wait_for_debounce(self, maximum_time_ms: typing.Union['hightime.timedelta', 'datetime.timedelta', int] = hightime.timedelta(milliseconds=5000)) -> None:
         r'''wait_for_debounce
 
         Pauses until all created paths have settled. If the time you specify
@@ -2377,7 +2379,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def wait_for_scan_complete(self, maximum_time_ms=hightime.timedelta(milliseconds=5000)):
+    def wait_for_scan_complete(self, maximum_time_ms: typing.Union['hightime.timedelta', 'datetime.timedelta', int] = hightime.timedelta(milliseconds=5000)) -> None:
         r'''wait_for_scan_complete
 
         Pauses until the switch module stops scanning or the maximum time has
@@ -2399,7 +2401,7 @@ class Session(_SessionBase):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def _close(self):
+    def _close(self) -> None:
         r'''_close
 
         Terminates the NI-SWITCH session and all of its properties and
@@ -2417,7 +2419,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def self_test(self):
+    def self_test(self) -> None:
         '''self_test
 
         Verifies that the driver can communicate with the switch module.
@@ -2441,7 +2443,7 @@ class Session(_SessionBase):
         return None
 
     @ivi_synchronized
-    def reset(self):
+    def reset(self) -> None:
         r'''reset
 
         Disconnects all created paths and returns the switch module to the state
@@ -2454,7 +2456,7 @@ class Session(_SessionBase):
         return
 
     @ivi_synchronized
-    def _self_test(self):
+    def _self_test(self) -> typing.Tuple[int, str]:
         r'''_self_test
 
         Verifies that the driver can communicate with the switch module.

--- a/generated/niswitch/setup.py
+++ b/generated/niswitch/setup.py
@@ -46,6 +46,7 @@ setup(
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
         'hightime>=0.2.0',
+        'typing',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/generated/nitclk/nitclk/session.py
+++ b/generated/nitclk/nitclk/session.py
@@ -2,8 +2,10 @@
 
 import array
 import ctypes
+import datetime
 import hightime
 import threading
+import typing
 
 import nitclk._attributes as _attributes
 import nitclk._converters as _converters
@@ -198,7 +200,7 @@ class SessionReference(object):
     def _get_tclk_session_reference(self):
         return self._session_number
 
-    def _get_attribute_vi_real64(self, attribute_id):
+    def _get_attribute_vi_real64(self, attribute_id: int) -> float:
         r'''_get_attribute_vi_real64
 
         Gets the value of an NI-TClk ViReal64 property.
@@ -226,7 +228,7 @@ class SessionReference(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(value_ctype.value)
 
-    def _get_attribute_vi_session(self, attribute_id):
+    def _get_attribute_vi_session(self, attribute_id: int) -> int:
         r'''_get_attribute_vi_session
 
         Gets the value of an NI-TClk ViSession property.
@@ -257,7 +259,7 @@ class SessionReference(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(value_ctype.value)
 
-    def _get_attribute_vi_string(self, attribute_id):
+    def _get_attribute_vi_string(self, attribute_id: int) -> str:
         r'''_get_attribute_vi_string
 
         This method queries the value of an NI-TClk ViString property. You
@@ -302,7 +304,7 @@ class SessionReference(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return value_ctype.value.decode(self._encoding)
 
-    def _get_extended_error_info(self):
+    def _get_extended_error_info(self) -> str:
         r'''_get_extended_error_info
 
         Reports extended error information for the most recent NI-TClk method
@@ -328,7 +330,7 @@ class SessionReference(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return error_string_ctype.value.decode(self._encoding)
 
-    def _set_attribute_vi_real64(self, attribute_id, value):
+    def _set_attribute_vi_real64(self, attribute_id: int, value: float) -> None:
         r'''_set_attribute_vi_real64
 
         Sets the value of an NI-TClk VIReal64 property.
@@ -358,7 +360,7 @@ class SessionReference(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def _set_attribute_vi_session(self, attribute_id, value):
+    def _set_attribute_vi_session(self, attribute_id: int, value: int) -> None:
         r'''_set_attribute_vi_session
 
         Sets the value of an NI-TClk ViSession property.
@@ -391,7 +393,7 @@ class SessionReference(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def _set_attribute_vi_string(self, attribute_id, value):
+    def _set_attribute_vi_string(self, attribute_id: int, value: str) -> None:
         r'''_set_attribute_vi_string
 
         Sets the value of an NI-TClk VIString property.
@@ -461,7 +463,7 @@ class _Session(object):
             return "Failed to retrieve error description."
 
     ''' These are code-generated '''
-    def configure_for_homogeneous_triggers(self, sessions):
+    def configure_for_homogeneous_triggers(self, sessions: typing.Iterable[typing.Any]) -> None:
         r'''configure_for_homogeneous_triggers
 
         Configures the properties commonly required for the TClk synchronization
@@ -597,7 +599,7 @@ class _Session(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def finish_sync_pulse_sender_synchronize(self, sessions, min_time=hightime.timedelta(seconds=0.0)):
+    def finish_sync_pulse_sender_synchronize(self, sessions: typing.Iterable[typing.Any], min_time: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=0.0)) -> None:
         r'''finish_sync_pulse_sender_synchronize
 
         Finishes synchronizing the Sync Pulse Sender.
@@ -621,7 +623,7 @@ class _Session(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def _get_extended_error_info(self):
+    def _get_extended_error_info(self) -> str:
         r'''_get_extended_error_info
 
         Reports extended error information for the most recent NI-TClk method
@@ -647,7 +649,7 @@ class _Session(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=True)
         return error_string_ctype.value.decode(self._encoding)
 
-    def initiate(self, sessions):
+    def initiate(self, sessions: typing.Iterable[typing.Any]) -> None:
         r'''initiate
 
         Initiates the acquisition or generation sessions specified, taking into
@@ -667,7 +669,7 @@ class _Session(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def is_done(self, sessions):
+    def is_done(self, sessions: typing.Iterable[typing.Any]) -> 'bool':
         r'''is_done
 
         Monitors the progress of the acquisitions and/or generations
@@ -691,7 +693,7 @@ class _Session(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return bool(done_ctype.value)
 
-    def setup_for_sync_pulse_sender_synchronize(self, sessions, min_time=hightime.timedelta(seconds=0.0)):
+    def setup_for_sync_pulse_sender_synchronize(self, sessions: typing.Iterable[typing.Any], min_time: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=0.0)) -> None:
         r'''setup_for_sync_pulse_sender_synchronize
 
         Configures the TClks on all the devices and prepares the Sync Pulse Sender for synchronization
@@ -715,7 +717,7 @@ class _Session(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def synchronize(self, sessions, min_tclk_period=hightime.timedelta(seconds=0.0)):
+    def synchronize(self, sessions: typing.Iterable[typing.Any], min_tclk_period: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=0.0)) -> None:
         r'''synchronize
 
         Synchronizes the TClk signals on the given sessions. After
@@ -744,7 +746,7 @@ class _Session(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def synchronize_to_sync_pulse_sender(self, sessions, min_time=hightime.timedelta(seconds=0.0)):
+    def synchronize_to_sync_pulse_sender(self, sessions: typing.Iterable[typing.Any], min_time: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=0.0)) -> None:
         r'''synchronize_to_sync_pulse_sender
 
         Synchronizes the other devices to the Sync Pulse Sender.
@@ -768,7 +770,7 @@ class _Session(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def wait_until_done(self, sessions, timeout=hightime.timedelta(seconds=0.0)):
+    def wait_until_done(self, sessions: typing.Iterable[typing.Any], timeout: typing.Union['hightime.timedelta', 'datetime.timedelta', float] = hightime.timedelta(seconds=0.0)) -> None:
         r'''wait_until_done
 
         Call this method to pause execution of your program until the

--- a/generated/nitclk/setup.py
+++ b/generated/nitclk/setup.py
@@ -46,6 +46,7 @@ setup(
         'enum34;python_version<"3.4"',
         'singledispatch;python_version<"3.4"',
         'hightime>=0.2.0',
+        'typing',
     ],
     setup_requires=['pytest-runner', ],
     tests_require=['pytest'],

--- a/src/nidcpower/templates/session.py/fancy_advanced_sequence.py.mako
+++ b/src/nidcpower/templates/session.py/fancy_advanced_sequence.py.mako
@@ -8,7 +8,7 @@
     # precalculate some lists
     attrs = helper.filter_codegen_attributes(config['attributes'])
 %>\
-    def ${f['python_name']}${suffix}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+    def ${f['python_name']}${suffix}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}) -> None:
         '''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}

--- a/src/nidcpower/templates/session.py/fancy_fetch.py.mako
+++ b/src/nidcpower/templates/session.py/fancy_fetch.py.mako
@@ -19,15 +19,14 @@
     else:
         raise ValueError('Only fetch_multiple and measure_multiple are supported. Got {0}'.format(f['python_name']))
 %>\
-    def ${f['python_name']}${suffix}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+    def ${f['python_name']}${suffix}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}) -> typing.List[typing.NamedTuple[float, float, bool]]:
         '''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}
         '''
-        import collections
-        Measurement = collections.namedtuple('Measurement', ['voltage', 'current', 'in_compliance'])
+        measurement = typing.NamedTuple('Measurement', [('voltage', 'float'), ('current', 'float'), ('in_compliance', 'bool')])
 
         voltage_measurements, current_measurements${in_compliance_return} = self._${f['python_name']}(${param_list})
 
-        return [Measurement(voltage=voltage_measurements[i], current=current_measurements[i], in_compliance=${in_compliance_value}) for i in range(${array_size})]
+        return [measurement(voltage=voltage_measurements[i], current=current_measurements[i], in_compliance=${in_compliance_value}) for i in range(${array_size})]
 

--- a/src/nidigital/templates/session.py/fancy_burst_pattern.py.mako
+++ b/src/nidigital/templates/session.py/fancy_burst_pattern.py.mako
@@ -4,7 +4,7 @@
     results and returns it to the caller.'''
     import build.helper as helper
 %>\
-    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}) -> typing.Optional[typing.Dict[int, bool]]:
         '''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}

--- a/src/nidigital/templates/session.py/fancy_fetch_capture_waveform.py.mako
+++ b/src/nidigital/templates/session.py/fancy_fetch_capture_waveform.py.mako
@@ -3,7 +3,7 @@
     import build.helper as helper
     suffix = method_template['method_python_name_suffix']
 %>\
-    def ${f['python_name']}${suffix}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_NUMPY_INTO_METHOD_DECLARATION)}):
+    def ${f['python_name']}${suffix}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_NUMPY_INTO_METHOD_DECLARATION)}) -> typing.Dict[int, memoryview]:
         '''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}

--- a/src/nidigital/templates/session.py/fancy_fetch_history_ram_cycle_information.py.mako
+++ b/src/nidigital/templates/session.py/fancy_fetch_history_ram_cycle_information.py.mako
@@ -3,7 +3,7 @@
     '''Forwards to History RAM fetch functions'''
     import build.helper as helper
 %>\
-    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}) -> typing.List[history_ram_cycle_information.HistoryRAMCycleInformation]:
         '''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}

--- a/src/nidigital/templates/session.py/fancy_get_pin_results_pin_information.py.mako
+++ b/src/nidigital/templates/session.py/fancy_get_pin_results_pin_information.py.mako
@@ -3,13 +3,12 @@
     '''Forwards to _fetch()/_read() with a nicer interface'''
     import build.helper as helper
 %>\
-    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}) -> typing.List[typing.Any]:
         '''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}
         '''
-        import collections
-        PinInfo = collections.namedtuple('PinInformation', ['pin_name', 'site_number', 'channel_name'])
+        pininfo = typing.NamedTuple('PinInformation', [('pin_name', 'str'), ('site_number', 'int'), ('channel_name', 'str')])
 
         pin_indexes, site_numbers, channel_indexes = self._${f['python_name']}()
         assert len(pin_indexes) == len(site_numbers), "length of returned arrays don't match"
@@ -20,7 +19,7 @@
             pin_name = "" if pin_indexes[i] == -1 else self._get_pin_name(pin_indexes[i])
             channel_names = self.get_channel_names(channel_indexes[i] - 1)  # channel_indexes are 1-based
             assert 1 == len(channel_names)
-            pin_infos.append(PinInfo(pin_name=pin_name, site_number=site_numbers[i], channel_name=channel_names[0]))
+            pin_infos.append(pininfo(pin_name=pin_name, site_number=site_numbers[i], channel_name=channel_names[0]))
 
         return pin_infos
 

--- a/src/nidigital/templates/session.py/fancy_get_site_pass_fail.py.mako
+++ b/src/nidigital/templates/session.py/fancy_get_site_pass_fail.py.mako
@@ -4,7 +4,7 @@
     dictionary where each key is a site number and value is a bool indicating pass/fail'''
     import build.helper as helper
 %>\
-    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}) -> typing.Dict[int, bool]:
         '''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}

--- a/src/nidigital/templates/session.py/fancy_load_specifications_levels_and_timing.py.mako
+++ b/src/nidigital/templates/session.py/fancy_load_specifications_levels_and_timing.py.mako
@@ -3,7 +3,7 @@
     '''Forwards to _load_specifications(), _load_levels(), and _load_timing().'''
     import build.helper as helper
 %>\
-    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}) -> None:
         '''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}

--- a/src/nidigital/templates/session.py/fancy_unload_specifications.py.mako
+++ b/src/nidigital/templates/session.py/fancy_unload_specifications.py.mako
@@ -3,7 +3,7 @@
     '''Forwards to _unload_specifications().'''
     import build.helper as helper
 %>\
-    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}) -> None:
         '''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}

--- a/src/nidigital/templates/session.py/fancy_write_source_waveform_site_unique.py.mako
+++ b/src/nidigital/templates/session.py/fancy_write_source_waveform_site_unique.py.mako
@@ -3,7 +3,7 @@
     import build.helper as helper
     suffix = method_template['method_python_name_suffix']
 %>\
-    def ${f['python_name']}${suffix}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+    def ${f['python_name']}${suffix}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}) -> None:
         '''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}

--- a/src/nifgen/templates/session.py/create_waveform.py.mako
+++ b/src/nifgen/templates/session.py/create_waveform.py.mako
@@ -3,7 +3,7 @@
     '''Dispatches to the appropriate "create waveform" method based on the waveform type.'''
     import build.helper as helper
 %>\
-    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}) -> int:
         '''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}

--- a/src/nifgen/templates/session.py/delete_waveform.py.mako
+++ b/src/nifgen/templates/session.py/delete_waveform.py.mako
@@ -3,7 +3,7 @@
     '''Dispatches to the appropriate "write waveform" method based on the waveform type.'''
     import build.helper as helper
 %>\
-    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}) -> None:
         '''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}

--- a/src/nifgen/templates/session.py/send_software_edge_trigger.py.mako
+++ b/src/nifgen/templates/session.py/send_software_edge_trigger.py.mako
@@ -3,7 +3,7 @@
     '''Need different behavior depending on whether we are called on a rep cap container or not'''
     import build.helper as helper
 %>\
-    def send_software_edge_trigger(self, trigger=None, trigger_id=None):
+    def send_software_edge_trigger(self, trigger=None, trigger_id=None) -> None:
         '''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}

--- a/src/nifgen/templates/session.py/set_next_write_position.py.mako
+++ b/src/nifgen/templates/session.py/set_next_write_position.py.mako
@@ -3,7 +3,7 @@
     '''Dispatches to the appropriate "write waveform" method based on the waveform type.'''
     import build.helper as helper
 %>\
-    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}) -> None:
         '''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}

--- a/src/nifgen/templates/session.py/write_waveform.py.mako
+++ b/src/nifgen/templates/session.py/write_waveform.py.mako
@@ -3,7 +3,7 @@
     '''Dispatches to the appropriate "write waveform" method based on the waveform type.'''
     import build.helper as helper
 %>\
-    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}) -> None:
         '''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}

--- a/src/nimodinst/templates/session.py.mako
+++ b/src/nimodinst/templates/session.py.mako
@@ -15,6 +15,7 @@
 %>\
 
 import ctypes
+import typing
 
 import ${module_name}._library_singleton as _library_singleton
 import ${module_name}._visatype as _visatype

--- a/src/niscope/templates/session.py/fancy_fetch.py.mako
+++ b/src/niscope/templates/session.py/fancy_fetch.py.mako
@@ -5,7 +5,7 @@
 
     suffix = method_template['method_python_name_suffix']
 %>\
-    def ${f['python_name']}${suffix}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+    def ${f['python_name']}${suffix}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}) -> typing.Iterable['waveform_info.WaveformInfo']:
         '''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}

--- a/src/niscope/templates/session.py/fancy_fetch_array_measurement.py.mako
+++ b/src/niscope/templates/session.py/fancy_fetch_array_measurement.py.mako
@@ -4,7 +4,7 @@
     import build.helper as helper
     suffix = method_template['method_python_name_suffix']
 %>\
-    def ${f['python_name']}${suffix}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+    def ${f['python_name']}${suffix}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}) -> typing.Iterable['waveform_info.WaveformInfo']:
         r'''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}

--- a/src/niscope/templates/session.py/fancy_fetch_measurement_stats.py.mako
+++ b/src/niscope/templates/session.py/fancy_fetch_measurement_stats.py.mako
@@ -4,7 +4,7 @@
     import build.helper as helper
     suffix = method_template['method_python_name_suffix']
 %>\
-    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}) -> typing.List[measurement_stats.MeasurementStats]:
         r'''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}

--- a/src/niscope/templates/session.py/fancy_get_cal_last_date.py.mako
+++ b/src/niscope/templates/session.py/fancy_get_cal_last_date.py.mako
@@ -7,7 +7,7 @@
     else: #f['python_name'] == "get_ext_cal_last_date_and_time"
         calibration_type = "EXTERNAL"
 %>\
-    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}) -> hightime.datetime:
         '''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}

--- a/src/niscope/templates/session.py/fancy_get_cal_last_temp.py.mako
+++ b/src/niscope/templates/session.py/fancy_get_cal_last_temp.py.mako
@@ -7,7 +7,7 @@
     else: # f['python_name'] == "get_ext_cal_last_temp"
         calibration_type = "EXTERNAL"
 %>\
-    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}) -> float:
         '''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}

--- a/src/niscope/templates/session.py/fetch_waveform.py.mako
+++ b/src/niscope/templates/session.py/fetch_waveform.py.mako
@@ -5,7 +5,7 @@
 
     suffix = method_template['method_python_name_suffix']
 %>\
-    def ${f['python_name']}${suffix}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_NUMPY_INTO_METHOD_DECLARATION)}):
+    def ${f['python_name']}${suffix}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_NUMPY_INTO_METHOD_DECLARATION)}) -> typing.Iterable['waveform_info.WaveformInfo']:
         '''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}

--- a/src/niscope/templates/session.py/get_equalization_filter_coefficients.py.mako
+++ b/src/niscope/templates/session.py/get_equalization_filter_coefficients.py.mako
@@ -5,7 +5,7 @@
 
     suffix = method_template['method_python_name_suffix']
 %>\
-    def ${f['python_name']}${suffix}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+    def ${f['python_name']}${suffix}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}) -> typing.Iterable[float]:
         '''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}

--- a/src/nitclk/templates/session.py.mako
+++ b/src/nitclk/templates/session.py.mako
@@ -14,8 +14,10 @@
 
 import array
 import ctypes
+import datetime
 import hightime
 import threading
+import typing
 
 import ${module_name}._attributes as _attributes
 import ${module_name}._converters as _converters


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- [ ] I've added tests applicable for this pull request
### What does this Pull Request accomplish?
* Add type hints to public API
    * Uses `type_in_documentation` metadata since it mostly has the information needed - we need the complete list of possible types in the API, not just the type that is passed into the DLL
    * Several special cases to deal with free form test
    * Not sure how to put this information into the metadata
* Most type hints are calculated
* A few in fancy functions are hardcoded
* The preferred method for type hinting namedtuples is to create a class that inherits from `typing.NamedTuple`. This would require the couple of namedtuples we have to be moved to custom types. I did not do that work for this PR.
### ~~List issues fixed by this Pull Request below, if any.~~
### What testing has been done?
* Unit tests and flake8 still pass with type hinting added
* Need to add mypy tests, maybe using examples?