### PR TITLE
Release version of docs link to release version of example files

### DIFF
--- a/build/templates/examples.rst.mako
+++ b/build/templates/examples.rst.mako
@@ -11,27 +11,42 @@
     examples = glob.glob(examples_dir + '/**/*.py', recursive=True)
     examples = sorted(examples)
 
-    # If there is no dev or pre ('a', 'b', 'rc'), then the url should link to the (soon to exist) release
-    # Otherwise, there should be a link to examples folder in src, in addition to url to latest released release
+    # The examples page will show 2 things:
+    #   1) URL to zip file containing all examples and in cases like nidigital, support files
+    #   2) Code snippet and URL to example file in src folder, for each example
+    #
+    #  - If there is dev or pre ('a', 'b', 'rc') in the VERSION file then:
+    #       - it means code generator is being run during development
+    #       - (1) will link to the zip file created during last release and the text will include "..for latest version.."
+    #       - (2) will include current code snippet and URL will point to master branch
+    #  - Else:
+    #       - it means code generator is being run during a release
+    #       - (1) will link to the zip file for the current release
+    #       - (2) will include current code snippet and URL will point to release version
+
     with open('./LATEST_RELEASE') as vf:
         latest_release_version = vf.read().strip()
-    released_url = 'https://github.com/ni/nimi-python/releases/download/{0}/{1}_examples.zip'.format(latest_release_version, module_name)
+    released_zip_url = 'https://github.com/ni/nimi-python/releases/download/{0}/{1}_examples.zip'.format(latest_release_version, module_name)
+
+    example_url_base = 'https://github.com/ni/nimi-python/blob/'
 
     # We need to use the global version and not the module version since the release version will match the global version
     # and may not match the module version
     with open('./VERSION') as vf:
         global_version = vf.read().strip()
-
     from packaging.version import Version
     v = Version(global_version)
+
     if v.dev is None and v.pre is None:
-        examples_link_text = '`You can download all {0} examples here <{1}>`_'.format(module_name, released_url)
+        examples_zip_url_text = '`You can download all {0} examples here <{1}>`_'.format(module_name, released_zip_url)
+        example_url_base += str(v)
     else:
-        examples_link_text = '`You can download all {0} examples for latest version here <{1}>`_'.format(module_name, released_url)
+        examples_zip_url_text = '`You can download all {0} examples for latest version here <{1}>`_'.format(module_name, released_zip_url)
+        example_url_base += 'master'
 %>\
 ${helper.get_rst_header_snippet('Examples', '=')}
 
-${examples_link_text}
+${examples_zip_url_text}
 
 % for e in examples:
 ${helper.get_rst_header_snippet(os.path.basename(e), '-')}
@@ -40,6 +55,6 @@ ${helper.get_rst_header_snippet(os.path.basename(e), '-')}
    :language: python
    :linenos:
    :encoding: utf8
-   :caption: `(${os.path.basename(e)}) <https://github.com/ni/nimi-python/blob/master/${e}>`_
+   :caption: `(${os.path.basename(e)}) <${example_url_base}/${e}>`_
 
 % endfor


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

- Before this PR, the release version of docs link to master version of examples files. e.g. The link [here](https://nimi-python.readthedocs.io/en/1.3.2/nidcpower/examples.html#id4) points to [https://github.com/ni/nimi-python/blob/master/src/nidcpower/examples/nidcpower_advanced_sequence.py](https://github.com/ni/nimi-python/blob/master/src/nidcpower/examples/nidcpower_advanced_sequence.py). With this change, it will point to [https://github.com/ni/nimi-python/blob/1.3.2/src/nidcpower/examples/nidcpower_advanced_sequence.py](https://github.com/ni/nimi-python/blob/1.3.2/src/nidcpower/examples/nidcpower_advanced_sequence.py).
- Update the comments and variable names in `examples.rst.mako` to improve maintainability of the code.


### List issues fixed by this Pull Request below, if any.

None

### What testing has been done?

Manually inspected the generated examples.rst for both `dev` and `release` states