### PR TITLE
Update nidigital_usage.inc with a basic PPMU example

### DIFF
--- a/docs/_static/nidigital_usage.inc
+++ b/docs/_static/nidigital_usage.inc
@@ -1,8 +1,8 @@
 Usage
 ------
 
-The following is a basic example of using the **nidigital** module to open a session to a digital pattern instrument
-and source/measure both voltage and current using the PPMU on selected channels.
+The following is a basic example of using the **nidigital** module to open a session to a digital pattern instrument,
+source current, and measure both voltage and current using the PPMU on selected channels.
 
 .. code-block:: python
 
@@ -34,7 +34,7 @@ and source/measure both voltage and current using the PPMU on selected channels.
         current_measurements = session.channels[channels].ppmu_measure(nidigital.PPMUMeasurementType.CURRENT)
         voltage_measurements = session.channels[channels].ppmu_measure(nidigital.PPMUMeasurementType.VOLTAGE)
 
-        print('{:,<20} {:,<10} {:,<10}'.format('Channel Name', 'Current', 'Voltage'))
+        print('{:<20} {:<10} {:<10}'.format('Channel Name', 'Current', 'Voltage'))
         for channel, current, voltage in zip(channels.split(','), current_measurements, voltage_measurements):
             print('{:<20} {:<10f} {:<10f}'.format(channel, current, voltage))
 

--- a/docs/_static/nidigital_usage.inc
+++ b/docs/_static/nidigital_usage.inc
@@ -1,27 +1,45 @@
 Usage
 ------
 
-The following is a basic example of using the **nidigital** module to open a session to a ....
+The following is a basic example of using the **nidigital** module to open a session to a digital pattern instrument
+and source/measure both voltage and current using the PPMU on selected channels.
 
 .. code-block:: python
 
     import nidigital
-    with nidigital.Session(resource_name='PXI1Slot2', channels='0') as session:
-        pass
+    import time
 
+    with nidigital.Session(resource_name='PXI1Slot2') as session:
 
-Some repeated capabilities can be chained. This is useful for some methods that can be used with the `pins`
-repeated capability. They can be chained with the `sites` repeated capability.
+        channels = 'PXI1Slot2/0,PXI1Slot2/1'
 
-.. code-block:: python
+        # Configure PPMU measurements
+        session.channels[channels].ppmu_aperture_time = 0.000004
+        session.channels[channels].ppmu_aperture_time_units = nidigital.PPMUApertureTimeUnits.SECONDS
 
-    import nidigital
-    # Configure the session.
+        session.channels[channels].ppmu_output_function = nidigital.PPMUOutputFunction.CURRENT
 
-    with nidigital.Session(resource_name='PXI1Slot2', channels='0') as session:
-        session.sites[0, 1].pins['PinA', 'PinB'].ppmu_source()
+        session.channels[channels].ppmu_current_level_range = 0.000002
+        session.channels[channels].ppmu_current_level = 0.000002
+        session.channels[channels].ppmu_voltage_limit_high = 3.3
+        session.channels[channels].ppmu_voltage_limit_low = 0
 
-This will apply the method/property to `'site0/PinA`, `site0/PinB`, `site1/PinA`, `site1/PinB'`
+        # Sourcing
+        session.channels[channels].ppmu_source()
+
+        # Settling time between sourcing and measuring
+        time.sleep(0.01)
+
+        # Measuring
+        current_measurements = session.channels[channels].ppmu_measure(nidigital.PPMUMeasurementType.CURRENT)
+        voltage_measurements = session.channels[channels].ppmu_measure(nidigital.PPMUMeasurementType.VOLTAGE)
+
+        print('{:,<20} {:,<10} {:,<10}'.format('Channel Name', 'Current', 'Voltage'))
+        for channel, current, voltage in zip(channels.split(','), current_measurements, voltage_measurements):
+            print('{:<20} {:<10f} {:<10f}'.format(channel, current, voltage))
+
+        # Disconnect all channels using programmable onboard switching
+        session.channels[channels].selected_function = nidigital.SelectedFunction.DISCONNECT
 
 Additional examples for NI-Digital Pattern Driver are located in src/nidigital/examples/ directory.
 

