### PR TITLE
API parity with NI-DCPower 20.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,20 @@ All notable changes to this project will be documented in this file.
 * ### `nidcpower` (NI-DCPower)
     * #### Added
         * API parity with NI-DCPower 20.7.0 by adding Output Cutoff functionality.
+        * Properties added:
+            * `output_cutoff_current_change_limit_high`
+            * `output_cutoff_current_change_limit_low`
+            * `output_cutoff_current_measure_limit_high`
+            * `output_cutoff_current_measure_limit_low`
+            * `output_cutoff_current_overrange_enabled`
+            * `output_cutoff_enabled`
+            * `output_cutoff_voltage_change_limit_high`
+            * `output_cutoff_voltage_change_limit_low`
+            * `output_cutoff_voltage_output_limit_high`
+            * `output_cutoff_voltage_output_limit_low`
+        * Methods added:
+            * `clear_latched_output_cutoff_state`
+            * `query_latched_output_cutoff_state`
     * #### Changed
     * #### Removed
 * ### `nidigital` (NI-Digital Pattern Driver)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file.
     * #### Removed
 * ### `nidcpower` (NI-DCPower)
     * #### Added
+        * API parity with NI-DCPower 20.7.0 by adding Output Cutoff functionality.
     * #### Changed
     * #### Removed
 * ### `nidigital` (NI-Digital Pattern Driver)

--- a/docs/nidcpower/class.rst
+++ b/docs/nidcpower/class.rst
@@ -155,6 +155,53 @@ abort
 
 
 
+clear_latched_output_cutoff_state
+---------------------------------
+
+    .. py:currentmodule:: nidcpower.Session
+
+    .. py:method:: clear_latched_output_cutoff_state(output_cutoff_reason)
+
+            Clears the state of an output cutoff that was engaged.
+            To clear the state for all output cutoff reasons, use :py:data:`~nidcpower.OutputCutoffReason.ALL`.
+
+            
+
+
+            .. tip:: This method requires repeated capabilities. If called directly on the
+                nidcpower.Session object, then the method will use all repeated capabilities in the session.
+                You can specify a subset of repeated capabilities using the Python index notation on an
+                nidcpower.Session repeated capabilities container, and calling this method on the result.
+
+
+            :param output_cutoff_reason:
+
+
+                Specifies the reasons for which to clear the output cutoff state.
+
+                +---------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputCutoffReason.ALL`                  | Clears all output cutoff conditions                                                                             |
+                +---------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputCutoffReason.VOLTAGE_OUTPUT_HIGH`  | Clears cutoffs caused when the output exceeded the high cutoff limit for voltage output                         |
+                +---------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputCutoffReason.VOLTAGE_OUTPUT_LOW`   | Clears cutoffs caused when the output fell below the low cutoff limit for voltage output                        |
+                +---------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputCutoffReason.CURRENT_MEASURE_HIGH` | Clears cutoffs caused when the measured current exceeded the high cutoff limit for current output               |
+                +---------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputCutoffReason.CURRENT_MEASURE_LOW`  | Clears cutoffs caused when the measured current fell below the low cutoff limit for current output              |
+                +---------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputCutoffReason.VOLTAGE_CHANGE_HIGH`  | Clears cutoffs caused when the voltage slew rate increased beyond the positive change cutoff for voltage output |
+                +---------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputCutoffReason.VOLTAGE_CHANGE_LOW`   | Clears cutoffs caused when the voltage slew rate decreased beyond the negative change cutoff for voltage output |
+                +---------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputCutoffReason.CURRENT_CHANGE_HIGH`  | Clears cutoffs caused when the current slew rate increased beyond the positive change cutoff for current output |
+                +---------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputCutoffReason.CURRENT_CHANGE_LOW`   | Clears cutoffs caused when the voltage slew rate decreased beyond the negative change cutoff for current output |
+                +---------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
+
+
+            :type output_cutoff_reason: :py:data:`nidcpower.OutputCutoffReason`
+
 close
 -----
 
@@ -261,11 +308,11 @@ configure_aperture_time
                 Specifies the units for **apertureTime**.
                 **Defined Values**:
 
-                +------------------------------------------------------------------+------------------------------+
-                | :py:data:`~nidcpower.ApertureTimeUnits.SECONDS` (1028)           | Specifies seconds.           |
-                +------------------------------------------------------------------+------------------------------+
-                | :py:data:`~nidcpower.ApertureTimeUnits.POWER_LINE_CYCLES` (1029) | Specifies Power Line Cycles. |
-                +------------------------------------------------------------------+------------------------------+
+                +-----------------------------------------------------------+------------------------------+
+                | :py:data:`~nidcpower.ApertureTimeUnits.SECONDS`           | Specifies seconds.           |
+                +-----------------------------------------------------------+------------------------------+
+                | :py:data:`~nidcpower.ApertureTimeUnits.POWER_LINE_CYCLES` | Specifies Power Line Cycles. |
+                +-----------------------------------------------------------+------------------------------+
 
 
             :type units: :py:data:`nidcpower.ApertureTimeUnits`
@@ -1157,11 +1204,11 @@ measure
                 Specifies whether a voltage or current value is measured.
                 **Defined Values**:
 
-                +----------------------------------------------------+------------------------------+
-                | :py:data:`~nidcpower.MeasurementTypes.VOLTAGE` (1) | The device measures voltage. |
-                +----------------------------------------------------+------------------------------+
-                | :py:data:`~nidcpower.MeasurementTypes.CURRENT` (0) | The device measures current. |
-                +----------------------------------------------------+------------------------------+
+                +------------------------------------------------+------------------------------+
+                | :py:data:`~nidcpower.MeasurementTypes.VOLTAGE` | The device measures voltage. |
+                +------------------------------------------------+------------------------------+
+                | :py:data:`~nidcpower.MeasurementTypes.CURRENT` | The device measures current. |
+                +------------------------------------------------+------------------------------+
 
 
             :type measurement_type: :py:data:`nidcpower.MeasurementTypes`
@@ -1267,6 +1314,71 @@ query_in_compliance
                     Returns whether the device output channel is in compliance.
 
                     
+
+
+
+query_latched_output_cutoff_state
+---------------------------------
+
+    .. py:currentmodule:: nidcpower.Session
+
+    .. py:method:: query_latched_output_cutoff_state(output_cutoff_reason)
+
+            Discovers if an output cutoff limit was exceeded for the specified reason. When an output cutoff is engaged, the output of the channel(s) is disconnected.
+            If a limit was exceeded, the state is latched until you clear it with the :py:meth:`nidcpower.Session.clear_latched_output_cutoff_state` method or the :py:meth:`nidcpower.Session.ResetWithChannels` method.
+
+            outputCutoffReason specifies the conditions for which an output is disconnected.
+
+            
+
+            .. note:: One or more of the referenced methods are not in the Python API for this driver.
+
+
+            .. tip:: This method requires repeated capabilities. If called directly on the
+                nidcpower.Session object, then the method will use all repeated capabilities in the session.
+                You can specify a subset of repeated capabilities using the Python index notation on an
+                nidcpower.Session repeated capabilities container, and calling this method on the result.
+
+
+            :param output_cutoff_reason:
+
+
+                Specifies which output cutoff conditions to query.
+
+                +---------------------------------------------------------------+--------------------------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputCutoffReason.ALL`                  | Any output cutoff condition was met                                                  |
+                +---------------------------------------------------------------+--------------------------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputCutoffReason.VOLTAGE_OUTPUT_HIGH`  | The output exceeded the high cutoff limit for voltage output                         |
+                +---------------------------------------------------------------+--------------------------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputCutoffReason.VOLTAGE_OUTPUT_LOW`   | The output fell below the low cutoff limit for voltage output                        |
+                +---------------------------------------------------------------+--------------------------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputCutoffReason.CURRENT_MEASURE_HIGH` | The measured current exceeded the high cutoff limit for current output               |
+                +---------------------------------------------------------------+--------------------------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputCutoffReason.CURRENT_MEASURE_LOW`  | The measured current fell below the low cutoff limit for current output              |
+                +---------------------------------------------------------------+--------------------------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputCutoffReason.VOLTAGE_CHANGE_HIGH`  | The voltage slew rate increased beyond the positive change cutoff for voltage output |
+                +---------------------------------------------------------------+--------------------------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputCutoffReason.VOLTAGE_CHANGE_LOW`   | The voltage slew rate decreased beyond the negative change cutoff for voltage output |
+                +---------------------------------------------------------------+--------------------------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputCutoffReason.CURRENT_CHANGE_HIGH`  | The current slew rate increased beyond the positive change cutoff for current output |
+                +---------------------------------------------------------------+--------------------------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputCutoffReason.CURRENT_CHANGE_LOW`   | The current slew rate decreased beyond the negative change cutoff for current output |
+                +---------------------------------------------------------------+--------------------------------------------------------------------------------------+
+
+
+            :type output_cutoff_reason: :py:data:`nidcpower.OutputCutoffReason`
+
+            :rtype: bool
+            :return:
+
+
+                    Specifies whether an output cutoff has engaged.
+
+                    +-------+------------------------------------------------------------------------------+
+                    | True  | An output cutoff has engaged for the conditions in **output cutoff reason**. |
+                    +-------+------------------------------------------------------------------------------+
+                    | False | No output cutoff has engaged.                                                |
+                    +-------+------------------------------------------------------------------------------+
 
 
 
@@ -1422,11 +1534,11 @@ query_output_state
                 Specifies the output state of the output channel that is being queried.
                 **Defined Values**:
 
-                +------------------------------------------------+-------------------------------------------------------------------+
-                | :py:data:`~nidcpower.OutputStates.VOLTAGE` (0) | The device maintains a constant voltage by adjusting the current. |
-                +------------------------------------------------+-------------------------------------------------------------------+
-                | :py:data:`~nidcpower.OutputStates.CURRENT` (1) | The device maintains a constant current by adjusting the voltage. |
-                +------------------------------------------------+-------------------------------------------------------------------+
+                +--------------------------------------------+-------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputStates.VOLTAGE` | The device maintains a constant voltage by adjusting the current. |
+                +--------------------------------------------+-------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputStates.CURRENT` | The device maintains a constant current by adjusting the voltage. |
+                +--------------------------------------------+-------------------------------------------------------------------+
 
 
             :type output_state: :py:data:`nidcpower.OutputStates`
@@ -1630,19 +1742,19 @@ send_software_edge_trigger
                 Specifies which trigger to assert.
                 **Defined Values:**
 
