### PR TITLE
Add converter function for resource name constructor parameter

### DIFF
--- a/build/templates/_converters.py.mako
+++ b/build/templates/_converters.py.mako
@@ -299,6 +299,8 @@ def _(resource_name):
     # Must be of form "Dev/0", "Dev/0:1", "Dev/0-1" or "Dev"
     fields = [item.strip() for item in resource_name.split('/')]
     device_name = fields[0]
+    if len(device_name) == 0:
+        raise errors.InvalidResourceNameError("Empty device name", resource_name)
     if len(fields) > 2:
         raise errors.InvalidResourceNameError("Multiple '/'", resource_name)
     if len(fields) == 1:

--- a/build/templates/_converters.py.mako
+++ b/build/templates/_converters.py.mako
@@ -275,18 +275,34 @@ def convert_chained_repeated_capability_to_parts(chained_repeated_capability):
 
 
 def convert_resource_name(resource_name):
-    return _convert_resource_name(resource_name)
+    '''Convert a resource_name into a comma-separated list of device/channel resources
+
+    Args:
+        resource_name - Supported types:
+            - str - list (comma-delimited)
+            - str - single item
+            - list of str
+            - tuple of str
+            - None
+
+    Returns:
+        str - comma delimited string of each device/channel
+    '''
+    if resource_name is None:
+        return ''
+
+    return ','.join(_convert_resource_name(resource_name))
 
 
 @singledispatch
 def _convert_resource_name(arg):
-    raise errors.InvalidResourceNameError('Invalid type', type(arg))
+    raise errors.InvalidResourceNameError(str(arg), "Invalid Type")
 
 
 # This parsing function duplicate the parsing in the driver, so if changes to the allowed format are made there, they will need to be replicated here.
 @_convert_resource_name.register(str)  # noqa: F811
 def _(resource_name):
-    '''String version (this is the most complex)
+    '''String version
 
     We need to deal with a range ('Dev/0-3' or 'Dev/0:3'), a list ('Dev/0,Dev/1,Dev/2,Dev/3') and a single item
     '''
@@ -300,15 +316,15 @@ def _(resource_name):
     fields = [item.strip() for item in resource_name.split('/')]
     device_name = fields[0]
     if len(device_name) == 0:
-        raise errors.InvalidResourceNameError("Empty device name", resource_name)
+        raise errors.InvalidResourceNameError(resource_name, "Empty device name")
     if len(fields) > 2:
-        raise errors.InvalidResourceNameError("Multiple '/'", resource_name)
+        raise errors.InvalidResourceNameError(resource_name, "Multiple '/'")
     if len(fields) == 1:
         return [device_name]
     if len(fields) == 2:
         repeated_capability = fields[1]
         if len(repeated_capability) == 0:
-            raise errors.InvalidResourceNameError("Missing channels after '/''", resource_name)
+            raise errors.InvalidResourceNameError(resource_name, "Missing channels after '/''")
 
     return [device_name + '/' + r for r in _convert_repeated_capabilities(repeated_capability, '')]
 
@@ -318,7 +334,7 @@ def _(resource_name):
 @_convert_resource_name.register(list)  # noqa: F811
 @_convert_resource_name.register(tuple)  # noqa: F811
 def _(resource_name):
-    '''Iterable version - can handle lists, ranges, and tuples'''
+    '''Iterable version - can handle lists and tuples'''
     resource_name_list = []
     for r in resource_name:
         resource_name_list += _convert_resource_name(r)

--- a/build/templates/_converters.py.mako
+++ b/build/templates/_converters.py.mako
@@ -274,6 +274,55 @@ def convert_chained_repeated_capability_to_parts(chained_repeated_capability):
     return [','.join(collections.OrderedDict.fromkeys(x)) for x in repeated_capability_lists]
 
 
+def convert_resource_name(resource_name):
+    return _convert_resource_name(resource_name)
+
+
+@singledispatch
+def _convert_resource_name(arg):
+    raise errors.InvalidResourceNameError('Invalid type', type(arg))
+
+
+# This parsing function duplicate the parsing in the driver, so if changes to the allowed format are made there, they will need to be replicated here.
+@_convert_resource_name.register(str)  # noqa: F811
+def _(resource_name):
+    '''String version (this is the most complex)
+
+    We need to deal with a range ('Dev/0-3' or 'Dev/0:3'), a list ('Dev/0,Dev/1,Dev/2,Dev/3') and a single item
+    '''
+    # First we deal with a list
+    resource_name_list = resource_name.split(',')
+    if len(resource_name_list) > 1:
+        # We have a list so call ourselves again to let the iterable instance handle it
+        return _convert_resource_name(resource_name_list)
+
+    # Must be of form "Dev/0", "Dev/0:1", "Dev/0-1" or "Dev"
+    fields = [item.strip() for item in resource_name.split('/')]
+    device_name = fields[0]
+    if len(fields) > 2:
+        raise errors.InvalidResourceNameError("Multiple '/'", resource_name)
+    if len(fields) == 1:
+        return [device_name]
+    if len(fields) == 2:
+        repeated_capability = fields[1]
+        if len(repeated_capability) == 0:
+            raise errors.InvalidResourceNameError("Missing channels after '/''", resource_name)
+
+    return [device_name + '/' + r for r in _convert_repeated_capabilities(repeated_capability, '')]
+
+
+# We cannot use collections.abc.Iterable here because strings are also iterable and then this
+# instance is what gets called instead of the string one.
+@_convert_resource_name.register(list)  # noqa: F811
+@_convert_resource_name.register(tuple)  # noqa: F811
+def _(resource_name):
+    '''Iterable version - can handle lists, ranges, and tuples'''
+    resource_name_list = []
+    for r in resource_name:
+        resource_name_list += _convert_resource_name(r)
+    return resource_name_list
+
+
 <%
 # Beginning of module-specific converters
 %>\

--- a/build/templates/errors.py.mako
+++ b/build/templates/errors.py.mako
@@ -89,6 +89,15 @@ class SelfTestError(Error):
 
 
 % endif
+% if 'InvalidResourceNameError' in extra_errors_used:
+class InvalidResourceNameError(Error):
+    '''An error due to an invalid character in a resource name'''
+
+    def __init__(self, invalid_character, invalid_string):
+        super(InvalidResourceNameError, self).__init__('An invalid character ({0}) was found in a resource name string ({1})'.format(invalid_character, invalid_string))
+
+
+% endif
 def handle_error(session, code, ignore_warnings, is_error_handling):
     '''handle_error
 

--- a/build/templates/errors.py.mako
+++ b/build/templates/errors.py.mako
@@ -91,10 +91,10 @@ class SelfTestError(Error):
 % endif
 % if 'InvalidResourceNameError' in extra_errors_used:
 class InvalidResourceNameError(Error):
-    '''An error due to an invalid character in a resource name'''
+    '''An error due to an incorrectly formatted resource name'''
 
-    def __init__(self, invalid_character, invalid_string):
-        super(InvalidResourceNameError, self).__init__('An invalid character ({0}) was found in a resource name string ({1})'.format(invalid_character, invalid_string))
+    def __init__(self, resource_name, message):
+        super(InvalidResourceNameError, self).__init__('The resource_name ({0}) is invalid: {1}'.format(resource_name, message))
 
 
 % endif

--- a/build/templates/errors.rst.mako
+++ b/build/templates/errors.rst.mako
@@ -65,6 +65,17 @@ ${helper.get_rst_header_snippet('SelfTestError', '-')}
 
 
 % endif
+% if 'InvalidResourceNameError' in extra_errors_used:
+${helper.get_rst_header_snippet('InvalidResourceNameError', '-')}
+
+    .. py:currentmodule:: ${module_name}.errors
+
+    .. exception:: InvalidResourceNameError
+
+        An error due to an invalid character in a resource name
+
+
+% endif
 ${helper.get_rst_header_snippet('DriverWarning', '-')}
 
     .. py:currentmodule:: ${module_name}.errors

--- a/build/templates/errors.rst.mako
+++ b/build/templates/errors.rst.mako
@@ -72,7 +72,7 @@ ${helper.get_rst_header_snippet('InvalidResourceNameError', '-')}
 
     .. exception:: InvalidResourceNameError
 
-        An error due to an invalid character in a resource name
+        An error due to an incorrectly formatted resource name
 
 
 % endif

--- a/build/templates/examples.rst.mako
+++ b/build/templates/examples.rst.mako
@@ -55,6 +55,6 @@ ${helper.get_rst_header_snippet(os.path.basename(e), '-')}
    :language: python
    :linenos:
    :encoding: utf8
