### PR TITLE
Add Note to clarify that is_site_enabled can only be called for one site

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI Modular Instruments Python API'
-copyright = '2017-2020, National Instruments'
+copyright = '2017-2021, National Instruments'
 author = 'National Instruments'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -1713,6 +1713,8 @@ is_site_enabled
 
             
 
+            .. note:: The method returns an error if more than one site is specified.
+
 
             .. tip:: This method requires repeated capabilities. If called directly on the
                 nidigital.Session object, then the method will use all repeated capabilities in the session.

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -2214,6 +2214,8 @@ class _SessionBase(object):
 
         TBD
 
+        Note: The method returns an error if more than one site is specified.
+
         Tip:
         This method requires repeated capabilities. If called directly on the
         nidigital.Session object, then the method will use all repeated capabilities in the session.

--- a/src/nidigital/metadata/functions.py
+++ b/src/nidigital/metadata/functions.py
@@ -2079,7 +2079,8 @@ the trigger conditions are met.
     },
     'IsSiteEnabled': {
         'documentation': {
-            'description': 'TBD'
+            'description': 'TBD',
+            'note': 'The function returns an error if more than one site is specified.\n'
         },
         'parameters': [
             {


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [ ] ~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

- [ ] ~I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Adds Note to the documentation for is_site_enabled, clarifying that it is an error to specify more than one site.

### List issues fixed by this Pull Request below, if any.

* Fix #1421 

### What testing has been done?