-                +---------------------------------------------------------------------+---------------------------------------+
-                | :py:data:`~nidcpower.NIDCPOWER_VAL_START_TRIGGER` (1034)            | Asserts the Start trigger.            |
-                +---------------------------------------------------------------------+---------------------------------------+
-                | :py:data:`~nidcpower.NIDCPOWER_VAL_SOURCE_TRIGGER` (1035)           | Asserts the Source trigger.           |
-                +---------------------------------------------------------------------+---------------------------------------+
-                | :py:data:`~nidcpower.NIDCPOWER_VAL_MEASURE_TRIGGER` (1036)          | Asserts the Measure trigger.          |
-                +---------------------------------------------------------------------+---------------------------------------+
-                | :py:data:`~nidcpower.NIDCPOWER_VAL_SEQUENCE_ADVANCE_TRIGGER` (1037) | Asserts the Sequence Advance trigger. |
-                +---------------------------------------------------------------------+---------------------------------------+
-                | :py:data:`~nidcpower.NIDCPOWER_VAL_PULSE_TRIGGER` (1053)            | Asserts the Pulse trigger.            |
-                +---------------------------------------------------------------------+---------------------------------------+
-                | :py:data:`~nidcpower.NIDCPOWER_VAL_SHUTDOWN_TRIGGER` (1118)         | Asserts the Shutdown trigger.         |
-                +---------------------------------------------------------------------+---------------------------------------+
+                +--------------------------------------------------------------+---------------------------------------+
+                | :py:data:`~nidcpower.NIDCPOWER_VAL_START_TRIGGER`            | Asserts the Start trigger.            |
+                +--------------------------------------------------------------+---------------------------------------+
+                | :py:data:`~nidcpower.NIDCPOWER_VAL_SOURCE_TRIGGER`           | Asserts the Source trigger.           |
+                +--------------------------------------------------------------+---------------------------------------+
+                | :py:data:`~nidcpower.NIDCPOWER_VAL_MEASURE_TRIGGER`          | Asserts the Measure trigger.          |
+                +--------------------------------------------------------------+---------------------------------------+
+                | :py:data:`~nidcpower.NIDCPOWER_VAL_SEQUENCE_ADVANCE_TRIGGER` | Asserts the Sequence Advance trigger. |
+                +--------------------------------------------------------------+---------------------------------------+
+                | :py:data:`~nidcpower.NIDCPOWER_VAL_PULSE_TRIGGER`            | Asserts the Pulse trigger.            |
+                +--------------------------------------------------------------+---------------------------------------+
+                | :py:data:`~nidcpower.NIDCPOWER_VAL_SHUTDOWN_TRIGGER`         | Asserts the Shutdown trigger.         |
+                +--------------------------------------------------------------+---------------------------------------+
 
                 .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
@@ -1755,19 +1867,19 @@ wait_for_event
                 Specifies which event to wait for.
                 **Defined Values:**
 
-                +------------------------------------------------------------------------------+--------------------------------------------------+
-                | :py:data:`~nidcpower.NIDCPOWER_VAL_SOURCE_COMPLETE_EVENT` (1030)             | Waits for the Source Complete event.             |
-                +------------------------------------------------------------------------------+--------------------------------------------------+
-                | :py:data:`~nidcpower.NIDCPOWER_VAL_MEASURE_COMPLETE_EVENT` (1031)            | Waits for the Measure Complete event.            |
-                +------------------------------------------------------------------------------+--------------------------------------------------+
-                | :py:data:`~nidcpower.NIDCPOWER_VAL_SEQUENCE_ITERATION_COMPLETE_EVENT` (1032) | Waits for the Sequence Iteration Complete event. |
-                +------------------------------------------------------------------------------+--------------------------------------------------+
-                | :py:data:`~nidcpower.NIDCPOWER_VAL_SEQUENCE_ENGINE_DONE_EVENT` (1033)        | Waits for the Sequence Engine Done event.        |
-                +------------------------------------------------------------------------------+--------------------------------------------------+
-                | :py:data:`~nidcpower.NIDCPOWER_VAL_PULSE_COMPLETE_EVENT` (1051 )             | Waits for the Pulse Complete event.              |
-                +------------------------------------------------------------------------------+--------------------------------------------------+
-                | :py:data:`~nidcpower.NIDCPOWER_VAL_READY_FOR_PULSE_TRIGGER_EVENT` (1052)     | Waits for the Ready for Pulse Trigger event.     |
-                +------------------------------------------------------------------------------+--------------------------------------------------+
+                +-----------------------------------------------------------------------+--------------------------------------------------+
+                | :py:data:`~nidcpower.NIDCPOWER_VAL_SOURCE_COMPLETE_EVENT`             | Waits for the Source Complete event.             |
+                +-----------------------------------------------------------------------+--------------------------------------------------+
+                | :py:data:`~nidcpower.NIDCPOWER_VAL_MEASURE_COMPLETE_EVENT`            | Waits for the Measure Complete event.            |
+                +-----------------------------------------------------------------------+--------------------------------------------------+
+                | :py:data:`~nidcpower.NIDCPOWER_VAL_SEQUENCE_ITERATION_COMPLETE_EVENT` | Waits for the Sequence Iteration Complete event. |
+                +-----------------------------------------------------------------------+--------------------------------------------------+
+                | :py:data:`~nidcpower.NIDCPOWER_VAL_SEQUENCE_ENGINE_DONE_EVENT`        | Waits for the Sequence Engine Done event.        |
+                +-----------------------------------------------------------------------+--------------------------------------------------+
+                | :py:data:`~nidcpower.NIDCPOWER_VAL_PULSE_COMPLETE_EVENT`              | Waits for the Pulse Complete event.              |
+                +-----------------------------------------------------------------------+--------------------------------------------------+
+                | :py:data:`~nidcpower.NIDCPOWER_VAL_READY_FOR_PULSE_TRIGGER_EVENT`     | Waits for the Ready for Pulse Trigger event.     |
+                +-----------------------------------------------------------------------+--------------------------------------------------+
 
                 .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
@@ -2336,12 +2448,6 @@ auxiliary_power_source_available
 
         .. note:: This property does not necessarily indicate if the device is using the auxiliary
 
-
-        .. tip:: This property can use repeated capabilities. If set or get directly on the
-            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
-            You can specify a subset of repeated capabilities using the Python index notation on an
-            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
-
         The following table lists the characteristics of this property.
 
             +----------------+-----------+
@@ -2351,7 +2457,7 @@ auxiliary_power_source_available
             +----------------+-----------+
             | Permissions    | read only |
             +----------------+-----------+
-            | Channel Based  | Yes       |
+            | Channel Based  | No        |
             +----------------+-----------+
             | Resettable     | No        |
             +----------------+-----------+
@@ -4203,6 +4309,403 @@ output_connected
                 - LabVIEW Property: **Source:Output Connected**
                 - C Attribute: **NIDCPOWER_ATTR_OUTPUT_CONNECTED**
 