-   :caption: `(${os.path.basename(e)}) <${example_url_base}/${e}>`_
+   :caption: `(${os.path.basename(e)}) <${example_url_base}/${e.replace('\\', '/')}>`_
 
 % endfor

--- a/docs/nidcpower/errors.rst
+++ b/docs/nidcpower/errors.rst
@@ -59,6 +59,16 @@ SelfTestError
         An error due to a failed self-test
 
 
+InvalidResourceNameError
+------------------------
+
+    .. py:currentmodule:: nidcpower.errors
+
+    .. exception:: InvalidResourceNameError
+
+        An error due to an invalid character in a resource name
+
+
 DriverWarning
 -------------
 

--- a/docs/nidcpower/errors.rst
+++ b/docs/nidcpower/errors.rst
@@ -66,7 +66,7 @@ InvalidResourceNameError
 
     .. exception:: InvalidResourceNameError
 
-        An error due to an invalid character in a resource name
+        An error due to an incorrectly formatted resource name
 
 
 DriverWarning

--- a/generated/nidcpower/nidcpower/_converters.py
+++ b/generated/nidcpower/nidcpower/_converters.py
@@ -294,6 +294,8 @@ def _(resource_name):
     # Must be of form "Dev/0", "Dev/0:1", "Dev/0-1" or "Dev"
     fields = [item.strip() for item in resource_name.split('/')]
     device_name = fields[0]
+    if len(device_name) == 0:
+        raise errors.InvalidResourceNameError("Empty device name", resource_name)
     if len(fields) > 2:
         raise errors.InvalidResourceNameError("Multiple '/'", resource_name)
     if len(fields) == 1:

--- a/generated/nidcpower/nidcpower/_converters.py
+++ b/generated/nidcpower/nidcpower/_converters.py
@@ -269,3 +269,52 @@ def convert_chained_repeated_capability_to_parts(chained_repeated_capability):
     return [','.join(collections.OrderedDict.fromkeys(x)) for x in repeated_capability_lists]
 
 
+def convert_resource_name(resource_name):
+    return _convert_resource_name(resource_name)
+
+
+@singledispatch
+def _convert_resource_name(arg):
+    raise errors.InvalidResourceNameError('Invalid type', type(arg))
+
+
+# This parsing function duplicate the parsing in the driver, so if changes to the allowed format are made there, they will need to be replicated here.
+@_convert_resource_name.register(str)  # noqa: F811
+def _(resource_name):
+    '''String version (this is the most complex)
+
+    We need to deal with a range ('Dev/0-3' or 'Dev/0:3'), a list ('Dev/0,Dev/1,Dev/2,Dev/3') and a single item
+    '''
+    # First we deal with a list
+    resource_name_list = resource_name.split(',')
+    if len(resource_name_list) > 1:
+        # We have a list so call ourselves again to let the iterable instance handle it
+        return _convert_resource_name(resource_name_list)
+
+    # Must be of form "Dev/0", "Dev/0:1", "Dev/0-1" or "Dev"
+    fields = [item.strip() for item in resource_name.split('/')]
+    device_name = fields[0]
+    if len(fields) > 2:
+        raise errors.InvalidResourceNameError("Multiple '/'", resource_name)
+    if len(fields) == 1:
+        return [device_name]
+    if len(fields) == 2:
+        repeated_capability = fields[1]
+        if len(repeated_capability) == 0:
+            raise errors.InvalidResourceNameError("Missing channels after '/''", resource_name)
+
+    return [device_name + '/' + r for r in _convert_repeated_capabilities(repeated_capability, '')]
+
+
+# We cannot use collections.abc.Iterable here because strings are also iterable and then this
+# instance is what gets called instead of the string one.
+@_convert_resource_name.register(list)  # noqa: F811
+@_convert_resource_name.register(tuple)  # noqa: F811
+def _(resource_name):
+    '''Iterable version - can handle lists, ranges, and tuples'''
+    resource_name_list = []
+    for r in resource_name:
+        resource_name_list += _convert_resource_name(r)
+    return resource_name_list
+
+

--- a/generated/nidcpower/nidcpower/errors.py
+++ b/generated/nidcpower/nidcpower/errors.py
@@ -74,10 +74,10 @@ class SelfTestError(Error):
 
 
 class InvalidResourceNameError(Error):
-    '''An error due to an invalid character in a resource name'''
+    '''An error due to an incorrectly formatted resource name'''
 
-    def __init__(self, invalid_character, invalid_string):
-        super(InvalidResourceNameError, self).__init__('An invalid character ({0}) was found in a resource name string ({1})'.format(invalid_character, invalid_string))
+    def __init__(self, resource_name, message):
+        super(InvalidResourceNameError, self).__init__('The resource_name ({0}) is invalid: {1}'.format(resource_name, message))
 
 
 def handle_error(session, code, ignore_warnings, is_error_handling):

--- a/generated/nidcpower/nidcpower/errors.py
+++ b/generated/nidcpower/nidcpower/errors.py
@@ -73,6 +73,13 @@ class SelfTestError(Error):
         super(SelfTestError, self).__init__('Self-test failed with code {0}: {1}'.format(code, msg))
 
 
