### PR TITLE
Update out of date information in contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ following installed:
         sudo pip install tox tox-globinterpreter --upgrade
 
 * Configure tox interpreter search - only required on Windows when not using WSL
-    - Copy <path to 64 bit python 3>\python.exe <path to 64 bit python3>\python3.exe
+    - Copy <path to 64 bit python3>\python.exe <path to 64 bit python3>\python3.exe
         - This can be any supported version of python 3
     - cd to GitHub repo location
     - <path to python 2>\python -m tox --scan <path 1>\python.exe <path 2>\python3.exe
@@ -126,16 +126,16 @@ System tests exercise the Python bindings. After you have successfully built
 **[nimi-python](https://github.com/ni/nimi-python)**, install the locally built PyPI
 packages using PyPI. For example:
 
-    python3 -m pip install -U bin/nidmm/dist/nidmm-0.1.0.dev4-py2.py3-none-any.whl
+    python3 -m pip install -U generated/nidmm/dist/nidmm-0.1.0.dev4-py2.py3-none-any.whl
 
 You can install all locally built packages in one fell swoop using the following command.
 This will work on Unix-based systems including Windows Subsystem for Linux.
 
-    find bin | grep \.whl | xargs sudo python3 -m pip install -U
+    find generated | grep \.whl | xargs sudo python3 -m pip install -U
 
 Then run the system tests for the desired driver, for example:
 
-    pytest bin/nidmm/system_tests
+    pytest src/nidmm/system_tests
 
 You can also use tox to run the system tests using all installed 64 bit Python versions
 


### PR DESCRIPTION
When referring to the generated .whl files, change path to be under 'generated' folder.
When referring to the system_tests, change path to be under 'src' folder.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [ ] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [ ] ~~I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

Corrects paths in CONTRIBUTING.md that were incorrect.

### List issues fixed by this Pull Request below, if any.

### What testing has been done?

Used the updated paths when installing the .whl files and running the system_tests.