+output_cutoff_current_change_limit_high
+---------------------------------------
+
+    .. py:attribute:: output_cutoff_current_change_limit_high
+
+        Specifies a limit for positive current slew rate, in amps per microsecond, for output cutoff.
+        If the current increases at a rate that exceeds this limit, the output is disconnected.
+
+        To find out whether an output has exceeded this limit, call the :py:meth:`nidcpower.Session.query_latched_output_cutoff_state` method with :py:data:`~nidcpower.OutputCutoffReason.CURRENT_CHANGE_HIGH` as the output cutoff reason.
+
+
+
+        .. note:: Refer to Supported Properties by Device for information about supported devices.
+
+
+        .. tip:: This property can use repeated capabilities. If set or get directly on the
+            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+            You can specify a subset of repeated capabilities using the Python index notation on an
+            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+
+        The following table lists the characteristics of this property.
+
+            +----------------+------------+
+            | Characteristic | Value      |
+            +================+============+
+            | Datatype       | float      |
+            +----------------+------------+
+            | Permissions    | read-write |
+            +----------------+------------+
+            | Channel Based  | Yes        |
+            +----------------+------------+
+            | Resettable     | No         |
+            +----------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Source:Output Cutoff:Current Change Limit High**
+                - C Attribute: **NIDCPOWER_ATTR_OUTPUT_CUTOFF_CURRENT_CHANGE_LIMIT_HIGH**
+
+output_cutoff_current_change_limit_low
+--------------------------------------
+
+    .. py:attribute:: output_cutoff_current_change_limit_low
+
+        Specifies a limit for negative current slew rate, in amps per microsecond, for output cutoff.
+        If the current decreases at a rate that exceeds this limit, the output is disconnected.
+
+        To find out whether an output has exceeded this limit, call the :py:meth:`nidcpower.Session.query_latched_output_cutoff_state` method with :py:data:`~nidcpower.OutputCutoffReason.CURRENT_CHANGE_LOW` as the output cutoff reason.
+
+
+
+        .. note:: Refer to Supported Properties by Device for information about supported devices.
+
+
+        .. tip:: This property can use repeated capabilities. If set or get directly on the
+            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+            You can specify a subset of repeated capabilities using the Python index notation on an
+            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+
+        The following table lists the characteristics of this property.
+
+            +----------------+------------+
+            | Characteristic | Value      |
+            +================+============+
+            | Datatype       | float      |
+            +----------------+------------+
+            | Permissions    | read-write |
+            +----------------+------------+
+            | Channel Based  | Yes        |
+            +----------------+------------+
+            | Resettable     | No         |
+            +----------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Source:Output Cutoff:Current Change Limit Low**
+                - C Attribute: **NIDCPOWER_ATTR_OUTPUT_CUTOFF_CURRENT_CHANGE_LIMIT_LOW**
+
+output_cutoff_current_measure_limit_high
+----------------------------------------
+
+    .. py:attribute:: output_cutoff_current_measure_limit_high
+
+        Specifies a high limit current value, in amps, for output cutoff.
+        If the measured current exceeds this limit, the output is disconnected.
+
+        To find out whether an output has exceeded this limit, call the :py:meth:`nidcpower.Session.query_latched_output_cutoff_state` method with :py:data:`~nidcpower.OutputCutoffReason.CURRENT_MEASURE_HIGH` as the output cutoff reason.
+
+
+
+        .. note:: Refer to Supported Properties by Device for information about supported devices.
+
+
+        .. tip:: This property can use repeated capabilities. If set or get directly on the
+            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+            You can specify a subset of repeated capabilities using the Python index notation on an
+            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+
+        The following table lists the characteristics of this property.
+
+            +----------------+------------+
+            | Characteristic | Value      |
+            +================+============+
+            | Datatype       | float      |
+            +----------------+------------+
+            | Permissions    | read-write |
+            +----------------+------------+
+            | Channel Based  | Yes        |
+            +----------------+------------+
+            | Resettable     | No         |
+            +----------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Source:Output Cutoff:Current Measure Limit High**
+                - C Attribute: **NIDCPOWER_ATTR_OUTPUT_CUTOFF_CURRENT_MEASURE_LIMIT_HIGH**
+
+output_cutoff_current_measure_limit_low
+---------------------------------------
+
+    .. py:attribute:: output_cutoff_current_measure_limit_low
+
+        Specifies a low limit current value, in amps, for output cutoff.
+        If the measured current falls below this limit, the output is disconnected.
+
+        To find out whether an output has fallen below this limit, call the :py:meth:`nidcpower.Session.query_latched_output_cutoff_state` method with :py:data:`~nidcpower.OutputCutoffReason.CURRENT_MEASURE_LOW` as the output cutoff reason.
+
+
+
+        .. note:: Refer to Supported Properties by Device for information about supported devices.
+
+
+        .. tip:: This property can use repeated capabilities. If set or get directly on the
+            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+            You can specify a subset of repeated capabilities using the Python index notation on an
+            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+
+        The following table lists the characteristics of this property.
+
+            +----------------+------------+
+            | Characteristic | Value      |
+            +================+============+
+            | Datatype       | float      |
+            +----------------+------------+
+            | Permissions    | read-write |
+            +----------------+------------+
+            | Channel Based  | Yes        |
+            +----------------+------------+
+            | Resettable     | No         |
+            +----------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Source:Output Cutoff:Current Measure Limit Low**
+                - C Attribute: **NIDCPOWER_ATTR_OUTPUT_CUTOFF_CURRENT_MEASURE_LIMIT_LOW**
+
+output_cutoff_current_overrange_enabled
+---------------------------------------
+
+    .. py:attribute:: output_cutoff_current_overrange_enabled
+
+        Enables or disables current overrange functionality for output cutoff. If enabled, the output is disconnected when the measured current saturates the current range.
+
+        To find out whether an output has exceeded this limit, call the :py:meth:`nidcpower.Session.query_latched_output_cutoff_state` method with :py:data:`~nidcpower.OutputCutoffReason.VOLTAGE_OUTPUT_HIGH` as the output cutoff reason.
+
+
+
+        .. note:: Refer to Supported Properties by Device for information about supported devices.
+
+
+        .. tip:: This property can use repeated capabilities. If set or get directly on the
+            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+            You can specify a subset of repeated capabilities using the Python index notation on an
+            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+
+        The following table lists the characteristics of this property.
+
+            +----------------+------------+
+            | Characteristic | Value      |
+            +================+============+
+            | Datatype       | bool       |
+            +----------------+------------+
+            | Permissions    | read-write |
+            +----------------+------------+
+            | Channel Based  | Yes        |
+            +----------------+------------+
+            | Resettable     | No         |
+            +----------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Source:Output Cutoff:Current Overrange Enabled**
+                - C Attribute: **NIDCPOWER_ATTR_OUTPUT_CUTOFF_CURRENT_OVERRANGE_ENABLED**
+
+output_cutoff_enabled
+---------------------
+
+    .. py:attribute:: output_cutoff_enabled
+
+        Enables or disables output cutoff functionality. If enabled, you can define output cutoffs that, if exceeded, cause the output of the specified channel(s) to be disconnected.
+        When this property is disabled, all other output cutoff properties are ignored.
+
+
+
+        .. note:: Refer to Supported Properties by Device for information about supported devices. Instruments that do not support this property behave as if this property were set to False.
+
+
+        .. tip:: This property can use repeated capabilities. If set or get directly on the
+            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+            You can specify a subset of repeated capabilities using the Python index notation on an
+            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+
+        The following table lists the characteristics of this property.
+
+            +----------------+------------+
+            | Characteristic | Value      |
+            +================+============+
+            | Datatype       | bool       |
+            +----------------+------------+
+            | Permissions    | read-write |
+            +----------------+------------+
+            | Channel Based  | Yes        |
+            +----------------+------------+
+            | Resettable     | No         |
+            +----------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Source:Output Cutoff:Enabled**
+                - C Attribute: **NIDCPOWER_ATTR_OUTPUT_CUTOFF_ENABLED**
+
+output_cutoff_voltage_change_limit_high
+---------------------------------------
+
+    .. py:attribute:: output_cutoff_voltage_change_limit_high
+
+        Specifies a limit for positive voltage slew rate, in volts per microsecond, for output cutoff.
+        If the voltage increases at a rate that exceeds this limit, the output is disconnected.
+
+        To find out whether an output has exceeded this limit, call the :py:meth:`nidcpower.Session.query_latched_output_cutoff_state` with :py:data:`~nidcpower.OutputCutoffReason.VOLTAGE_CHANGE_HIGH` as the output cutoff reason.
+
+
+
+        .. note:: Refer to Supported Properties by Device for information about supported devices.
+
+
+        .. tip:: This property can use repeated capabilities. If set or get directly on the
+            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+            You can specify a subset of repeated capabilities using the Python index notation on an
+            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+
+        The following table lists the characteristics of this property.
+
+            +----------------+------------+
+            | Characteristic | Value      |
+            +================+============+
+            | Datatype       | float      |
+            +----------------+------------+
+            | Permissions    | read-write |
+            +----------------+------------+
+            | Channel Based  | Yes        |
+            +----------------+------------+
+            | Resettable     | No         |
+            +----------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Source:Output Cutoff:Voltage Change Limit High**
+                - C Attribute: **NIDCPOWER_ATTR_OUTPUT_CUTOFF_VOLTAGE_CHANGE_LIMIT_HIGH**
+
+output_cutoff_voltage_change_limit_low
+--------------------------------------
+
+    .. py:attribute:: output_cutoff_voltage_change_limit_low
+
+        Specifies a limit for negative voltage slew rate, in volts per microsecond, for output cutoff.
+        If the voltage decreases at a rate that exceeds this limit, the output is disconnected.
+
+        To find out whether an output has exceeded this limit, call the :py:meth:`nidcpower.Session.query_latched_output_cutoff_state` with :py:data:`~nidcpower.OutputCutoffReason.VOLTAGE_CHANGE_LOW` as the output cutoff reason.
+
+
+
+        .. note:: Refer to Supported Properties by Device for information about supported devices.
+
+
+        .. tip:: This property can use repeated capabilities. If set or get directly on the
+            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+            You can specify a subset of repeated capabilities using the Python index notation on an
+            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+
+        The following table lists the characteristics of this property.
+
+            +----------------+------------+
+            | Characteristic | Value      |
+            +================+============+
+            | Datatype       | float      |
+            +----------------+------------+
+            | Permissions    | read-write |
+            +----------------+------------+
+            | Channel Based  | Yes        |
+            +----------------+------------+
+            | Resettable     | No         |
+            +----------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Source:Output Cutoff:Voltage Change Limit Low**
+                - C Attribute: **NIDCPOWER_ATTR_OUTPUT_CUTOFF_VOLTAGE_CHANGE_LIMIT_LOW**
+
+output_cutoff_voltage_output_limit_high
+---------------------------------------
+
+    .. py:attribute:: output_cutoff_voltage_output_limit_high
+
+        Specifies a high limit voltage value, in volts, for output cutoff.
+        If the voltage output exceeds this limit, the output is disconnected.
+
+        To find out whether an output has exceeded this limit, call the :py:meth:`nidcpower.Session.query_latched_output_cutoff_state` method with :py:data:`~nidcpower.OutputCutoffReason.VOLTAGE_OUTPUT_HIGH` as the output cutoff reason.
+
+
+
+        .. note:: Refer to Supported Properties by Device for information about supported devices.
+
+
+        .. tip:: This property can use repeated capabilities. If set or get directly on the
+            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+            You can specify a subset of repeated capabilities using the Python index notation on an
+            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+
+        The following table lists the characteristics of this property.
+
+            +----------------+------------+
+            | Characteristic | Value      |
+            +================+============+
+            | Datatype       | float      |
+            +----------------+------------+
+            | Permissions    | read-write |
+            +----------------+------------+
+            | Channel Based  | Yes        |
+            +----------------+------------+
+            | Resettable     | No         |
+            +----------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Source:Output Cutoff:Voltage Output Limit High**
+                - C Attribute: **NIDCPOWER_ATTR_OUTPUT_CUTOFF_VOLTAGE_OUTPUT_LIMIT_HIGH**
+
+output_cutoff_voltage_output_limit_low
+--------------------------------------
+
+    .. py:attribute:: output_cutoff_voltage_output_limit_low
+
+        Specifies a low limit voltage value, in volts, for output cutoff.
+        If the voltage output falls below this limit, the output is disconnected.
+
+        To find out whether an output has fallen below this limit, call the :py:meth:`nidcpower.Session.query_latched_output_cutoff_state` method with :py:data:`~nidcpower.OutputCutoffReason.VOLTAGE_OUTPUT_LOW` as the output cutoff reason.
+
+
+
+        .. note:: Refer to Supported Properties by Device for information about supported devices.
+
+
+        .. tip:: This property can use repeated capabilities. If set or get directly on the
+            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+            You can specify a subset of repeated capabilities using the Python index notation on an
+            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+
+        The following table lists the characteristics of this property.
+
+            +----------------+------------+
+            | Characteristic | Value      |
+            +================+============+
+            | Datatype       | float      |
+            +----------------+------------+
+            | Permissions    | read-write |
+            +----------------+------------+
+            | Channel Based  | Yes        |
+            +----------------+------------+
+            | Resettable     | No         |
+            +----------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Source:Output Cutoff:Voltage Output Limit Low**
+                - C Attribute: **NIDCPOWER_ATTR_OUTPUT_CUTOFF_VOLTAGE_OUTPUT_LIMIT_LOW**
+
 output_enabled
 --------------
 
@@ -4574,14 +5077,6 @@ power_source_in_use
 
         Indicates whether the device is using the internal or auxiliary power source to generate power.
 
-
-
-
-        .. tip:: This property can use repeated capabilities. If set or get directly on the
-            nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
-            You can specify a subset of repeated capabilities using the Python index notation on an
-            nidcpower.Session repeated capabilities container, and calling set/get value on the result.
-
         The following table lists the characteristics of this property.
 
             +----------------+------------------------+
@@ -4591,7 +5086,7 @@ power_source_in_use
             +----------------+------------------------+
             | Permissions    | read only              |
             +----------------+------------------------+
-            | Channel Based  | Yes                    |
+            | Channel Based  | No                     |
             +----------------+------------------------+
             | Resettable     | No                     |
             +----------------+------------------------+

--- a/docs/nidcpower/enums.rst
+++ b/docs/nidcpower/enums.rst
@@ -345,6 +345,101 @@ OutputCapacitance
 
 
 
+OutputCutoffReason
+------------------
+
+.. py:class:: OutputCutoffReason
+
+    .. py:attribute:: OutputCutoffReason.ALL
+
+
+
+        Queries any output cutoff condition; clears all output cutoff conditions.
+
+        
+
+
+
+    .. py:attribute:: OutputCutoffReason.VOLTAGE_OUTPUT_HIGH
+
+
+
+        Queries or clears cutoff conditions when the output exceeded the high cutoff limit for voltage output.
+
+        
+
+
+
+    .. py:attribute:: OutputCutoffReason.VOLTAGE_OUTPUT_LOW
+
+
+
+        Queries or clears cutoff conditions when the output fell below the low cutoff limit for voltage output.
+
+        
+
+
+
+    .. py:attribute:: OutputCutoffReason.CURRENT_MEASURE_HIGH
+
+
+
+        Queries or clears cutoff conditions when the measured current exceeded the high cutoff limit for current output.
+
+        
+
+
+
+    .. py:attribute:: OutputCutoffReason.CURRENT_MEASURE_LOW
+
+
+
+        Queries or clears cutoff conditions when the measured current fell below the low cutoff limit for current output.
+
+        
+
+
+
+    .. py:attribute:: OutputCutoffReason.VOLTAGE_CHANGE_HIGH
+
+
+
+        Queries or clears cutoff conditions when the voltage slew rate increased beyond the positive change cutoff for voltage output.
+
+        
+
+
+
+    .. py:attribute:: OutputCutoffReason.VOLTAGE_CHANGE_LOW
+
+
+
+        Queries or clears cutoff conditions when the voltage slew rate decreased beyond the negative change cutoff for voltage output.
+
+        
+
+
+
+    .. py:attribute:: OutputCutoffReason.CURRENT_CHANGE_HIGH
+
+
+
+        Queries or clears cutoff conditions when the current slew rate increased beyond the positive change cutoff for current output.
+
+        
+
+
+
+    .. py:attribute:: OutputCutoffReason.CURRENT_CHANGE_LOW
+
+
+
+        Queries or clears cutoff conditions when the current slew rate decreased beyond the negative change cutoff for current output.
+
+        
+
+
+
 OutputFunction
 --------------
 

--- a/generated/nidcpower/nidcpower/_library.py
+++ b/generated/nidcpower/nidcpower/_library.py
@@ -20,6 +20,7 @@ class Library(object):
         # We cache the cfunc object from the ctypes.CDLL object
         self.niDCPower_Abort_cfunc = None
         self.niDCPower_CalSelfCalibrate_cfunc = None
+        self.niDCPower_ClearLatchedOutputCutoffState_cfunc = None
         self.niDCPower_Commit_cfunc = None
         self.niDCPower_ConfigureApertureTime_cfunc = None
         self.niDCPower_CreateAdvancedSequence_cfunc = None
@@ -50,6 +51,7 @@ class Library(object):
         self.niDCPower_MeasureMultiple_cfunc = None
         self.niDCPower_ParseChannelCount_cfunc = None
         self.niDCPower_QueryInCompliance_cfunc = None
+        self.niDCPower_QueryLatchedOutputCutoffState_cfunc = None
         self.niDCPower_QueryMaxCurrentLimit_cfunc = None
         self.niDCPower_QueryMaxVoltageLevel_cfunc = None
         self.niDCPower_QueryMinCurrentLimit_cfunc = None