--- a/generated/nidigital/README.rst
+++ b/generated/nidigital/README.rst
@@ -128,27 +128,45 @@ We welcome contributions! You can clone the project repository, build it, and in
 Usage
 ------
 
-The following is a basic example of using the **nidigital** module to open a session to a ....
+The following is a basic example of using the **nidigital** module to open a session to a digital pattern instrument
+and source/measure both voltage and current using the PPMU on selected channels.
 
 .. code-block:: python
 
     import nidigital
-    with nidigital.Session(resource_name='PXI1Slot2', channels='0') as session:
-        pass
+    import time
 
+    with nidigital.Session(resource_name='PXI1Slot2') as session:
 
-Some repeated capabilities can be chained. This is useful for some methods that can be used with the `pins`
-repeated capability. They can be chained with the `sites` repeated capability.
+        channels = 'PXI1Slot2/0,PXI1Slot2/1'
 
-.. code-block:: python
+        # Configure PPMU measurements
+        session.channels[channels].ppmu_aperture_time = 0.000004
+        session.channels[channels].ppmu_aperture_time_units = nidigital.PPMUApertureTimeUnits.SECONDS
 
-    import nidigital
-    # Configure the session.
+        session.channels[channels].ppmu_output_function = nidigital.PPMUOutputFunction.CURRENT
 
-    with nidigital.Session(resource_name='PXI1Slot2', channels='0') as session:
-        session.sites[0, 1].pins['PinA', 'PinB'].ppmu_source()
+        session.channels[channels].ppmu_current_level_range = 0.000002
+        session.channels[channels].ppmu_current_level = 0.000002
+        session.channels[channels].ppmu_voltage_limit_high = 3.3
+        session.channels[channels].ppmu_voltage_limit_low = 0
 
-This will apply the method/property to `'site0/PinA`, `site0/PinB`, `site1/PinA`, `site1/PinB'`
+        # Sourcing
+        session.channels[channels].ppmu_source()
+
+        # Settling time between sourcing and measuring
+        time.sleep(0.01)
+
+        # Measuring
+        current_measurements = session.channels[channels].ppmu_measure(nidigital.PPMUMeasurementType.CURRENT)
+        voltage_measurements = session.channels[channels].ppmu_measure(nidigital.PPMUMeasurementType.VOLTAGE)
+
+        print('{:,<20} {:,<10} {:,<10}'.format('Channel Name', 'Current', 'Voltage'))
+        for channel, current, voltage in zip(channels.split(','), current_measurements, voltage_measurements):
+            print('{:<20} {:<10f} {:<10f}'.format(channel, current, voltage))
+
+        # Disconnect all channels using programmable onboard switching
+        session.channels[channels].selected_function = nidigital.SelectedFunction.DISCONNECT
 
 Additional examples for NI-Digital Pattern Driver are located in src/nidigital/examples/ directory.
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Update nidigital_usage.inc to include code snippet of a basic PPMU example that does not use configuration files generated by digital pattern editor.

### List issues fixed by this Pull Request below, if any.

* Fix #1145 

### What testing has been done?

Copy and paste this code snippet into an actual Python file, add option string for simulation, and run the example to produce this output:
```
PS Microsoft.PowerShell.Core\FileSystem::\\wsl$\Ubuntu\home\jxie\nimi-python> & C:/Users/Admin/AppData/Local/Programs/Python/Python38/python.exe //wsl$/Ubuntu/home/jxie/nimi-python/src/nidigital/examples/nidigital_example.py      
Channel Name,,,,,,,, Current,,, Voltage,,,
PXI1Slot2/0          0.000000   0.000000
PXI1Slot2/1          0.000000   0.000000

```