### PR TITLE
Modified repeated capabilities converter to support resource names

### DIFF
--- a/build/templates/_converters.py.mako
+++ b/build/templates/_converters.py.mako
@@ -75,13 +75,19 @@ def _(repeated_capability, prefix):
     if len(rc) > 1:
         if len(rc) > 2:
             raise errors.InvalidRepeatedCapabilityError("Multiple '-' or ':'", repeated_capability)
-        start = int(rc[0])
-        end = int(rc[1])
-        if end < start:
-            rng = range(start, end - 1, -1)
+        try:
+            start = int(rc[0])
+            end = int(rc[1])
+        except ValueError:
+            # This exception raised when repeated_capability is of the form "dev/0-1". rc[0] == "dev/0" in this case.
+            # Just return the repeated_capability string as-is in that case.
+            pass
         else:
-            rng = range(start, end + 1)
-        return _convert_repeated_capabilities(rng, prefix)
+            if end < start:
+                rng = range(start, end - 1, -1)
+            else:
+                rng = range(start, end + 1)
+            return _convert_repeated_capabilities(rng, prefix)
 
     # If we made it here, it must be a simple item so we remove any prefix and return
     return [repeated_capability.replace(prefix, '').strip()]

--- a/build/templates/_converters.py.mako
+++ b/build/templates/_converters.py.mako
@@ -79,7 +79,7 @@ def _(repeated_capability, prefix):
             start = int(rc[0])
             end = int(rc[1])
         except ValueError:
-            # This exception raised when repeated_capability is of the form "dev/0-1". rc[0] == "dev/0" in this case.
+            # This exception is raised when repeated_capability is of the form "dev/0-1". rc[0] == "dev/0" in this case.
             # Just return the repeated_capability string as-is in that case.
             pass
         else:

--- a/generated/nidcpower/nidcpower/_converters.py
+++ b/generated/nidcpower/nidcpower/_converters.py
@@ -70,13 +70,19 @@ def _(repeated_capability, prefix):
     if len(rc) > 1:
         if len(rc) > 2:
             raise errors.InvalidRepeatedCapabilityError("Multiple '-' or ':'", repeated_capability)
-        start = int(rc[0])
-        end = int(rc[1])
-        if end < start:
-            rng = range(start, end - 1, -1)
+        try:
+            start = int(rc[0])
+            end = int(rc[1])
+        except ValueError:
+            # This exception raised when repeated_capability is of the form "dev/0-1". rc[0] == "dev/0" in this case.
+            # Just return the repeated_capability string as-is in that case.
+            pass
         else:
-            rng = range(start, end + 1)
-        return _convert_repeated_capabilities(rng, prefix)
+            if end < start:
+                rng = range(start, end - 1, -1)
+            else:
+                rng = range(start, end + 1)
+            return _convert_repeated_capabilities(rng, prefix)
 
     # If we made it here, it must be a simple item so we remove any prefix and return
     return [repeated_capability.replace(prefix, '').strip()]

--- a/generated/nidigital/nidigital/_converters.py
+++ b/generated/nidigital/nidigital/_converters.py
@@ -70,13 +70,19 @@ def _(repeated_capability, prefix):
     if len(rc) > 1:
         if len(rc) > 2:
             raise errors.InvalidRepeatedCapabilityError("Multiple '-' or ':'", repeated_capability)
-        start = int(rc[0])
-        end = int(rc[1])
-        if end < start:
-            rng = range(start, end - 1, -1)
+        try:
+            start = int(rc[0])
+            end = int(rc[1])
+        except ValueError:
+            # This exception raised when repeated_capability is of the form "dev/0-1". rc[0] == "dev/0" in this case.
+            # Just return the repeated_capability string as-is in that case.
+            pass
         else:
-            rng = range(start, end + 1)
-        return _convert_repeated_capabilities(rng, prefix)
+            if end < start:
+                rng = range(start, end - 1, -1)
+            else:
+                rng = range(start, end + 1)
+            return _convert_repeated_capabilities(rng, prefix)
 
     # If we made it here, it must be a simple item so we remove any prefix and return
     return [repeated_capability.replace(prefix, '').strip()]

--- a/generated/nidmm/nidmm/_converters.py
+++ b/generated/nidmm/nidmm/_converters.py
@@ -70,13 +70,19 @@ def _(repeated_capability, prefix):
     if len(rc) > 1:
         if len(rc) > 2:
             raise errors.InvalidRepeatedCapabilityError("Multiple '-' or ':'", repeated_capability)