+class InvalidResourceNameError(Error):
+    '''An error due to an invalid character in a resource name'''
+
+    def __init__(self, invalid_character, invalid_string):
+        super(InvalidResourceNameError, self).__init__('An invalid character ({0}) was found in a resource name string ({1})'.format(invalid_character, invalid_string))
+
+
 def handle_error(session, code, ignore_warnings, is_error_handling):
     '''handle_error
 

--- a/generated/nidigital/nidigital/_converters.py
+++ b/generated/nidigital/nidigital/_converters.py
@@ -294,6 +294,8 @@ def _(resource_name):
     # Must be of form "Dev/0", "Dev/0:1", "Dev/0-1" or "Dev"
     fields = [item.strip() for item in resource_name.split('/')]
     device_name = fields[0]
+    if len(device_name) == 0:
+        raise errors.InvalidResourceNameError("Empty device name", resource_name)
     if len(fields) > 2:
         raise errors.InvalidResourceNameError("Multiple '/'", resource_name)
     if len(fields) == 1:

--- a/generated/nidigital/nidigital/_converters.py
+++ b/generated/nidigital/nidigital/_converters.py
@@ -269,3 +269,52 @@ def convert_chained_repeated_capability_to_parts(chained_repeated_capability):
     return [','.join(collections.OrderedDict.fromkeys(x)) for x in repeated_capability_lists]
 
 
+def convert_resource_name(resource_name):
+    return _convert_resource_name(resource_name)
+
+
+@singledispatch
+def _convert_resource_name(arg):
+    raise errors.InvalidResourceNameError('Invalid type', type(arg))
+
+
+# This parsing function duplicate the parsing in the driver, so if changes to the allowed format are made there, they will need to be replicated here.
+@_convert_resource_name.register(str)  # noqa: F811
+def _(resource_name):
+    '''String version (this is the most complex)
+
+    We need to deal with a range ('Dev/0-3' or 'Dev/0:3'), a list ('Dev/0,Dev/1,Dev/2,Dev/3') and a single item
+    '''
+    # First we deal with a list
+    resource_name_list = resource_name.split(',')
+    if len(resource_name_list) > 1:
+        # We have a list so call ourselves again to let the iterable instance handle it
+        return _convert_resource_name(resource_name_list)
+
+    # Must be of form "Dev/0", "Dev/0:1", "Dev/0-1" or "Dev"
+    fields = [item.strip() for item in resource_name.split('/')]
+    device_name = fields[0]
+    if len(fields) > 2:
+        raise errors.InvalidResourceNameError("Multiple '/'", resource_name)
+    if len(fields) == 1:
+        return [device_name]
+    if len(fields) == 2:
+        repeated_capability = fields[1]
+        if len(repeated_capability) == 0:
+            raise errors.InvalidResourceNameError("Missing channels after '/''", resource_name)
+
+    return [device_name + '/' + r for r in _convert_repeated_capabilities(repeated_capability, '')]
+
+
+# We cannot use collections.abc.Iterable here because strings are also iterable and then this
+# instance is what gets called instead of the string one.
+@_convert_resource_name.register(list)  # noqa: F811
+@_convert_resource_name.register(tuple)  # noqa: F811
+def _(resource_name):
+    '''Iterable version - can handle lists, ranges, and tuples'''
+    resource_name_list = []
+    for r in resource_name:
+        resource_name_list += _convert_resource_name(r)
+    return resource_name_list
+
+

--- a/generated/nidmm/nidmm/_converters.py
+++ b/generated/nidmm/nidmm/_converters.py
@@ -294,6 +294,8 @@ def _(resource_name):
     # Must be of form "Dev/0", "Dev/0:1", "Dev/0-1" or "Dev"
     fields = [item.strip() for item in resource_name.split('/')]
     device_name = fields[0]
+    if len(device_name) == 0:
+        raise errors.InvalidResourceNameError("Empty device name", resource_name)
     if len(fields) > 2:
         raise errors.InvalidResourceNameError("Multiple '/'", resource_name)
     if len(fields) == 1:

--- a/generated/nidmm/nidmm/_converters.py
+++ b/generated/nidmm/nidmm/_converters.py
@@ -269,3 +269,52 @@ def convert_chained_repeated_capability_to_parts(chained_repeated_capability):
     return [','.join(collections.OrderedDict.fromkeys(x)) for x in repeated_capability_lists]
 
 
+def convert_resource_name(resource_name):
+    return _convert_resource_name(resource_name)
+
+
+@singledispatch
+def _convert_resource_name(arg):
+    raise errors.InvalidResourceNameError('Invalid type', type(arg))
+
+
+# This parsing function duplicate the parsing in the driver, so if changes to the allowed format are made there, they will need to be replicated here.
+@_convert_resource_name.register(str)  # noqa: F811
+def _(resource_name):
+    '''String version (this is the most complex)
+
+    We need to deal with a range ('Dev/0-3' or 'Dev/0:3'), a list ('Dev/0,Dev/1,Dev/2,Dev/3') and a single item
+    '''
+    # First we deal with a list
+    resource_name_list = resource_name.split(',')
+    if len(resource_name_list) > 1:
+        # We have a list so call ourselves again to let the iterable instance handle it
+        return _convert_resource_name(resource_name_list)
+
+    # Must be of form "Dev/0", "Dev/0:1", "Dev/0-1" or "Dev"
+    fields = [item.strip() for item in resource_name.split('/')]
+    device_name = fields[0]
+    if len(fields) > 2:
+        raise errors.InvalidResourceNameError("Multiple '/'", resource_name)
+    if len(fields) == 1:
+        return [device_name]
+    if len(fields) == 2:
+        repeated_capability = fields[1]
+        if len(repeated_capability) == 0:
+            raise errors.InvalidResourceNameError("Missing channels after '/''", resource_name)
+
+    return [device_name + '/' + r for r in _convert_repeated_capabilities(repeated_capability, '')]
+
+
+# We cannot use collections.abc.Iterable here because strings are also iterable and then this
+# instance is what gets called instead of the string one.
+@_convert_resource_name.register(list)  # noqa: F811
+@_convert_resource_name.register(tuple)  # noqa: F811
+def _(resource_name):
+    '''Iterable version - can handle lists, ranges, and tuples'''
+    resource_name_list = []
+    for r in resource_name:
+        resource_name_list += _convert_resource_name(r)
+    return resource_name_list
+
+

--- a/generated/nifake/nifake/_converters.py
+++ b/generated/nifake/nifake/_converters.py
@@ -294,6 +294,8 @@ def _(resource_name):
     # Must be of form "Dev/0", "Dev/0:1", "Dev/0-1" or "Dev"
     fields = [item.strip() for item in resource_name.split('/')]
     device_name = fields[0]
+    if len(device_name) == 0:
+        raise errors.InvalidResourceNameError("Empty device name", resource_name)
     if len(fields) > 2:
         raise errors.InvalidResourceNameError("Multiple '/'", resource_name)
     if len(fields) == 1:

--- a/generated/nifake/nifake/errors.py
+++ b/generated/nifake/nifake/errors.py
@@ -74,10 +74,10 @@ class SelfTestError(Error):
 
 
 class InvalidResourceNameError(Error):
-    '''An error due to an invalid character in a resource name'''
+    '''An error due to an incorrectly formatted resource name'''
 
-    def __init__(self, invalid_character, invalid_string):
-        super(InvalidResourceNameError, self).__init__('An invalid character ({0}) was found in a resource name string ({1})'.format(invalid_character, invalid_string))
+    def __init__(self, resource_name, message):
+        super(InvalidResourceNameError, self).__init__('The resource_name ({0}) is invalid: {1}'.format(resource_name, message))
 
 
 def handle_error(session, code, ignore_warnings, is_error_handling):

--- a/generated/nifake/nifake/errors.py
+++ b/generated/nifake/nifake/errors.py
@@ -73,6 +73,13 @@ class SelfTestError(Error):
         super(SelfTestError, self).__init__('Self-test failed with code {0}: {1}'.format(code, msg))
 
 
+class InvalidResourceNameError(Error):
+    '''An error due to an invalid character in a resource name'''
+
+    def __init__(self, invalid_character, invalid_string):
+        super(InvalidResourceNameError, self).__init__('An invalid character ({0}) was found in a resource name string ({1})'.format(invalid_character, invalid_string))
+
+
 def handle_error(session, code, ignore_warnings, is_error_handling):
     '''handle_error
 

--- a/generated/nifake/nifake/unit_tests/test_converters.py
+++ b/generated/nifake/nifake/unit_tests/test_converters.py
@@ -310,7 +310,32 @@ def test_resource_name_mixed():
 
 def test_invalid_resource_name():
     try:
+        _converters.convert_resource_name('')
+        assert False
+    except errors.InvalidResourceNameError:
+        pass
+    try:
         _converters.convert_resource_name('/')
+        assert False
+    except errors.InvalidResourceNameError:
+        pass
+    try:
+        _converters.convert_resource_name('Dev,')
+        assert False
+    except errors.InvalidResourceNameError:
+        pass
+    try:
+        _converters.convert_resource_name('Dev/')
+        assert False
+    except errors.InvalidResourceNameError:
+        pass
+    try:
+        _converters.convert_resource_name('Dev/0/1')
+        assert False
+    except errors.InvalidResourceNameError:
+        pass
+    try:
+        _converters.convert_resource_name(0)
         assert False
     except errors.InvalidResourceNameError:
         pass

--- a/generated/nifake/nifake/unit_tests/test_converters.py
+++ b/generated/nifake/nifake/unit_tests/test_converters.py
@@ -238,74 +238,79 @@ def test_repeated_capabilies_without_prefix():
 
 
 # Tests - resource name
+def test_resource_name_none():
+    test_result_list = _converters.convert_resource_name(None)
+    assert test_result_list == ''
+
+
 def test_resource_name_string():
     test_result_list = _converters.convert_resource_name('Dev1')
-    assert test_result_list == ['Dev1']
+    assert test_result_list == 'Dev1'
     test_result_list = _converters.convert_resource_name('Dev1,Dev2')
-    assert test_result_list == ['Dev1', 'Dev2']
+    assert test_result_list == 'Dev1,Dev2'
     test_result_list = _converters.convert_resource_name('Dev1/0')
-    assert test_result_list == ['Dev1/0']
+    assert test_result_list == 'Dev1/0'
     test_result_list = _converters.convert_resource_name('Dev1/0:1, Dev2/0-1')
-    assert test_result_list == ['Dev1/0', 'Dev1/1', 'Dev2/0', 'Dev2/1']
+    assert test_result_list == 'Dev1/0,Dev1/1,Dev2/0,Dev2/1'
     test_result_list = _converters.convert_resource_name('Dev1, Dev2/0-2')
-    assert test_result_list == ['Dev1', 'Dev2/0', 'Dev2/1', 'Dev2/2']
+    assert test_result_list == 'Dev1,Dev2/0,Dev2/1,Dev2/2'
 
 
 def test_resource_name_unicode_string():
     test_result_list = _converters.convert_resource_name(u'Dev1')
-    assert test_result_list == ['Dev1']
+    assert test_result_list == 'Dev1'
     test_result_list = _converters.convert_resource_name(u'Dev1,Dev2')
-    assert test_result_list == ['Dev1', 'Dev2']
+    assert test_result_list == 'Dev1,Dev2'
     test_result_list = _converters.convert_resource_name(u'Dev1/0')
-    assert test_result_list == ['Dev1/0']
+    assert test_result_list == 'Dev1/0'
     test_result_list = _converters.convert_resource_name(u'Dev1/0:1, Dev2/0-1')
-    assert test_result_list == ['Dev1/0', 'Dev1/1', 'Dev2/0', 'Dev2/1']
+    assert test_result_list == 'Dev1/0,Dev1/1,Dev2/0,Dev2/1'
     test_result_list = _converters.convert_resource_name(u'Dev1, Dev2/0-2')
-    assert test_result_list == ['Dev1', 'Dev2/0', 'Dev2/1', 'Dev2/2']
+    assert test_result_list == 'Dev1,Dev2/0,Dev2/1,Dev2/2'
 
 
 def test_resource_name_raw_string():
     test_result_list = _converters.convert_resource_name(r'Dev1')
