### PR TITLE
Make parameter type check in write_source_waveform_site_unique more r…

### DIFF
--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -2914,6 +2914,9 @@ class Session(_SessionBase):
             waveform_data ({ int: basic sequence of unsigned int, int: basic sequence of unsigned int, ... }): Dictionary where each key is a site number and value is a collection of samples to use as source data
 
         '''
+        from collections.abc import Mapping
+        if not isinstance(waveform_data, Mapping):
+            raise TypeError("Expecting waveform_data to be a dictionary but got {}".format(type(waveform_data)))
         site_list = []
         # We assume all the entries are the same length (we'll check later) to make the array the correct size
         # Get an entry from the dictionary from https://stackoverflow.com/questions/30362391/how-do-you-find-the-first-key-in-a-dictionary

--- a/src/nidigital/templates/session.py/fancy_write_source_waveform_site_unique.py.mako
+++ b/src/nidigital/templates/session.py/fancy_write_source_waveform_site_unique.py.mako
@@ -8,6 +8,9 @@
 
         ${helper.get_function_docstring(f, False, config, indent=8)}
         '''
+        from collections.abc import Mapping
+        if not isinstance(waveform_data, Mapping):
+            raise TypeError("Expecting waveform_data to be a dictionary but got {}".format(type(waveform_data)))
         site_list = []
         # We assume all the entries are the same length (we'll check later) to make the array the correct size
         # Get an entry from the dictionary from https://stackoverflow.com/questions/30362391/how-do-you-find-the-first-key-in-a-dictionary


### PR DESCRIPTION
…obust

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

Making the parameter type check in write_source_waveform_site_unique() more robust by checking whether waveform_data is a dictionary type. Add system test test_source_waveform_parallel_site_unique_wrong_type() to validate wrong type of waveform_data passing in will raise a TypeError.

### List issues fixed by this Pull Request below, if any.

* Fix #1185 

### What testing has been done?

Add new system test test_source_waveform_parallel_site_unique_wrong_type() and passing all system tests.
