### PR TITLE
Ensure URLs in generated documentation files do not contain backslashes when building on Windows

### DIFF
--- a/build/templates/examples.rst.mako
+++ b/build/templates/examples.rst.mako
@@ -55,6 +55,6 @@ ${helper.get_rst_header_snippet(os.path.basename(e), '-')}
    :language: python
    :linenos:
    :encoding: utf8
-   :caption: `(${os.path.basename(e)}) <${example_url_base}/${e}>`_
+   :caption: `(${os.path.basename(e)}) <${example_url_base}/${e.replace('\\', '/')}>`_
 
 % endfor


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [ ] ~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- [ ] ~I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
Documentation files generated on a Windows operating system contained URL paths with backslashes instead of forward slashes because these URLs were obtained from Windows file paths. This change ensures those backslashes in those file paths are converted to forward slashes to create normalized URLs.

### List issues fixed by this Pull Request below, if any.

### What testing has been done?
Built documentation and verified no changes between local files and repo.