@@ -86,6 +88,14 @@ class Library(object):
                 self.niDCPower_CalSelfCalibrate_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_CalSelfCalibrate_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_CalSelfCalibrate_cfunc(vi, channel_name)
+
+    def niDCPower_ClearLatchedOutputCutoffState(self, vi, channel_name, output_cutoff_reason):  # noqa: N802
+        with self._func_lock:
+            if self.niDCPower_ClearLatchedOutputCutoffState_cfunc is None:
+                self.niDCPower_ClearLatchedOutputCutoffState_cfunc = self._library.niDCPower_ClearLatchedOutputCutoffState
+                self.niDCPower_ClearLatchedOutputCutoffState_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
+                self.niDCPower_ClearLatchedOutputCutoffState_cfunc.restype = ViStatus  # noqa: F405
+        return self.niDCPower_ClearLatchedOutputCutoffState_cfunc(vi, channel_name, output_cutoff_reason)
 
     def niDCPower_Commit(self, vi):  # noqa: N802
         with self._func_lock:
@@ -326,6 +336,14 @@ class Library(object):
                 self.niDCPower_QueryInCompliance_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDCPower_QueryInCompliance_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_QueryInCompliance_cfunc(vi, channel_name, in_compliance)
+
+    def niDCPower_QueryLatchedOutputCutoffState(self, vi, channel_name, output_cutoff_reason, output_cutoff_state):  # noqa: N802
+        with self._func_lock:
+            if self.niDCPower_QueryLatchedOutputCutoffState_cfunc is None:
+                self.niDCPower_QueryLatchedOutputCutoffState_cfunc = self._library.niDCPower_QueryLatchedOutputCutoffState
+                self.niDCPower_QueryLatchedOutputCutoffState_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViBoolean)]  # noqa: F405
+                self.niDCPower_QueryLatchedOutputCutoffState_cfunc.restype = ViStatus  # noqa: F405
+        return self.niDCPower_QueryLatchedOutputCutoffState_cfunc(vi, channel_name, output_cutoff_reason, output_cutoff_state)
 
     def niDCPower_QueryMaxCurrentLimit(self, vi, channel_name, voltage_level, max_current_limit):  # noqa: N802
         with self._func_lock:

--- a/generated/nidcpower/nidcpower/enums.py
+++ b/generated/nidcpower/nidcpower/enums.py
@@ -147,6 +147,45 @@ class OutputCapacitance(Enum):
     '''
 
 
+class OutputCutoffReason(Enum):
+    ALL = -1
+    r'''
+    Queries any output cutoff condition; clears all output cutoff conditions.
+    '''
+    VOLTAGE_OUTPUT_HIGH = 1
+    r'''
+    Queries or clears cutoff conditions when the output exceeded the high cutoff limit for voltage output.
+    '''
+    VOLTAGE_OUTPUT_LOW = 2
+    r'''
+    Queries or clears cutoff conditions when the output fell below the low cutoff limit for voltage output.
+    '''
+    CURRENT_MEASURE_HIGH = 4
+    r'''
+    Queries or clears cutoff conditions when the measured current exceeded the high cutoff limit for current output.
+    '''
+    CURRENT_MEASURE_LOW = 8
+    r'''
+    Queries or clears cutoff conditions when the measured current fell below the low cutoff limit for current output.
+    '''
+    VOLTAGE_CHANGE_HIGH = 16
+    r'''
+    Queries or clears cutoff conditions when the voltage slew rate increased beyond the positive change cutoff for voltage output.
+    '''
+    VOLTAGE_CHANGE_LOW = 32
+    r'''
+    Queries or clears cutoff conditions when the voltage slew rate decreased beyond the negative change cutoff for voltage output.
+    '''
+    CURRENT_CHANGE_HIGH = 64
+    r'''
+    Queries or clears cutoff conditions when the current slew rate increased beyond the positive change cutoff for current output.
+    '''
+    CURRENT_CHANGE_LOW = 128
+    r'''
+    Queries or clears cutoff conditions when the current slew rate decreased beyond the negative change cutoff for current output.
+    '''
+
+
 class OutputFunction(Enum):
     DC_VOLTAGE = 1006
     r'''

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -326,12 +326,6 @@ class _SessionBase(object):
     power source to generate power. Use the power_source_in_use property to retrieve this information.
 
     Note: This property does not necessarily indicate if the device is using the auxiliary
-
-    Tip:
-    This property can use repeated capabilities. If set or get directly on the
-    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
-    You can specify a subset of repeated capabilities using the Python index notation on an
-    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
     '''
     channel_count = _attributes.AttributeViInt32(1050203)
     '''Type: int
@@ -1067,6 +1061,163 @@ class _SessionBase(object):
     You can specify a subset of repeated capabilities using the Python index notation on an
     nidcpower.Session repeated capabilities container, and calling set/get value on the result.
     '''
+    output_cutoff_current_change_limit_high = _attributes.AttributeViReal64(1150295)
+    '''Type: float
+
+    Specifies a limit for positive current slew rate, in amps per microsecond, for output cutoff.
+    If the current increases at a rate that exceeds this limit, the output is disconnected.
+
+    To find out whether an output has exceeded this limit, call the query_latched_output_cutoff_state method with OutputCutoffReason.CURRENT_CHANGE_HIGH as the output cutoff reason.
+
+    Note: Refer to Supported Properties by Device for information about supported devices.
+
+    Tip:
+    This property can use repeated capabilities. If set or get directly on the
+    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+    You can specify a subset of repeated capabilities using the Python index notation on an
+    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+    '''
+    output_cutoff_current_change_limit_low = _attributes.AttributeViReal64(1150239)
+    '''Type: float
+
+    Specifies a limit for negative current slew rate, in amps per microsecond, for output cutoff.
+    If the current decreases at a rate that exceeds this limit, the output is disconnected.
+
+    To find out whether an output has exceeded this limit, call the query_latched_output_cutoff_state method with OutputCutoffReason.CURRENT_CHANGE_LOW as the output cutoff reason.
+
+    Note: Refer to Supported Properties by Device for information about supported devices.
+
+    Tip:
+    This property can use repeated capabilities. If set or get directly on the
+    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+    You can specify a subset of repeated capabilities using the Python index notation on an
+    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+    '''
+    output_cutoff_current_measure_limit_high = _attributes.AttributeViReal64(1150237)
+    '''Type: float
+
+    Specifies a high limit current value, in amps, for output cutoff.
+    If the measured current exceeds this limit, the output is disconnected.
+
+    To find out whether an output has exceeded this limit, call the query_latched_output_cutoff_state method with OutputCutoffReason.CURRENT_MEASURE_HIGH as the output cutoff reason.
+
+    Note: Refer to Supported Properties by Device for information about supported devices.
+
+    Tip:
+    This property can use repeated capabilities. If set or get directly on the
+    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+    You can specify a subset of repeated capabilities using the Python index notation on an
+    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+    '''
+    output_cutoff_current_measure_limit_low = _attributes.AttributeViReal64(1150293)
+    '''Type: float
+
+    Specifies a low limit current value, in amps, for output cutoff.
+    If the measured current falls below this limit, the output is disconnected.
+
+    To find out whether an output has fallen below this limit, call the query_latched_output_cutoff_state method with OutputCutoffReason.CURRENT_MEASURE_LOW as the output cutoff reason.
+
+    Note: Refer to Supported Properties by Device for information about supported devices.
+
+    Tip:
+    This property can use repeated capabilities. If set or get directly on the
+    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+    You can specify a subset of repeated capabilities using the Python index notation on an
+    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+    '''
+    output_cutoff_current_overrange_enabled = _attributes.AttributeViBoolean(1150240)
+    '''Type: bool
+
+    Enables or disables current overrange functionality for output cutoff. If enabled, the output is disconnected when the measured current saturates the current range.
+
+    To find out whether an output has exceeded this limit, call the query_latched_output_cutoff_state method with OutputCutoffReason.VOLTAGE_OUTPUT_HIGH as the output cutoff reason.
+
+    Note: Refer to Supported Properties by Device for information about supported devices.
+
+    Tip:
+    This property can use repeated capabilities. If set or get directly on the
+    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+    You can specify a subset of repeated capabilities using the Python index notation on an
+    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+    '''
+    output_cutoff_enabled = _attributes.AttributeViBoolean(1150235)
+    '''Type: bool
+
+    Enables or disables output cutoff functionality. If enabled, you can define output cutoffs that, if exceeded, cause the output of the specified channel(s) to be disconnected.
+    When this property is disabled, all other output cutoff properties are ignored.
+
+    Note: Refer to Supported Properties by Device for information about supported devices. Instruments that do not support this property behave as if this property were set to False.
+
+    Tip:
+    This property can use repeated capabilities. If set or get directly on the
+    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+    You can specify a subset of repeated capabilities using the Python index notation on an
+    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+    '''
+    output_cutoff_voltage_change_limit_high = _attributes.AttributeViReal64(1150294)
+    '''Type: float
+
+    Specifies a limit for positive voltage slew rate, in volts per microsecond, for output cutoff.
+    If the voltage increases at a rate that exceeds this limit, the output is disconnected.
+
+    To find out whether an output has exceeded this limit, call the query_latched_output_cutoff_state with OutputCutoffReason.VOLTAGE_CHANGE_HIGH as the output cutoff reason.
+
+    Note: Refer to Supported Properties by Device for information about supported devices.
+
+    Tip:
+    This property can use repeated capabilities. If set or get directly on the
+    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+    You can specify a subset of repeated capabilities using the Python index notation on an
+    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+    '''
+    output_cutoff_voltage_change_limit_low = _attributes.AttributeViReal64(1150238)
+    '''Type: float
+
+    Specifies a limit for negative voltage slew rate, in volts per microsecond, for output cutoff.
+    If the voltage decreases at a rate that exceeds this limit, the output is disconnected.
+
+    To find out whether an output has exceeded this limit, call the query_latched_output_cutoff_state with OutputCutoffReason.VOLTAGE_CHANGE_LOW as the output cutoff reason.
+
+    Note: Refer to Supported Properties by Device for information about supported devices.
+
+    Tip:
+    This property can use repeated capabilities. If set or get directly on the
+    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+    You can specify a subset of repeated capabilities using the Python index notation on an
+    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+    '''
+    output_cutoff_voltage_output_limit_high = _attributes.AttributeViReal64(1150236)
+    '''Type: float
+
+    Specifies a high limit voltage value, in volts, for output cutoff.
+    If the voltage output exceeds this limit, the output is disconnected.
+
+    To find out whether an output has exceeded this limit, call the query_latched_output_cutoff_state method with OutputCutoffReason.VOLTAGE_OUTPUT_HIGH as the output cutoff reason.
+
+    Note: Refer to Supported Properties by Device for information about supported devices.
+
+    Tip:
+    This property can use repeated capabilities. If set or get directly on the
+    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+    You can specify a subset of repeated capabilities using the Python index notation on an
+    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+    '''
+    output_cutoff_voltage_output_limit_low = _attributes.AttributeViReal64(1150292)
+    '''Type: float
+
+    Specifies a low limit voltage value, in volts, for output cutoff.
+    If the voltage output falls below this limit, the output is disconnected.
+
+    To find out whether an output has fallen below this limit, call the query_latched_output_cutoff_state method with OutputCutoffReason.VOLTAGE_OUTPUT_LOW as the output cutoff reason.
+
+    Note: Refer to Supported Properties by Device for information about supported devices.
+
+    Tip:
+    This property can use repeated capabilities. If set or get directly on the
+    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
+    You can specify a subset of repeated capabilities using the Python index notation on an
+    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
+    '''
     output_enabled = _attributes.AttributeViBoolean(1250006)
     '''Type: bool
 