-    assert test_result_list == ['Dev1']
+    assert test_result_list == 'Dev1'
     test_result_list = _converters.convert_resource_name(r'Dev1,Dev2')
-    assert test_result_list == ['Dev1', 'Dev2']
+    assert test_result_list == 'Dev1,Dev2'
     test_result_list = _converters.convert_resource_name(r'Dev1/0')
-    assert test_result_list == ['Dev1/0']
+    assert test_result_list == 'Dev1/0'
     test_result_list = _converters.convert_resource_name(r'Dev1/0:1, Dev2/0-1')
-    assert test_result_list == ['Dev1/0', 'Dev1/1', 'Dev2/0', 'Dev2/1']
+    assert test_result_list == 'Dev1/0,Dev1/1,Dev2/0,Dev2/1'
     test_result_list = _converters.convert_resource_name(r'Dev1, Dev2/0-2')
-    assert test_result_list == ['Dev1', 'Dev2/0', 'Dev2/1', 'Dev2/2']
+    assert test_result_list == 'Dev1,Dev2/0,Dev2/1,Dev2/2'
 
 
 def test_resource_name_list():
     test_result_list = _converters.convert_resource_name(['Dev1'])
-    assert test_result_list == ['Dev1']
+    assert test_result_list == 'Dev1'
     test_result_list = _converters.convert_resource_name(['Dev1', 'Dev2'])
-    assert test_result_list == ['Dev1', 'Dev2']
+    assert test_result_list == 'Dev1,Dev2'
     test_result_list = _converters.convert_resource_name(['Dev1/0'])
-    assert test_result_list == ['Dev1/0']
+    assert test_result_list == 'Dev1/0'
     test_result_list = _converters.convert_resource_name(['Dev1/0:1', 'Dev2/0-1'])
-    assert test_result_list == ['Dev1/0', 'Dev1/1', 'Dev2/0', 'Dev2/1']
+    assert test_result_list == 'Dev1/0,Dev1/1,Dev2/0,Dev2/1'
     test_result_list = _converters.convert_resource_name(['Dev1', 'Dev2/0-2'])
-    assert test_result_list == ['Dev1', 'Dev2/0', 'Dev2/1', 'Dev2/2']
+    assert test_result_list == 'Dev1,Dev2/0,Dev2/1,Dev2/2'
 
 
 def test_resource_name_tuple():
     test_result_list = _converters.convert_resource_name(('Dev1'))
-    assert test_result_list == ['Dev1']
+    assert test_result_list == 'Dev1'
     test_result_list = _converters.convert_resource_name(('Dev1', 'Dev2'))
-    assert test_result_list == ['Dev1', 'Dev2']
+    assert test_result_list == 'Dev1,Dev2'
     test_result_list = _converters.convert_resource_name(('Dev1/0'))
-    assert test_result_list == ['Dev1/0']
+    assert test_result_list == 'Dev1/0'
     test_result_list = _converters.convert_resource_name(('Dev1/0:1', 'Dev2/0-1'))
-    assert test_result_list == ['Dev1/0', 'Dev1/1', 'Dev2/0', 'Dev2/1']
+    assert test_result_list == 'Dev1/0,Dev1/1,Dev2/0,Dev2/1'
     test_result_list = _converters.convert_resource_name(('Dev1', 'Dev2/0-2'))
-    assert test_result_list == ['Dev1', 'Dev2/0', 'Dev2/1', 'Dev2/2']
+    assert test_result_list == 'Dev1,Dev2/0,Dev2/1,Dev2/2'
 
 
 def test_resource_name_mixed():
     test_result_list = _converters.convert_resource_name(['Dev1', ('Dev2/0', 'Dev2/1'), ['Dev3/0:1', 'Dev4/1:2'], 'Dev5/1'])
-    assert test_result_list == ['Dev1', 'Dev2/0', 'Dev2/1', 'Dev3/0', 'Dev3/1', 'Dev4/1', 'Dev4/2', 'Dev5/1']
+    assert test_result_list == 'Dev1,Dev2/0,Dev2/1,Dev3/0,Dev3/1,Dev4/1,Dev4/2,Dev5/1'
 
 
 def test_invalid_resource_name():

--- a/generated/nifake/nifake/unit_tests/test_converters.py
+++ b/generated/nifake/nifake/unit_tests/test_converters.py
@@ -237,6 +237,85 @@ def test_repeated_capabilies_without_prefix():
     assert test_result == '0,2,4,5,6,7,8,9,11,12,13,14,16,17'
 
 
+# Tests - resource name
+def test_resource_name_string():
+    test_result_list = _converters.convert_resource_name('Dev1')
+    assert test_result_list == ['Dev1']
+    test_result_list = _converters.convert_resource_name('Dev1,Dev2')
+    assert test_result_list == ['Dev1', 'Dev2']
+    test_result_list = _converters.convert_resource_name('Dev1/0')
+    assert test_result_list == ['Dev1/0']
+    test_result_list = _converters.convert_resource_name('Dev1/0:1, Dev2/0-1')
+    assert test_result_list == ['Dev1/0', 'Dev1/1', 'Dev2/0', 'Dev2/1']
+    test_result_list = _converters.convert_resource_name('Dev1, Dev2/0-2')
+    assert test_result_list == ['Dev1', 'Dev2/0', 'Dev2/1', 'Dev2/2']
+
+
+def test_resource_name_unicode_string():
+    test_result_list = _converters.convert_resource_name(u'Dev1')
+    assert test_result_list == ['Dev1']
+    test_result_list = _converters.convert_resource_name(u'Dev1,Dev2')
+    assert test_result_list == ['Dev1', 'Dev2']
+    test_result_list = _converters.convert_resource_name(u'Dev1/0')
+    assert test_result_list == ['Dev1/0']
+    test_result_list = _converters.convert_resource_name(u'Dev1/0:1, Dev2/0-1')
+    assert test_result_list == ['Dev1/0', 'Dev1/1', 'Dev2/0', 'Dev2/1']
+    test_result_list = _converters.convert_resource_name(u'Dev1, Dev2/0-2')
+    assert test_result_list == ['Dev1', 'Dev2/0', 'Dev2/1', 'Dev2/2']
+
+
+def test_resource_name_raw_string():
+    test_result_list = _converters.convert_resource_name(r'Dev1')
+    assert test_result_list == ['Dev1']
+    test_result_list = _converters.convert_resource_name(r'Dev1,Dev2')
+    assert test_result_list == ['Dev1', 'Dev2']
+    test_result_list = _converters.convert_resource_name(r'Dev1/0')
+    assert test_result_list == ['Dev1/0']
+    test_result_list = _converters.convert_resource_name(r'Dev1/0:1, Dev2/0-1')
+    assert test_result_list == ['Dev1/0', 'Dev1/1', 'Dev2/0', 'Dev2/1']
+    test_result_list = _converters.convert_resource_name(r'Dev1, Dev2/0-2')
+    assert test_result_list == ['Dev1', 'Dev2/0', 'Dev2/1', 'Dev2/2']
+
+
+def test_resource_name_list():
+    test_result_list = _converters.convert_resource_name(['Dev1'])
+    assert test_result_list == ['Dev1']
+    test_result_list = _converters.convert_resource_name(['Dev1', 'Dev2'])
+    assert test_result_list == ['Dev1', 'Dev2']
+    test_result_list = _converters.convert_resource_name(['Dev1/0'])
+    assert test_result_list == ['Dev1/0']
+    test_result_list = _converters.convert_resource_name(['Dev1/0:1', 'Dev2/0-1'])
+    assert test_result_list == ['Dev1/0', 'Dev1/1', 'Dev2/0', 'Dev2/1']
+    test_result_list = _converters.convert_resource_name(['Dev1', 'Dev2/0-2'])
+    assert test_result_list == ['Dev1', 'Dev2/0', 'Dev2/1', 'Dev2/2']
+
+
+def test_resource_name_tuple():
+    test_result_list = _converters.convert_resource_name(('Dev1'))
+    assert test_result_list == ['Dev1']
+    test_result_list = _converters.convert_resource_name(('Dev1', 'Dev2'))
+    assert test_result_list == ['Dev1', 'Dev2']
+    test_result_list = _converters.convert_resource_name(('Dev1/0'))
+    assert test_result_list == ['Dev1/0']
+    test_result_list = _converters.convert_resource_name(('Dev1/0:1', 'Dev2/0-1'))
+    assert test_result_list == ['Dev1/0', 'Dev1/1', 'Dev2/0', 'Dev2/1']
+    test_result_list = _converters.convert_resource_name(('Dev1', 'Dev2/0-2'))
+    assert test_result_list == ['Dev1', 'Dev2/0', 'Dev2/1', 'Dev2/2']
+
+
+def test_resource_name_mixed():
+    test_result_list = _converters.convert_resource_name(['Dev1', ('Dev2/0', 'Dev2/1'), ['Dev3/0:1', 'Dev4/1:2'], 'Dev5/1'])
+    assert test_result_list == ['Dev1', 'Dev2/0', 'Dev2/1', 'Dev3/0', 'Dev3/1', 'Dev4/1', 'Dev4/2', 'Dev5/1']
+
+
+def test_invalid_resource_name():
+    try:
+        _converters.convert_resource_name('/')
+        assert False
+    except errors.InvalidResourceNameError:
+        pass
+
+
 def test_convert_chained_repeated_capability_to_parts_three_parts():
     chained_rep_cap = ('site0/test/PinA,site0/test/PinB,site0/test/PinC,'
                        'site1/test/PinA,site1/test/PinB,site1/test/PinC')

