### PR TITLE
API parity with NI-Digital 20.6.0 - Add support for frequency counter measurement mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,10 @@ All notable changes to this project will be documented in this file.
     * #### Removed
 * ### `nidigital` (NI-Digital Pattern Driver)
     * #### Added
-        * API reference documentation
+        * API reference documentation and API usage examples
+        * API parity with NI-Digital Pattern Driver 20.6.0 by adding support for configuration of frequency counter measurement mode. The following properties are added:
+            * `frequency_counter_measurement_mode`
+            * `frequency_counter_hysteresis_enabled`
     * #### Changed
     * #### Removed
 * ### `nidmm` (NI-DMM)

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -3321,6 +3321,66 @@ exported_start_trigger_output_terminal
 
                 - C Attribute: **NIDIGITAL_ATTR_EXPORTED_START_TRIGGER_OUTPUT_TERMINAL**
 
+frequency_counter_hysteresis_enabled
+------------------------------------
+
+    .. py:attribute:: frequency_counter_hysteresis_enabled
+
+        Specifies whether hysteresis is enabled for the frequency counters of the digital pattern instrument.
+
+        The following table lists the characteristics of this property.
+
+            +----------------+------------+
+            | Characteristic | Value      |
+            +================+============+
+            | Datatype       | bool       |
+            +----------------+------------+
+            | Permissions    | read-write |
+            +----------------+------------+
+            | Channel Based  | No         |
+            +----------------+------------+
+            | Resettable     | Yes        |
+            +----------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - C Attribute: **NIDIGITAL_ATTR_FREQUENCY_COUNTER_HYSTERESIS_ENABLED**
+
+frequency_counter_measurement_mode
+----------------------------------
+
+    .. py:attribute:: frequency_counter_measurement_mode
+
+        Determines how the frequency counters of the digital pattern instrument make measurements.
+
+        +----------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+        | Valid Values:                                                  |                                                                                                                                                                                                                                                                                                                                                                                                  |
+        +================================================================+==================================================================================================================================================================================================================================================================================================================================================================================================+
+        | :py:data:`~nidigital.FrequencyMeasurementMode.BANKED` (3700)   | Each discrete frequency counter is mapped to specific channels and makes frequency measurements from only those channels. Use banked mode when you need access to the full measure frequency range of the instrument. **Note:** If you request frequency measurements from multiple channels within the same bank, the measurements are made in series for the channels in that bank.            |
+        +----------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+        | :py:data:`~nidigital.FrequencyMeasurementMode.PARALLEL` (3701) | All discrete frequency counters make frequency measurements from all channels in parallel with one another. Use parallel mode to increase the speed of frequency measurements if you do not need access to the full measure frequency range of the instrument; in parallel mode, you can also add :py:attr:`nidigital.Session.frequency_counter_hysteresis_enabled` to reduce measurement noise. |
+        +----------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+        The following table lists the characteristics of this property.
+
+            +----------------+--------------------------------+
+            | Characteristic | Value                          |
+            +================+================================+
+            | Datatype       | enums.FrequencyMeasurementMode |
+            +----------------+--------------------------------+
+            | Permissions    | read-write                     |
+            +----------------+--------------------------------+
+            | Channel Based  | No                             |
+            +----------------+--------------------------------+
+            | Resettable     | Yes                            |
+            +----------------+--------------------------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - C Attribute: **NIDIGITAL_ATTR_FREQUENCY_COUNTER_MEASUREMENT_MODE**
+
 frequency_counter_measurement_time
 ----------------------------------
 

--- a/docs/nidigital/enums.rst
+++ b/docs/nidigital/enums.rst
@@ -101,6 +101,35 @@ DriveFormat
 
 
 
+FrequencyMeasurementMode
+------------------------
+
+.. py:class:: FrequencyMeasurementMode
+
+    .. py:attribute:: FrequencyMeasurementMode.BANKED
+
+
+
+        Frequency measurements are made serially for groups of channels associated with a single frequency counter for each group.
+
+        Maximum frequency measured: 200 MHz.
+
+        
+
+
+
+    .. py:attribute:: FrequencyMeasurementMode.PARALLEL
+
+
+
+        Frequency measurements are made by multiple frequency counters in parallel.
+
+        Maximum frequency measured: 100 MHz.
+
+        
+
+
+
 HistoryRAMCyclesToAcquire
 -------------------------
 