@@ -1220,12 +1371,6 @@ class _SessionBase(object):
     '''Type: enums.PowerSourceInUse
 
     Indicates whether the device is using the internal or auxiliary power source to generate power.
-
-    Tip:
-    This property can use repeated capabilities. If set or get directly on the
-    nidcpower.Session object, then the set/get will use all repeated capabilities in the session.
-    You can specify a subset of repeated capabilities using the Python index notation on an
-    nidcpower.Session repeated capabilities container, and calling set/get value on the result.
     '''
     pulse_bias_current_level = _attributes.AttributeViReal64(1150088)
     '''Type: float
@@ -2646,6 +2791,52 @@ class _SessionBase(object):
         return
 
     @ivi_synchronized
+    def clear_latched_output_cutoff_state(self, output_cutoff_reason):
+        r'''clear_latched_output_cutoff_state
+
+        Clears the state of an output cutoff that was engaged.
+        To clear the state for all output cutoff reasons, use OutputCutoffReason.ALL.
+
+        Tip:
+        This method requires repeated capabilities. If called directly on the
+        nidcpower.Session object, then the method will use all repeated capabilities in the session.
+        You can specify a subset of repeated capabilities using the Python index notation on an
+        nidcpower.Session repeated capabilities container, and calling this method on the result.
+
+        Args:
+            output_cutoff_reason (enums.OutputCutoffReason): Specifies the reasons for which to clear the output cutoff state.
+
+                +-----------------------------------------+-----------------------------------------------------------------------------------------------------------------+
+                | OutputCutoffReason.ALL                  | Clears all output cutoff conditions                                                                             |
+                +-----------------------------------------+-----------------------------------------------------------------------------------------------------------------+
+                | OutputCutoffReason.VOLTAGE_OUTPUT_HIGH  | Clears cutoffs caused when the output exceeded the high cutoff limit for voltage output                         |
+                +-----------------------------------------+-----------------------------------------------------------------------------------------------------------------+
+                | OutputCutoffReason.VOLTAGE_OUTPUT_LOW   | Clears cutoffs caused when the output fell below the low cutoff limit for voltage output                        |
+                +-----------------------------------------+-----------------------------------------------------------------------------------------------------------------+
+                | OutputCutoffReason.CURRENT_MEASURE_HIGH | Clears cutoffs caused when the measured current exceeded the high cutoff limit for current output               |
+                +-----------------------------------------+-----------------------------------------------------------------------------------------------------------------+
+                | OutputCutoffReason.CURRENT_MEASURE_LOW  | Clears cutoffs caused when the measured current fell below the low cutoff limit for current output              |
+                +-----------------------------------------+-----------------------------------------------------------------------------------------------------------------+
+                | OutputCutoffReason.VOLTAGE_CHANGE_HIGH  | Clears cutoffs caused when the voltage slew rate increased beyond the positive change cutoff for voltage output |
+                +-----------------------------------------+-----------------------------------------------------------------------------------------------------------------+
+                | OutputCutoffReason.VOLTAGE_CHANGE_LOW   | Clears cutoffs caused when the voltage slew rate decreased beyond the negative change cutoff for voltage output |
+                +-----------------------------------------+-----------------------------------------------------------------------------------------------------------------+
+                | OutputCutoffReason.CURRENT_CHANGE_HIGH  | Clears cutoffs caused when the current slew rate increased beyond the positive change cutoff for current output |
+                +-----------------------------------------+-----------------------------------------------------------------------------------------------------------------+
+                | OutputCutoffReason.CURRENT_CHANGE_LOW   | Clears cutoffs caused when the voltage slew rate decreased beyond the negative change cutoff for current output |
+                +-----------------------------------------+-----------------------------------------------------------------------------------------------------------------+
+
+        '''
+        if type(output_cutoff_reason) is not enums.OutputCutoffReason:
+            raise TypeError('Parameter output_cutoff_reason must be of type ' + str(enums.OutputCutoffReason))
+        vi_ctype = _visatype.ViSession(self._vi)  # case S110
+        channel_name_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
+        output_cutoff_reason_ctype = _visatype.ViInt32(output_cutoff_reason.value)  # case S130
+        error_code = self._library.niDCPower_ClearLatchedOutputCutoffState(vi_ctype, channel_name_ctype, output_cutoff_reason_ctype)
+        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
+        return
+
+    @ivi_synchronized
     def configure_aperture_time(self, aperture_time, units=enums.ApertureTimeUnits.SECONDS):
         r'''configure_aperture_time
 
@@ -2684,11 +2875,11 @@ class _SessionBase(object):
             units (enums.ApertureTimeUnits): Specifies the units for **apertureTime**.
                 **Defined Values**:
 
-                +--------------------------------------------+------------------------------+
-                | ApertureTimeUnits.SECONDS (1028)           | Specifies seconds.           |
-                +--------------------------------------------+------------------------------+
-                | ApertureTimeUnits.POWER_LINE_CYCLES (1029) | Specifies Power Line Cycles. |
-                +--------------------------------------------+------------------------------+
+                +-------------------------------------+------------------------------+
+                | ApertureTimeUnits.SECONDS           | Specifies seconds.           |
+                +-------------------------------------+------------------------------+
+                | ApertureTimeUnits.POWER_LINE_CYCLES | Specifies Power Line Cycles. |
+                +-------------------------------------+------------------------------+
 
         '''
         if type(units) is not enums.ApertureTimeUnits:
@@ -3256,11 +3447,11 @@ class _SessionBase(object):
             measurement_type (enums.MeasurementTypes): Specifies whether a voltage or current value is measured.
                 **Defined Values**:
 
-                +------------------------------+------------------------------+
-                | MeasurementTypes.VOLTAGE (1) | The device measures voltage. |
-                +------------------------------+------------------------------+
-                | MeasurementTypes.CURRENT (0) | The device measures current. |
-                +------------------------------+------------------------------+
+                +--------------------------+------------------------------+
+                | MeasurementTypes.VOLTAGE | The device measures voltage. |
+                +--------------------------+------------------------------+
+                | MeasurementTypes.CURRENT | The device measures current. |
+                +--------------------------+------------------------------+
 
 
         Returns:
@@ -3387,6 +3578,68 @@ class _SessionBase(object):
         return bool(in_compliance_ctype.value)
 
     @ivi_synchronized
+    def query_latched_output_cutoff_state(self, output_cutoff_reason):
+        r'''query_latched_output_cutoff_state
+
+        Discovers if an output cutoff limit was exceeded for the specified reason. When an output cutoff is engaged, the output of the channel(s) is disconnected.
+        If a limit was exceeded, the state is latched until you clear it with the clear_latched_output_cutoff_state method or the ResetWithChannels method.
+
+        outputCutoffReason specifies the conditions for which an output is disconnected.
+
+        Note:
+        One or more of the referenced methods are not in the Python API for this driver.
+
+        Tip:
+        This method requires repeated capabilities. If called directly on the
+        nidcpower.Session object, then the method will use all repeated capabilities in the session.
+        You can specify a subset of repeated capabilities using the Python index notation on an
+        nidcpower.Session repeated capabilities container, and calling this method on the result.
+
+        Args:
+            output_cutoff_reason (enums.OutputCutoffReason): Specifies which output cutoff conditions to query.
+
+                +-----------------------------------------+--------------------------------------------------------------------------------------+
+                | OutputCutoffReason.ALL                  | Any output cutoff condition was met                                                  |
+                +-----------------------------------------+--------------------------------------------------------------------------------------+
+                | OutputCutoffReason.VOLTAGE_OUTPUT_HIGH  | The output exceeded the high cutoff limit for voltage output                         |
+                +-----------------------------------------+--------------------------------------------------------------------------------------+
+                | OutputCutoffReason.VOLTAGE_OUTPUT_LOW   | The output fell below the low cutoff limit for voltage output                        |
+                +-----------------------------------------+--------------------------------------------------------------------------------------+
+                | OutputCutoffReason.CURRENT_MEASURE_HIGH | The measured current exceeded the high cutoff limit for current output               |
+                +-----------------------------------------+--------------------------------------------------------------------------------------+
+                | OutputCutoffReason.CURRENT_MEASURE_LOW  | The measured current fell below the low cutoff limit for current output              |
+                +-----------------------------------------+--------------------------------------------------------------------------------------+
+                | OutputCutoffReason.VOLTAGE_CHANGE_HIGH  | The voltage slew rate increased beyond the positive change cutoff for voltage output |
+                +-----------------------------------------+--------------------------------------------------------------------------------------+
+                | OutputCutoffReason.VOLTAGE_CHANGE_LOW   | The voltage slew rate decreased beyond the negative change cutoff for voltage output |
+                +-----------------------------------------+--------------------------------------------------------------------------------------+
+                | OutputCutoffReason.CURRENT_CHANGE_HIGH  | The current slew rate increased beyond the positive change cutoff for current output |
+                +-----------------------------------------+--------------------------------------------------------------------------------------+
+                | OutputCutoffReason.CURRENT_CHANGE_LOW   | The current slew rate decreased beyond the negative change cutoff for current output |
+                +-----------------------------------------+--------------------------------------------------------------------------------------+
+
+
+        Returns:
+            output_cutoff_state (bool): Specifies whether an output cutoff has engaged.
+
+                +-------+------------------------------------------------------------------------------+
+                | True  | An output cutoff has engaged for the conditions in **output cutoff reason**. |
+                +-------+------------------------------------------------------------------------------+
+                | False | No output cutoff has engaged.                                                |
+                +-------+------------------------------------------------------------------------------+
+
+        '''
+        if type(output_cutoff_reason) is not enums.OutputCutoffReason:
+            raise TypeError('Parameter output_cutoff_reason must be of type ' + str(enums.OutputCutoffReason))
+        vi_ctype = _visatype.ViSession(self._vi)  # case S110
+        channel_name_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
+        output_cutoff_reason_ctype = _visatype.ViInt32(output_cutoff_reason.value)  # case S130
+        output_cutoff_state_ctype = _visatype.ViBoolean()  # case S220
+        error_code = self._library.niDCPower_QueryLatchedOutputCutoffState(vi_ctype, channel_name_ctype, output_cutoff_reason_ctype, None if output_cutoff_state_ctype is None else (ctypes.pointer(output_cutoff_state_ctype)))
+        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
+        return bool(output_cutoff_state_ctype.value)
+
+    @ivi_synchronized
     def query_max_current_limit(self, voltage_level):
         r'''query_max_current_limit
 
@@ -3500,11 +3753,11 @@ class _SessionBase(object):
             output_state (enums.OutputStates): Specifies the output state of the output channel that is being queried.
                 **Defined Values**:
 
-                +--------------------------+-------------------------------------------------------------------+
-                | OutputStates.VOLTAGE (0) | The device maintains a constant voltage by adjusting the current. |
-                +--------------------------+-------------------------------------------------------------------+
-                | OutputStates.CURRENT (1) | The device maintains a constant current by adjusting the voltage. |
-                +--------------------------+-------------------------------------------------------------------+
+                +----------------------+-------------------------------------------------------------------+
+                | OutputStates.VOLTAGE | The device maintains a constant voltage by adjusting the current. |
+                +----------------------+-------------------------------------------------------------------+
+                | OutputStates.CURRENT | The device maintains a constant current by adjusting the voltage. |
+                +----------------------+-------------------------------------------------------------------+
 
 
         Returns:
@@ -5172,19 +5425,19 @@ class Session(_SessionBase):
             trigger (enums.SendSoftwareEdgeTriggerType): Specifies which trigger to assert.
                 **Defined Values:**
 