-        start = int(rc[0])
-        end = int(rc[1])
-        if end < start:
-            rng = range(start, end - 1, -1)
+        try:
+            start = int(rc[0])
+            end = int(rc[1])
+        except ValueError:
+            # This exception raised when repeated_capability is of the form "dev/0-1". rc[0] == "dev/0" in this case.
+            # Just return the repeated_capability string as-is in that case.
+            pass
         else:
-            rng = range(start, end + 1)
-        return _convert_repeated_capabilities(rng, prefix)
+            if end < start:
+                rng = range(start, end - 1, -1)
+            else:
+                rng = range(start, end + 1)
+            return _convert_repeated_capabilities(rng, prefix)
 
     # If we made it here, it must be a simple item so we remove any prefix and return
     return [repeated_capability.replace(prefix, '').strip()]

--- a/generated/nifake/nifake/_converters.py
+++ b/generated/nifake/nifake/_converters.py
@@ -70,13 +70,19 @@ def _(repeated_capability, prefix):
     if len(rc) > 1:
         if len(rc) > 2:
             raise errors.InvalidRepeatedCapabilityError("Multiple '-' or ':'", repeated_capability)
-        start = int(rc[0])
-        end = int(rc[1])
-        if end < start:
-            rng = range(start, end - 1, -1)
+        try:
+            start = int(rc[0])
+            end = int(rc[1])
+        except ValueError:
+            # This exception raised when repeated_capability is of the form "dev/0-1". rc[0] == "dev/0" in this case.
+            # Just return the repeated_capability string as-is in that case.
+            pass
         else:
-            rng = range(start, end + 1)
-        return _convert_repeated_capabilities(rng, prefix)
+            if end < start:
+                rng = range(start, end - 1, -1)
+            else:
+                rng = range(start, end + 1)
+            return _convert_repeated_capabilities(rng, prefix)
 
     # If we made it here, it must be a simple item so we remove any prefix and return
     return [repeated_capability.replace(prefix, '').strip()]

--- a/generated/nifake/nifake/unit_tests/test_converters.py
+++ b/generated/nifake/nifake/unit_tests/test_converters.py
@@ -76,7 +76,7 @@ def test_convert_seconds_real64_to_timedeltas():
 
 
 # Tests - repeated capabilities
-def test_repeated_capabilies_string_channel():
+def test_repeated_capabilities_string_channel():
     test_result_list = _converters.convert_repeated_capabilities('0')
     assert test_result_list == ['0']
     test_result_list = _converters.convert_repeated_capabilities('r0')
@@ -85,12 +85,12 @@ def test_repeated_capabilies_string_channel():
     assert test_result_list == ['0', '1']
 
 
-def test_repeated_capabilies_string_prefix():
+def test_repeated_capabilities_string_prefix():
     test_result_list = _converters.convert_repeated_capabilities('0', prefix='ScriptTrigger')
     assert test_result_list == ['ScriptTrigger0']
 
 
-def test_repeated_capabilies_list_channel():
+def test_repeated_capabilities_list_channel():
     test_result_list = _converters.convert_repeated_capabilities(['0'])
     assert test_result_list == ['0']
     test_result_list = _converters.convert_repeated_capabilities(['r0'])
@@ -103,7 +103,7 @@ def test_repeated_capabilies_list_channel():
     assert test_result_list == ['0', '1', '3']
 
 
-def test_repeated_capabilies_list_prefix():
+def test_repeated_capabilities_list_prefix():
     test_result_list = _converters.convert_repeated_capabilities(['ScriptTrigger0', 'ScriptTrigger1'], prefix='ScriptTrigger')
     assert test_result_list == ['ScriptTrigger0', 'ScriptTrigger1']
     test_result_list = _converters.convert_repeated_capabilities(['0'], prefix='ScriptTrigger')
@@ -114,7 +114,7 @@ def test_repeated_capabilies_list_prefix():
     assert test_result_list == ['ScriptTrigger0', 'ScriptTrigger1']
 
 
-def test_repeated_capabilies_tuple_channel():
+def test_repeated_capabilities_tuple_channel():
     test_result_list = _converters.convert_repeated_capabilities(('0'))
     assert test_result_list == ['0']
     test_result_list = _converters.convert_repeated_capabilities(('0,1'))
@@ -127,7 +127,7 @@ def test_repeated_capabilies_tuple_channel():
     assert test_result_list == ['0', '1', '3']
 
 