--- a/generated/nifgen/nifgen/_converters.py
+++ b/generated/nifgen/nifgen/_converters.py
@@ -294,6 +294,8 @@ def _(resource_name):
     # Must be of form "Dev/0", "Dev/0:1", "Dev/0-1" or "Dev"
     fields = [item.strip() for item in resource_name.split('/')]
     device_name = fields[0]
+    if len(device_name) == 0:
+        raise errors.InvalidResourceNameError("Empty device name", resource_name)
     if len(fields) > 2:
         raise errors.InvalidResourceNameError("Multiple '/'", resource_name)
     if len(fields) == 1:

--- a/generated/nifgen/nifgen/_converters.py
+++ b/generated/nifgen/nifgen/_converters.py
@@ -269,3 +269,52 @@ def convert_chained_repeated_capability_to_parts(chained_repeated_capability):
     return [','.join(collections.OrderedDict.fromkeys(x)) for x in repeated_capability_lists]
 
 
+def convert_resource_name(resource_name):
+    return _convert_resource_name(resource_name)
+
+
+@singledispatch
+def _convert_resource_name(arg):
+    raise errors.InvalidResourceNameError('Invalid type', type(arg))
+
+
+# This parsing function duplicate the parsing in the driver, so if changes to the allowed format are made there, they will need to be replicated here.
+@_convert_resource_name.register(str)  # noqa: F811
+def _(resource_name):
+    '''String version (this is the most complex)
+
+    We need to deal with a range ('Dev/0-3' or 'Dev/0:3'), a list ('Dev/0,Dev/1,Dev/2,Dev/3') and a single item
+    '''
+    # First we deal with a list
+    resource_name_list = resource_name.split(',')
+    if len(resource_name_list) > 1:
+        # We have a list so call ourselves again to let the iterable instance handle it
+        return _convert_resource_name(resource_name_list)
+
+    # Must be of form "Dev/0", "Dev/0:1", "Dev/0-1" or "Dev"
+    fields = [item.strip() for item in resource_name.split('/')]
+    device_name = fields[0]
+    if len(fields) > 2:
+        raise errors.InvalidResourceNameError("Multiple '/'", resource_name)
+    if len(fields) == 1:
+        return [device_name]
+    if len(fields) == 2:
+        repeated_capability = fields[1]
+        if len(repeated_capability) == 0:
+            raise errors.InvalidResourceNameError("Missing channels after '/''", resource_name)
+
+    return [device_name + '/' + r for r in _convert_repeated_capabilities(repeated_capability, '')]
+
+
+# We cannot use collections.abc.Iterable here because strings are also iterable and then this
+# instance is what gets called instead of the string one.
+@_convert_resource_name.register(list)  # noqa: F811
+@_convert_resource_name.register(tuple)  # noqa: F811
+def _(resource_name):
+    '''Iterable version - can handle lists, ranges, and tuples'''
+    resource_name_list = []
+    for r in resource_name:
+        resource_name_list += _convert_resource_name(r)
+    return resource_name_list
+
+

--- a/generated/nimodinst/nimodinst/_converters.py
+++ b/generated/nimodinst/nimodinst/_converters.py
@@ -294,6 +294,8 @@ def _(resource_name):
     # Must be of form "Dev/0", "Dev/0:1", "Dev/0-1" or "Dev"
     fields = [item.strip() for item in resource_name.split('/')]
     device_name = fields[0]
+    if len(device_name) == 0:
+        raise errors.InvalidResourceNameError("Empty device name", resource_name)
     if len(fields) > 2:
         raise errors.InvalidResourceNameError("Multiple '/'", resource_name)
     if len(fields) == 1:

--- a/generated/nimodinst/nimodinst/_converters.py
+++ b/generated/nimodinst/nimodinst/_converters.py
@@ -269,3 +269,52 @@ def convert_chained_repeated_capability_to_parts(chained_repeated_capability):
     return [','.join(collections.OrderedDict.fromkeys(x)) for x in repeated_capability_lists]
 
 
+def convert_resource_name(resource_name):
+    return _convert_resource_name(resource_name)
+
+
+@singledispatch
+def _convert_resource_name(arg):
+    raise errors.InvalidResourceNameError('Invalid type', type(arg))
+
+
+# This parsing function duplicate the parsing in the driver, so if changes to the allowed format are made there, they will need to be replicated here.
+@_convert_resource_name.register(str)  # noqa: F811
+def _(resource_name):
+    '''String version (this is the most complex)
+
+    We need to deal with a range ('Dev/0-3' or 'Dev/0:3'), a list ('Dev/0,Dev/1,Dev/2,Dev/3') and a single item
+    '''
+    # First we deal with a list
+    resource_name_list = resource_name.split(',')
+    if len(resource_name_list) > 1:
+        # We have a list so call ourselves again to let the iterable instance handle it
+        return _convert_resource_name(resource_name_list)
+
+    # Must be of form "Dev/0", "Dev/0:1", "Dev/0-1" or "Dev"
+    fields = [item.strip() for item in resource_name.split('/')]
+    device_name = fields[0]
+    if len(fields) > 2:
+        raise errors.InvalidResourceNameError("Multiple '/'", resource_name)
+    if len(fields) == 1:
+        return [device_name]
+    if len(fields) == 2:
+        repeated_capability = fields[1]
+        if len(repeated_capability) == 0:
+            raise errors.InvalidResourceNameError("Missing channels after '/''", resource_name)
+
+    return [device_name + '/' + r for r in _convert_repeated_capabilities(repeated_capability, '')]
+
+
+# We cannot use collections.abc.Iterable here because strings are also iterable and then this
+# instance is what gets called instead of the string one.
+@_convert_resource_name.register(list)  # noqa: F811
+@_convert_resource_name.register(tuple)  # noqa: F811
+def _(resource_name):
+    '''Iterable version - can handle lists, ranges, and tuples'''
+    resource_name_list = []
+    for r in resource_name:
+        resource_name_list += _convert_resource_name(r)
+    return resource_name_list
+
+

--- a/generated/niscope/niscope/_converters.py
+++ b/generated/niscope/niscope/_converters.py
@@ -294,6 +294,8 @@ def _(resource_name):
     # Must be of form "Dev/0", "Dev/0:1", "Dev/0-1" or "Dev"
     fields = [item.strip() for item in resource_name.split('/')]
     device_name = fields[0]
+    if len(device_name) == 0:
+        raise errors.InvalidResourceNameError("Empty device name", resource_name)
     if len(fields) > 2:
         raise errors.InvalidResourceNameError("Multiple '/'", resource_name)
     if len(fields) == 1:

--- a/generated/niscope/niscope/_converters.py
+++ b/generated/niscope/niscope/_converters.py
@@ -269,3 +269,52 @@ def convert_chained_repeated_capability_to_parts(chained_repeated_capability):
     return [','.join(collections.OrderedDict.fromkeys(x)) for x in repeated_capability_lists]
 
 