-                +-----------------------------------------------+---------------------------------------+
-                | NIDCPOWER_VAL_START_TRIGGER (1034)            | Asserts the Start trigger.            |
-                +-----------------------------------------------+---------------------------------------+
-                | NIDCPOWER_VAL_SOURCE_TRIGGER (1035)           | Asserts the Source trigger.           |
-                +-----------------------------------------------+---------------------------------------+
-                | NIDCPOWER_VAL_MEASURE_TRIGGER (1036)          | Asserts the Measure trigger.          |
-                +-----------------------------------------------+---------------------------------------+
-                | NIDCPOWER_VAL_SEQUENCE_ADVANCE_TRIGGER (1037) | Asserts the Sequence Advance trigger. |
-                +-----------------------------------------------+---------------------------------------+
-                | NIDCPOWER_VAL_PULSE_TRIGGER (1053)            | Asserts the Pulse trigger.            |
-                +-----------------------------------------------+---------------------------------------+
-                | NIDCPOWER_VAL_SHUTDOWN_TRIGGER (1118)         | Asserts the Shutdown trigger.         |
-                +-----------------------------------------------+---------------------------------------+
+                +----------------------------------------+---------------------------------------+
+                | NIDCPOWER_VAL_START_TRIGGER            | Asserts the Start trigger.            |
+                +----------------------------------------+---------------------------------------+
+                | NIDCPOWER_VAL_SOURCE_TRIGGER           | Asserts the Source trigger.           |
+                +----------------------------------------+---------------------------------------+
+                | NIDCPOWER_VAL_MEASURE_TRIGGER          | Asserts the Measure trigger.          |
+                +----------------------------------------+---------------------------------------+
+                | NIDCPOWER_VAL_SEQUENCE_ADVANCE_TRIGGER | Asserts the Sequence Advance trigger. |
+                +----------------------------------------+---------------------------------------+
+                | NIDCPOWER_VAL_PULSE_TRIGGER            | Asserts the Pulse trigger.            |
+                +----------------------------------------+---------------------------------------+
+                | NIDCPOWER_VAL_SHUTDOWN_TRIGGER         | Asserts the Shutdown trigger.         |
+                +----------------------------------------+---------------------------------------+
 
                 Note:
                 One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
@@ -5219,19 +5472,19 @@ class Session(_SessionBase):
             event_id (enums.Event): Specifies which event to wait for.
                 **Defined Values:**
 
-                +--------------------------------------------------------+--------------------------------------------------+
-                | NIDCPOWER_VAL_SOURCE_COMPLETE_EVENT (1030)             | Waits for the Source Complete event.             |
-                +--------------------------------------------------------+--------------------------------------------------+
-                | NIDCPOWER_VAL_MEASURE_COMPLETE_EVENT (1031)            | Waits for the Measure Complete event.            |
-                +--------------------------------------------------------+--------------------------------------------------+
-                | NIDCPOWER_VAL_SEQUENCE_ITERATION_COMPLETE_EVENT (1032) | Waits for the Sequence Iteration Complete event. |
-                +--------------------------------------------------------+--------------------------------------------------+
-                | NIDCPOWER_VAL_SEQUENCE_ENGINE_DONE_EVENT (1033)        | Waits for the Sequence Engine Done event.        |
-                +--------------------------------------------------------+--------------------------------------------------+
-                | NIDCPOWER_VAL_PULSE_COMPLETE_EVENT (1051 )             | Waits for the Pulse Complete event.              |
-                +--------------------------------------------------------+--------------------------------------------------+
-                | NIDCPOWER_VAL_READY_FOR_PULSE_TRIGGER_EVENT (1052)     | Waits for the Ready for Pulse Trigger event.     |
-                +--------------------------------------------------------+--------------------------------------------------+
+                +-------------------------------------------------+--------------------------------------------------+
+                | NIDCPOWER_VAL_SOURCE_COMPLETE_EVENT             | Waits for the Source Complete event.             |
+                +-------------------------------------------------+--------------------------------------------------+
+                | NIDCPOWER_VAL_MEASURE_COMPLETE_EVENT            | Waits for the Measure Complete event.            |
+                +-------------------------------------------------+--------------------------------------------------+
+                | NIDCPOWER_VAL_SEQUENCE_ITERATION_COMPLETE_EVENT | Waits for the Sequence Iteration Complete event. |
+                +-------------------------------------------------+--------------------------------------------------+
+                | NIDCPOWER_VAL_SEQUENCE_ENGINE_DONE_EVENT        | Waits for the Sequence Engine Done event.        |
+                +-------------------------------------------------+--------------------------------------------------+
+                | NIDCPOWER_VAL_PULSE_COMPLETE_EVENT              | Waits for the Pulse Complete event.              |
+                +-------------------------------------------------+--------------------------------------------------+
+                | NIDCPOWER_VAL_READY_FOR_PULSE_TRIGGER_EVENT     | Waits for the Ready for Pulse Trigger event.     |
+                +-------------------------------------------------+--------------------------------------------------+
 
                 Note:
                 One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.

--- a/generated/nidcpower/nidcpower/unit_tests/_mock_helper.py
+++ b/generated/nidcpower/nidcpower/unit_tests/_mock_helper.py
@@ -20,6 +20,8 @@ class SideEffectsHelper(object):
         self._defaults['Abort']['return'] = 0
         self._defaults['CalSelfCalibrate'] = {}
         self._defaults['CalSelfCalibrate']['return'] = 0
+        self._defaults['ClearLatchedOutputCutoffState'] = {}
+        self._defaults['ClearLatchedOutputCutoffState']['return'] = 0
         self._defaults['Commit'] = {}
         self._defaults['Commit']['return'] = 0
         self._defaults['ConfigureApertureTime'] = {}
@@ -113,6 +115,9 @@ class SideEffectsHelper(object):
         self._defaults['QueryInCompliance'] = {}
         self._defaults['QueryInCompliance']['return'] = 0
         self._defaults['QueryInCompliance']['inCompliance'] = None
+        self._defaults['QueryLatchedOutputCutoffState'] = {}
+        self._defaults['QueryLatchedOutputCutoffState']['return'] = 0
+        self._defaults['QueryLatchedOutputCutoffState']['outputCutoffState'] = None
         self._defaults['QueryMaxCurrentLimit'] = {}
         self._defaults['QueryMaxCurrentLimit']['return'] = 0
         self._defaults['QueryMaxCurrentLimit']['maxCurrentLimit'] = None
@@ -178,6 +183,11 @@ class SideEffectsHelper(object):
         if self._defaults['CalSelfCalibrate']['return'] != 0:
             return self._defaults['CalSelfCalibrate']['return']
         return self._defaults['CalSelfCalibrate']['return']
+
+    def niDCPower_ClearLatchedOutputCutoffState(self, vi, channel_name, output_cutoff_reason):  # noqa: N802
+        if self._defaults['ClearLatchedOutputCutoffState']['return'] != 0:
+            return self._defaults['ClearLatchedOutputCutoffState']['return']
+        return self._defaults['ClearLatchedOutputCutoffState']['return']
 
     def niDCPower_Commit(self, vi):  # noqa: N802
         if self._defaults['Commit']['return'] != 0:
@@ -529,6 +539,16 @@ class SideEffectsHelper(object):
             in_compliance.contents.value = self._defaults['QueryInCompliance']['inCompliance']
         return self._defaults['QueryInCompliance']['return']
 
+    def niDCPower_QueryLatchedOutputCutoffState(self, vi, channel_name, output_cutoff_reason, output_cutoff_state):  # noqa: N802
+        if self._defaults['QueryLatchedOutputCutoffState']['return'] != 0:
+            return self._defaults['QueryLatchedOutputCutoffState']['return']
+        # output_cutoff_state
+        if self._defaults['QueryLatchedOutputCutoffState']['outputCutoffState'] is None:
+            raise MockFunctionCallError("niDCPower_QueryLatchedOutputCutoffState", param='outputCutoffState')
+        if output_cutoff_state is not None:
+            output_cutoff_state.contents.value = self._defaults['QueryLatchedOutputCutoffState']['outputCutoffState']
+        return self._defaults['QueryLatchedOutputCutoffState']['return']
+
     def niDCPower_QueryMaxCurrentLimit(self, vi, channel_name, voltage_level, max_current_limit):  # noqa: N802
         if self._defaults['QueryMaxCurrentLimit']['return'] != 0:
             return self._defaults['QueryMaxCurrentLimit']['return']
@@ -688,6 +708,8 @@ class SideEffectsHelper(object):
         mock_library.niDCPower_Abort.return_value = 0
         mock_library.niDCPower_CalSelfCalibrate.side_effect = MockFunctionCallError("niDCPower_CalSelfCalibrate")
         mock_library.niDCPower_CalSelfCalibrate.return_value = 0
+        mock_library.niDCPower_ClearLatchedOutputCutoffState.side_effect = MockFunctionCallError("niDCPower_ClearLatchedOutputCutoffState")
+        mock_library.niDCPower_ClearLatchedOutputCutoffState.return_value = 0
         mock_library.niDCPower_Commit.side_effect = MockFunctionCallError("niDCPower_Commit")
         mock_library.niDCPower_Commit.return_value = 0
         mock_library.niDCPower_ConfigureApertureTime.side_effect = MockFunctionCallError("niDCPower_ConfigureApertureTime")
@@ -748,6 +770,8 @@ class SideEffectsHelper(object):
         mock_library.niDCPower_ParseChannelCount.return_value = 0
         mock_library.niDCPower_QueryInCompliance.side_effect = MockFunctionCallError("niDCPower_QueryInCompliance")
         mock_library.niDCPower_QueryInCompliance.return_value = 0
+        mock_library.niDCPower_QueryLatchedOutputCutoffState.side_effect = MockFunctionCallError("niDCPower_QueryLatchedOutputCutoffState")
+        mock_library.niDCPower_QueryLatchedOutputCutoffState.return_value = 0
         mock_library.niDCPower_QueryMaxCurrentLimit.side_effect = MockFunctionCallError("niDCPower_QueryMaxCurrentLimit")
         mock_library.niDCPower_QueryMaxCurrentLimit.return_value = 0
         mock_library.niDCPower_QueryMaxVoltageLevel.side_effect = MockFunctionCallError("niDCPower_QueryMaxVoltageLevel")