-def test_repeated_capabilies_tuple_prefix():
+def test_repeated_capabilities_tuple_prefix():
     test_result_list = _converters.convert_repeated_capabilities(('ScriptTrigger0,ScriptTrigger1'), prefix='ScriptTrigger')
     assert test_result_list == ['ScriptTrigger0', 'ScriptTrigger1']
     test_result_list = _converters.convert_repeated_capabilities(('0'), prefix='ScriptTrigger')
@@ -138,7 +138,7 @@ def test_repeated_capabilies_tuple_prefix():
     assert test_result_list == ['ScriptTrigger0', 'ScriptTrigger1']
 
 
-def test_repeated_capabilies_unicode():
+def test_repeated_capabilities_unicode():
     test_result_list = _converters.convert_repeated_capabilities(u'ScriptTrigger0,ScriptTrigger1', prefix='ScriptTrigger')
     assert test_result_list == ['ScriptTrigger0', 'ScriptTrigger1']
     test_result_list = _converters.convert_repeated_capabilities(u'ScriptTrigger0,ScriptTrigger1', prefix=u'ScriptTrigger')
@@ -147,7 +147,7 @@ def test_repeated_capabilies_unicode():
     assert test_result_list == ['ScriptTrigger0', 'ScriptTrigger1']
 
 
-def test_repeated_capabilies_raw():
+def test_repeated_capabilities_raw():
     test_result_list = _converters.convert_repeated_capabilities(r'ScriptTrigger0,ScriptTrigger1', prefix='ScriptTrigger')
     assert test_result_list == ['ScriptTrigger0', 'ScriptTrigger1']
     test_result_list = _converters.convert_repeated_capabilities(r'ScriptTrigger0,ScriptTrigger1', prefix=r'ScriptTrigger')
@@ -162,7 +162,7 @@ def test_repeated_capabilies_raw():
     assert test_result_list == ['ScriptTrigger0', 'ScriptTrigger1']
 
 
-def test_repeated_capabilies_slice_channel():
+def test_repeated_capabilities_slice_channel():
     test_result_list = _converters.convert_repeated_capabilities(slice(0, 1))
     assert test_result_list == ['0']
     test_result_list = _converters.convert_repeated_capabilities(slice(0, 2))
@@ -171,21 +171,21 @@ def test_repeated_capabilies_slice_channel():
     assert test_result_list == ['0', '1']
 
 
-def test_repeated_capabilies_mixed_channel():
+def test_repeated_capabilities_mixed_channel():
     test_result_list = _converters.convert_repeated_capabilities((slice(0, 1), '2', [4, '5-6'], '7-9', '11:14', '16, 17'))
     assert test_result_list == ['0', '2', '4', '5', '6', '7', '8', '9', '11', '12', '13', '14', '16', '17']
     test_result_list = _converters.convert_repeated_capabilities([slice(0, 1), '2', [4, '5-6'], '7-9', '11:14', '16, 17'])
     assert test_result_list == ['0', '2', '4', '5', '6', '7', '8', '9', '11', '12', '13', '14', '16', '17']
 
 
-def test_repeated_capabilies_mixed_prefix():
+def test_repeated_capabilities_mixed_prefix():
     test_result_list = _converters.convert_repeated_capabilities((slice(0, 1), '2', [4, '5-6'], '7-9', '11:14', '16, 17'), prefix='ScriptTrigger')
     assert test_result_list == ['ScriptTrigger0', 'ScriptTrigger2', 'ScriptTrigger4', 'ScriptTrigger5', 'ScriptTrigger6', 'ScriptTrigger7', 'ScriptTrigger8', 'ScriptTrigger9', 'ScriptTrigger11', 'ScriptTrigger12', 'ScriptTrigger13', 'ScriptTrigger14', 'ScriptTrigger16', 'ScriptTrigger17']
     test_result_list = _converters.convert_repeated_capabilities([slice(0, 1), '2', [4, '5-6'], '7-9', '11:14', '16, 17'], prefix='ScriptTrigger')
     assert test_result_list == ['ScriptTrigger0', 'ScriptTrigger2', 'ScriptTrigger4', 'ScriptTrigger5', 'ScriptTrigger6', 'ScriptTrigger7', 'ScriptTrigger8', 'ScriptTrigger9', 'ScriptTrigger11', 'ScriptTrigger12', 'ScriptTrigger13', 'ScriptTrigger14', 'ScriptTrigger16', 'ScriptTrigger17']
 
 