--- a/generated/nidigital/nidigital/enums.py
+++ b/generated/nidigital/nidigital/enums.py
@@ -45,6 +45,21 @@ class DriveFormat(Enum):
     '''
 
 
+class FrequencyMeasurementMode(Enum):
+    BANKED = 3700
+    r'''
+    Frequency measurements are made serially for groups of channels associated with a single frequency counter for each group.
+
+    Maximum frequency measured: 200 MHz.
+    '''
+    PARALLEL = 3701
+    r'''
+    Frequency measurements are made by multiple frequency counters in parallel.
+
+    Maximum frequency measured: 100 MHz.
+    '''
+
+
 class HistoryRAMCyclesToAcquire(Enum):
     FAILED = 2303
     r'''

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -399,6 +399,24 @@ class _SessionBase(object):
     | PXI_Trig7            | PXI trigger line 7          |
     +----------------------+-----------------------------+
     '''
+    frequency_counter_hysteresis_enabled = _attributes.AttributeViBoolean(1150085)
+    '''Type: bool
+
+    Specifies whether hysteresis is enabled for the frequency counters of the digital pattern instrument.
+    '''
+    frequency_counter_measurement_mode = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.FrequencyMeasurementMode, 1150084)
+    '''Type: enums.FrequencyMeasurementMode
+
+    Determines how the frequency counters of the digital pattern instrument make measurements.
+
+    +------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | Valid Values:                            |                                                                                                                                                                                                                                                                                                                                                                                       |
+    +==========================================+=======================================================================================================================================================================================================================================================================================================================================================================================+
+    | FrequencyMeasurementMode.BANKED (3700)   | Each discrete frequency counter is mapped to specific channels and makes frequency measurements from only those channels. Use banked mode when you need access to the full measure frequency range of the instrument. **Note:** If you request frequency measurements from multiple channels within the same bank, the measurements are made in series for the channels in that bank. |
+    +------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | FrequencyMeasurementMode.PARALLEL (3701) | All discrete frequency counters make frequency measurements from all channels in parallel with one another. Use parallel mode to increase the speed of frequency measurements if you do not need access to the full measure frequency range of the instrument; in parallel mode, you can also add frequency_counter_hysteresis_enabled to reduce measurement noise.                   |
+    +------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    '''
     frequency_counter_measurement_time = _attributes.AttributeViReal64TimeDeltaSeconds(1150069)
     '''Type: float in seconds or datetime.timedelta
 

--- a/src/nidigital/metadata/attributes.py
+++ b/src/nidigital/metadata/attributes.py
@@ -1161,6 +1161,23 @@ attributes = {
     1150084: {
         'access': 'read-write',
         'channel_based': False,
+        'documentation': {
+            'description': 'Determines how the frequency counters of the digital pattern instrument make measurements.\n',
+            'table_body': [
+                [
+                    'NIDIGITAL_VAL_BANKED (3700)',
+                    'Each discrete frequency counter is mapped to specific channels and makes frequency measurements from only those channels. Use banked mode when you need access to the full measure frequency range of the instrument. **Note:** If you request frequency measurements from multiple channels within the same bank, the measurements are made in series for the channels in that bank.'
+                ],
+                [
+                    'NIDIGITAL_VAL_PARALLEL (3701)',
+                    'All discrete frequency counters make frequency measurements from all channels in parallel with one another. Use parallel mode to increase the speed of frequency measurements if you do not need access to the full measure frequency range of the instrument; in parallel mode, you can also add NIDIGITAL_ATTR_FREQUENCY_COUNTER_HYSTERESIS_ENABLED to reduce measurement noise.'
+                ]
+            ],
+            'table_header': [
+                'Valid Values:'
+            ]
+        },
+        'enum': 'FrequencyMeasurementMode',
         'name': 'FREQUENCY_COUNTER_MEASUREMENT_MODE',
         'resettable': True,
         'type': 'ViInt32'
@@ -1168,6 +1185,9 @@ attributes = {
     1150085: {
         'access': 'read-write',
         'channel_based': False,
+        'documentation': {
+            'description': 'Specifies whether hysteresis is enabled for the frequency counters of the digital pattern instrument.\n'
+        },
         'name': 'FREQUENCY_COUNTER_HYSTERESIS_ENABLED',
         'resettable': True,
         'type': 'ViBoolean'

--- a/src/nidigital/metadata/attributes_addon.py
+++ b/src/nidigital/metadata/attributes_addon.py
@@ -2,13 +2,5 @@
 # Any changes to the API should be made here. attributes.py is code generated
 
 attributes_override_metadata = {
-    1150084: {
-        # FREQUENCY_COUNTER_MEASUREMENT_MODE (Unreleased as of NI-Digital 19.0.1)
-        'codegen_method': 'no'
-    },
-    1150085: {
-        # FREQUENCY_COUNTER_HYSTERESIS_ENABLED (Unreleased as of NI-Digital 19.0.1)
-        'codegen_method': 'no'
-    },
 }
 

--- a/src/nidigital/metadata/enums.py
+++ b/src/nidigital/metadata/enums.py
@@ -165,18 +165,18 @@ enums = {
             }
         ]
     },
-    'MeasurementMode': {
+    'FrequencyMeasurementMode': {
         'values': [
             {
                 'documentation': {
-                    'description': 'Frequency measurements are done in banks'
+                    'description': 'Frequency measurements are made serially for groups of channels associated with a single frequency counter for each group.\n\nMaximum frequency measured: 200 MHz.'
                 },
                 'name': 'NIDIGITAL_VAL_BANKED',
                 'value': 3700
             },
             {
                 'documentation': {
-                    'description': 'Frequency measurements are done in parallel'
+                    'description': 'Frequency measurements are made by multiple frequency counters in parallel.\n\nMaximum frequency measured: 100 MHz.'
                 },
                 'name': 'NIDIGITAL_VAL_PARALLEL',
                 'value': 3701


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

API parity with NI-Digital Pattern Driver 20.6.0 by adding support for configuration of frequency counter measurement mode. The following properties are added:
 - `frequency_counter_measurement_mode`
 - `frequency_counter_hysteresis_enabled`

### List issues fixed by this Pull Request below, if any.

None

### What testing has been done?

None