--- a/src/nidcpower/metadata/attributes.py
+++ b/src/nidcpower/metadata/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 20.7.0d8
+# This file is generated from NI-DCPower API metadata version 20.7.0d409
 attributes = {
     1050003: {
         'access': 'read-write',
@@ -170,7 +170,7 @@ attributes = {
     },
     1150001: {
         'access': 'read only',
-        'channel_based': True,
+        'channel_based': False,
         'documentation': {
             'description': 'Indicates whether the device is using the internal or auxiliary power source to generate power.'
         },
@@ -182,7 +182,7 @@ attributes = {
     },
     1150002: {
         'access': 'read only',
-        'channel_based': True,
+        'channel_based': False,
         'documentation': {
             'description': '\nIndicates whether an auxiliary power source is connected to the device.\nA value of VI_FALSE may indicate that the auxiliary input fuse has blown.  Refer to the Detecting Internal/Auxiliary Power topic in the NI DC Power Supplies and SMUs Help for  more information about internal and auxiliary power.\npower source to generate power. Use the NIDCPOWER_ATTR_POWER_SOURCE_IN_USE attribute to retrieve this information.\n',
             'note': 'This attribute does not necessarily indicate if the device is using the auxiliary'
@@ -1550,6 +1550,78 @@ attributes = {
         'resettable': False,
         'type': 'ViInt32'
     },
+    1150235: {
+        'access': 'read-write',
+        'channel_based': True,
+        'documentation': {
+            'description': '\nEnables or disables output cutoff functionality. If enabled, you can define output cutoffs that, if exceeded, cause the output of the specified channel(s) to be disconnected.\nWhen this attribute is disabled, all other output cutoff attributes are ignored.',
+            'note': 'Refer to Supported Attributes by Device for information about supported devices. Instruments that do not support this attribute behave as if this attribute were set to VI_FALSE.'
+        },
+        'lv_property': 'Source:Output Cutoff:Enabled',
+        'name': 'OUTPUT_CUTOFF_ENABLED',
+        'resettable': False,
+        'type': 'ViBoolean'
+    },
+    1150236: {
+        'access': 'read-write',
+        'channel_based': True,
+        'documentation': {
+            'description': '\nSpecifies a high limit voltage value, in volts, for output cutoff.\nIf the voltage output exceeds this limit, the output is disconnected.\n\nTo find out whether an output has exceeded this limit, call the niDCPower_QueryLatchedOutputCutoffState function with NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_VOLTAGE_OUTPUT_HIGH as the output cutoff reason.\n',
+            'note': 'Refer to Supported Attributes by Device for information about supported devices.'
+        },
+        'lv_property': 'Source:Output Cutoff:Voltage Output Limit High',
+        'name': 'OUTPUT_CUTOFF_VOLTAGE_OUTPUT_LIMIT_HIGH',
+        'resettable': False,
+        'type': 'ViReal64'
+    },
+    1150237: {
+        'access': 'read-write',
+        'channel_based': True,
+        'documentation': {
+            'description': '\nSpecifies a high limit current value, in amps, for output cutoff.\nIf the measured current exceeds this limit, the output is disconnected.\n\nTo find out whether an output has exceeded this limit, call the niDCPower_QueryLatchedOutputCutoffState function with NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_CURRENT_MEASURE_HIGH as the output cutoff reason.\n',
+            'note': 'Refer to Supported Attributes by Device for information about supported devices.'
+        },
+        'lv_property': 'Source:Output Cutoff:Current Measure Limit High',
+        'name': 'OUTPUT_CUTOFF_CURRENT_MEASURE_LIMIT_HIGH',
+        'resettable': False,
+        'type': 'ViReal64'
+    },
+    1150238: {
+        'access': 'read-write',
+        'channel_based': True,
+        'documentation': {
+            'description': '\nSpecifies a limit for negative voltage slew rate, in volts per microsecond, for output cutoff.\nIf the voltage decreases at a rate that exceeds this limit, the output is disconnected.\n\nTo find out whether an output has exceeded this limit, call the niDCPower_QueryLatchedOutputCutoffState with NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_VOLTAGE_CHANGE_LOW as the output cutoff reason.\n',
+            'note': 'Refer to Supported Attributes by Device for information about supported devices.'
+        },
+        'lv_property': 'Source:Output Cutoff:Voltage Change Limit Low',
+        'name': 'OUTPUT_CUTOFF_VOLTAGE_CHANGE_LIMIT_LOW',
+        'resettable': False,
+        'type': 'ViReal64'
+    },
+    1150239: {
+        'access': 'read-write',
+        'channel_based': True,
+        'documentation': {
+            'description': '\nSpecifies a limit for negative current slew rate, in amps per microsecond, for output cutoff.\nIf the current decreases at a rate that exceeds this limit, the output is disconnected.\n\nTo find out whether an output has exceeded this limit, call the niDCPower_QueryLatchedOutputCutoffState function with NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_CURRENT_CHANGE_LOW as the output cutoff reason.\n',
+            'note': 'Refer to Supported Attributes by Device for information about supported devices.'
+        },
+        'lv_property': 'Source:Output Cutoff:Current Change Limit Low',
+        'name': 'OUTPUT_CUTOFF_CURRENT_CHANGE_LIMIT_LOW',
+        'resettable': False,
+        'type': 'ViReal64'
+    },
+    1150240: {
+        'access': 'read-write',
+        'channel_based': True,
+        'documentation': {
+            'description': '\nEnables or disables current overrange functionality for output cutoff. If enabled, the output is disconnected when the measured current saturates the current range.\n\nTo find out whether an output has exceeded this limit, call the niDCPower_QueryLatchedOutputCutoffState function with NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_VOLTAGE_OUTPUT_HIGH as the output cutoff reason.\n',
+            'note': 'Refer to Supported Attributes by Device for information about supported devices.'
+        },
+        'lv_property': 'Source:Output Cutoff:Current Overrange Enabled',
+        'name': 'OUTPUT_CUTOFF_CURRENT_OVERRANGE_ENABLED',
+        'resettable': False,
+        'type': 'ViBoolean'
+    },
     1150244: {
         'access': 'read-write',
         'channel_based': True,
@@ -1688,6 +1760,54 @@ attributes = {
         'name': 'DIGITAL_EDGE_SHUTDOWN_TRIGGER_INPUT_TERMINAL',
         'resettable': False,
         'type': 'ViString'
+    },
+    1150292: {
+        'access': 'read-write',
+        'channel_based': True,
+        'documentation': {
+            'description': '\nSpecifies a low limit voltage value, in volts, for output cutoff.\nIf the voltage output falls below this limit, the output is disconnected.\n\nTo find out whether an output has fallen below this limit, call the niDCPower_QueryLatchedOutputCutoffState function with NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_VOLTAGE_OUTPUT_LOW as the output cutoff reason.\n',
+            'note': 'Refer to Supported Attributes by Device for information about supported devices.'
+        },
+        'lv_property': 'Source:Output Cutoff:Voltage Output Limit Low',
+        'name': 'OUTPUT_CUTOFF_VOLTAGE_OUTPUT_LIMIT_LOW',
+        'resettable': False,
+        'type': 'ViReal64'
+    },
+    1150293: {
+        'access': 'read-write',
+        'channel_based': True,
+        'documentation': {
+            'description': '\nSpecifies a low limit current value, in amps, for output cutoff.\nIf the measured current falls below this limit, the output is disconnected.\n\nTo find out whether an output has fallen below this limit, call the niDCPower_QueryLatchedOutputCutoffState function with NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_CURRENT_MEASURE_LOW as the output cutoff reason.\n',
+            'note': 'Refer to Supported Attributes by Device for information about supported devices.'
+        },
+        'lv_property': 'Source:Output Cutoff:Current Measure Limit Low',
+        'name': 'OUTPUT_CUTOFF_CURRENT_MEASURE_LIMIT_LOW',
+        'resettable': False,
+        'type': 'ViReal64'
+    },
+    1150294: {
+        'access': 'read-write',
+        'channel_based': True,
+        'documentation': {
+            'description': '\nSpecifies a limit for positive voltage slew rate, in volts per microsecond, for output cutoff.\nIf the voltage increases at a rate that exceeds this limit, the output is disconnected.\n\nTo find out whether an output has exceeded this limit, call the niDCPower_QueryLatchedOutputCutoffState with NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_VOLTAGE_CHANGE_HIGH as the output cutoff reason.\n',
+            'note': 'Refer to Supported Attributes by Device for information about supported devices.'
+        },
+        'lv_property': 'Source:Output Cutoff:Voltage Change Limit High',
+        'name': 'OUTPUT_CUTOFF_VOLTAGE_CHANGE_LIMIT_HIGH',
+        'resettable': False,
+        'type': 'ViReal64'
+    },
+    1150295: {
+        'access': 'read-write',
+        'channel_based': True,
+        'documentation': {
+            'description': '\nSpecifies a limit for positive current slew rate, in amps per microsecond, for output cutoff.\nIf the current increases at a rate that exceeds this limit, the output is disconnected.\n\nTo find out whether an output has exceeded this limit, call the niDCPower_QueryLatchedOutputCutoffState function with NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_CURRENT_CHANGE_HIGH as the output cutoff reason.\n',
+            'note': 'Refer to Supported Attributes by Device for information about supported devices.'
+        },
+        'lv_property': 'Source:Output Cutoff:Current Change Limit High',
+        'name': 'OUTPUT_CUTOFF_CURRENT_CHANGE_LIMIT_HIGH',
+        'resettable': False,
+        'type': 'ViReal64'
     },
     1250001: {
         'access': 'read-write',

--- a/src/nidcpower/metadata/config.py
+++ b/src/nidcpower/metadata/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 20.7.0d8
+# This file is generated from NI-DCPower API metadata version 20.7.0d409
 config = {
-    'api_version': '20.7.0d8',
+    'api_version': '20.7.0d409',
     'c_function_prefix': 'niDCPower_',
     'close_function': 'close',
     'context_manager_name': {

--- a/src/nidcpower/metadata/enums.py
+++ b/src/nidcpower/metadata/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 20.7.0d8
+# This file is generated from NI-DCPower API metadata version 20.7.0d409
 enums = {
     'ApertureTimeUnits': {
         'values': [
@@ -372,6 +372,73 @@ enums = {
                 },
                 'name': 'NIDCPOWER_VAL_HIGH',
                 'value': 1011
+            }
+        ]
+    },
+    'OutputCutoffReason': {
+        'values': [
+            {
+                'documentation': {
+                    'description': 'Queries any output cutoff condition; clears all output cutoff conditions.'
+                },
+                'name': 'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_ALL',
+                'value': -1
+            },
+            {
+                'documentation': {
+                    'description': 'Queries or clears cutoff conditions when the output exceeded the high cutoff limit for voltage output.'
+                },
+                'name': 'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_VOLTAGE_OUTPUT_HIGH',
+                'value': 1
+            },
+            {
+                'documentation': {
+                    'description': 'Queries or clears cutoff conditions when the output fell below the low cutoff limit for voltage output.'
+                },
+                'name': 'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_VOLTAGE_OUTPUT_LOW',
+                'value': 2
+            },
+            {
+                'documentation': {
+                    'description': 'Queries or clears cutoff conditions when the measured current exceeded the high cutoff limit for current output.'
+                },
+                'name': 'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_CURRENT_MEASURE_HIGH',
+                'value': 4
+            },
+            {
+                'documentation': {
+                    'description': 'Queries or clears cutoff conditions when the measured current fell below the low cutoff limit for current output.'
+                },
+                'name': 'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_CURRENT_MEASURE_LOW',
+                'value': 8
+            },
+            {
+                'documentation': {
+                    'description': 'Queries or clears cutoff conditions when the voltage slew rate increased beyond the positive change cutoff for voltage output.'
+                },
+                'name': 'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_VOLTAGE_CHANGE_HIGH',
+                'value': 16
+            },
+            {
+                'documentation': {
+                    'description': 'Queries or clears cutoff conditions when the voltage slew rate decreased beyond the negative change cutoff for voltage output.'
+                },
+                'name': 'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_VOLTAGE_CHANGE_LOW',
+                'value': 32
+            },
+            {
+                'documentation': {
+                    'description': 'Queries or clears cutoff conditions when the current slew rate increased beyond the positive change cutoff for current output.'
+                },
+                'name': 'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_CURRENT_CHANGE_HIGH',
+                'value': 64
+            },
+            {
+                'documentation': {
+                    'description': 'Queries or clears cutoff conditions when the current slew rate decreased beyond the negative change cutoff for current output.'
+                },
+                'name': 'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_CURRENT_CHANGE_LOW',
+                'value': 128
             }
         ]
     },

--- a/src/nidcpower/metadata/functions.py
+++ b/src/nidcpower/metadata/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 20.7.0d8
+# This file is generated from NI-DCPower API metadata version 20.7.0d409
 functions = {
     'Abort': {
         'documentation': {
@@ -41,6 +41,77 @@ functions = {
             }
         ],
         'python_name': 'self_cal',
+        'returns': 'ViStatus'
+    },
+    'ClearLatchedOutputCutoffState': {
+        'documentation': {
+            'description': 'Clears the state of an output cutoff that was engaged.\nTo clear the state for all output cutoff reasons, use NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_ALL.\n'
+        },
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': '\nIdentifies a particular instrument session. **vi** is obtained from the\nniDCPower_InitializeWithChannels function.\n'
+                },
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': '\nSpecifies the output channel(s) to which this configuration value\napplies. Specify multiple channels by using a channel list or a channel\nrange. A channel list is a comma (,) separated sequence of channel names\n(for example, 0,2 specifies channels 0 and 2). A channel range is a\nlower bound channel followed by a hyphen (-) or colon (:) followed by an\nupper bound channel (for example, 0-2 specifies channels 0, 1, and 2).\nIn the Running state, multiple output channel configurations are\nperformed sequentially based on the order specified in this parameter.\n'
+                },
+                'name': 'channelName',
+                'type': 'ViConstString'
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Specifies the reasons for which to clear the output cutoff state.\n',
+                    'table_body': [
+                        [
+                            'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_ALL',
+                            'Clears all output cutoff conditions'
+                        ],
+                        [
+                            'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_VOLTAGE_OUTPUT_HIGH',
+                            'Clears cutoffs caused when the output exceeded the high cutoff limit for voltage output'
+                        ],
+                        [
+                            'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_VOLTAGE_OUTPUT_LOW',
+                            'Clears cutoffs caused when the output fell below the low cutoff limit for voltage output'
+                        ],
+                        [
+                            'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_CURRENT_MEASURE_HIGH',
+                            'Clears cutoffs caused when the measured current exceeded the high cutoff limit for current output'
+                        ],
+                        [
+                            'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_CURRENT_MEASURE_LOW',
+                            'Clears cutoffs caused when the measured current fell below the low cutoff limit for current output'
+                        ],
+                        [
+                            'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_VOLTAGE_CHANGE_HIGH',
+                            'Clears cutoffs caused when the voltage slew rate increased beyond the positive change cutoff for voltage output'
+                        ],
+                        [
+                            'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_VOLTAGE_CHANGE_LOW',
+                            'Clears cutoffs caused when the voltage slew rate decreased beyond the negative change cutoff for voltage output'
+                        ],
+                        [
+                            'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_CURRENT_CHANGE_HIGH',
+                            'Clears cutoffs caused when the current slew rate increased beyond the positive change cutoff for current output'
+                        ],
+                        [
+                            'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_CURRENT_CHANGE_LOW',
+                            'Clears cutoffs caused when the voltage slew rate decreased beyond the negative change cutoff for current output'
+                        ]
+                    ]
+                },
+                'enum': 'OutputCutoffReason',
+                'name': 'outputCutoffReason',
+                'type': 'ViInt32'
+            }
+        ],
         'returns': 'ViStatus'
     },
     'Commit': {
@@ -96,11 +167,11 @@ functions = {
                     'description': '\nSpecifies the units for **apertureTime**.\n**Defined Values**:\n',
                     'table_body': [
                         [
-                            'NIDCPOWER_VAL_SECONDS (1028)',
+                            'NIDCPOWER_VAL_SECONDS',
                             'Specifies seconds.'
                         ],
                         [
-                            'NIDCPOWER_VAL_POWER_LINE_CYCLES (1029)',
+                            'NIDCPOWER_VAL_POWER_LINE_CYCLES',
                             'Specifies Power Line Cycles.'
                         ]
                     ]
@@ -1862,11 +1933,11 @@ functions = {
                     'description': '\nSpecifies whether a voltage or current value is measured.\n**Defined Values**:\n',
                     'table_body': [
                         [
-                            'NIDCPOWER_VAL_MEASURE_VOLTAGE (1)',
+                            'NIDCPOWER_VAL_MEASURE_VOLTAGE',
                             'The device measures voltage.'
                         ],
                         [
-                            'NIDCPOWER_VAL_MEASURE_CURRENT (0)',
+                            'NIDCPOWER_VAL_MEASURE_CURRENT',
                             'The device measures current.'
                         ]
                     ]
@@ -1989,6 +2060,95 @@ functions = {
                     'description': 'Returns whether the device output channel is in compliance.'
                 },
                 'name': 'inCompliance',
+                'type': 'ViBoolean'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'QueryLatchedOutputCutoffState': {
+        'documentation': {
+            'description': '\nDiscovers if an output cutoff limit was exceeded for the specified reason. When an output cutoff is engaged, the output of the channel(s) is disconnected.\nIf a limit was exceeded, the state is latched until you clear it with the niDCPower_ClearLatchedOutputCutoffState function or the niDCPower_ResetWithChannels function.\n\noutputCutoffReason specifies the conditions for which an output is disconnected.\n'
+        },
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': '\nIdentifies a particular instrument session. **vi** is obtained from the\nniDCPower_InitializeWithChannels function.\n'
+                },
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': '\nSpecifies the output channel(s) to which this configuration value\napplies. Specify multiple channels by using a channel list or a channel\nrange. A channel list is a comma (,) separated sequence of channel names\n(for example, 0,2 specifies channels 0 and 2). A channel range is a\nlower bound channel followed by a hyphen (-) or colon (:) followed by an\nupper bound channel (for example, 0-2 specifies channels 0, 1, and 2).\nIn the Running state, multiple output channel configurations are\nperformed sequentially based on the order specified in this parameter.\n'
+                },
+                'name': 'channelName',
+                'type': 'ViConstString'
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Specifies which output cutoff conditions to query.\n',
+                    'table_body': [
+                        [
+                            'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_ALL',
+                            'Any output cutoff condition was met'
+                        ],
+                        [
+                            'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_VOLTAGE_OUTPUT_HIGH',
+                            'The output exceeded the high cutoff limit for voltage output'
+                        ],
+                        [
+                            'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_VOLTAGE_OUTPUT_LOW',
+                            'The output fell below the low cutoff limit for voltage output'
+                        ],
+                        [
+                            'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_CURRENT_MEASURE_HIGH',
+                            'The measured current exceeded the high cutoff limit for current output'
+                        ],
+                        [
+                            'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_CURRENT_MEASURE_LOW',
+                            'The measured current fell below the low cutoff limit for current output'
+                        ],
+                        [
+                            'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_VOLTAGE_CHANGE_HIGH',
+                            'The voltage slew rate increased beyond the positive change cutoff for voltage output'
+                        ],
+                        [
+                            'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_VOLTAGE_CHANGE_LOW',
+                            'The voltage slew rate decreased beyond the negative change cutoff for voltage output'
+                        ],
+                        [
+                            'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_CURRENT_CHANGE_HIGH',
+                            'The current slew rate increased beyond the positive change cutoff for current output'
+                        ],
+                        [
+                            'NIDCPOWER_VAL_OUTPUT_CUTOFF_REASON_CURRENT_CHANGE_LOW',
+                            'The current slew rate decreased beyond the negative change cutoff for current output'
+                        ]
+                    ]
+                },
+                'enum': 'OutputCutoffReason',
+                'name': 'outputCutoffReason',
+                'type': 'ViInt32'
+            },
+            {
+                'direction': 'out',
+                'documentation': {
+                    'description': 'Specifies whether an output cutoff has engaged.\n',
+                    'table_body': [
+                        [
+                            'VI_TRUE',
+                            'An output cutoff has engaged for the conditions in **output cutoff reason**.'
+                        ],
+                        [
+                            'VI_FALSE',
+                            'No output cutoff has engaged.'
+                        ]
+                    ]
+                },
+                'name': 'outputCutoffState',
                 'type': 'ViBoolean'
             }
         ],
@@ -2141,11 +2301,11 @@ functions = {
                     'description': '\nSpecifies the output state of the output channel that is being queried.\n**Defined Values**:\n',
                     'table_body': [
                         [
-                            'NIDCPOWER_VAL_OUTPUT_CONSTANT_VOLTAGE (0)',
+                            'NIDCPOWER_VAL_OUTPUT_CONSTANT_VOLTAGE',
                             'The device maintains a constant voltage by adjusting the current.'
                         ],
                         [
-                            'NIDCPOWER_VAL_OUTPUT_CONSTANT_CURRENT (1)',
+                            'NIDCPOWER_VAL_OUTPUT_CONSTANT_CURRENT',
                             'The device maintains a constant current by adjusting the voltage.'
                         ]
                     ]
@@ -2241,27 +2401,27 @@ functions = {
                     'description': '\nSpecifies which trigger to assert.\n**Defined Values:**\n',
                     'table_body': [
                         [
-                            'NIDCPOWER_VAL_START_TRIGGER (1034)',
+                            'NIDCPOWER_VAL_START_TRIGGER',
                             'Asserts the Start trigger.'
                         ],
                         [
-                            'NIDCPOWER_VAL_SOURCE_TRIGGER (1035)',
+                            'NIDCPOWER_VAL_SOURCE_TRIGGER',
                             'Asserts the Source trigger.'
                         ],
                         [
-                            'NIDCPOWER_VAL_MEASURE_TRIGGER (1036)',
+                            'NIDCPOWER_VAL_MEASURE_TRIGGER',
                             'Asserts the Measure trigger.'
                         ],
                         [
-                            'NIDCPOWER_VAL_SEQUENCE_ADVANCE_TRIGGER (1037)',
+                            'NIDCPOWER_VAL_SEQUENCE_ADVANCE_TRIGGER',
                             'Asserts the Sequence Advance trigger.'
                         ],
                         [
-                            'NIDCPOWER_VAL_PULSE_TRIGGER (1053)',
+                            'NIDCPOWER_VAL_PULSE_TRIGGER',
                             'Asserts the Pulse trigger.'
                         ],
                         [
-                            'NIDCPOWER_VAL_SHUTDOWN_TRIGGER (1118)',
+                            'NIDCPOWER_VAL_SHUTDOWN_TRIGGER',
                             'Asserts the Shutdown trigger.'
                         ]
                     ]
@@ -2594,27 +2754,27 @@ functions = {
                     'description': '\nSpecifies which event to wait for.\n**Defined Values:**\n',
                     'table_body': [
                         [
-                            'NIDCPOWER_VAL_SOURCE_COMPLETE_EVENT (1030)',
+                            'NIDCPOWER_VAL_SOURCE_COMPLETE_EVENT',
                             'Waits for the Source Complete event.'
                         ],
                         [
-                            'NIDCPOWER_VAL_MEASURE_COMPLETE_EVENT (1031)',
+                            'NIDCPOWER_VAL_MEASURE_COMPLETE_EVENT',
                             'Waits for the Measure Complete event.'
                         ],
                         [
-                            'NIDCPOWER_VAL_SEQUENCE_ITERATION_COMPLETE_EVENT (1032)',
+                            'NIDCPOWER_VAL_SEQUENCE_ITERATION_COMPLETE_EVENT',
                             'Waits for the Sequence Iteration Complete event.'
                         ],
                         [
-                            'NIDCPOWER_VAL_SEQUENCE_ENGINE_DONE_EVENT (1033)',
+                            'NIDCPOWER_VAL_SEQUENCE_ENGINE_DONE_EVENT',
                             'Waits for the Sequence Engine Done event.'
                         ],
                         [
-                            'NIDCPOWER_VAL_PULSE_COMPLETE_EVENT (1051 )',
+                            'NIDCPOWER_VAL_PULSE_COMPLETE_EVENT',
                             'Waits for the Pulse Complete event.'
                         ],
                         [
-                            'NIDCPOWER_VAL_READY_FOR_PULSE_TRIGGER_EVENT (1052)',
+                            'NIDCPOWER_VAL_READY_FOR_PULSE_TRIGGER_EVENT',
                             'Waits for the Ready for Pulse Trigger event.'
                         ]
                     ]


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

- API parity with NI-DCPower 20.7.0 by adding Output Cutoff functionality.
- Remove channels repeated capability from two properties in nidcpower that was previously added erroneously - `auxiliary_power_source_available` and `power_source_in_use`.
- Remove references to enum values (numerical values used by underlying C driver) from public method documentation.

### List issues fixed by this Pull Request below, if any.

None

### What testing has been done?

PR build