-def test_invalid_repeated_capabilies():
+def test_invalid_repeated_capabilities():
     try:
         _converters.convert_repeated_capabilities('6-8-10')
         assert False
@@ -223,7 +223,7 @@ def test_invalid_repeated_capabilies():
         pass
 
 
-def test_repeated_capabilies_slice_prefix():
+def test_repeated_capabilities_slice_prefix():
     test_result_list = _converters.convert_repeated_capabilities(slice(0, 1), prefix='ScriptTrigger')
     assert test_result_list == ['ScriptTrigger0']
     test_result_list = _converters.convert_repeated_capabilities(slice(0, 2), prefix='ScriptTrigger')
@@ -232,9 +232,64 @@ def test_repeated_capabilies_slice_prefix():
     assert test_result_list == ['ScriptTrigger0', 'ScriptTrigger1']
 
 
-def test_repeated_capabilies_without_prefix():
+def test_repeated_capabilities_without_prefix():
     test_result = _converters.convert_repeated_capabilities_without_prefix((slice(0, 1), '2', [4, '5-6'], '7-9', '11:14', '16, 17'))
     assert test_result == '0,2,4,5,6,7,8,9,11,12,13,14,16,17'
+
+
+def test_repeated_capabilities_string_resource_name():
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix('Dev1')
+    assert test_result_list == 'Dev1'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix('Dev1,Dev2')
+    assert test_result_list == 'Dev1,Dev2'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix('Dev1/0')
+    assert test_result_list == 'Dev1/0'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix('Dev1/0:1, Dev2/0-1')
+    assert test_result_list == 'Dev1/0:1,Dev2/0-1'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix('Dev1, Dev2/0-2')
+    assert test_result_list == 'Dev1,Dev2/0-2'
+
+
+def test_repeated_capabilities_list_resource_name():
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix(['Dev1'])
+    assert test_result_list == 'Dev1'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix(['Dev1', 'Dev2'])
+    assert test_result_list == 'Dev1,Dev2'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix(['Dev1/0'])
+    assert test_result_list == 'Dev1/0'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix(['Dev1/0:1', 'Dev2/0-1'])
+    assert test_result_list == 'Dev1/0:1,Dev2/0-1'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix(['Dev1', 'Dev2/0-2'])
+    assert test_result_list == 'Dev1,Dev2/0-2'
+
+
+def test_repeated_capabilities_tuple_resource_name():
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix(('Dev1'))
+    assert test_result_list == 'Dev1'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix(('Dev1', 'Dev2'))
+    assert test_result_list == 'Dev1,Dev2'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix(('Dev1/0'))
+    assert test_result_list == 'Dev1/0'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix(('Dev1/0:1', 'Dev2/0-1'))
+    assert test_result_list == 'Dev1/0:1,Dev2/0-1'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix(('Dev1', 'Dev2/0-2'))
+    assert test_result_list == 'Dev1,Dev2/0-2'
+
+
+def test_repeated_capabilities_mixed_resource_name():
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix(['Dev1', ('Dev2/0', 'Dev2/1'), ['Dev3/0:1', 'Dev4/1:2'], 'Dev5/1'])
+    assert test_result_list == 'Dev1,Dev2/0,Dev2/1,Dev3/0:1,Dev4/1:2,Dev5/1'
+
+
+def test_repeated_capabilities_invalid_resource_names():
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix('/')
+    assert test_result_list == '/'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix('Dev/')
+    assert test_result_list == 'Dev/'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix('Dev,')
+    assert test_result_list == 'Dev,'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix('Dev/1/1,')
+    assert test_result_list == 'Dev/1/1,'
 
 
 def test_convert_chained_repeated_capability_to_parts_three_parts():

--- a/generated/nifgen/nifgen/_converters.py
+++ b/generated/nifgen/nifgen/_converters.py
@@ -70,13 +70,19 @@ def _(repeated_capability, prefix):
     if len(rc) > 1:
         if len(rc) > 2:
             raise errors.InvalidRepeatedCapabilityError("Multiple '-' or ':'", repeated_capability)
-        start = int(rc[0])
-        end = int(rc[1])
-        if end < start:
-            rng = range(start, end - 1, -1)
+        try:
+            start = int(rc[0])
+            end = int(rc[1])
+        except ValueError:
+            # This exception raised when repeated_capability is of the form "dev/0-1". rc[0] == "dev/0" in this case.
+            # Just return the repeated_capability string as-is in that case.
+            pass
         else:
-            rng = range(start, end + 1)
-        return _convert_repeated_capabilities(rng, prefix)
+            if end < start:
+                rng = range(start, end - 1, -1)
+            else:
+                rng = range(start, end + 1)
+            return _convert_repeated_capabilities(rng, prefix)
 
     # If we made it here, it must be a simple item so we remove any prefix and return
     return [repeated_capability.replace(prefix, '').strip()]

--- a/generated/nimodinst/nimodinst/_converters.py
+++ b/generated/nimodinst/nimodinst/_converters.py
@@ -70,13 +70,19 @@ def _(repeated_capability, prefix):
     if len(rc) > 1:
         if len(rc) > 2:
             raise errors.InvalidRepeatedCapabilityError("Multiple '-' or ':'", repeated_capability)
-        start = int(rc[0])
-        end = int(rc[1])
-        if end < start:
-            rng = range(start, end - 1, -1)
+        try:
+            start = int(rc[0])
+            end = int(rc[1])
+        except ValueError:
+            # This exception raised when repeated_capability is of the form "dev/0-1". rc[0] == "dev/0" in this case.
+            # Just return the repeated_capability string as-is in that case.
+            pass
         else:
-            rng = range(start, end + 1)
-        return _convert_repeated_capabilities(rng, prefix)
+            if end < start:
+                rng = range(start, end - 1, -1)
+            else:
+                rng = range(start, end + 1)
+            return _convert_repeated_capabilities(rng, prefix)
 
     # If we made it here, it must be a simple item so we remove any prefix and return
     return [repeated_capability.replace(prefix, '').strip()]

--- a/generated/niscope/niscope/_converters.py
+++ b/generated/niscope/niscope/_converters.py
@@ -70,13 +70,19 @@ def _(repeated_capability, prefix):
     if len(rc) > 1:
         if len(rc) > 2:
             raise errors.InvalidRepeatedCapabilityError("Multiple '-' or ':'", repeated_capability)
-        start = int(rc[0])
-        end = int(rc[1])
-        if end < start:
-            rng = range(start, end - 1, -1)
+        try:
+            start = int(rc[0])
+            end = int(rc[1])
+        except ValueError:
+            # This exception raised when repeated_capability is of the form "dev/0-1". rc[0] == "dev/0" in this case.
+            # Just return the repeated_capability string as-is in that case.
+            pass
         else:
-            rng = range(start, end + 1)
-        return _convert_repeated_capabilities(rng, prefix)
+            if end < start:
+                rng = range(start, end - 1, -1)
+            else:
+                rng = range(start, end + 1)
+            return _convert_repeated_capabilities(rng, prefix)
 
     # If we made it here, it must be a simple item so we remove any prefix and return
     return [repeated_capability.replace(prefix, '').strip()]

--- a/generated/nise/nise/_converters.py
+++ b/generated/nise/nise/_converters.py
@@ -70,13 +70,19 @@ def _(repeated_capability, prefix):
     if len(rc) > 1:
         if len(rc) > 2:
             raise errors.InvalidRepeatedCapabilityError("Multiple '-' or ':'", repeated_capability)
-        start = int(rc[0])
-        end = int(rc[1])
-        if end < start:
-            rng = range(start, end - 1, -1)
+        try:
+            start = int(rc[0])
+            end = int(rc[1])
+        except ValueError:
+            # This exception raised when repeated_capability is of the form "dev/0-1". rc[0] == "dev/0" in this case.
+            # Just return the repeated_capability string as-is in that case.
+            pass
         else:
-            rng = range(start, end + 1)
-        return _convert_repeated_capabilities(rng, prefix)
+            if end < start:
+                rng = range(start, end - 1, -1)
+            else:
+                rng = range(start, end + 1)
+            return _convert_repeated_capabilities(rng, prefix)
 
     # If we made it here, it must be a simple item so we remove any prefix and return
     return [repeated_capability.replace(prefix, '').strip()]

--- a/generated/niswitch/niswitch/_converters.py
+++ b/generated/niswitch/niswitch/_converters.py
@@ -70,13 +70,19 @@ def _(repeated_capability, prefix):
     if len(rc) > 1:
         if len(rc) > 2:
             raise errors.InvalidRepeatedCapabilityError("Multiple '-' or ':'", repeated_capability)