+def convert_resource_name(resource_name):
+    return _convert_resource_name(resource_name)
+
+
+@singledispatch
+def _convert_resource_name(arg):
+    raise errors.InvalidResourceNameError('Invalid type', type(arg))
+
+
+# This parsing function duplicate the parsing in the driver, so if changes to the allowed format are made there, they will need to be replicated here.
+@_convert_resource_name.register(str)  # noqa: F811
+def _(resource_name):
+    '''String version (this is the most complex)
+
+    We need to deal with a range ('Dev/0-3' or 'Dev/0:3'), a list ('Dev/0,Dev/1,Dev/2,Dev/3') and a single item
+    '''
+    # First we deal with a list
+    resource_name_list = resource_name.split(',')
+    if len(resource_name_list) > 1:
+        # We have a list so call ourselves again to let the iterable instance handle it
+        return _convert_resource_name(resource_name_list)
+
+    # Must be of form "Dev/0", "Dev/0:1", "Dev/0-1" or "Dev"
+    fields = [item.strip() for item in resource_name.split('/')]
+    device_name = fields[0]
+    if len(fields) > 2:
+        raise errors.InvalidResourceNameError("Multiple '/'", resource_name)
+    if len(fields) == 1:
+        return [device_name]
+    if len(fields) == 2:
+        repeated_capability = fields[1]
+        if len(repeated_capability) == 0:
+            raise errors.InvalidResourceNameError("Missing channels after '/''", resource_name)
+
+    return [device_name + '/' + r for r in _convert_repeated_capabilities(repeated_capability, '')]
+
+
+# We cannot use collections.abc.Iterable here because strings are also iterable and then this
+# instance is what gets called instead of the string one.
+@_convert_resource_name.register(list)  # noqa: F811
+@_convert_resource_name.register(tuple)  # noqa: F811
+def _(resource_name):
+    '''Iterable version - can handle lists, ranges, and tuples'''
+    resource_name_list = []
+    for r in resource_name:
+        resource_name_list += _convert_resource_name(r)
+    return resource_name_list
+
+

--- a/generated/nise/nise/_converters.py
+++ b/generated/nise/nise/_converters.py
@@ -294,6 +294,8 @@ def _(resource_name):
     # Must be of form "Dev/0", "Dev/0:1", "Dev/0-1" or "Dev"
     fields = [item.strip() for item in resource_name.split('/')]
     device_name = fields[0]
+    if len(device_name) == 0:
+        raise errors.InvalidResourceNameError("Empty device name", resource_name)
     if len(fields) > 2:
         raise errors.InvalidResourceNameError("Multiple '/'", resource_name)
     if len(fields) == 1:

--- a/generated/nise/nise/_converters.py
+++ b/generated/nise/nise/_converters.py
@@ -269,3 +269,52 @@ def convert_chained_repeated_capability_to_parts(chained_repeated_capability):
     return [','.join(collections.OrderedDict.fromkeys(x)) for x in repeated_capability_lists]
 
 
+def convert_resource_name(resource_name):
+    return _convert_resource_name(resource_name)
+
+
+@singledispatch
+def _convert_resource_name(arg):
+    raise errors.InvalidResourceNameError('Invalid type', type(arg))
+
+
+# This parsing function duplicate the parsing in the driver, so if changes to the allowed format are made there, they will need to be replicated here.
+@_convert_resource_name.register(str)  # noqa: F811
+def _(resource_name):
+    '''String version (this is the most complex)
+
+    We need to deal with a range ('Dev/0-3' or 'Dev/0:3'), a list ('Dev/0,Dev/1,Dev/2,Dev/3') and a single item
+    '''
+    # First we deal with a list
+    resource_name_list = resource_name.split(',')
+    if len(resource_name_list) > 1:
+        # We have a list so call ourselves again to let the iterable instance handle it
+        return _convert_resource_name(resource_name_list)
+
+    # Must be of form "Dev/0", "Dev/0:1", "Dev/0-1" or "Dev"
+    fields = [item.strip() for item in resource_name.split('/')]
+    device_name = fields[0]
+    if len(fields) > 2:
+        raise errors.InvalidResourceNameError("Multiple '/'", resource_name)
+    if len(fields) == 1:
+        return [device_name]
+    if len(fields) == 2:
+        repeated_capability = fields[1]
+        if len(repeated_capability) == 0:
+            raise errors.InvalidResourceNameError("Missing channels after '/''", resource_name)
+
+    return [device_name + '/' + r for r in _convert_repeated_capabilities(repeated_capability, '')]
+
+
+# We cannot use collections.abc.Iterable here because strings are also iterable and then this
+# instance is what gets called instead of the string one.
+@_convert_resource_name.register(list)  # noqa: F811
+@_convert_resource_name.register(tuple)  # noqa: F811
+def _(resource_name):
+    '''Iterable version - can handle lists, ranges, and tuples'''
+    resource_name_list = []
+    for r in resource_name:
+        resource_name_list += _convert_resource_name(r)
+    return resource_name_list
+
+

--- a/generated/niswitch/niswitch/_converters.py
+++ b/generated/niswitch/niswitch/_converters.py
@@ -294,6 +294,8 @@ def _(resource_name):
     # Must be of form "Dev/0", "Dev/0:1", "Dev/0-1" or "Dev"
     fields = [item.strip() for item in resource_name.split('/')]
     device_name = fields[0]
+    if len(device_name) == 0:
+        raise errors.InvalidResourceNameError("Empty device name", resource_name)
     if len(fields) > 2:
         raise errors.InvalidResourceNameError("Multiple '/'", resource_name)
     if len(fields) == 1:

--- a/generated/niswitch/niswitch/_converters.py
+++ b/generated/niswitch/niswitch/_converters.py
@@ -269,3 +269,52 @@ def convert_chained_repeated_capability_to_parts(chained_repeated_capability):
     return [','.join(collections.OrderedDict.fromkeys(x)) for x in repeated_capability_lists]
 
 
+def convert_resource_name(resource_name):
+    return _convert_resource_name(resource_name)
+
+
+@singledispatch
+def _convert_resource_name(arg):
+    raise errors.InvalidResourceNameError('Invalid type', type(arg))
+
+
+# This parsing function duplicate the parsing in the driver, so if changes to the allowed format are made there, they will need to be replicated here.
+@_convert_resource_name.register(str)  # noqa: F811
+def _(resource_name):
+    '''String version (this is the most complex)
+
+    We need to deal with a range ('Dev/0-3' or 'Dev/0:3'), a list ('Dev/0,Dev/1,Dev/2,Dev/3') and a single item
+    '''
+    # First we deal with a list
+    resource_name_list = resource_name.split(',')
+    if len(resource_name_list) > 1:
+        # We have a list so call ourselves again to let the iterable instance handle it
+        return _convert_resource_name(resource_name_list)
+
+    # Must be of form "Dev/0", "Dev/0:1", "Dev/0-1" or "Dev"
+    fields = [item.strip() for item in resource_name.split('/')]
+    device_name = fields[0]
+    if len(fields) > 2:
+        raise errors.InvalidResourceNameError("Multiple '/'", resource_name)
+    if len(fields) == 1:
+        return [device_name]
+    if len(fields) == 2:
+        repeated_capability = fields[1]
+        if len(repeated_capability) == 0:
+            raise errors.InvalidResourceNameError("Missing channels after '/''", resource_name)
+
+    return [device_name + '/' + r for r in _convert_repeated_capabilities(repeated_capability, '')]
+
+
+# We cannot use collections.abc.Iterable here because strings are also iterable and then this
+# instance is what gets called instead of the string one.
+@_convert_resource_name.register(list)  # noqa: F811
+@_convert_resource_name.register(tuple)  # noqa: F811
+def _(resource_name):
+    '''Iterable version - can handle lists, ranges, and tuples'''
+    resource_name_list = []
+    for r in resource_name:
+        resource_name_list += _convert_resource_name(r)
+    return resource_name_list
+
+

--- a/generated/nitclk/nitclk/_converters.py
+++ b/generated/nitclk/nitclk/_converters.py
@@ -294,6 +294,8 @@ def _(resource_name):
     # Must be of form "Dev/0", "Dev/0:1", "Dev/0-1" or "Dev"
     fields = [item.strip() for item in resource_name.split('/')]
     device_name = fields[0]
+    if len(device_name) == 0:
+        raise errors.InvalidResourceNameError("Empty device name", resource_name)
     if len(fields) > 2:
         raise errors.InvalidResourceNameError("Multiple '/'", resource_name)
     if len(fields) == 1:

--- a/generated/nitclk/nitclk/_converters.py
+++ b/generated/nitclk/nitclk/_converters.py
@@ -269,6 +269,55 @@ def convert_chained_repeated_capability_to_parts(chained_repeated_capability):
     return [','.join(collections.OrderedDict.fromkeys(x)) for x in repeated_capability_lists]
 
 