-        start = int(rc[0])
-        end = int(rc[1])
-        if end < start:
-            rng = range(start, end - 1, -1)
+        try:
+            start = int(rc[0])
+            end = int(rc[1])
+        except ValueError:
+            # This exception raised when repeated_capability is of the form "dev/0-1". rc[0] == "dev/0" in this case.
+            # Just return the repeated_capability string as-is in that case.
+            pass
         else:
-            rng = range(start, end + 1)
-        return _convert_repeated_capabilities(rng, prefix)
+            if end < start:
+                rng = range(start, end - 1, -1)
+            else:
+                rng = range(start, end + 1)
+            return _convert_repeated_capabilities(rng, prefix)
 
     # If we made it here, it must be a simple item so we remove any prefix and return
     return [repeated_capability.replace(prefix, '').strip()]

--- a/generated/nitclk/nitclk/_converters.py
+++ b/generated/nitclk/nitclk/_converters.py
@@ -70,13 +70,19 @@ def _(repeated_capability, prefix):
     if len(rc) > 1:
         if len(rc) > 2:
             raise errors.InvalidRepeatedCapabilityError("Multiple '-' or ':'", repeated_capability)
-        start = int(rc[0])
-        end = int(rc[1])
-        if end < start:
-            rng = range(start, end - 1, -1)
+        try:
+            start = int(rc[0])
+            end = int(rc[1])
+        except ValueError:
+            # This exception raised when repeated_capability is of the form "dev/0-1". rc[0] == "dev/0" in this case.
+            # Just return the repeated_capability string as-is in that case.
+            pass
         else:
-            rng = range(start, end + 1)
-        return _convert_repeated_capabilities(rng, prefix)
+            if end < start:
+                rng = range(start, end - 1, -1)
+            else:
+                rng = range(start, end + 1)
+            return _convert_repeated_capabilities(rng, prefix)
 
     # If we made it here, it must be a simple item so we remove any prefix and return
     return [repeated_capability.replace(prefix, '').strip()]

--- a/src/nifake/unit_tests/test_converters.py
+++ b/src/nifake/unit_tests/test_converters.py
@@ -290,6 +290,8 @@ def test_repeated_capabilities_invalid_resource_names():
     assert test_result_list == 'Dev,'
     test_result_list = _converters.convert_repeated_capabilities_without_prefix('Dev/1/1,')
     assert test_result_list == 'Dev/1/1,'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix('0/1:2,')
+    assert test_result_list == '0/1:2,'
 
 
 def test_convert_chained_repeated_capability_to_parts_three_parts():

--- a/src/nifake/unit_tests/test_converters.py
+++ b/src/nifake/unit_tests/test_converters.py
@@ -76,7 +76,7 @@ def test_convert_seconds_real64_to_timedeltas():
 
 
 # Tests - repeated capabilities
-def test_repeated_capabilies_string_channel():
+def test_repeated_capabilities_string_channel():
     test_result_list = _converters.convert_repeated_capabilities('0')
     assert test_result_list == ['0']
     test_result_list = _converters.convert_repeated_capabilities('r0')
@@ -85,12 +85,12 @@ def test_repeated_capabilies_string_channel():
     assert test_result_list == ['0', '1']
 
 
-def test_repeated_capabilies_string_prefix():
+def test_repeated_capabilities_string_prefix():
     test_result_list = _converters.convert_repeated_capabilities('0', prefix='ScriptTrigger')
     assert test_result_list == ['ScriptTrigger0']
 
 
-def test_repeated_capabilies_list_channel():
+def test_repeated_capabilities_list_channel():
     test_result_list = _converters.convert_repeated_capabilities(['0'])
     assert test_result_list == ['0']
     test_result_list = _converters.convert_repeated_capabilities(['r0'])
@@ -103,7 +103,7 @@ def test_repeated_capabilies_list_channel():
     assert test_result_list == ['0', '1', '3']
 
 
-def test_repeated_capabilies_list_prefix():
+def test_repeated_capabilities_list_prefix():
     test_result_list = _converters.convert_repeated_capabilities(['ScriptTrigger0', 'ScriptTrigger1'], prefix='ScriptTrigger')
     assert test_result_list == ['ScriptTrigger0', 'ScriptTrigger1']
     test_result_list = _converters.convert_repeated_capabilities(['0'], prefix='ScriptTrigger')
@@ -114,7 +114,7 @@ def test_repeated_capabilies_list_prefix():
     assert test_result_list == ['ScriptTrigger0', 'ScriptTrigger1']
 
 
-def test_repeated_capabilies_tuple_channel():
+def test_repeated_capabilities_tuple_channel():
     test_result_list = _converters.convert_repeated_capabilities(('0'))
     assert test_result_list == ['0']
     test_result_list = _converters.convert_repeated_capabilities(('0,1'))
@@ -127,7 +127,7 @@ def test_repeated_capabilies_tuple_channel():
     assert test_result_list == ['0', '1', '3']
 
 
-def test_repeated_capabilies_tuple_prefix():
+def test_repeated_capabilities_tuple_prefix():
     test_result_list = _converters.convert_repeated_capabilities(('ScriptTrigger0,ScriptTrigger1'), prefix='ScriptTrigger')
     assert test_result_list == ['ScriptTrigger0', 'ScriptTrigger1']
     test_result_list = _converters.convert_repeated_capabilities(('0'), prefix='ScriptTrigger')
@@ -138,7 +138,7 @@ def test_repeated_capabilies_tuple_prefix():
     assert test_result_list == ['ScriptTrigger0', 'ScriptTrigger1']
 
 
-def test_repeated_capabilies_unicode():
+def test_repeated_capabilities_unicode():
     test_result_list = _converters.convert_repeated_capabilities(u'ScriptTrigger0,ScriptTrigger1', prefix='ScriptTrigger')
     assert test_result_list == ['ScriptTrigger0', 'ScriptTrigger1']
     test_result_list = _converters.convert_repeated_capabilities(u'ScriptTrigger0,ScriptTrigger1', prefix=u'ScriptTrigger')
@@ -147,7 +147,7 @@ def test_repeated_capabilies_unicode():
     assert test_result_list == ['ScriptTrigger0', 'ScriptTrigger1']
 
 
-def test_repeated_capabilies_raw():
+def test_repeated_capabilities_raw():
     test_result_list = _converters.convert_repeated_capabilities(r'ScriptTrigger0,ScriptTrigger1', prefix='ScriptTrigger')
     assert test_result_list == ['ScriptTrigger0', 'ScriptTrigger1']
     test_result_list = _converters.convert_repeated_capabilities(r'ScriptTrigger0,ScriptTrigger1', prefix=r'ScriptTrigger')
@@ -162,7 +162,7 @@ def test_repeated_capabilies_raw():
     assert test_result_list == ['ScriptTrigger0', 'ScriptTrigger1']
 
 
-def test_repeated_capabilies_slice_channel():
+def test_repeated_capabilities_slice_channel():
     test_result_list = _converters.convert_repeated_capabilities(slice(0, 1))
     assert test_result_list == ['0']
     test_result_list = _converters.convert_repeated_capabilities(slice(0, 2))
@@ -171,21 +171,21 @@ def test_repeated_capabilies_slice_channel():
     assert test_result_list == ['0', '1']
 
 
-def test_repeated_capabilies_mixed_channel():
+def test_repeated_capabilities_mixed_channel():
     test_result_list = _converters.convert_repeated_capabilities((slice(0, 1), '2', [4, '5-6'], '7-9', '11:14', '16, 17'))
     assert test_result_list == ['0', '2', '4', '5', '6', '7', '8', '9', '11', '12', '13', '14', '16', '17']
     test_result_list = _converters.convert_repeated_capabilities([slice(0, 1), '2', [4, '5-6'], '7-9', '11:14', '16, 17'])
     assert test_result_list == ['0', '2', '4', '5', '6', '7', '8', '9', '11', '12', '13', '14', '16', '17']
 
 
-def test_repeated_capabilies_mixed_prefix():
+def test_repeated_capabilities_mixed_prefix():
     test_result_list = _converters.convert_repeated_capabilities((slice(0, 1), '2', [4, '5-6'], '7-9', '11:14', '16, 17'), prefix='ScriptTrigger')
     assert test_result_list == ['ScriptTrigger0', 'ScriptTrigger2', 'ScriptTrigger4', 'ScriptTrigger5', 'ScriptTrigger6', 'ScriptTrigger7', 'ScriptTrigger8', 'ScriptTrigger9', 'ScriptTrigger11', 'ScriptTrigger12', 'ScriptTrigger13', 'ScriptTrigger14', 'ScriptTrigger16', 'ScriptTrigger17']
     test_result_list = _converters.convert_repeated_capabilities([slice(0, 1), '2', [4, '5-6'], '7-9', '11:14', '16, 17'], prefix='ScriptTrigger')
     assert test_result_list == ['ScriptTrigger0', 'ScriptTrigger2', 'ScriptTrigger4', 'ScriptTrigger5', 'ScriptTrigger6', 'ScriptTrigger7', 'ScriptTrigger8', 'ScriptTrigger9', 'ScriptTrigger11', 'ScriptTrigger12', 'ScriptTrigger13', 'ScriptTrigger14', 'ScriptTrigger16', 'ScriptTrigger17']
 
 