+def convert_resource_name(resource_name):
+    return _convert_resource_name(resource_name)
+
+
+@singledispatch
+def _convert_resource_name(arg):
+    raise errors.InvalidResourceNameError('Invalid type', type(arg))
+
+
+# This parsing function duplicate the parsing in the driver, so if changes to the allowed format are made there, they will need to be replicated here.
+@_convert_resource_name.register(str)  # noqa: F811
+def _(resource_name):
+    '''String version (this is the most complex)
+
+    We need to deal with a range ('Dev/0-3' or 'Dev/0:3'), a list ('Dev/0,Dev/1,Dev/2,Dev/3') and a single item
+    '''
+    # First we deal with a list
+    resource_name_list = resource_name.split(',')
+    if len(resource_name_list) > 1:
+        # We have a list so call ourselves again to let the iterable instance handle it
+        return _convert_resource_name(resource_name_list)
+
+    # Must be of form "Dev/0", "Dev/0:1", "Dev/0-1" or "Dev"
+    fields = [item.strip() for item in resource_name.split('/')]
+    device_name = fields[0]
+    if len(fields) > 2:
+        raise errors.InvalidResourceNameError("Multiple '/'", resource_name)
+    if len(fields) == 1:
+        return [device_name]
+    if len(fields) == 2:
+        repeated_capability = fields[1]
+        if len(repeated_capability) == 0:
+            raise errors.InvalidResourceNameError("Missing channels after '/''", resource_name)
+
+    return [device_name + '/' + r for r in _convert_repeated_capabilities(repeated_capability, '')]
+
+
+# We cannot use collections.abc.Iterable here because strings are also iterable and then this
+# instance is what gets called instead of the string one.
+@_convert_resource_name.register(list)  # noqa: F811
+@_convert_resource_name.register(tuple)  # noqa: F811
+def _(resource_name):
+    '''Iterable version - can handle lists, ranges, and tuples'''
+    resource_name_list = []
+    for r in resource_name:
+        resource_name_list += _convert_resource_name(r)
+    return resource_name_list
+
+
 # nitclk specific converters
 def convert_to_nitclk_session_number(item):
     '''Convert from supported objects to NI-TClk Session Num

--- a/src/nidcpower/metadata/config.py
+++ b/src/nidcpower/metadata/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 20.7.0d8
+# This file is generated from NI-DCPower API metadata version 20.7.0d9999
 config = {
-    'api_version': '20.7.0d8',
+    'api_version': '20.7.0d9999',
     'c_function_prefix': 'niDCPower_',
     'close_function': 'close',
     'context_manager_name': {
@@ -14,7 +14,8 @@ config = {
     'driver_name': 'NI-DCPower',
     'extra_errors_used': [
         'InvalidRepeatedCapabilityError',
-        'SelfTestError'
+        'SelfTestError',
+        'InvalidResourceNameError'
     ],
     'init_function': 'InitializeWithChannels',
     'library_info': {

--- a/src/nifake/metadata/config.py
+++ b/src/nifake/metadata/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 1.2.0d9
+# This file is generated from NI-FAKE API metadata version 21.0.0d3
 config = {
-    'api_version': '1.2.0d9',
+    'api_version': '21.0.0d3',
     'c_function_prefix': 'niFake_',
     'close_function': 'close',
     'context_manager_name': {
@@ -22,7 +22,8 @@ config = {
     ],
     'extra_errors_used': [
         'InvalidRepeatedCapabilityError',
-        'SelfTestError'
+        'SelfTestError',
+        'InvalidResourceNameError'
     ],
     'init_function': 'InitWithOptions',
     'library_info': {
@@ -52,10 +53,10 @@ config = {
         },
         {
             'prefix': 'site',
-            'python_name': 'sites',
-        },
+            'python_name': 'sites'
+        }
     ],
     'session_class_description': 'An NI-FAKE session to a fake MI driver whose sole purpose is to test nimi-python code generation',
     'session_handle_parameter_name': 'vi',
-    'uses_nitclk': True,
+    'uses_nitclk': True
 }

--- a/src/nifake/unit_tests/test_converters.py
+++ b/src/nifake/unit_tests/test_converters.py
@@ -310,7 +310,32 @@ def test_resource_name_mixed():
 
 def test_invalid_resource_name():
     try:
+        _converters.convert_resource_name('')
+        assert False
+    except errors.InvalidResourceNameError:
+        pass
+    try:
         _converters.convert_resource_name('/')
+        assert False
+    except errors.InvalidResourceNameError:
+        pass
+    try:
+        _converters.convert_resource_name('Dev,')
+        assert False
+    except errors.InvalidResourceNameError:
+        pass
+    try:
+        _converters.convert_resource_name('Dev/')
+        assert False
+    except errors.InvalidResourceNameError:
+        pass
+    try:
+        _converters.convert_resource_name('Dev/0/1')
+        assert False
+    except errors.InvalidResourceNameError:
+        pass
+    try:
+        _converters.convert_resource_name(0)
         assert False
     except errors.InvalidResourceNameError:
         pass

--- a/src/nifake/unit_tests/test_converters.py
+++ b/src/nifake/unit_tests/test_converters.py
@@ -238,74 +238,79 @@ def test_repeated_capabilies_without_prefix():
 
 
 # Tests - resource name
+def test_resource_name_none():
+    test_result_list = _converters.convert_resource_name(None)
+    assert test_result_list == ''
+
+
 def test_resource_name_string():
     test_result_list = _converters.convert_resource_name('Dev1')
-    assert test_result_list == ['Dev1']
+    assert test_result_list == 'Dev1'
     test_result_list = _converters.convert_resource_name('Dev1,Dev2')
-    assert test_result_list == ['Dev1', 'Dev2']
+    assert test_result_list == 'Dev1,Dev2'
     test_result_list = _converters.convert_resource_name('Dev1/0')
-    assert test_result_list == ['Dev1/0']
+    assert test_result_list == 'Dev1/0'
     test_result_list = _converters.convert_resource_name('Dev1/0:1, Dev2/0-1')
-    assert test_result_list == ['Dev1/0', 'Dev1/1', 'Dev2/0', 'Dev2/1']
+    assert test_result_list == 'Dev1/0,Dev1/1,Dev2/0,Dev2/1'
     test_result_list = _converters.convert_resource_name('Dev1, Dev2/0-2')
-    assert test_result_list == ['Dev1', 'Dev2/0', 'Dev2/1', 'Dev2/2']
+    assert test_result_list == 'Dev1,Dev2/0,Dev2/1,Dev2/2'
 
 
 def test_resource_name_unicode_string():
     test_result_list = _converters.convert_resource_name(u'Dev1')
-    assert test_result_list == ['Dev1']
+    assert test_result_list == 'Dev1'
     test_result_list = _converters.convert_resource_name(u'Dev1,Dev2')
-    assert test_result_list == ['Dev1', 'Dev2']
+    assert test_result_list == 'Dev1,Dev2'
     test_result_list = _converters.convert_resource_name(u'Dev1/0')
-    assert test_result_list == ['Dev1/0']
+    assert test_result_list == 'Dev1/0'
     test_result_list = _converters.convert_resource_name(u'Dev1/0:1, Dev2/0-1')
-    assert test_result_list == ['Dev1/0', 'Dev1/1', 'Dev2/0', 'Dev2/1']
+    assert test_result_list == 'Dev1/0,Dev1/1,Dev2/0,Dev2/1'
     test_result_list = _converters.convert_resource_name(u'Dev1, Dev2/0-2')
-    assert test_result_list == ['Dev1', 'Dev2/0', 'Dev2/1', 'Dev2/2']
+    assert test_result_list == 'Dev1,Dev2/0,Dev2/1,Dev2/2'
 
 
 def test_resource_name_raw_string():
     test_result_list = _converters.convert_resource_name(r'Dev1')
-    assert test_result_list == ['Dev1']
+    assert test_result_list == 'Dev1'
     test_result_list = _converters.convert_resource_name(r'Dev1,Dev2')
-    assert test_result_list == ['Dev1', 'Dev2']
+    assert test_result_list == 'Dev1,Dev2'
     test_result_list = _converters.convert_resource_name(r'Dev1/0')
-    assert test_result_list == ['Dev1/0']
+    assert test_result_list == 'Dev1/0'
     test_result_list = _converters.convert_resource_name(r'Dev1/0:1, Dev2/0-1')
-    assert test_result_list == ['Dev1/0', 'Dev1/1', 'Dev2/0', 'Dev2/1']
+    assert test_result_list == 'Dev1/0,Dev1/1,Dev2/0,Dev2/1'
     test_result_list = _converters.convert_resource_name(r'Dev1, Dev2/0-2')
-    assert test_result_list == ['Dev1', 'Dev2/0', 'Dev2/1', 'Dev2/2']
+    assert test_result_list == 'Dev1,Dev2/0,Dev2/1,Dev2/2'
 
 
 def test_resource_name_list():
     test_result_list = _converters.convert_resource_name(['Dev1'])
-    assert test_result_list == ['Dev1']
+    assert test_result_list == 'Dev1'
     test_result_list = _converters.convert_resource_name(['Dev1', 'Dev2'])
-    assert test_result_list == ['Dev1', 'Dev2']
+    assert test_result_list == 'Dev1,Dev2'
     test_result_list = _converters.convert_resource_name(['Dev1/0'])
-    assert test_result_list == ['Dev1/0']
+    assert test_result_list == 'Dev1/0'
     test_result_list = _converters.convert_resource_name(['Dev1/0:1', 'Dev2/0-1'])
-    assert test_result_list == ['Dev1/0', 'Dev1/1', 'Dev2/0', 'Dev2/1']
+    assert test_result_list == 'Dev1/0,Dev1/1,Dev2/0,Dev2/1'
     test_result_list = _converters.convert_resource_name(['Dev1', 'Dev2/0-2'])
-    assert test_result_list == ['Dev1', 'Dev2/0', 'Dev2/1', 'Dev2/2']
+    assert test_result_list == 'Dev1,Dev2/0,Dev2/1,Dev2/2'
 
 
 def test_resource_name_tuple():
     test_result_list = _converters.convert_resource_name(('Dev1'))
-    assert test_result_list == ['Dev1']
+    assert test_result_list == 'Dev1'
     test_result_list = _converters.convert_resource_name(('Dev1', 'Dev2'))
-    assert test_result_list == ['Dev1', 'Dev2']
+    assert test_result_list == 'Dev1,Dev2'
     test_result_list = _converters.convert_resource_name(('Dev1/0'))
-    assert test_result_list == ['Dev1/0']
+    assert test_result_list == 'Dev1/0'
     test_result_list = _converters.convert_resource_name(('Dev1/0:1', 'Dev2/0-1'))
-    assert test_result_list == ['Dev1/0', 'Dev1/1', 'Dev2/0', 'Dev2/1']
+    assert test_result_list == 'Dev1/0,Dev1/1,Dev2/0,Dev2/1'
     test_result_list = _converters.convert_resource_name(('Dev1', 'Dev2/0-2'))
-    assert test_result_list == ['Dev1', 'Dev2/0', 'Dev2/1', 'Dev2/2']
+    assert test_result_list == 'Dev1,Dev2/0,Dev2/1,Dev2/2'
 
 
 def test_resource_name_mixed():
     test_result_list = _converters.convert_resource_name(['Dev1', ('Dev2/0', 'Dev2/1'), ['Dev3/0:1', 'Dev4/1:2'], 'Dev5/1'])
-    assert test_result_list == ['Dev1', 'Dev2/0', 'Dev2/1', 'Dev3/0', 'Dev3/1', 'Dev4/1', 'Dev4/2', 'Dev5/1']
+    assert test_result_list == 'Dev1,Dev2/0,Dev2/1,Dev3/0,Dev3/1,Dev4/1,Dev4/2,Dev5/1'
 
 
 def test_invalid_resource_name():

--- a/src/nifake/unit_tests/test_converters.py
+++ b/src/nifake/unit_tests/test_converters.py
@@ -237,6 +237,85 @@ def test_repeated_capabilies_without_prefix():
     assert test_result == '0,2,4,5,6,7,8,9,11,12,13,14,16,17'
 
 
+# Tests - resource name
+def test_resource_name_string():
+    test_result_list = _converters.convert_resource_name('Dev1')
+    assert test_result_list == ['Dev1']
+    test_result_list = _converters.convert_resource_name('Dev1,Dev2')
+    assert test_result_list == ['Dev1', 'Dev2']
+    test_result_list = _converters.convert_resource_name('Dev1/0')
+    assert test_result_list == ['Dev1/0']
+    test_result_list = _converters.convert_resource_name('Dev1/0:1, Dev2/0-1')
+    assert test_result_list == ['Dev1/0', 'Dev1/1', 'Dev2/0', 'Dev2/1']
+    test_result_list = _converters.convert_resource_name('Dev1, Dev2/0-2')
+    assert test_result_list == ['Dev1', 'Dev2/0', 'Dev2/1', 'Dev2/2']
+
+
+def test_resource_name_unicode_string():
+    test_result_list = _converters.convert_resource_name(u'Dev1')
+    assert test_result_list == ['Dev1']
+    test_result_list = _converters.convert_resource_name(u'Dev1,Dev2')
+    assert test_result_list == ['Dev1', 'Dev2']
+    test_result_list = _converters.convert_resource_name(u'Dev1/0')
+    assert test_result_list == ['Dev1/0']
+    test_result_list = _converters.convert_resource_name(u'Dev1/0:1, Dev2/0-1')
+    assert test_result_list == ['Dev1/0', 'Dev1/1', 'Dev2/0', 'Dev2/1']
+    test_result_list = _converters.convert_resource_name(u'Dev1, Dev2/0-2')
+    assert test_result_list == ['Dev1', 'Dev2/0', 'Dev2/1', 'Dev2/2']
+
+
+def test_resource_name_raw_string():
+    test_result_list = _converters.convert_resource_name(r'Dev1')
+    assert test_result_list == ['Dev1']
+    test_result_list = _converters.convert_resource_name(r'Dev1,Dev2')
+    assert test_result_list == ['Dev1', 'Dev2']
+    test_result_list = _converters.convert_resource_name(r'Dev1/0')
+    assert test_result_list == ['Dev1/0']
+    test_result_list = _converters.convert_resource_name(r'Dev1/0:1, Dev2/0-1')
+    assert test_result_list == ['Dev1/0', 'Dev1/1', 'Dev2/0', 'Dev2/1']
+    test_result_list = _converters.convert_resource_name(r'Dev1, Dev2/0-2')
+    assert test_result_list == ['Dev1', 'Dev2/0', 'Dev2/1', 'Dev2/2']
+
+
+def test_resource_name_list():
+    test_result_list = _converters.convert_resource_name(['Dev1'])
+    assert test_result_list == ['Dev1']
+    test_result_list = _converters.convert_resource_name(['Dev1', 'Dev2'])
+    assert test_result_list == ['Dev1', 'Dev2']
+    test_result_list = _converters.convert_resource_name(['Dev1/0'])
+    assert test_result_list == ['Dev1/0']
+    test_result_list = _converters.convert_resource_name(['Dev1/0:1', 'Dev2/0-1'])
+    assert test_result_list == ['Dev1/0', 'Dev1/1', 'Dev2/0', 'Dev2/1']
+    test_result_list = _converters.convert_resource_name(['Dev1', 'Dev2/0-2'])
+    assert test_result_list == ['Dev1', 'Dev2/0', 'Dev2/1', 'Dev2/2']
+
+
+def test_resource_name_tuple():
+    test_result_list = _converters.convert_resource_name(('Dev1'))
+    assert test_result_list == ['Dev1']
+    test_result_list = _converters.convert_resource_name(('Dev1', 'Dev2'))
+    assert test_result_list == ['Dev1', 'Dev2']
+    test_result_list = _converters.convert_resource_name(('Dev1/0'))
+    assert test_result_list == ['Dev1/0']
+    test_result_list = _converters.convert_resource_name(('Dev1/0:1', 'Dev2/0-1'))
+    assert test_result_list == ['Dev1/0', 'Dev1/1', 'Dev2/0', 'Dev2/1']
+    test_result_list = _converters.convert_resource_name(('Dev1', 'Dev2/0-2'))
+    assert test_result_list == ['Dev1', 'Dev2/0', 'Dev2/1', 'Dev2/2']
+
+
+def test_resource_name_mixed():
+    test_result_list = _converters.convert_resource_name(['Dev1', ('Dev2/0', 'Dev2/1'), ['Dev3/0:1', 'Dev4/1:2'], 'Dev5/1'])
+    assert test_result_list == ['Dev1', 'Dev2/0', 'Dev2/1', 'Dev3/0', 'Dev3/1', 'Dev4/1', 'Dev4/2', 'Dev5/1']
+
+
+def test_invalid_resource_name():
+    try:
+        _converters.convert_resource_name('/')
+        assert False
+    except errors.InvalidResourceNameError:
+        pass
+
+
 def test_convert_chained_repeated_capability_to_parts_three_parts():
     chained_rep_cap = ('site0/test/PinA,site0/test/PinB,site0/test/PinC,'
                        'site1/test/PinA,site1/test/PinB,site1/test/PinC')


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [ ] ~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

Adds a converter function to convert a resource_name parameter that can specify multiple instruments and channels from a python sequence (list, tuple) to a comma-separated string as expected by the driver. This new function is currently not used but will soon be used by the nidcpower session constructor once it supports independent channels. 

### List issues fixed by this Pull Request below, if any.

### What testing has been done?

Added unit tests for the converter function in nifake/unit_tests/test_converters.py.