-def test_invalid_repeated_capabilies():
+def test_invalid_repeated_capabilities():
     try:
         _converters.convert_repeated_capabilities('6-8-10')
         assert False
@@ -223,7 +223,7 @@ def test_invalid_repeated_capabilies():
         pass
 
 
-def test_repeated_capabilies_slice_prefix():
+def test_repeated_capabilities_slice_prefix():
     test_result_list = _converters.convert_repeated_capabilities(slice(0, 1), prefix='ScriptTrigger')
     assert test_result_list == ['ScriptTrigger0']
     test_result_list = _converters.convert_repeated_capabilities(slice(0, 2), prefix='ScriptTrigger')
@@ -232,9 +232,64 @@ def test_repeated_capabilies_slice_prefix():
     assert test_result_list == ['ScriptTrigger0', 'ScriptTrigger1']
 
 
-def test_repeated_capabilies_without_prefix():
+def test_repeated_capabilities_without_prefix():
     test_result = _converters.convert_repeated_capabilities_without_prefix((slice(0, 1), '2', [4, '5-6'], '7-9', '11:14', '16, 17'))
     assert test_result == '0,2,4,5,6,7,8,9,11,12,13,14,16,17'
+
+
+def test_repeated_capabilities_string_resource_name():
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix('Dev1')
+    assert test_result_list == 'Dev1'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix('Dev1,Dev2')
+    assert test_result_list == 'Dev1,Dev2'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix('Dev1/0')
+    assert test_result_list == 'Dev1/0'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix('Dev1/0:1, Dev2/0-1')
+    assert test_result_list == 'Dev1/0:1,Dev2/0-1'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix('Dev1, Dev2/0-2')
+    assert test_result_list == 'Dev1,Dev2/0-2'
+
+
+def test_repeated_capabilities_list_resource_name():
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix(['Dev1'])
+    assert test_result_list == 'Dev1'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix(['Dev1', 'Dev2'])
+    assert test_result_list == 'Dev1,Dev2'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix(['Dev1/0'])
+    assert test_result_list == 'Dev1/0'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix(['Dev1/0:1', 'Dev2/0-1'])
+    assert test_result_list == 'Dev1/0:1,Dev2/0-1'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix(['Dev1', 'Dev2/0-2'])
+    assert test_result_list == 'Dev1,Dev2/0-2'
+
+
+def test_repeated_capabilities_tuple_resource_name():
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix(('Dev1'))
+    assert test_result_list == 'Dev1'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix(('Dev1', 'Dev2'))
+    assert test_result_list == 'Dev1,Dev2'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix(('Dev1/0'))
+    assert test_result_list == 'Dev1/0'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix(('Dev1/0:1', 'Dev2/0-1'))
+    assert test_result_list == 'Dev1/0:1,Dev2/0-1'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix(('Dev1', 'Dev2/0-2'))
+    assert test_result_list == 'Dev1,Dev2/0-2'
+
+
+def test_repeated_capabilities_mixed_resource_name():
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix(['Dev1', ('Dev2/0', 'Dev2/1'), ['Dev3/0:1', 'Dev4/1:2'], 'Dev5/1'])
+    assert test_result_list == 'Dev1,Dev2/0,Dev2/1,Dev3/0:1,Dev4/1:2,Dev5/1'
+
+
+def test_repeated_capabilities_invalid_resource_names():
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix('/')
+    assert test_result_list == '/'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix('Dev/')
+    assert test_result_list == 'Dev/'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix('Dev,')
+    assert test_result_list == 'Dev,'
+    test_result_list = _converters.convert_repeated_capabilities_without_prefix('Dev/1/1,')
+    assert test_result_list == 'Dev/1/1,'
 
 
 def test_convert_chained_repeated_capability_to_parts_three_parts():


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [ ] ~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- [ ] ~I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

In preparation for implementing independent channels constructor that takes a resource name parameter, we needed a converter that supports lists and tuples of resource names. With this modification to the existing repeated capabilities converter we can use it also for resource names.

### List issues fixed by this Pull Request below, if any.

### What testing has been done?

Added unit tests to validate resource name conversions.
