### PR TITLE
Improve error message when function not found in driver runtime

### DIFF
--- a/build/templates/_library.py.mako
+++ b/build/templates/_library.py.mako
@@ -51,7 +51,12 @@ class Library(object):
     def ${c_func_name}(${param_names_method}):  # noqa: N802
         with self._func_lock:
             if self.${c_func_name}_cfunc is None:
-                self.${c_func_name}_cfunc = self._library.${c_func_name}
+                try:
+                    self.${c_func_name}_cfunc = self._library.${c_func_name}
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.${c_func_name}_cfunc.argtypes = [${param_ctypes_library}]  # noqa: F405
                 self.${c_func_name}_cfunc.restype = ${f['returns']}  # noqa: F405
         return self.${c_func_name}_cfunc(${param_names_library})

--- a/build/templates/_library.py.mako
+++ b/build/templates/_library.py.mako
@@ -54,9 +54,9 @@ class Library(object):
                 try:
                     self.${c_func_name}_cfunc = self._library.${c_func_name}
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function ${c_func_name} was not found in the ${driver_name} runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.${c_func_name}_cfunc.argtypes = [${param_ctypes_library}]  # noqa: F405
                 self.${c_func_name}_cfunc.restype = ${f['returns']}  # noqa: F405
         return self.${c_func_name}_cfunc(${param_names_library})

--- a/build/templates/errors.py.mako
+++ b/build/templates/errors.py.mako
@@ -69,6 +69,13 @@ class DriverNotInstalledError(Error):
         super(DriverNotInstalledError, self).__init__('The ${driver_name} runtime could not be loaded. Make sure it is installed and its bitness matches that of your Python interpreter. Please visit http://www.ni.com/downloads/drivers/ to download and install it.')
 
 
+class DriverTooOldError(Error):
+    '''An error due to using this module with an older version of the driver runtime.'''
+
+    def __init__(self):
+        super(DriverTooOldError, self).__init__('A function was not found in the ${driver_name} runtime. Please visit http://www.ni.com/downloads/drivers/ to download a newer version and install it.')
+
+
 % if 'InvalidRepeatedCapabilityError' in extra_errors_used:
 class InvalidRepeatedCapabilityError(Error):
     '''An error due to an invalid character in a repeated capability'''

--- a/generated/nidcpower/nidcpower/_library.py
+++ b/generated/nidcpower/nidcpower/_library.py
@@ -79,9 +79,9 @@ class Library(object):
                 try:
                     self.niDCPower_Abort_cfunc = self._library.niDCPower_Abort
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_Abort was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_Abort_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_Abort_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_Abort_cfunc(vi)
@@ -92,9 +92,9 @@ class Library(object):
                 try:
                     self.niDCPower_CalSelfCalibrate_cfunc = self._library.niDCPower_CalSelfCalibrate
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_CalSelfCalibrate was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_CalSelfCalibrate_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_CalSelfCalibrate_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_CalSelfCalibrate_cfunc(vi, channel_name)
@@ -105,9 +105,9 @@ class Library(object):
                 try:
                     self.niDCPower_ClearLatchedOutputCutoffState_cfunc = self._library.niDCPower_ClearLatchedOutputCutoffState
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_ClearLatchedOutputCutoffState was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_ClearLatchedOutputCutoffState_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niDCPower_ClearLatchedOutputCutoffState_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ClearLatchedOutputCutoffState_cfunc(vi, channel_name, output_cutoff_reason)
@@ -118,9 +118,9 @@ class Library(object):
                 try:
                     self.niDCPower_Commit_cfunc = self._library.niDCPower_Commit
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_Commit was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_Commit_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_Commit_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_Commit_cfunc(vi)
@@ -131,9 +131,9 @@ class Library(object):
                 try:
                     self.niDCPower_ConfigureApertureTime_cfunc = self._library.niDCPower_ConfigureApertureTime
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_ConfigureApertureTime was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_ConfigureApertureTime_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32]  # noqa: F405
                 self.niDCPower_ConfigureApertureTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ConfigureApertureTime_cfunc(vi, channel_name, aperture_time, units)
@@ -144,9 +144,9 @@ class Library(object):
                 try:
                     self.niDCPower_CreateAdvancedSequence_cfunc = self._library.niDCPower_CreateAdvancedSequence
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_CreateAdvancedSequence was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_CreateAdvancedSequence_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt32), ViBoolean]  # noqa: F405
                 self.niDCPower_CreateAdvancedSequence_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_CreateAdvancedSequence_cfunc(vi, sequence_name, attribute_id_count, attribute_ids, set_as_active_sequence)
@@ -157,9 +157,9 @@ class Library(object):
                 try:
                     self.niDCPower_CreateAdvancedSequenceStep_cfunc = self._library.niDCPower_CreateAdvancedSequenceStep
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_CreateAdvancedSequenceStep was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_CreateAdvancedSequenceStep_cfunc.argtypes = [ViSession, ViBoolean]  # noqa: F405
                 self.niDCPower_CreateAdvancedSequenceStep_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_CreateAdvancedSequenceStep_cfunc(vi, set_as_active_step)
@@ -170,9 +170,9 @@ class Library(object):
                 try:
                     self.niDCPower_DeleteAdvancedSequence_cfunc = self._library.niDCPower_DeleteAdvancedSequence
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_DeleteAdvancedSequence was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_DeleteAdvancedSequence_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_DeleteAdvancedSequence_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_DeleteAdvancedSequence_cfunc(vi, sequence_name)
@@ -183,9 +183,9 @@ class Library(object):
                 try:
                     self.niDCPower_Disable_cfunc = self._library.niDCPower_Disable
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_Disable was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_Disable_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_Disable_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_Disable_cfunc(vi)
@@ -196,9 +196,9 @@ class Library(object):
                 try:
                     self.niDCPower_ExportAttributeConfigurationBuffer_cfunc = self._library.niDCPower_ExportAttributeConfigurationBuffer
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_ExportAttributeConfigurationBuffer was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_ExportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niDCPower_ExportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ExportAttributeConfigurationBuffer_cfunc(vi, size, configuration)
@@ -209,9 +209,9 @@ class Library(object):
                 try:
                     self.niDCPower_ExportAttributeConfigurationFile_cfunc = self._library.niDCPower_ExportAttributeConfigurationFile
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_ExportAttributeConfigurationFile was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_ExportAttributeConfigurationFile_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_ExportAttributeConfigurationFile_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ExportAttributeConfigurationFile_cfunc(vi, file_path)
@@ -222,9 +222,9 @@ class Library(object):
                 try:
                     self.niDCPower_FetchMultiple_cfunc = self._library.niDCPower_FetchMultiple
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_FetchMultiple was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_FetchMultiple_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViBoolean), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDCPower_FetchMultiple_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_FetchMultiple_cfunc(vi, channel_name, timeout, count, voltage_measurements, current_measurements, in_compliance, actual_count)
@@ -235,9 +235,9 @@ class Library(object):
                 try:
                     self.niDCPower_GetAttributeViBoolean_cfunc = self._library.niDCPower_GetAttributeViBoolean
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_GetAttributeViBoolean was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDCPower_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -248,9 +248,9 @@ class Library(object):
                 try:
                     self.niDCPower_GetAttributeViInt32_cfunc = self._library.niDCPower_GetAttributeViInt32
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_GetAttributeViInt32 was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_GetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDCPower_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -261,9 +261,9 @@ class Library(object):
                 try:
                     self.niDCPower_GetAttributeViInt64_cfunc = self._library.niDCPower_GetAttributeViInt64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_GetAttributeViInt64 was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_GetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt64)]  # noqa: F405
                 self.niDCPower_GetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetAttributeViInt64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -274,9 +274,9 @@ class Library(object):
                 try:
                     self.niDCPower_GetAttributeViReal64_cfunc = self._library.niDCPower_GetAttributeViReal64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_GetAttributeViReal64 was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_GetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -287,9 +287,9 @@ class Library(object):
                 try:
                     self.niDCPower_GetAttributeViString_cfunc = self._library.niDCPower_GetAttributeViString
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_GetAttributeViString was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetAttributeViString_cfunc(vi, channel_name, attribute_id, buffer_size, attribute_value)
@@ -300,9 +300,9 @@ class Library(object):
                 try:
                     self.niDCPower_GetChannelName_cfunc = self._library.niDCPower_GetChannelName
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_GetChannelName was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_GetChannelName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_GetChannelName_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetChannelName_cfunc(vi, index, buffer_size, channel_name)
@@ -313,9 +313,9 @@ class Library(object):
                 try:
                     self.niDCPower_GetError_cfunc = self._library.niDCPower_GetError
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_GetError was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_GetError_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetError_cfunc(vi, code, buffer_size, description)
@@ -326,9 +326,9 @@ class Library(object):
                 try:
                     self.niDCPower_GetExtCalLastDateAndTime_cfunc = self._library.niDCPower_GetExtCalLastDateAndTime
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_GetExtCalLastDateAndTime was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_GetExtCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDCPower_GetExtCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetExtCalLastDateAndTime_cfunc(vi, year, month, day, hour, minute)
@@ -339,9 +339,9 @@ class Library(object):
                 try:
                     self.niDCPower_GetExtCalLastTemp_cfunc = self._library.niDCPower_GetExtCalLastTemp
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_GetExtCalLastTemp was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_GetExtCalLastTemp_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_GetExtCalLastTemp_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetExtCalLastTemp_cfunc(vi, temperature)
@@ -352,9 +352,9 @@ class Library(object):
                 try:
                     self.niDCPower_GetExtCalRecommendedInterval_cfunc = self._library.niDCPower_GetExtCalRecommendedInterval
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_GetExtCalRecommendedInterval was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_GetExtCalRecommendedInterval_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDCPower_GetExtCalRecommendedInterval_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetExtCalRecommendedInterval_cfunc(vi, months)
@@ -365,9 +365,9 @@ class Library(object):
                 try:
                     self.niDCPower_GetSelfCalLastDateAndTime_cfunc = self._library.niDCPower_GetSelfCalLastDateAndTime
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_GetSelfCalLastDateAndTime was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_GetSelfCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDCPower_GetSelfCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetSelfCalLastDateAndTime_cfunc(vi, year, month, day, hour, minute)
@@ -378,9 +378,9 @@ class Library(object):
                 try:
                     self.niDCPower_GetSelfCalLastTemp_cfunc = self._library.niDCPower_GetSelfCalLastTemp
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_GetSelfCalLastTemp was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_GetSelfCalLastTemp_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_GetSelfCalLastTemp_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetSelfCalLastTemp_cfunc(vi, temperature)
@@ -391,9 +391,9 @@ class Library(object):
                 try:
                     self.niDCPower_ImportAttributeConfigurationBuffer_cfunc = self._library.niDCPower_ImportAttributeConfigurationBuffer
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_ImportAttributeConfigurationBuffer was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_ImportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niDCPower_ImportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ImportAttributeConfigurationBuffer_cfunc(vi, size, configuration)
@@ -404,9 +404,9 @@ class Library(object):
                 try:
                     self.niDCPower_ImportAttributeConfigurationFile_cfunc = self._library.niDCPower_ImportAttributeConfigurationFile
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_ImportAttributeConfigurationFile was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_ImportAttributeConfigurationFile_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_ImportAttributeConfigurationFile_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ImportAttributeConfigurationFile_cfunc(vi, file_path)
@@ -417,9 +417,9 @@ class Library(object):
                 try:
                     self.niDCPower_InitializeWithChannels_cfunc = self._library.niDCPower_InitializeWithChannels
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_InitializeWithChannels was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_InitializeWithChannels_cfunc.argtypes = [ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViBoolean, ctypes.POINTER(ViChar), ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niDCPower_InitializeWithChannels_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_InitializeWithChannels_cfunc(resource_name, channels, reset, option_string, vi)
@@ -430,9 +430,9 @@ class Library(object):
                 try:
                     self.niDCPower_Initiate_cfunc = self._library.niDCPower_Initiate
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_Initiate was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_Initiate_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_Initiate_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_Initiate_cfunc(vi)
@@ -443,9 +443,9 @@ class Library(object):
                 try:
                     self.niDCPower_LockSession_cfunc = self._library.niDCPower_LockSession
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_LockSession was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_LockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDCPower_LockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_LockSession_cfunc(vi, caller_has_lock)
@@ -456,9 +456,9 @@ class Library(object):
                 try:
                     self.niDCPower_Measure_cfunc = self._library.niDCPower_Measure
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_Measure was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_Measure_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_Measure_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_Measure_cfunc(vi, channel_name, measurement_type, measurement)
@@ -469,9 +469,9 @@ class Library(object):
                 try:
                     self.niDCPower_MeasureMultiple_cfunc = self._library.niDCPower_MeasureMultiple
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_MeasureMultiple was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_MeasureMultiple_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_MeasureMultiple_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_MeasureMultiple_cfunc(vi, channel_name, voltage_measurements, current_measurements)
@@ -482,9 +482,9 @@ class Library(object):
                 try:
                     self.niDCPower_ParseChannelCount_cfunc = self._library.niDCPower_ParseChannelCount
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_ParseChannelCount was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_ParseChannelCount_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViUInt32)]  # noqa: F405
                 self.niDCPower_ParseChannelCount_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ParseChannelCount_cfunc(vi, channels_string, number_of_channels)
@@ -495,9 +495,9 @@ class Library(object):
                 try:
                     self.niDCPower_QueryInCompliance_cfunc = self._library.niDCPower_QueryInCompliance
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_QueryInCompliance was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_QueryInCompliance_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDCPower_QueryInCompliance_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_QueryInCompliance_cfunc(vi, channel_name, in_compliance)
@@ -508,9 +508,9 @@ class Library(object):
                 try:
                     self.niDCPower_QueryLatchedOutputCutoffState_cfunc = self._library.niDCPower_QueryLatchedOutputCutoffState
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_QueryLatchedOutputCutoffState was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_QueryLatchedOutputCutoffState_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDCPower_QueryLatchedOutputCutoffState_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_QueryLatchedOutputCutoffState_cfunc(vi, channel_name, output_cutoff_reason, output_cutoff_state)
@@ -521,9 +521,9 @@ class Library(object):
                 try:
                     self.niDCPower_QueryMaxCurrentLimit_cfunc = self._library.niDCPower_QueryMaxCurrentLimit
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_QueryMaxCurrentLimit was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_QueryMaxCurrentLimit_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_QueryMaxCurrentLimit_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_QueryMaxCurrentLimit_cfunc(vi, channel_name, voltage_level, max_current_limit)
@@ -534,9 +534,9 @@ class Library(object):
                 try:
                     self.niDCPower_QueryMaxVoltageLevel_cfunc = self._library.niDCPower_QueryMaxVoltageLevel
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_QueryMaxVoltageLevel was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_QueryMaxVoltageLevel_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_QueryMaxVoltageLevel_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_QueryMaxVoltageLevel_cfunc(vi, channel_name, current_limit, max_voltage_level)
@@ -547,9 +547,9 @@ class Library(object):
                 try:
                     self.niDCPower_QueryMinCurrentLimit_cfunc = self._library.niDCPower_QueryMinCurrentLimit
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_QueryMinCurrentLimit was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_QueryMinCurrentLimit_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_QueryMinCurrentLimit_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_QueryMinCurrentLimit_cfunc(vi, channel_name, voltage_level, min_current_limit)
@@ -560,9 +560,9 @@ class Library(object):
                 try:
                     self.niDCPower_QueryOutputState_cfunc = self._library.niDCPower_QueryOutputState
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_QueryOutputState was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_QueryOutputState_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDCPower_QueryOutputState_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_QueryOutputState_cfunc(vi, channel_name, output_state, in_state)
@@ -573,9 +573,9 @@ class Library(object):
                 try:
                     self.niDCPower_ReadCurrentTemperature_cfunc = self._library.niDCPower_ReadCurrentTemperature
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_ReadCurrentTemperature was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_ReadCurrentTemperature_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_ReadCurrentTemperature_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ReadCurrentTemperature_cfunc(vi, temperature)
@@ -586,9 +586,9 @@ class Library(object):
                 try:
                     self.niDCPower_ResetDevice_cfunc = self._library.niDCPower_ResetDevice
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_ResetDevice was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_ResetDevice_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_ResetDevice_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ResetDevice_cfunc(vi)
@@ -599,9 +599,9 @@ class Library(object):
                 try:
                     self.niDCPower_ResetWithDefaults_cfunc = self._library.niDCPower_ResetWithDefaults
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_ResetWithDefaults was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_ResetWithDefaults_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_ResetWithDefaults_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ResetWithDefaults_cfunc(vi)
@@ -612,9 +612,9 @@ class Library(object):
                 try:
                     self.niDCPower_SendSoftwareEdgeTrigger_cfunc = self._library.niDCPower_SendSoftwareEdgeTrigger
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_SendSoftwareEdgeTrigger was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_SendSoftwareEdgeTrigger_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niDCPower_SendSoftwareEdgeTrigger_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_SendSoftwareEdgeTrigger_cfunc(vi, trigger)
@@ -625,9 +625,9 @@ class Library(object):
                 try:
                     self.niDCPower_SetAttributeViBoolean_cfunc = self._library.niDCPower_SetAttributeViBoolean
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_SetAttributeViBoolean was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViBoolean]  # noqa: F405
                 self.niDCPower_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_SetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -638,9 +638,9 @@ class Library(object):
                 try:
                     self.niDCPower_SetAttributeViInt32_cfunc = self._library.niDCPower_SetAttributeViInt32
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_SetAttributeViInt32 was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_SetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32]  # noqa: F405
                 self.niDCPower_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_SetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -651,9 +651,9 @@ class Library(object):
                 try:
                     self.niDCPower_SetAttributeViInt64_cfunc = self._library.niDCPower_SetAttributeViInt64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_SetAttributeViInt64 was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_SetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt64]  # noqa: F405
                 self.niDCPower_SetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_SetAttributeViInt64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -664,9 +664,9 @@ class Library(object):
                 try:
                     self.niDCPower_SetAttributeViReal64_cfunc = self._library.niDCPower_SetAttributeViReal64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_SetAttributeViReal64 was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niDCPower_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_SetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -677,9 +677,9 @@ class Library(object):
                 try:
                     self.niDCPower_SetAttributeViString_cfunc = self._library.niDCPower_SetAttributeViString
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_SetAttributeViString was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_SetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_SetAttributeViString_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -690,9 +690,9 @@ class Library(object):
                 try:
                     self.niDCPower_SetSequence_cfunc = self._library.niDCPower_SetSequence
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_SetSequence was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_SetSequence_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ViUInt32]  # noqa: F405
                 self.niDCPower_SetSequence_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_SetSequence_cfunc(vi, channel_name, values, source_delays, size)
@@ -703,9 +703,9 @@ class Library(object):
                 try:
                     self.niDCPower_UnlockSession_cfunc = self._library.niDCPower_UnlockSession
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_UnlockSession was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_UnlockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDCPower_UnlockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_UnlockSession_cfunc(vi, caller_has_lock)
@@ -716,9 +716,9 @@ class Library(object):
                 try:
                     self.niDCPower_WaitForEvent_cfunc = self._library.niDCPower_WaitForEvent
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_WaitForEvent was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_WaitForEvent_cfunc.argtypes = [ViSession, ViInt32, ViReal64]  # noqa: F405
                 self.niDCPower_WaitForEvent_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_WaitForEvent_cfunc(vi, event_id, timeout)
@@ -729,9 +729,9 @@ class Library(object):
                 try:
                     self.niDCPower_close_cfunc = self._library.niDCPower_close
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_close was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_close_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_close_cfunc(vi)
@@ -742,9 +742,9 @@ class Library(object):
                 try:
                     self.niDCPower_error_message_cfunc = self._library.niDCPower_error_message
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_error_message was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_error_message_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_error_message_cfunc(vi, error_code, error_message)
@@ -755,9 +755,9 @@ class Library(object):
                 try:
                     self.niDCPower_reset_cfunc = self._library.niDCPower_reset
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_reset was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_reset_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_reset_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_reset_cfunc(vi)
@@ -768,9 +768,9 @@ class Library(object):
                 try:
                     self.niDCPower_self_test_cfunc = self._library.niDCPower_self_test
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDCPower_self_test was not found in the NI-DCPower runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDCPower_self_test_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_self_test_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_self_test_cfunc(vi, self_test_result, self_test_message)

--- a/generated/nidcpower/nidcpower/_library.py
+++ b/generated/nidcpower/nidcpower/_library.py
@@ -76,7 +76,7 @@ class Library(object):
 
     def _get_library_function(self, name):
         try:
-            function = getattr(self._library, 'fred')
+            function = getattr(self._library, name)
         except AttributeError as e:
             raise errors.DriverTooOldError() from e
         return function

--- a/generated/nidcpower/nidcpower/_library.py
+++ b/generated/nidcpower/nidcpower/_library.py
@@ -2,6 +2,7 @@
 # This file was generated
 
 import ctypes
+import nidcpower.errors as errors
 import threading
 
 from nidcpower._visatype import *  # noqa: F403,H303
@@ -73,15 +74,17 @@ class Library(object):
         self.niDCPower_reset_cfunc = None
         self.niDCPower_self_test_cfunc = None
 
+    def _get_library_function(self, name):
+        try:
+            function = getattr(self._library, 'fred')
+        except AttributeError as e:
+            raise errors.DriverTooOldError() from e
+        return function
+
     def niDCPower_Abort(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_Abort_cfunc is None:
-                try:
-                    self.niDCPower_Abort_cfunc = self._library.niDCPower_Abort
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_Abort was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_Abort_cfunc = self._get_library_function('niDCPower_Abort')
                 self.niDCPower_Abort_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_Abort_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_Abort_cfunc(vi)
@@ -89,12 +92,7 @@ class Library(object):
     def niDCPower_CalSelfCalibrate(self, vi, channel_name):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_CalSelfCalibrate_cfunc is None:
-                try:
-                    self.niDCPower_CalSelfCalibrate_cfunc = self._library.niDCPower_CalSelfCalibrate
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_CalSelfCalibrate was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_CalSelfCalibrate_cfunc = self._get_library_function('niDCPower_CalSelfCalibrate')
                 self.niDCPower_CalSelfCalibrate_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_CalSelfCalibrate_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_CalSelfCalibrate_cfunc(vi, channel_name)
@@ -102,12 +100,7 @@ class Library(object):
     def niDCPower_ClearLatchedOutputCutoffState(self, vi, channel_name, output_cutoff_reason):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_ClearLatchedOutputCutoffState_cfunc is None:
-                try:
-                    self.niDCPower_ClearLatchedOutputCutoffState_cfunc = self._library.niDCPower_ClearLatchedOutputCutoffState
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_ClearLatchedOutputCutoffState was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_ClearLatchedOutputCutoffState_cfunc = self._get_library_function('niDCPower_ClearLatchedOutputCutoffState')
                 self.niDCPower_ClearLatchedOutputCutoffState_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niDCPower_ClearLatchedOutputCutoffState_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ClearLatchedOutputCutoffState_cfunc(vi, channel_name, output_cutoff_reason)
@@ -115,12 +108,7 @@ class Library(object):
     def niDCPower_Commit(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_Commit_cfunc is None:
-                try:
-                    self.niDCPower_Commit_cfunc = self._library.niDCPower_Commit
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_Commit was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_Commit_cfunc = self._get_library_function('niDCPower_Commit')
                 self.niDCPower_Commit_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_Commit_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_Commit_cfunc(vi)
@@ -128,12 +116,7 @@ class Library(object):
     def niDCPower_ConfigureApertureTime(self, vi, channel_name, aperture_time, units):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_ConfigureApertureTime_cfunc is None:
-                try:
-                    self.niDCPower_ConfigureApertureTime_cfunc = self._library.niDCPower_ConfigureApertureTime
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_ConfigureApertureTime was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_ConfigureApertureTime_cfunc = self._get_library_function('niDCPower_ConfigureApertureTime')
                 self.niDCPower_ConfigureApertureTime_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32]  # noqa: F405
                 self.niDCPower_ConfigureApertureTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ConfigureApertureTime_cfunc(vi, channel_name, aperture_time, units)
@@ -141,12 +124,7 @@ class Library(object):
     def niDCPower_CreateAdvancedSequence(self, vi, sequence_name, attribute_id_count, attribute_ids, set_as_active_sequence):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_CreateAdvancedSequence_cfunc is None:
-                try:
-                    self.niDCPower_CreateAdvancedSequence_cfunc = self._library.niDCPower_CreateAdvancedSequence
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_CreateAdvancedSequence was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_CreateAdvancedSequence_cfunc = self._get_library_function('niDCPower_CreateAdvancedSequence')
                 self.niDCPower_CreateAdvancedSequence_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt32), ViBoolean]  # noqa: F405
                 self.niDCPower_CreateAdvancedSequence_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_CreateAdvancedSequence_cfunc(vi, sequence_name, attribute_id_count, attribute_ids, set_as_active_sequence)
@@ -154,12 +132,7 @@ class Library(object):
     def niDCPower_CreateAdvancedSequenceStep(self, vi, set_as_active_step):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_CreateAdvancedSequenceStep_cfunc is None:
-                try:
-                    self.niDCPower_CreateAdvancedSequenceStep_cfunc = self._library.niDCPower_CreateAdvancedSequenceStep
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_CreateAdvancedSequenceStep was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_CreateAdvancedSequenceStep_cfunc = self._get_library_function('niDCPower_CreateAdvancedSequenceStep')
                 self.niDCPower_CreateAdvancedSequenceStep_cfunc.argtypes = [ViSession, ViBoolean]  # noqa: F405
                 self.niDCPower_CreateAdvancedSequenceStep_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_CreateAdvancedSequenceStep_cfunc(vi, set_as_active_step)
@@ -167,12 +140,7 @@ class Library(object):
     def niDCPower_DeleteAdvancedSequence(self, vi, sequence_name):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_DeleteAdvancedSequence_cfunc is None:
-                try:
-                    self.niDCPower_DeleteAdvancedSequence_cfunc = self._library.niDCPower_DeleteAdvancedSequence
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_DeleteAdvancedSequence was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_DeleteAdvancedSequence_cfunc = self._get_library_function('niDCPower_DeleteAdvancedSequence')
                 self.niDCPower_DeleteAdvancedSequence_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_DeleteAdvancedSequence_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_DeleteAdvancedSequence_cfunc(vi, sequence_name)
@@ -180,12 +148,7 @@ class Library(object):
     def niDCPower_Disable(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_Disable_cfunc is None:
-                try:
-                    self.niDCPower_Disable_cfunc = self._library.niDCPower_Disable
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_Disable was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_Disable_cfunc = self._get_library_function('niDCPower_Disable')
                 self.niDCPower_Disable_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_Disable_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_Disable_cfunc(vi)
@@ -193,12 +156,7 @@ class Library(object):
     def niDCPower_ExportAttributeConfigurationBuffer(self, vi, size, configuration):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_ExportAttributeConfigurationBuffer_cfunc is None:
-                try:
-                    self.niDCPower_ExportAttributeConfigurationBuffer_cfunc = self._library.niDCPower_ExportAttributeConfigurationBuffer
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_ExportAttributeConfigurationBuffer was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_ExportAttributeConfigurationBuffer_cfunc = self._get_library_function('niDCPower_ExportAttributeConfigurationBuffer')
                 self.niDCPower_ExportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niDCPower_ExportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ExportAttributeConfigurationBuffer_cfunc(vi, size, configuration)
@@ -206,12 +164,7 @@ class Library(object):
     def niDCPower_ExportAttributeConfigurationFile(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_ExportAttributeConfigurationFile_cfunc is None:
-                try:
-                    self.niDCPower_ExportAttributeConfigurationFile_cfunc = self._library.niDCPower_ExportAttributeConfigurationFile
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_ExportAttributeConfigurationFile was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_ExportAttributeConfigurationFile_cfunc = self._get_library_function('niDCPower_ExportAttributeConfigurationFile')
                 self.niDCPower_ExportAttributeConfigurationFile_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_ExportAttributeConfigurationFile_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ExportAttributeConfigurationFile_cfunc(vi, file_path)
@@ -219,12 +172,7 @@ class Library(object):
     def niDCPower_FetchMultiple(self, vi, channel_name, timeout, count, voltage_measurements, current_measurements, in_compliance, actual_count):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_FetchMultiple_cfunc is None:
-                try:
-                    self.niDCPower_FetchMultiple_cfunc = self._library.niDCPower_FetchMultiple
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_FetchMultiple was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_FetchMultiple_cfunc = self._get_library_function('niDCPower_FetchMultiple')
                 self.niDCPower_FetchMultiple_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViBoolean), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDCPower_FetchMultiple_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_FetchMultiple_cfunc(vi, channel_name, timeout, count, voltage_measurements, current_measurements, in_compliance, actual_count)
@@ -232,12 +180,7 @@ class Library(object):
     def niDCPower_GetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_GetAttributeViBoolean_cfunc is None:
-                try:
-                    self.niDCPower_GetAttributeViBoolean_cfunc = self._library.niDCPower_GetAttributeViBoolean
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_GetAttributeViBoolean was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_GetAttributeViBoolean_cfunc = self._get_library_function('niDCPower_GetAttributeViBoolean')
                 self.niDCPower_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDCPower_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -245,12 +188,7 @@ class Library(object):
     def niDCPower_GetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_GetAttributeViInt32_cfunc is None:
-                try:
-                    self.niDCPower_GetAttributeViInt32_cfunc = self._library.niDCPower_GetAttributeViInt32
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_GetAttributeViInt32 was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_GetAttributeViInt32_cfunc = self._get_library_function('niDCPower_GetAttributeViInt32')
                 self.niDCPower_GetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDCPower_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -258,12 +196,7 @@ class Library(object):
     def niDCPower_GetAttributeViInt64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_GetAttributeViInt64_cfunc is None:
-                try:
-                    self.niDCPower_GetAttributeViInt64_cfunc = self._library.niDCPower_GetAttributeViInt64
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_GetAttributeViInt64 was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_GetAttributeViInt64_cfunc = self._get_library_function('niDCPower_GetAttributeViInt64')
                 self.niDCPower_GetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt64)]  # noqa: F405
                 self.niDCPower_GetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetAttributeViInt64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -271,12 +204,7 @@ class Library(object):
     def niDCPower_GetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_GetAttributeViReal64_cfunc is None:
-                try:
-                    self.niDCPower_GetAttributeViReal64_cfunc = self._library.niDCPower_GetAttributeViReal64
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_GetAttributeViReal64 was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_GetAttributeViReal64_cfunc = self._get_library_function('niDCPower_GetAttributeViReal64')
                 self.niDCPower_GetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -284,12 +212,7 @@ class Library(object):
     def niDCPower_GetAttributeViString(self, vi, channel_name, attribute_id, buffer_size, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_GetAttributeViString_cfunc is None:
-                try:
-                    self.niDCPower_GetAttributeViString_cfunc = self._library.niDCPower_GetAttributeViString
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_GetAttributeViString was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_GetAttributeViString_cfunc = self._get_library_function('niDCPower_GetAttributeViString')
                 self.niDCPower_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetAttributeViString_cfunc(vi, channel_name, attribute_id, buffer_size, attribute_value)
@@ -297,12 +220,7 @@ class Library(object):
     def niDCPower_GetChannelName(self, vi, index, buffer_size, channel_name):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_GetChannelName_cfunc is None:
-                try:
-                    self.niDCPower_GetChannelName_cfunc = self._library.niDCPower_GetChannelName
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_GetChannelName was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_GetChannelName_cfunc = self._get_library_function('niDCPower_GetChannelName')
                 self.niDCPower_GetChannelName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_GetChannelName_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetChannelName_cfunc(vi, index, buffer_size, channel_name)
@@ -310,12 +228,7 @@ class Library(object):
     def niDCPower_GetError(self, vi, code, buffer_size, description):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_GetError_cfunc is None:
-                try:
-                    self.niDCPower_GetError_cfunc = self._library.niDCPower_GetError
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_GetError was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_GetError_cfunc = self._get_library_function('niDCPower_GetError')
                 self.niDCPower_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_GetError_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetError_cfunc(vi, code, buffer_size, description)
@@ -323,12 +236,7 @@ class Library(object):
     def niDCPower_GetExtCalLastDateAndTime(self, vi, year, month, day, hour, minute):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_GetExtCalLastDateAndTime_cfunc is None:
-                try:
-                    self.niDCPower_GetExtCalLastDateAndTime_cfunc = self._library.niDCPower_GetExtCalLastDateAndTime
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_GetExtCalLastDateAndTime was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_GetExtCalLastDateAndTime_cfunc = self._get_library_function('niDCPower_GetExtCalLastDateAndTime')
                 self.niDCPower_GetExtCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDCPower_GetExtCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetExtCalLastDateAndTime_cfunc(vi, year, month, day, hour, minute)
@@ -336,12 +244,7 @@ class Library(object):
     def niDCPower_GetExtCalLastTemp(self, vi, temperature):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_GetExtCalLastTemp_cfunc is None:
-                try:
-                    self.niDCPower_GetExtCalLastTemp_cfunc = self._library.niDCPower_GetExtCalLastTemp
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_GetExtCalLastTemp was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_GetExtCalLastTemp_cfunc = self._get_library_function('niDCPower_GetExtCalLastTemp')
                 self.niDCPower_GetExtCalLastTemp_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_GetExtCalLastTemp_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetExtCalLastTemp_cfunc(vi, temperature)
@@ -349,12 +252,7 @@ class Library(object):
     def niDCPower_GetExtCalRecommendedInterval(self, vi, months):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_GetExtCalRecommendedInterval_cfunc is None:
-                try:
-                    self.niDCPower_GetExtCalRecommendedInterval_cfunc = self._library.niDCPower_GetExtCalRecommendedInterval
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_GetExtCalRecommendedInterval was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_GetExtCalRecommendedInterval_cfunc = self._get_library_function('niDCPower_GetExtCalRecommendedInterval')
                 self.niDCPower_GetExtCalRecommendedInterval_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDCPower_GetExtCalRecommendedInterval_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetExtCalRecommendedInterval_cfunc(vi, months)
@@ -362,12 +260,7 @@ class Library(object):
     def niDCPower_GetSelfCalLastDateAndTime(self, vi, year, month, day, hour, minute):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_GetSelfCalLastDateAndTime_cfunc is None:
-                try:
-                    self.niDCPower_GetSelfCalLastDateAndTime_cfunc = self._library.niDCPower_GetSelfCalLastDateAndTime
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_GetSelfCalLastDateAndTime was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_GetSelfCalLastDateAndTime_cfunc = self._get_library_function('niDCPower_GetSelfCalLastDateAndTime')
                 self.niDCPower_GetSelfCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDCPower_GetSelfCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetSelfCalLastDateAndTime_cfunc(vi, year, month, day, hour, minute)
@@ -375,12 +268,7 @@ class Library(object):
     def niDCPower_GetSelfCalLastTemp(self, vi, temperature):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_GetSelfCalLastTemp_cfunc is None:
-                try:
-                    self.niDCPower_GetSelfCalLastTemp_cfunc = self._library.niDCPower_GetSelfCalLastTemp
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_GetSelfCalLastTemp was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_GetSelfCalLastTemp_cfunc = self._get_library_function('niDCPower_GetSelfCalLastTemp')
                 self.niDCPower_GetSelfCalLastTemp_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_GetSelfCalLastTemp_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetSelfCalLastTemp_cfunc(vi, temperature)
@@ -388,12 +276,7 @@ class Library(object):
     def niDCPower_ImportAttributeConfigurationBuffer(self, vi, size, configuration):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_ImportAttributeConfigurationBuffer_cfunc is None:
-                try:
-                    self.niDCPower_ImportAttributeConfigurationBuffer_cfunc = self._library.niDCPower_ImportAttributeConfigurationBuffer
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_ImportAttributeConfigurationBuffer was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_ImportAttributeConfigurationBuffer_cfunc = self._get_library_function('niDCPower_ImportAttributeConfigurationBuffer')
                 self.niDCPower_ImportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niDCPower_ImportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ImportAttributeConfigurationBuffer_cfunc(vi, size, configuration)
@@ -401,12 +284,7 @@ class Library(object):
     def niDCPower_ImportAttributeConfigurationFile(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_ImportAttributeConfigurationFile_cfunc is None:
-                try:
-                    self.niDCPower_ImportAttributeConfigurationFile_cfunc = self._library.niDCPower_ImportAttributeConfigurationFile
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_ImportAttributeConfigurationFile was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_ImportAttributeConfigurationFile_cfunc = self._get_library_function('niDCPower_ImportAttributeConfigurationFile')
                 self.niDCPower_ImportAttributeConfigurationFile_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_ImportAttributeConfigurationFile_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ImportAttributeConfigurationFile_cfunc(vi, file_path)
@@ -414,12 +292,7 @@ class Library(object):
     def niDCPower_InitializeWithChannels(self, resource_name, channels, reset, option_string, vi):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_InitializeWithChannels_cfunc is None:
-                try:
-                    self.niDCPower_InitializeWithChannels_cfunc = self._library.niDCPower_InitializeWithChannels
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_InitializeWithChannels was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_InitializeWithChannels_cfunc = self._get_library_function('niDCPower_InitializeWithChannels')
                 self.niDCPower_InitializeWithChannels_cfunc.argtypes = [ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViBoolean, ctypes.POINTER(ViChar), ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niDCPower_InitializeWithChannels_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_InitializeWithChannels_cfunc(resource_name, channels, reset, option_string, vi)
@@ -427,12 +300,7 @@ class Library(object):
     def niDCPower_Initiate(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_Initiate_cfunc is None:
-                try:
-                    self.niDCPower_Initiate_cfunc = self._library.niDCPower_Initiate
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_Initiate was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_Initiate_cfunc = self._get_library_function('niDCPower_Initiate')
                 self.niDCPower_Initiate_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_Initiate_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_Initiate_cfunc(vi)
@@ -440,12 +308,7 @@ class Library(object):
     def niDCPower_LockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_LockSession_cfunc is None:
-                try:
-                    self.niDCPower_LockSession_cfunc = self._library.niDCPower_LockSession
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_LockSession was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_LockSession_cfunc = self._get_library_function('niDCPower_LockSession')
                 self.niDCPower_LockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDCPower_LockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_LockSession_cfunc(vi, caller_has_lock)
@@ -453,12 +316,7 @@ class Library(object):
     def niDCPower_Measure(self, vi, channel_name, measurement_type, measurement):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_Measure_cfunc is None:
-                try:
-                    self.niDCPower_Measure_cfunc = self._library.niDCPower_Measure
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_Measure was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_Measure_cfunc = self._get_library_function('niDCPower_Measure')
                 self.niDCPower_Measure_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_Measure_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_Measure_cfunc(vi, channel_name, measurement_type, measurement)
@@ -466,12 +324,7 @@ class Library(object):
     def niDCPower_MeasureMultiple(self, vi, channel_name, voltage_measurements, current_measurements):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_MeasureMultiple_cfunc is None:
-                try:
-                    self.niDCPower_MeasureMultiple_cfunc = self._library.niDCPower_MeasureMultiple
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_MeasureMultiple was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_MeasureMultiple_cfunc = self._get_library_function('niDCPower_MeasureMultiple')
                 self.niDCPower_MeasureMultiple_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_MeasureMultiple_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_MeasureMultiple_cfunc(vi, channel_name, voltage_measurements, current_measurements)
@@ -479,12 +332,7 @@ class Library(object):
     def niDCPower_ParseChannelCount(self, vi, channels_string, number_of_channels):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_ParseChannelCount_cfunc is None:
-                try:
-                    self.niDCPower_ParseChannelCount_cfunc = self._library.niDCPower_ParseChannelCount
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_ParseChannelCount was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_ParseChannelCount_cfunc = self._get_library_function('niDCPower_ParseChannelCount')
                 self.niDCPower_ParseChannelCount_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViUInt32)]  # noqa: F405
                 self.niDCPower_ParseChannelCount_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ParseChannelCount_cfunc(vi, channels_string, number_of_channels)
@@ -492,12 +340,7 @@ class Library(object):
     def niDCPower_QueryInCompliance(self, vi, channel_name, in_compliance):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_QueryInCompliance_cfunc is None:
-                try:
-                    self.niDCPower_QueryInCompliance_cfunc = self._library.niDCPower_QueryInCompliance
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_QueryInCompliance was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_QueryInCompliance_cfunc = self._get_library_function('niDCPower_QueryInCompliance')
                 self.niDCPower_QueryInCompliance_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDCPower_QueryInCompliance_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_QueryInCompliance_cfunc(vi, channel_name, in_compliance)
@@ -505,12 +348,7 @@ class Library(object):
     def niDCPower_QueryLatchedOutputCutoffState(self, vi, channel_name, output_cutoff_reason, output_cutoff_state):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_QueryLatchedOutputCutoffState_cfunc is None:
-                try:
-                    self.niDCPower_QueryLatchedOutputCutoffState_cfunc = self._library.niDCPower_QueryLatchedOutputCutoffState
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_QueryLatchedOutputCutoffState was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_QueryLatchedOutputCutoffState_cfunc = self._get_library_function('niDCPower_QueryLatchedOutputCutoffState')
                 self.niDCPower_QueryLatchedOutputCutoffState_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDCPower_QueryLatchedOutputCutoffState_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_QueryLatchedOutputCutoffState_cfunc(vi, channel_name, output_cutoff_reason, output_cutoff_state)
@@ -518,12 +356,7 @@ class Library(object):
     def niDCPower_QueryMaxCurrentLimit(self, vi, channel_name, voltage_level, max_current_limit):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_QueryMaxCurrentLimit_cfunc is None:
-                try:
-                    self.niDCPower_QueryMaxCurrentLimit_cfunc = self._library.niDCPower_QueryMaxCurrentLimit
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_QueryMaxCurrentLimit was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_QueryMaxCurrentLimit_cfunc = self._get_library_function('niDCPower_QueryMaxCurrentLimit')
                 self.niDCPower_QueryMaxCurrentLimit_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_QueryMaxCurrentLimit_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_QueryMaxCurrentLimit_cfunc(vi, channel_name, voltage_level, max_current_limit)
@@ -531,12 +364,7 @@ class Library(object):
     def niDCPower_QueryMaxVoltageLevel(self, vi, channel_name, current_limit, max_voltage_level):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_QueryMaxVoltageLevel_cfunc is None:
-                try:
-                    self.niDCPower_QueryMaxVoltageLevel_cfunc = self._library.niDCPower_QueryMaxVoltageLevel
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_QueryMaxVoltageLevel was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_QueryMaxVoltageLevel_cfunc = self._get_library_function('niDCPower_QueryMaxVoltageLevel')
                 self.niDCPower_QueryMaxVoltageLevel_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_QueryMaxVoltageLevel_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_QueryMaxVoltageLevel_cfunc(vi, channel_name, current_limit, max_voltage_level)
@@ -544,12 +372,7 @@ class Library(object):
     def niDCPower_QueryMinCurrentLimit(self, vi, channel_name, voltage_level, min_current_limit):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_QueryMinCurrentLimit_cfunc is None:
-                try:
-                    self.niDCPower_QueryMinCurrentLimit_cfunc = self._library.niDCPower_QueryMinCurrentLimit
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_QueryMinCurrentLimit was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_QueryMinCurrentLimit_cfunc = self._get_library_function('niDCPower_QueryMinCurrentLimit')
                 self.niDCPower_QueryMinCurrentLimit_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_QueryMinCurrentLimit_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_QueryMinCurrentLimit_cfunc(vi, channel_name, voltage_level, min_current_limit)
@@ -557,12 +380,7 @@ class Library(object):
     def niDCPower_QueryOutputState(self, vi, channel_name, output_state, in_state):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_QueryOutputState_cfunc is None:
-                try:
-                    self.niDCPower_QueryOutputState_cfunc = self._library.niDCPower_QueryOutputState
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_QueryOutputState was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_QueryOutputState_cfunc = self._get_library_function('niDCPower_QueryOutputState')
                 self.niDCPower_QueryOutputState_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDCPower_QueryOutputState_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_QueryOutputState_cfunc(vi, channel_name, output_state, in_state)
@@ -570,12 +388,7 @@ class Library(object):
     def niDCPower_ReadCurrentTemperature(self, vi, temperature):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_ReadCurrentTemperature_cfunc is None:
-                try:
-                    self.niDCPower_ReadCurrentTemperature_cfunc = self._library.niDCPower_ReadCurrentTemperature
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_ReadCurrentTemperature was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_ReadCurrentTemperature_cfunc = self._get_library_function('niDCPower_ReadCurrentTemperature')
                 self.niDCPower_ReadCurrentTemperature_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_ReadCurrentTemperature_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ReadCurrentTemperature_cfunc(vi, temperature)
@@ -583,12 +396,7 @@ class Library(object):
     def niDCPower_ResetDevice(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_ResetDevice_cfunc is None:
-                try:
-                    self.niDCPower_ResetDevice_cfunc = self._library.niDCPower_ResetDevice
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_ResetDevice was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_ResetDevice_cfunc = self._get_library_function('niDCPower_ResetDevice')
                 self.niDCPower_ResetDevice_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_ResetDevice_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ResetDevice_cfunc(vi)
@@ -596,12 +404,7 @@ class Library(object):
     def niDCPower_ResetWithDefaults(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_ResetWithDefaults_cfunc is None:
-                try:
-                    self.niDCPower_ResetWithDefaults_cfunc = self._library.niDCPower_ResetWithDefaults
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_ResetWithDefaults was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_ResetWithDefaults_cfunc = self._get_library_function('niDCPower_ResetWithDefaults')
                 self.niDCPower_ResetWithDefaults_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_ResetWithDefaults_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ResetWithDefaults_cfunc(vi)
@@ -609,12 +412,7 @@ class Library(object):
     def niDCPower_SendSoftwareEdgeTrigger(self, vi, trigger):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_SendSoftwareEdgeTrigger_cfunc is None:
-                try:
-                    self.niDCPower_SendSoftwareEdgeTrigger_cfunc = self._library.niDCPower_SendSoftwareEdgeTrigger
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_SendSoftwareEdgeTrigger was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_SendSoftwareEdgeTrigger_cfunc = self._get_library_function('niDCPower_SendSoftwareEdgeTrigger')
                 self.niDCPower_SendSoftwareEdgeTrigger_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niDCPower_SendSoftwareEdgeTrigger_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_SendSoftwareEdgeTrigger_cfunc(vi, trigger)
@@ -622,12 +420,7 @@ class Library(object):
     def niDCPower_SetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_SetAttributeViBoolean_cfunc is None:
-                try:
-                    self.niDCPower_SetAttributeViBoolean_cfunc = self._library.niDCPower_SetAttributeViBoolean
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_SetAttributeViBoolean was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_SetAttributeViBoolean_cfunc = self._get_library_function('niDCPower_SetAttributeViBoolean')
                 self.niDCPower_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViBoolean]  # noqa: F405
                 self.niDCPower_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_SetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -635,12 +428,7 @@ class Library(object):
     def niDCPower_SetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_SetAttributeViInt32_cfunc is None:
-                try:
-                    self.niDCPower_SetAttributeViInt32_cfunc = self._library.niDCPower_SetAttributeViInt32
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_SetAttributeViInt32 was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_SetAttributeViInt32_cfunc = self._get_library_function('niDCPower_SetAttributeViInt32')
                 self.niDCPower_SetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32]  # noqa: F405
                 self.niDCPower_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_SetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -648,12 +436,7 @@ class Library(object):
     def niDCPower_SetAttributeViInt64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_SetAttributeViInt64_cfunc is None:
-                try:
-                    self.niDCPower_SetAttributeViInt64_cfunc = self._library.niDCPower_SetAttributeViInt64
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_SetAttributeViInt64 was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_SetAttributeViInt64_cfunc = self._get_library_function('niDCPower_SetAttributeViInt64')
                 self.niDCPower_SetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt64]  # noqa: F405
                 self.niDCPower_SetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_SetAttributeViInt64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -661,12 +444,7 @@ class Library(object):
     def niDCPower_SetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_SetAttributeViReal64_cfunc is None:
-                try:
-                    self.niDCPower_SetAttributeViReal64_cfunc = self._library.niDCPower_SetAttributeViReal64
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_SetAttributeViReal64 was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_SetAttributeViReal64_cfunc = self._get_library_function('niDCPower_SetAttributeViReal64')
                 self.niDCPower_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niDCPower_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_SetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -674,12 +452,7 @@ class Library(object):
     def niDCPower_SetAttributeViString(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_SetAttributeViString_cfunc is None:
-                try:
-                    self.niDCPower_SetAttributeViString_cfunc = self._library.niDCPower_SetAttributeViString
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_SetAttributeViString was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_SetAttributeViString_cfunc = self._get_library_function('niDCPower_SetAttributeViString')
                 self.niDCPower_SetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_SetAttributeViString_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -687,12 +460,7 @@ class Library(object):
     def niDCPower_SetSequence(self, vi, channel_name, values, source_delays, size):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_SetSequence_cfunc is None:
-                try:
-                    self.niDCPower_SetSequence_cfunc = self._library.niDCPower_SetSequence
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_SetSequence was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_SetSequence_cfunc = self._get_library_function('niDCPower_SetSequence')
                 self.niDCPower_SetSequence_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ViUInt32]  # noqa: F405
                 self.niDCPower_SetSequence_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_SetSequence_cfunc(vi, channel_name, values, source_delays, size)
@@ -700,12 +468,7 @@ class Library(object):
     def niDCPower_UnlockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_UnlockSession_cfunc is None:
-                try:
-                    self.niDCPower_UnlockSession_cfunc = self._library.niDCPower_UnlockSession
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_UnlockSession was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_UnlockSession_cfunc = self._get_library_function('niDCPower_UnlockSession')
                 self.niDCPower_UnlockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDCPower_UnlockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_UnlockSession_cfunc(vi, caller_has_lock)
@@ -713,12 +476,7 @@ class Library(object):
     def niDCPower_WaitForEvent(self, vi, event_id, timeout):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_WaitForEvent_cfunc is None:
-                try:
-                    self.niDCPower_WaitForEvent_cfunc = self._library.niDCPower_WaitForEvent
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_WaitForEvent was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_WaitForEvent_cfunc = self._get_library_function('niDCPower_WaitForEvent')
                 self.niDCPower_WaitForEvent_cfunc.argtypes = [ViSession, ViInt32, ViReal64]  # noqa: F405
                 self.niDCPower_WaitForEvent_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_WaitForEvent_cfunc(vi, event_id, timeout)
@@ -726,12 +484,7 @@ class Library(object):
     def niDCPower_close(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_close_cfunc is None:
-                try:
-                    self.niDCPower_close_cfunc = self._library.niDCPower_close
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_close was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_close_cfunc = self._get_library_function('niDCPower_close')
                 self.niDCPower_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_close_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_close_cfunc(vi)
@@ -739,12 +492,7 @@ class Library(object):
     def niDCPower_error_message(self, vi, error_code, error_message):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_error_message_cfunc is None:
-                try:
-                    self.niDCPower_error_message_cfunc = self._library.niDCPower_error_message
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_error_message was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_error_message_cfunc = self._get_library_function('niDCPower_error_message')
                 self.niDCPower_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_error_message_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_error_message_cfunc(vi, error_code, error_message)
@@ -752,12 +500,7 @@ class Library(object):
     def niDCPower_reset(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_reset_cfunc is None:
-                try:
-                    self.niDCPower_reset_cfunc = self._library.niDCPower_reset
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_reset was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_reset_cfunc = self._get_library_function('niDCPower_reset')
                 self.niDCPower_reset_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_reset_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_reset_cfunc(vi)
@@ -765,12 +508,7 @@ class Library(object):
     def niDCPower_self_test(self, vi, self_test_result, self_test_message):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_self_test_cfunc is None:
-                try:
-                    self.niDCPower_self_test_cfunc = self._library.niDCPower_self_test
-                except AttributeError as e:
-                    raise AttributeError("Function niDCPower_self_test was not found in the NI-DCPower runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDCPower_self_test_cfunc = self._get_library_function('niDCPower_self_test')
                 self.niDCPower_self_test_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_self_test_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_self_test_cfunc(vi, self_test_result, self_test_message)

--- a/generated/nidcpower/nidcpower/_library.py
+++ b/generated/nidcpower/nidcpower/_library.py
@@ -76,7 +76,12 @@ class Library(object):
     def niDCPower_Abort(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_Abort_cfunc is None:
-                self.niDCPower_Abort_cfunc = self._library.niDCPower_Abort
+                try:
+                    self.niDCPower_Abort_cfunc = self._library.niDCPower_Abort
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_Abort_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_Abort_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_Abort_cfunc(vi)
@@ -84,7 +89,12 @@ class Library(object):
     def niDCPower_CalSelfCalibrate(self, vi, channel_name):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_CalSelfCalibrate_cfunc is None:
-                self.niDCPower_CalSelfCalibrate_cfunc = self._library.niDCPower_CalSelfCalibrate
+                try:
+                    self.niDCPower_CalSelfCalibrate_cfunc = self._library.niDCPower_CalSelfCalibrate
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_CalSelfCalibrate_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_CalSelfCalibrate_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_CalSelfCalibrate_cfunc(vi, channel_name)
@@ -92,7 +102,12 @@ class Library(object):
     def niDCPower_ClearLatchedOutputCutoffState(self, vi, channel_name, output_cutoff_reason):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_ClearLatchedOutputCutoffState_cfunc is None:
-                self.niDCPower_ClearLatchedOutputCutoffState_cfunc = self._library.niDCPower_ClearLatchedOutputCutoffState
+                try:
+                    self.niDCPower_ClearLatchedOutputCutoffState_cfunc = self._library.niDCPower_ClearLatchedOutputCutoffState
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_ClearLatchedOutputCutoffState_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niDCPower_ClearLatchedOutputCutoffState_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ClearLatchedOutputCutoffState_cfunc(vi, channel_name, output_cutoff_reason)
@@ -100,7 +115,12 @@ class Library(object):
     def niDCPower_Commit(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_Commit_cfunc is None:
-                self.niDCPower_Commit_cfunc = self._library.niDCPower_Commit
+                try:
+                    self.niDCPower_Commit_cfunc = self._library.niDCPower_Commit
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_Commit_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_Commit_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_Commit_cfunc(vi)
@@ -108,7 +128,12 @@ class Library(object):
     def niDCPower_ConfigureApertureTime(self, vi, channel_name, aperture_time, units):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_ConfigureApertureTime_cfunc is None:
-                self.niDCPower_ConfigureApertureTime_cfunc = self._library.niDCPower_ConfigureApertureTime
+                try:
+                    self.niDCPower_ConfigureApertureTime_cfunc = self._library.niDCPower_ConfigureApertureTime
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_ConfigureApertureTime_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32]  # noqa: F405
                 self.niDCPower_ConfigureApertureTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ConfigureApertureTime_cfunc(vi, channel_name, aperture_time, units)
@@ -116,7 +141,12 @@ class Library(object):
     def niDCPower_CreateAdvancedSequence(self, vi, sequence_name, attribute_id_count, attribute_ids, set_as_active_sequence):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_CreateAdvancedSequence_cfunc is None:
-                self.niDCPower_CreateAdvancedSequence_cfunc = self._library.niDCPower_CreateAdvancedSequence
+                try:
+                    self.niDCPower_CreateAdvancedSequence_cfunc = self._library.niDCPower_CreateAdvancedSequence
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_CreateAdvancedSequence_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt32), ViBoolean]  # noqa: F405
                 self.niDCPower_CreateAdvancedSequence_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_CreateAdvancedSequence_cfunc(vi, sequence_name, attribute_id_count, attribute_ids, set_as_active_sequence)
@@ -124,7 +154,12 @@ class Library(object):
     def niDCPower_CreateAdvancedSequenceStep(self, vi, set_as_active_step):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_CreateAdvancedSequenceStep_cfunc is None:
-                self.niDCPower_CreateAdvancedSequenceStep_cfunc = self._library.niDCPower_CreateAdvancedSequenceStep
+                try:
+                    self.niDCPower_CreateAdvancedSequenceStep_cfunc = self._library.niDCPower_CreateAdvancedSequenceStep
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_CreateAdvancedSequenceStep_cfunc.argtypes = [ViSession, ViBoolean]  # noqa: F405
                 self.niDCPower_CreateAdvancedSequenceStep_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_CreateAdvancedSequenceStep_cfunc(vi, set_as_active_step)
@@ -132,7 +167,12 @@ class Library(object):
     def niDCPower_DeleteAdvancedSequence(self, vi, sequence_name):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_DeleteAdvancedSequence_cfunc is None:
-                self.niDCPower_DeleteAdvancedSequence_cfunc = self._library.niDCPower_DeleteAdvancedSequence
+                try:
+                    self.niDCPower_DeleteAdvancedSequence_cfunc = self._library.niDCPower_DeleteAdvancedSequence
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_DeleteAdvancedSequence_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_DeleteAdvancedSequence_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_DeleteAdvancedSequence_cfunc(vi, sequence_name)
@@ -140,7 +180,12 @@ class Library(object):
     def niDCPower_Disable(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_Disable_cfunc is None:
-                self.niDCPower_Disable_cfunc = self._library.niDCPower_Disable
+                try:
+                    self.niDCPower_Disable_cfunc = self._library.niDCPower_Disable
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_Disable_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_Disable_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_Disable_cfunc(vi)
@@ -148,7 +193,12 @@ class Library(object):
     def niDCPower_ExportAttributeConfigurationBuffer(self, vi, size, configuration):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_ExportAttributeConfigurationBuffer_cfunc is None:
-                self.niDCPower_ExportAttributeConfigurationBuffer_cfunc = self._library.niDCPower_ExportAttributeConfigurationBuffer
+                try:
+                    self.niDCPower_ExportAttributeConfigurationBuffer_cfunc = self._library.niDCPower_ExportAttributeConfigurationBuffer
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_ExportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niDCPower_ExportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ExportAttributeConfigurationBuffer_cfunc(vi, size, configuration)
@@ -156,7 +206,12 @@ class Library(object):
     def niDCPower_ExportAttributeConfigurationFile(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_ExportAttributeConfigurationFile_cfunc is None:
-                self.niDCPower_ExportAttributeConfigurationFile_cfunc = self._library.niDCPower_ExportAttributeConfigurationFile
+                try:
+                    self.niDCPower_ExportAttributeConfigurationFile_cfunc = self._library.niDCPower_ExportAttributeConfigurationFile
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_ExportAttributeConfigurationFile_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_ExportAttributeConfigurationFile_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ExportAttributeConfigurationFile_cfunc(vi, file_path)
@@ -164,7 +219,12 @@ class Library(object):
     def niDCPower_FetchMultiple(self, vi, channel_name, timeout, count, voltage_measurements, current_measurements, in_compliance, actual_count):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_FetchMultiple_cfunc is None:
-                self.niDCPower_FetchMultiple_cfunc = self._library.niDCPower_FetchMultiple
+                try:
+                    self.niDCPower_FetchMultiple_cfunc = self._library.niDCPower_FetchMultiple
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_FetchMultiple_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViBoolean), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDCPower_FetchMultiple_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_FetchMultiple_cfunc(vi, channel_name, timeout, count, voltage_measurements, current_measurements, in_compliance, actual_count)
@@ -172,7 +232,12 @@ class Library(object):
     def niDCPower_GetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_GetAttributeViBoolean_cfunc is None:
-                self.niDCPower_GetAttributeViBoolean_cfunc = self._library.niDCPower_GetAttributeViBoolean
+                try:
+                    self.niDCPower_GetAttributeViBoolean_cfunc = self._library.niDCPower_GetAttributeViBoolean
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDCPower_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -180,7 +245,12 @@ class Library(object):
     def niDCPower_GetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_GetAttributeViInt32_cfunc is None:
-                self.niDCPower_GetAttributeViInt32_cfunc = self._library.niDCPower_GetAttributeViInt32
+                try:
+                    self.niDCPower_GetAttributeViInt32_cfunc = self._library.niDCPower_GetAttributeViInt32
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_GetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDCPower_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -188,7 +258,12 @@ class Library(object):
     def niDCPower_GetAttributeViInt64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_GetAttributeViInt64_cfunc is None:
-                self.niDCPower_GetAttributeViInt64_cfunc = self._library.niDCPower_GetAttributeViInt64
+                try:
+                    self.niDCPower_GetAttributeViInt64_cfunc = self._library.niDCPower_GetAttributeViInt64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_GetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt64)]  # noqa: F405
                 self.niDCPower_GetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetAttributeViInt64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -196,7 +271,12 @@ class Library(object):
     def niDCPower_GetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_GetAttributeViReal64_cfunc is None:
-                self.niDCPower_GetAttributeViReal64_cfunc = self._library.niDCPower_GetAttributeViReal64
+                try:
+                    self.niDCPower_GetAttributeViReal64_cfunc = self._library.niDCPower_GetAttributeViReal64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_GetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -204,7 +284,12 @@ class Library(object):
     def niDCPower_GetAttributeViString(self, vi, channel_name, attribute_id, buffer_size, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_GetAttributeViString_cfunc is None:
-                self.niDCPower_GetAttributeViString_cfunc = self._library.niDCPower_GetAttributeViString
+                try:
+                    self.niDCPower_GetAttributeViString_cfunc = self._library.niDCPower_GetAttributeViString
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetAttributeViString_cfunc(vi, channel_name, attribute_id, buffer_size, attribute_value)
@@ -212,7 +297,12 @@ class Library(object):
     def niDCPower_GetChannelName(self, vi, index, buffer_size, channel_name):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_GetChannelName_cfunc is None:
-                self.niDCPower_GetChannelName_cfunc = self._library.niDCPower_GetChannelName
+                try:
+                    self.niDCPower_GetChannelName_cfunc = self._library.niDCPower_GetChannelName
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_GetChannelName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_GetChannelName_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetChannelName_cfunc(vi, index, buffer_size, channel_name)
@@ -220,7 +310,12 @@ class Library(object):
     def niDCPower_GetError(self, vi, code, buffer_size, description):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_GetError_cfunc is None:
-                self.niDCPower_GetError_cfunc = self._library.niDCPower_GetError
+                try:
+                    self.niDCPower_GetError_cfunc = self._library.niDCPower_GetError
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_GetError_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetError_cfunc(vi, code, buffer_size, description)
@@ -228,7 +323,12 @@ class Library(object):
     def niDCPower_GetExtCalLastDateAndTime(self, vi, year, month, day, hour, minute):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_GetExtCalLastDateAndTime_cfunc is None:
-                self.niDCPower_GetExtCalLastDateAndTime_cfunc = self._library.niDCPower_GetExtCalLastDateAndTime
+                try:
+                    self.niDCPower_GetExtCalLastDateAndTime_cfunc = self._library.niDCPower_GetExtCalLastDateAndTime
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_GetExtCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDCPower_GetExtCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetExtCalLastDateAndTime_cfunc(vi, year, month, day, hour, minute)
@@ -236,7 +336,12 @@ class Library(object):
     def niDCPower_GetExtCalLastTemp(self, vi, temperature):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_GetExtCalLastTemp_cfunc is None:
-                self.niDCPower_GetExtCalLastTemp_cfunc = self._library.niDCPower_GetExtCalLastTemp
+                try:
+                    self.niDCPower_GetExtCalLastTemp_cfunc = self._library.niDCPower_GetExtCalLastTemp
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_GetExtCalLastTemp_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_GetExtCalLastTemp_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetExtCalLastTemp_cfunc(vi, temperature)
@@ -244,7 +349,12 @@ class Library(object):
     def niDCPower_GetExtCalRecommendedInterval(self, vi, months):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_GetExtCalRecommendedInterval_cfunc is None:
-                self.niDCPower_GetExtCalRecommendedInterval_cfunc = self._library.niDCPower_GetExtCalRecommendedInterval
+                try:
+                    self.niDCPower_GetExtCalRecommendedInterval_cfunc = self._library.niDCPower_GetExtCalRecommendedInterval
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_GetExtCalRecommendedInterval_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDCPower_GetExtCalRecommendedInterval_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetExtCalRecommendedInterval_cfunc(vi, months)
@@ -252,7 +362,12 @@ class Library(object):
     def niDCPower_GetSelfCalLastDateAndTime(self, vi, year, month, day, hour, minute):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_GetSelfCalLastDateAndTime_cfunc is None:
-                self.niDCPower_GetSelfCalLastDateAndTime_cfunc = self._library.niDCPower_GetSelfCalLastDateAndTime
+                try:
+                    self.niDCPower_GetSelfCalLastDateAndTime_cfunc = self._library.niDCPower_GetSelfCalLastDateAndTime
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_GetSelfCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDCPower_GetSelfCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetSelfCalLastDateAndTime_cfunc(vi, year, month, day, hour, minute)
@@ -260,7 +375,12 @@ class Library(object):
     def niDCPower_GetSelfCalLastTemp(self, vi, temperature):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_GetSelfCalLastTemp_cfunc is None:
-                self.niDCPower_GetSelfCalLastTemp_cfunc = self._library.niDCPower_GetSelfCalLastTemp
+                try:
+                    self.niDCPower_GetSelfCalLastTemp_cfunc = self._library.niDCPower_GetSelfCalLastTemp
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_GetSelfCalLastTemp_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_GetSelfCalLastTemp_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_GetSelfCalLastTemp_cfunc(vi, temperature)
@@ -268,7 +388,12 @@ class Library(object):
     def niDCPower_ImportAttributeConfigurationBuffer(self, vi, size, configuration):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_ImportAttributeConfigurationBuffer_cfunc is None:
-                self.niDCPower_ImportAttributeConfigurationBuffer_cfunc = self._library.niDCPower_ImportAttributeConfigurationBuffer
+                try:
+                    self.niDCPower_ImportAttributeConfigurationBuffer_cfunc = self._library.niDCPower_ImportAttributeConfigurationBuffer
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_ImportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niDCPower_ImportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ImportAttributeConfigurationBuffer_cfunc(vi, size, configuration)
@@ -276,7 +401,12 @@ class Library(object):
     def niDCPower_ImportAttributeConfigurationFile(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_ImportAttributeConfigurationFile_cfunc is None:
-                self.niDCPower_ImportAttributeConfigurationFile_cfunc = self._library.niDCPower_ImportAttributeConfigurationFile
+                try:
+                    self.niDCPower_ImportAttributeConfigurationFile_cfunc = self._library.niDCPower_ImportAttributeConfigurationFile
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_ImportAttributeConfigurationFile_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_ImportAttributeConfigurationFile_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ImportAttributeConfigurationFile_cfunc(vi, file_path)
@@ -284,7 +414,12 @@ class Library(object):
     def niDCPower_InitializeWithChannels(self, resource_name, channels, reset, option_string, vi):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_InitializeWithChannels_cfunc is None:
-                self.niDCPower_InitializeWithChannels_cfunc = self._library.niDCPower_InitializeWithChannels
+                try:
+                    self.niDCPower_InitializeWithChannels_cfunc = self._library.niDCPower_InitializeWithChannels
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_InitializeWithChannels_cfunc.argtypes = [ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViBoolean, ctypes.POINTER(ViChar), ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niDCPower_InitializeWithChannels_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_InitializeWithChannels_cfunc(resource_name, channels, reset, option_string, vi)
@@ -292,7 +427,12 @@ class Library(object):
     def niDCPower_Initiate(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_Initiate_cfunc is None:
-                self.niDCPower_Initiate_cfunc = self._library.niDCPower_Initiate
+                try:
+                    self.niDCPower_Initiate_cfunc = self._library.niDCPower_Initiate
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_Initiate_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_Initiate_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_Initiate_cfunc(vi)
@@ -300,7 +440,12 @@ class Library(object):
     def niDCPower_LockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_LockSession_cfunc is None:
-                self.niDCPower_LockSession_cfunc = self._library.niDCPower_LockSession
+                try:
+                    self.niDCPower_LockSession_cfunc = self._library.niDCPower_LockSession
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_LockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDCPower_LockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_LockSession_cfunc(vi, caller_has_lock)
@@ -308,7 +453,12 @@ class Library(object):
     def niDCPower_Measure(self, vi, channel_name, measurement_type, measurement):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_Measure_cfunc is None:
-                self.niDCPower_Measure_cfunc = self._library.niDCPower_Measure
+                try:
+                    self.niDCPower_Measure_cfunc = self._library.niDCPower_Measure
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_Measure_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_Measure_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_Measure_cfunc(vi, channel_name, measurement_type, measurement)
@@ -316,7 +466,12 @@ class Library(object):
     def niDCPower_MeasureMultiple(self, vi, channel_name, voltage_measurements, current_measurements):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_MeasureMultiple_cfunc is None:
-                self.niDCPower_MeasureMultiple_cfunc = self._library.niDCPower_MeasureMultiple
+                try:
+                    self.niDCPower_MeasureMultiple_cfunc = self._library.niDCPower_MeasureMultiple
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_MeasureMultiple_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_MeasureMultiple_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_MeasureMultiple_cfunc(vi, channel_name, voltage_measurements, current_measurements)
@@ -324,7 +479,12 @@ class Library(object):
     def niDCPower_ParseChannelCount(self, vi, channels_string, number_of_channels):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_ParseChannelCount_cfunc is None:
-                self.niDCPower_ParseChannelCount_cfunc = self._library.niDCPower_ParseChannelCount
+                try:
+                    self.niDCPower_ParseChannelCount_cfunc = self._library.niDCPower_ParseChannelCount
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_ParseChannelCount_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViUInt32)]  # noqa: F405
                 self.niDCPower_ParseChannelCount_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ParseChannelCount_cfunc(vi, channels_string, number_of_channels)
@@ -332,7 +492,12 @@ class Library(object):
     def niDCPower_QueryInCompliance(self, vi, channel_name, in_compliance):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_QueryInCompliance_cfunc is None:
-                self.niDCPower_QueryInCompliance_cfunc = self._library.niDCPower_QueryInCompliance
+                try:
+                    self.niDCPower_QueryInCompliance_cfunc = self._library.niDCPower_QueryInCompliance
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_QueryInCompliance_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDCPower_QueryInCompliance_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_QueryInCompliance_cfunc(vi, channel_name, in_compliance)
@@ -340,7 +505,12 @@ class Library(object):
     def niDCPower_QueryLatchedOutputCutoffState(self, vi, channel_name, output_cutoff_reason, output_cutoff_state):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_QueryLatchedOutputCutoffState_cfunc is None:
-                self.niDCPower_QueryLatchedOutputCutoffState_cfunc = self._library.niDCPower_QueryLatchedOutputCutoffState
+                try:
+                    self.niDCPower_QueryLatchedOutputCutoffState_cfunc = self._library.niDCPower_QueryLatchedOutputCutoffState
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_QueryLatchedOutputCutoffState_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDCPower_QueryLatchedOutputCutoffState_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_QueryLatchedOutputCutoffState_cfunc(vi, channel_name, output_cutoff_reason, output_cutoff_state)
@@ -348,7 +518,12 @@ class Library(object):
     def niDCPower_QueryMaxCurrentLimit(self, vi, channel_name, voltage_level, max_current_limit):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_QueryMaxCurrentLimit_cfunc is None:
-                self.niDCPower_QueryMaxCurrentLimit_cfunc = self._library.niDCPower_QueryMaxCurrentLimit
+                try:
+                    self.niDCPower_QueryMaxCurrentLimit_cfunc = self._library.niDCPower_QueryMaxCurrentLimit
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_QueryMaxCurrentLimit_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_QueryMaxCurrentLimit_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_QueryMaxCurrentLimit_cfunc(vi, channel_name, voltage_level, max_current_limit)
@@ -356,7 +531,12 @@ class Library(object):
     def niDCPower_QueryMaxVoltageLevel(self, vi, channel_name, current_limit, max_voltage_level):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_QueryMaxVoltageLevel_cfunc is None:
-                self.niDCPower_QueryMaxVoltageLevel_cfunc = self._library.niDCPower_QueryMaxVoltageLevel
+                try:
+                    self.niDCPower_QueryMaxVoltageLevel_cfunc = self._library.niDCPower_QueryMaxVoltageLevel
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_QueryMaxVoltageLevel_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_QueryMaxVoltageLevel_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_QueryMaxVoltageLevel_cfunc(vi, channel_name, current_limit, max_voltage_level)
@@ -364,7 +544,12 @@ class Library(object):
     def niDCPower_QueryMinCurrentLimit(self, vi, channel_name, voltage_level, min_current_limit):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_QueryMinCurrentLimit_cfunc is None:
-                self.niDCPower_QueryMinCurrentLimit_cfunc = self._library.niDCPower_QueryMinCurrentLimit
+                try:
+                    self.niDCPower_QueryMinCurrentLimit_cfunc = self._library.niDCPower_QueryMinCurrentLimit
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_QueryMinCurrentLimit_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_QueryMinCurrentLimit_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_QueryMinCurrentLimit_cfunc(vi, channel_name, voltage_level, min_current_limit)
@@ -372,7 +557,12 @@ class Library(object):
     def niDCPower_QueryOutputState(self, vi, channel_name, output_state, in_state):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_QueryOutputState_cfunc is None:
-                self.niDCPower_QueryOutputState_cfunc = self._library.niDCPower_QueryOutputState
+                try:
+                    self.niDCPower_QueryOutputState_cfunc = self._library.niDCPower_QueryOutputState
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_QueryOutputState_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDCPower_QueryOutputState_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_QueryOutputState_cfunc(vi, channel_name, output_state, in_state)
@@ -380,7 +570,12 @@ class Library(object):
     def niDCPower_ReadCurrentTemperature(self, vi, temperature):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_ReadCurrentTemperature_cfunc is None:
-                self.niDCPower_ReadCurrentTemperature_cfunc = self._library.niDCPower_ReadCurrentTemperature
+                try:
+                    self.niDCPower_ReadCurrentTemperature_cfunc = self._library.niDCPower_ReadCurrentTemperature
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_ReadCurrentTemperature_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDCPower_ReadCurrentTemperature_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ReadCurrentTemperature_cfunc(vi, temperature)
@@ -388,7 +583,12 @@ class Library(object):
     def niDCPower_ResetDevice(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_ResetDevice_cfunc is None:
-                self.niDCPower_ResetDevice_cfunc = self._library.niDCPower_ResetDevice
+                try:
+                    self.niDCPower_ResetDevice_cfunc = self._library.niDCPower_ResetDevice
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_ResetDevice_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_ResetDevice_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ResetDevice_cfunc(vi)
@@ -396,7 +596,12 @@ class Library(object):
     def niDCPower_ResetWithDefaults(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_ResetWithDefaults_cfunc is None:
-                self.niDCPower_ResetWithDefaults_cfunc = self._library.niDCPower_ResetWithDefaults
+                try:
+                    self.niDCPower_ResetWithDefaults_cfunc = self._library.niDCPower_ResetWithDefaults
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_ResetWithDefaults_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_ResetWithDefaults_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_ResetWithDefaults_cfunc(vi)
@@ -404,7 +609,12 @@ class Library(object):
     def niDCPower_SendSoftwareEdgeTrigger(self, vi, trigger):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_SendSoftwareEdgeTrigger_cfunc is None:
-                self.niDCPower_SendSoftwareEdgeTrigger_cfunc = self._library.niDCPower_SendSoftwareEdgeTrigger
+                try:
+                    self.niDCPower_SendSoftwareEdgeTrigger_cfunc = self._library.niDCPower_SendSoftwareEdgeTrigger
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_SendSoftwareEdgeTrigger_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niDCPower_SendSoftwareEdgeTrigger_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_SendSoftwareEdgeTrigger_cfunc(vi, trigger)
@@ -412,7 +622,12 @@ class Library(object):
     def niDCPower_SetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_SetAttributeViBoolean_cfunc is None:
-                self.niDCPower_SetAttributeViBoolean_cfunc = self._library.niDCPower_SetAttributeViBoolean
+                try:
+                    self.niDCPower_SetAttributeViBoolean_cfunc = self._library.niDCPower_SetAttributeViBoolean
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViBoolean]  # noqa: F405
                 self.niDCPower_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_SetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -420,7 +635,12 @@ class Library(object):
     def niDCPower_SetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_SetAttributeViInt32_cfunc is None:
-                self.niDCPower_SetAttributeViInt32_cfunc = self._library.niDCPower_SetAttributeViInt32
+                try:
+                    self.niDCPower_SetAttributeViInt32_cfunc = self._library.niDCPower_SetAttributeViInt32
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_SetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32]  # noqa: F405
                 self.niDCPower_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_SetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -428,7 +648,12 @@ class Library(object):
     def niDCPower_SetAttributeViInt64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_SetAttributeViInt64_cfunc is None:
-                self.niDCPower_SetAttributeViInt64_cfunc = self._library.niDCPower_SetAttributeViInt64
+                try:
+                    self.niDCPower_SetAttributeViInt64_cfunc = self._library.niDCPower_SetAttributeViInt64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_SetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt64]  # noqa: F405
                 self.niDCPower_SetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_SetAttributeViInt64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -436,7 +661,12 @@ class Library(object):
     def niDCPower_SetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_SetAttributeViReal64_cfunc is None:
-                self.niDCPower_SetAttributeViReal64_cfunc = self._library.niDCPower_SetAttributeViReal64
+                try:
+                    self.niDCPower_SetAttributeViReal64_cfunc = self._library.niDCPower_SetAttributeViReal64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niDCPower_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_SetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -444,7 +674,12 @@ class Library(object):
     def niDCPower_SetAttributeViString(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_SetAttributeViString_cfunc is None:
-                self.niDCPower_SetAttributeViString_cfunc = self._library.niDCPower_SetAttributeViString
+                try:
+                    self.niDCPower_SetAttributeViString_cfunc = self._library.niDCPower_SetAttributeViString
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_SetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_SetAttributeViString_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -452,7 +687,12 @@ class Library(object):
     def niDCPower_SetSequence(self, vi, channel_name, values, source_delays, size):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_SetSequence_cfunc is None:
-                self.niDCPower_SetSequence_cfunc = self._library.niDCPower_SetSequence
+                try:
+                    self.niDCPower_SetSequence_cfunc = self._library.niDCPower_SetSequence
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_SetSequence_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ViUInt32]  # noqa: F405
                 self.niDCPower_SetSequence_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_SetSequence_cfunc(vi, channel_name, values, source_delays, size)
@@ -460,7 +700,12 @@ class Library(object):
     def niDCPower_UnlockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_UnlockSession_cfunc is None:
-                self.niDCPower_UnlockSession_cfunc = self._library.niDCPower_UnlockSession
+                try:
+                    self.niDCPower_UnlockSession_cfunc = self._library.niDCPower_UnlockSession
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_UnlockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDCPower_UnlockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_UnlockSession_cfunc(vi, caller_has_lock)
@@ -468,7 +713,12 @@ class Library(object):
     def niDCPower_WaitForEvent(self, vi, event_id, timeout):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_WaitForEvent_cfunc is None:
-                self.niDCPower_WaitForEvent_cfunc = self._library.niDCPower_WaitForEvent
+                try:
+                    self.niDCPower_WaitForEvent_cfunc = self._library.niDCPower_WaitForEvent
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_WaitForEvent_cfunc.argtypes = [ViSession, ViInt32, ViReal64]  # noqa: F405
                 self.niDCPower_WaitForEvent_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_WaitForEvent_cfunc(vi, event_id, timeout)
@@ -476,7 +726,12 @@ class Library(object):
     def niDCPower_close(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_close_cfunc is None:
-                self.niDCPower_close_cfunc = self._library.niDCPower_close
+                try:
+                    self.niDCPower_close_cfunc = self._library.niDCPower_close
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_close_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_close_cfunc(vi)
@@ -484,7 +739,12 @@ class Library(object):
     def niDCPower_error_message(self, vi, error_code, error_message):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_error_message_cfunc is None:
-                self.niDCPower_error_message_cfunc = self._library.niDCPower_error_message
+                try:
+                    self.niDCPower_error_message_cfunc = self._library.niDCPower_error_message
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_error_message_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_error_message_cfunc(vi, error_code, error_message)
@@ -492,7 +752,12 @@ class Library(object):
     def niDCPower_reset(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_reset_cfunc is None:
-                self.niDCPower_reset_cfunc = self._library.niDCPower_reset
+                try:
+                    self.niDCPower_reset_cfunc = self._library.niDCPower_reset
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_reset_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDCPower_reset_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_reset_cfunc(vi)
@@ -500,7 +765,12 @@ class Library(object):
     def niDCPower_self_test(self, vi, self_test_result, self_test_message):  # noqa: N802
         with self._func_lock:
             if self.niDCPower_self_test_cfunc is None:
-                self.niDCPower_self_test_cfunc = self._library.niDCPower_self_test
+                try:
+                    self.niDCPower_self_test_cfunc = self._library.niDCPower_self_test
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDCPower_self_test_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDCPower_self_test_cfunc.restype = ViStatus  # noqa: F405
         return self.niDCPower_self_test_cfunc(vi, self_test_result, self_test_message)

--- a/generated/nidcpower/nidcpower/errors.py
+++ b/generated/nidcpower/nidcpower/errors.py
@@ -57,6 +57,13 @@ class DriverNotInstalledError(Error):
         super(DriverNotInstalledError, self).__init__('The NI-DCPower runtime could not be loaded. Make sure it is installed and its bitness matches that of your Python interpreter. Please visit http://www.ni.com/downloads/drivers/ to download and install it.')
 
 
+class DriverTooOldError(Error):
+    '''An error due to using this module with an older version of the driver runtime.'''
+
+    def __init__(self):
+        super(DriverTooOldError, self).__init__('A function was not found in the NI-DCPower runtime. Please visit http://www.ni.com/downloads/drivers/ to download a newer version and install it.')
+
+
 class InvalidRepeatedCapabilityError(Error):
     '''An error due to an invalid character in a repeated capability'''
 

--- a/generated/nidigital/nidigital/_library.py
+++ b/generated/nidigital/nidigital/_library.py
@@ -116,7 +116,7 @@ class Library(object):
 
     def _get_library_function(self, name):
         try:
-            function = getattr(self._library, 'fred')
+            function = getattr(self._library, name)
         except AttributeError as e:
             raise errors.DriverTooOldError() from e
         return function

--- a/generated/nidigital/nidigital/_library.py
+++ b/generated/nidigital/nidigital/_library.py
@@ -119,9 +119,9 @@ class Library(object):
                 try:
                     self.niDigital_Abort_cfunc = self._library.niDigital_Abort
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_Abort was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_Abort_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_Abort_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_Abort_cfunc(vi)
@@ -132,9 +132,9 @@ class Library(object):
                 try:
                     self.niDigital_AbortKeepAlive_cfunc = self._library.niDigital_AbortKeepAlive
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_AbortKeepAlive was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_AbortKeepAlive_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_AbortKeepAlive_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_AbortKeepAlive_cfunc(vi)
@@ -145,9 +145,9 @@ class Library(object):
                 try:
                     self.niDigital_ApplyLevelsAndTiming_cfunc = self._library.niDigital_ApplyLevelsAndTiming
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_ApplyLevelsAndTiming was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_ApplyLevelsAndTiming_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_ApplyLevelsAndTiming_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ApplyLevelsAndTiming_cfunc(vi, site_list, levels_sheet, timing_sheet, initial_state_high_pins, initial_state_low_pins, initial_state_tristate_pins)
@@ -158,9 +158,9 @@ class Library(object):
                 try:
                     self.niDigital_ApplyTDROffsets_cfunc = self._library.niDigital_ApplyTDROffsets
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_ApplyTDROffsets was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_ApplyTDROffsets_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDigital_ApplyTDROffsets_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ApplyTDROffsets_cfunc(vi, channel_list, num_offsets, offsets)
@@ -171,9 +171,9 @@ class Library(object):
                 try:
                     self.niDigital_BurstPattern_cfunc = self._library.niDigital_BurstPattern
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_BurstPattern was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_BurstPattern_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViBoolean, ViBoolean, ViReal64]  # noqa: F405
                 self.niDigital_BurstPattern_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_BurstPattern_cfunc(vi, site_list, start_label, select_digital_function, wait_until_done, timeout)
@@ -184,9 +184,9 @@ class Library(object):
                 try:
                     self.niDigital_ClockGenerator_Abort_cfunc = self._library.niDigital_ClockGenerator_Abort
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_ClockGenerator_Abort was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_ClockGenerator_Abort_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_ClockGenerator_Abort_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ClockGenerator_Abort_cfunc(vi, channel_list)
@@ -197,9 +197,9 @@ class Library(object):
                 try:
                     self.niDigital_ClockGenerator_GenerateClock_cfunc = self._library.niDigital_ClockGenerator_GenerateClock
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_ClockGenerator_GenerateClock was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_ClockGenerator_GenerateClock_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViBoolean]  # noqa: F405
                 self.niDigital_ClockGenerator_GenerateClock_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ClockGenerator_GenerateClock_cfunc(vi, channel_list, frequency, select_digital_function)
@@ -210,9 +210,9 @@ class Library(object):
                 try:
                     self.niDigital_Commit_cfunc = self._library.niDigital_Commit
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_Commit was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_Commit_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_Commit_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_Commit_cfunc(vi)
@@ -223,9 +223,9 @@ class Library(object):
                 try:
                     self.niDigital_ConfigureActiveLoadLevels_cfunc = self._library.niDigital_ConfigureActiveLoadLevels
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_ConfigureActiveLoadLevels was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_ConfigureActiveLoadLevels_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niDigital_ConfigureActiveLoadLevels_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureActiveLoadLevels_cfunc(vi, channel_list, iol, ioh, vcom)
@@ -236,9 +236,9 @@ class Library(object):
                 try:
                     self.niDigital_ConfigurePatternBurstSites_cfunc = self._library.niDigital_ConfigurePatternBurstSites
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_ConfigurePatternBurstSites was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_ConfigurePatternBurstSites_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_ConfigurePatternBurstSites_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigurePatternBurstSites_cfunc(vi, site_list)
@@ -249,9 +249,9 @@ class Library(object):
                 try:
                     self.niDigital_ConfigureTimeSetCompareEdgesStrobe_cfunc = self._library.niDigital_ConfigureTimeSetCompareEdgesStrobe
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_ConfigureTimeSetCompareEdgesStrobe was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_ConfigureTimeSetCompareEdgesStrobe_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViReal64]  # noqa: F405
                 self.niDigital_ConfigureTimeSetCompareEdgesStrobe_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureTimeSetCompareEdgesStrobe_cfunc(vi, pin_list, time_set_name, strobe_edge)
@@ -262,9 +262,9 @@ class Library(object):
                 try:
                     self.niDigital_ConfigureTimeSetCompareEdgesStrobe2x_cfunc = self._library.niDigital_ConfigureTimeSetCompareEdgesStrobe2x
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_ConfigureTimeSetCompareEdgesStrobe2x was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_ConfigureTimeSetCompareEdgesStrobe2x_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViReal64, ViReal64]  # noqa: F405
                 self.niDigital_ConfigureTimeSetCompareEdgesStrobe2x_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureTimeSetCompareEdgesStrobe2x_cfunc(vi, pin_list, time_set_name, strobe_edge, strobe2_edge)
@@ -275,9 +275,9 @@ class Library(object):
                 try:
                     self.niDigital_ConfigureTimeSetDriveEdges_cfunc = self._library.niDigital_ConfigureTimeSetDriveEdges
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_ConfigureTimeSetDriveEdges was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_ConfigureTimeSetDriveEdges_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViReal64, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niDigital_ConfigureTimeSetDriveEdges_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureTimeSetDriveEdges_cfunc(vi, pin_list, time_set_name, format, drive_on_edge, drive_data_edge, drive_return_edge, drive_off_edge)
@@ -288,9 +288,9 @@ class Library(object):
                 try:
                     self.niDigital_ConfigureTimeSetDriveEdges2x_cfunc = self._library.niDigital_ConfigureTimeSetDriveEdges2x
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_ConfigureTimeSetDriveEdges2x was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_ConfigureTimeSetDriveEdges2x_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViReal64, ViReal64, ViReal64, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niDigital_ConfigureTimeSetDriveEdges2x_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureTimeSetDriveEdges2x_cfunc(vi, pin_list, time_set_name, format, drive_on_edge, drive_data_edge, drive_return_edge, drive_off_edge, drive_data2_edge, drive_return2_edge)
@@ -301,9 +301,9 @@ class Library(object):
                 try:
                     self.niDigital_ConfigureTimeSetDriveFormat_cfunc = self._library.niDigital_ConfigureTimeSetDriveFormat
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_ConfigureTimeSetDriveFormat was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_ConfigureTimeSetDriveFormat_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niDigital_ConfigureTimeSetDriveFormat_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureTimeSetDriveFormat_cfunc(vi, pin_list, time_set_name, drive_format)
@@ -314,9 +314,9 @@ class Library(object):
                 try:
                     self.niDigital_ConfigureTimeSetEdge_cfunc = self._library.niDigital_ConfigureTimeSetEdge
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_ConfigureTimeSetEdge was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_ConfigureTimeSetEdge_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViReal64]  # noqa: F405
                 self.niDigital_ConfigureTimeSetEdge_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureTimeSetEdge_cfunc(vi, pin_list, time_set_name, edge, time)
@@ -327,9 +327,9 @@ class Library(object):
                 try:
                     self.niDigital_ConfigureTimeSetEdgeMultiplier_cfunc = self._library.niDigital_ConfigureTimeSetEdgeMultiplier
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_ConfigureTimeSetEdgeMultiplier was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_ConfigureTimeSetEdgeMultiplier_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niDigital_ConfigureTimeSetEdgeMultiplier_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureTimeSetEdgeMultiplier_cfunc(vi, pin_list, time_set_name, edge_multiplier)
@@ -340,9 +340,9 @@ class Library(object):
                 try:
                     self.niDigital_ConfigureTimeSetPeriod_cfunc = self._library.niDigital_ConfigureTimeSetPeriod
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_ConfigureTimeSetPeriod was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_ConfigureTimeSetPeriod_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64]  # noqa: F405
                 self.niDigital_ConfigureTimeSetPeriod_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureTimeSetPeriod_cfunc(vi, time_set_name, period)
@@ -353,9 +353,9 @@ class Library(object):
                 try:
                     self.niDigital_ConfigureVoltageLevels_cfunc = self._library.niDigital_ConfigureVoltageLevels
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_ConfigureVoltageLevels was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_ConfigureVoltageLevels_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViReal64, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niDigital_ConfigureVoltageLevels_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureVoltageLevels_cfunc(vi, channel_list, vil, vih, vol, voh, vterm)
@@ -366,9 +366,9 @@ class Library(object):
                 try:
                     self.niDigital_CreateCaptureWaveformFromFileDigicapture_cfunc = self._library.niDigital_CreateCaptureWaveformFromFileDigicapture
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_CreateCaptureWaveformFromFileDigicapture was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_CreateCaptureWaveformFromFileDigicapture_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_CreateCaptureWaveformFromFileDigicapture_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_CreateCaptureWaveformFromFileDigicapture_cfunc(vi, waveform_name, waveform_file_path)
@@ -379,9 +379,9 @@ class Library(object):
                 try:
                     self.niDigital_CreateCaptureWaveformParallel_cfunc = self._library.niDigital_CreateCaptureWaveformParallel
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_CreateCaptureWaveformParallel was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_CreateCaptureWaveformParallel_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_CreateCaptureWaveformParallel_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_CreateCaptureWaveformParallel_cfunc(vi, pin_list, waveform_name)
@@ -392,9 +392,9 @@ class Library(object):
                 try:
                     self.niDigital_CreateCaptureWaveformSerial_cfunc = self._library.niDigital_CreateCaptureWaveformSerial
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_CreateCaptureWaveformSerial was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_CreateCaptureWaveformSerial_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViUInt32, ViInt32]  # noqa: F405
                 self.niDigital_CreateCaptureWaveformSerial_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_CreateCaptureWaveformSerial_cfunc(vi, pin_list, waveform_name, sample_width, bit_order)
@@ -405,9 +405,9 @@ class Library(object):
                 try:
                     self.niDigital_CreateSourceWaveformFromFileTDMS_cfunc = self._library.niDigital_CreateSourceWaveformFromFileTDMS
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_CreateSourceWaveformFromFileTDMS was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_CreateSourceWaveformFromFileTDMS_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViBoolean]  # noqa: F405
                 self.niDigital_CreateSourceWaveformFromFileTDMS_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_CreateSourceWaveformFromFileTDMS_cfunc(vi, waveform_name, waveform_file_path, write_waveform_data)
@@ -418,9 +418,9 @@ class Library(object):
                 try:
                     self.niDigital_CreateSourceWaveformParallel_cfunc = self._library.niDigital_CreateSourceWaveformParallel
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_CreateSourceWaveformParallel was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_CreateSourceWaveformParallel_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niDigital_CreateSourceWaveformParallel_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_CreateSourceWaveformParallel_cfunc(vi, pin_list, waveform_name, data_mapping)
@@ -431,9 +431,9 @@ class Library(object):
                 try:
                     self.niDigital_CreateSourceWaveformSerial_cfunc = self._library.niDigital_CreateSourceWaveformSerial
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_CreateSourceWaveformSerial was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_CreateSourceWaveformSerial_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViUInt32, ViInt32]  # noqa: F405
                 self.niDigital_CreateSourceWaveformSerial_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_CreateSourceWaveformSerial_cfunc(vi, pin_list, waveform_name, data_mapping, sample_width, bit_order)
@@ -444,9 +444,9 @@ class Library(object):
                 try:
                     self.niDigital_CreateTimeSet_cfunc = self._library.niDigital_CreateTimeSet
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_CreateTimeSet was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_CreateTimeSet_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_CreateTimeSet_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_CreateTimeSet_cfunc(vi, name)
@@ -457,9 +457,9 @@ class Library(object):
                 try:
                     self.niDigital_DeleteAllTimeSets_cfunc = self._library.niDigital_DeleteAllTimeSets
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_DeleteAllTimeSets was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_DeleteAllTimeSets_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_DeleteAllTimeSets_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_DeleteAllTimeSets_cfunc(vi)
@@ -470,9 +470,9 @@ class Library(object):
                 try:
                     self.niDigital_DisableSites_cfunc = self._library.niDigital_DisableSites
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_DisableSites was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_DisableSites_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_DisableSites_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_DisableSites_cfunc(vi, site_list)
@@ -483,9 +483,9 @@ class Library(object):
                 try:
                     self.niDigital_EnableSites_cfunc = self._library.niDigital_EnableSites
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_EnableSites was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_EnableSites_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_EnableSites_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_EnableSites_cfunc(vi, site_list)
@@ -496,9 +496,9 @@ class Library(object):
                 try:
                     self.niDigital_FetchCaptureWaveformU32_cfunc = self._library.niDigital_FetchCaptureWaveformU32
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_FetchCaptureWaveformU32 was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_FetchCaptureWaveformU32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViReal64, ViInt32, ctypes.POINTER(ViUInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_FetchCaptureWaveformU32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_FetchCaptureWaveformU32_cfunc(vi, site_list, waveform_name, samples_to_read, timeout, data_buffer_size, data, actual_num_waveforms, actual_samples_per_waveform)
@@ -509,9 +509,9 @@ class Library(object):
                 try:
                     self.niDigital_FetchHistoryRAMCycleInformation_cfunc = self._library.niDigital_FetchHistoryRAMCycleInformation
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_FetchHistoryRAMCycleInformation was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_FetchHistoryRAMCycleInformation_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt64, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt64), ctypes.POINTER(ViInt64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_FetchHistoryRAMCycleInformation_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_FetchHistoryRAMCycleInformation_cfunc(vi, site, sample_index, pattern_index, time_set_index, vector_number, cycle_number, num_dut_cycles)
@@ -522,9 +522,9 @@ class Library(object):
                 try:
                     self.niDigital_FetchHistoryRAMCyclePinData_cfunc = self._library.niDigital_FetchHistoryRAMCyclePinData
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_FetchHistoryRAMCyclePinData was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_FetchHistoryRAMCyclePinData_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt64, ViInt32, ViInt32, ctypes.POINTER(ViUInt8), ctypes.POINTER(ViUInt8), ctypes.POINTER(ViBoolean), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_FetchHistoryRAMCyclePinData_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_FetchHistoryRAMCyclePinData_cfunc(vi, site, pin_list, sample_index, dut_cycle_index, pin_data_buffer_size, expected_pin_states, actual_pin_states, per_pin_pass_fail, actual_num_pin_data)
@@ -535,9 +535,9 @@ class Library(object):
                 try:
                     self.niDigital_FetchHistoryRAMScanCycleNumber_cfunc = self._library.niDigital_FetchHistoryRAMScanCycleNumber
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_FetchHistoryRAMScanCycleNumber was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_FetchHistoryRAMScanCycleNumber_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt64, ctypes.POINTER(ViInt64)]  # noqa: F405
                 self.niDigital_FetchHistoryRAMScanCycleNumber_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_FetchHistoryRAMScanCycleNumber_cfunc(vi, site, sample_index, scan_cycle_number)
@@ -548,9 +548,9 @@ class Library(object):
                 try:
                     self.niDigital_FrequencyCounter_MeasureFrequency_cfunc = self._library.niDigital_FrequencyCounter_MeasureFrequency
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_FrequencyCounter_MeasureFrequency was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_FrequencyCounter_MeasureFrequency_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_FrequencyCounter_MeasureFrequency_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_FrequencyCounter_MeasureFrequency_cfunc(vi, channel_list, frequencies_buffer_size, frequencies, actual_num_frequencies)
@@ -561,9 +561,9 @@ class Library(object):
                 try:
                     self.niDigital_GetAttributeViBoolean_cfunc = self._library.niDigital_GetAttributeViBoolean
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_GetAttributeViBoolean was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDigital_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetAttributeViBoolean_cfunc(vi, channel_name, attribute, value)
@@ -574,9 +574,9 @@ class Library(object):
                 try:
                     self.niDigital_GetAttributeViInt32_cfunc = self._library.niDigital_GetAttributeViInt32
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_GetAttributeViInt32 was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_GetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetAttributeViInt32_cfunc(vi, channel_name, attribute, value)
@@ -587,9 +587,9 @@ class Library(object):
                 try:
                     self.niDigital_GetAttributeViInt64_cfunc = self._library.niDigital_GetAttributeViInt64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_GetAttributeViInt64 was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_GetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt64)]  # noqa: F405
                 self.niDigital_GetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetAttributeViInt64_cfunc(vi, channel_name, attribute, value)
@@ -600,9 +600,9 @@ class Library(object):
                 try:
                     self.niDigital_GetAttributeViReal64_cfunc = self._library.niDigital_GetAttributeViReal64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_GetAttributeViReal64 was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_GetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDigital_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetAttributeViReal64_cfunc(vi, channel_name, attribute, value)
@@ -613,9 +613,9 @@ class Library(object):
                 try:
                     self.niDigital_GetAttributeViString_cfunc = self._library.niDigital_GetAttributeViString
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_GetAttributeViString was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetAttributeViString_cfunc(vi, channel_name, attribute, buffer_size, value)
@@ -626,9 +626,9 @@ class Library(object):
                 try:
                     self.niDigital_GetChannelNameFromString_cfunc = self._library.niDigital_GetChannelNameFromString
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_GetChannelNameFromString was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_GetChannelNameFromString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_GetChannelNameFromString_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetChannelNameFromString_cfunc(vi, indices, name_buffer_size, names)
@@ -639,9 +639,9 @@ class Library(object):
                 try:
                     self.niDigital_GetError_cfunc = self._library.niDigital_GetError
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_GetError was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_GetError_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetError_cfunc(vi, error_code, error_description_buffer_size, error_description)
@@ -652,9 +652,9 @@ class Library(object):
                 try:
                     self.niDigital_GetFailCount_cfunc = self._library.niDigital_GetFailCount
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_GetFailCount was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_GetFailCount_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_GetFailCount_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetFailCount_cfunc(vi, channel_list, buffer_size, failure_count, actual_num_read)
@@ -665,9 +665,9 @@ class Library(object):
                 try:
                     self.niDigital_GetHistoryRAMSampleCount_cfunc = self._library.niDigital_GetHistoryRAMSampleCount
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_GetHistoryRAMSampleCount was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_GetHistoryRAMSampleCount_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViInt64)]  # noqa: F405
                 self.niDigital_GetHistoryRAMSampleCount_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetHistoryRAMSampleCount_cfunc(vi, site, sample_count)
@@ -678,9 +678,9 @@ class Library(object):
                 try:
                     self.niDigital_GetPatternName_cfunc = self._library.niDigital_GetPatternName
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_GetPatternName was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_GetPatternName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_GetPatternName_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetPatternName_cfunc(vi, pattern_index, name_buffer_size, name)
@@ -691,9 +691,9 @@ class Library(object):
                 try:
                     self.niDigital_GetPatternPinList_cfunc = self._library.niDigital_GetPatternPinList
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_GetPatternPinList was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_GetPatternPinList_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_GetPatternPinList_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetPatternPinList_cfunc(vi, start_label, pin_list_buffer_size, pin_list)
@@ -704,9 +704,9 @@ class Library(object):
                 try:
                     self.niDigital_GetPinName_cfunc = self._library.niDigital_GetPinName
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_GetPinName was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_GetPinName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_GetPinName_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetPinName_cfunc(vi, pin_index, name_buffer_size, name)
@@ -717,9 +717,9 @@ class Library(object):
                 try:
                     self.niDigital_GetPinResultsPinInformation_cfunc = self._library.niDigital_GetPinResultsPinInformation
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_GetPinResultsPinInformation was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_GetPinResultsPinInformation_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_GetPinResultsPinInformation_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetPinResultsPinInformation_cfunc(vi, channel_list, buffer_size, pin_indexes, site_numbers, channel_indexes, actual_num_values)
@@ -730,9 +730,9 @@ class Library(object):
                 try:
                     self.niDigital_GetSitePassFail_cfunc = self._library.niDigital_GetSitePassFail
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_GetSitePassFail was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_GetSitePassFail_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViBoolean), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_GetSitePassFail_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetSitePassFail_cfunc(vi, site_list, pass_fail_buffer_size, pass_fail, actual_num_sites)
@@ -743,9 +743,9 @@ class Library(object):
                 try:
                     self.niDigital_GetSiteResultsSiteNumbers_cfunc = self._library.niDigital_GetSiteResultsSiteNumbers
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_GetSiteResultsSiteNumbers was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_GetSiteResultsSiteNumbers_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_GetSiteResultsSiteNumbers_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetSiteResultsSiteNumbers_cfunc(vi, site_list, site_result_type, site_numbers_buffer_size, site_numbers, actual_num_site_numbers)
@@ -756,9 +756,9 @@ class Library(object):
                 try:
                     self.niDigital_GetTimeSetDriveFormat_cfunc = self._library.niDigital_GetTimeSetDriveFormat
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_GetTimeSetDriveFormat was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_GetTimeSetDriveFormat_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_GetTimeSetDriveFormat_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetTimeSetDriveFormat_cfunc(vi, pin, time_set_name, format)
@@ -769,9 +769,9 @@ class Library(object):
                 try:
                     self.niDigital_GetTimeSetEdge_cfunc = self._library.niDigital_GetTimeSetEdge
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_GetTimeSetEdge was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_GetTimeSetEdge_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDigital_GetTimeSetEdge_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetTimeSetEdge_cfunc(vi, pin, time_set_name, edge, time)
@@ -782,9 +782,9 @@ class Library(object):
                 try:
                     self.niDigital_GetTimeSetEdgeMultiplier_cfunc = self._library.niDigital_GetTimeSetEdgeMultiplier
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_GetTimeSetEdgeMultiplier was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_GetTimeSetEdgeMultiplier_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_GetTimeSetEdgeMultiplier_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetTimeSetEdgeMultiplier_cfunc(vi, pin, time_set_name, edge_multiplier)
@@ -795,9 +795,9 @@ class Library(object):
                 try:
                     self.niDigital_GetTimeSetName_cfunc = self._library.niDigital_GetTimeSetName
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_GetTimeSetName was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_GetTimeSetName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_GetTimeSetName_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetTimeSetName_cfunc(vi, time_set_index, name_buffer_size, name)
@@ -808,9 +808,9 @@ class Library(object):
                 try:
                     self.niDigital_GetTimeSetPeriod_cfunc = self._library.niDigital_GetTimeSetPeriod
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_GetTimeSetPeriod was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_GetTimeSetPeriod_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDigital_GetTimeSetPeriod_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetTimeSetPeriod_cfunc(vi, time_set_name, period)
@@ -821,9 +821,9 @@ class Library(object):
                 try:
                     self.niDigital_InitWithOptions_cfunc = self._library.niDigital_InitWithOptions
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_InitWithOptions was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_InitWithOptions_cfunc.argtypes = [ctypes.POINTER(ViChar), ViBoolean, ViBoolean, ctypes.POINTER(ViChar), ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niDigital_InitWithOptions_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_InitWithOptions_cfunc(resource_name, id_query, reset_device, option_string, new_vi)
@@ -834,9 +834,9 @@ class Library(object):
                 try:
                     self.niDigital_Initiate_cfunc = self._library.niDigital_Initiate
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_Initiate was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_Initiate_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_Initiate_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_Initiate_cfunc(vi)
@@ -847,9 +847,9 @@ class Library(object):
                 try:
                     self.niDigital_IsDone_cfunc = self._library.niDigital_IsDone
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_IsDone was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_IsDone_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDigital_IsDone_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_IsDone_cfunc(vi, done)
@@ -860,9 +860,9 @@ class Library(object):
                 try:
                     self.niDigital_IsSiteEnabled_cfunc = self._library.niDigital_IsSiteEnabled
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_IsSiteEnabled was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_IsSiteEnabled_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDigital_IsSiteEnabled_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_IsSiteEnabled_cfunc(vi, site, enable)
@@ -873,9 +873,9 @@ class Library(object):
                 try:
                     self.niDigital_LoadLevels_cfunc = self._library.niDigital_LoadLevels
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_LoadLevels was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_LoadLevels_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_LoadLevels_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_LoadLevels_cfunc(vi, file_path)
@@ -886,9 +886,9 @@ class Library(object):
                 try:
                     self.niDigital_LoadPattern_cfunc = self._library.niDigital_LoadPattern
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_LoadPattern was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_LoadPattern_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_LoadPattern_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_LoadPattern_cfunc(vi, file_path)
@@ -899,9 +899,9 @@ class Library(object):
                 try:
                     self.niDigital_LoadPinMap_cfunc = self._library.niDigital_LoadPinMap
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_LoadPinMap was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_LoadPinMap_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_LoadPinMap_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_LoadPinMap_cfunc(vi, file_path)
@@ -912,9 +912,9 @@ class Library(object):
                 try:
                     self.niDigital_LoadSpecifications_cfunc = self._library.niDigital_LoadSpecifications
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_LoadSpecifications was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_LoadSpecifications_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_LoadSpecifications_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_LoadSpecifications_cfunc(vi, file_path)
@@ -925,9 +925,9 @@ class Library(object):
                 try:
                     self.niDigital_LoadTiming_cfunc = self._library.niDigital_LoadTiming
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_LoadTiming was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_LoadTiming_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_LoadTiming_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_LoadTiming_cfunc(vi, file_path)
@@ -938,9 +938,9 @@ class Library(object):
                 try:
                     self.niDigital_LockSession_cfunc = self._library.niDigital_LockSession
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_LockSession was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_LockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDigital_LockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_LockSession_cfunc(vi, caller_has_lock)
@@ -951,9 +951,9 @@ class Library(object):
                 try:
                     self.niDigital_PPMU_Measure_cfunc = self._library.niDigital_PPMU_Measure
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_PPMU_Measure was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_PPMU_Measure_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_PPMU_Measure_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_PPMU_Measure_cfunc(vi, channel_list, measurement_type, buffer_size, measurements, actual_num_read)
@@ -964,9 +964,9 @@ class Library(object):
                 try:
                     self.niDigital_PPMU_Source_cfunc = self._library.niDigital_PPMU_Source
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_PPMU_Source was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_PPMU_Source_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_PPMU_Source_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_PPMU_Source_cfunc(vi, channel_list)
@@ -977,9 +977,9 @@ class Library(object):
                 try:
                     self.niDigital_ReadSequencerFlag_cfunc = self._library.niDigital_ReadSequencerFlag
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_ReadSequencerFlag was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_ReadSequencerFlag_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDigital_ReadSequencerFlag_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ReadSequencerFlag_cfunc(vi, flag, value)
@@ -990,9 +990,9 @@ class Library(object):
                 try:
                     self.niDigital_ReadSequencerRegister_cfunc = self._library.niDigital_ReadSequencerRegister
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_ReadSequencerRegister was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_ReadSequencerRegister_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_ReadSequencerRegister_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ReadSequencerRegister_cfunc(vi, reg, value)
@@ -1003,9 +1003,9 @@ class Library(object):
                 try:
                     self.niDigital_ReadStatic_cfunc = self._library.niDigital_ReadStatic
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_ReadStatic was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_ReadStatic_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViUInt8), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_ReadStatic_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ReadStatic_cfunc(vi, channel_list, buffer_size, data, actual_num_read)
@@ -1016,9 +1016,9 @@ class Library(object):
                 try:
                     self.niDigital_ResetDevice_cfunc = self._library.niDigital_ResetDevice
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_ResetDevice was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_ResetDevice_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_ResetDevice_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ResetDevice_cfunc(vi)
@@ -1029,9 +1029,9 @@ class Library(object):
                 try:
                     self.niDigital_SelfCalibrate_cfunc = self._library.niDigital_SelfCalibrate
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_SelfCalibrate was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_SelfCalibrate_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_SelfCalibrate_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_SelfCalibrate_cfunc(vi)
@@ -1042,9 +1042,9 @@ class Library(object):
                 try:
                     self.niDigital_SendSoftwareEdgeTrigger_cfunc = self._library.niDigital_SendSoftwareEdgeTrigger
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_SendSoftwareEdgeTrigger was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_SendSoftwareEdgeTrigger_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_SendSoftwareEdgeTrigger_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_SendSoftwareEdgeTrigger_cfunc(vi, trigger, trigger_identifier)
@@ -1055,9 +1055,9 @@ class Library(object):
                 try:
                     self.niDigital_SetAttributeViBoolean_cfunc = self._library.niDigital_SetAttributeViBoolean
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_SetAttributeViBoolean was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViBoolean]  # noqa: F405
                 self.niDigital_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_SetAttributeViBoolean_cfunc(vi, channel_name, attribute, value)
@@ -1068,9 +1068,9 @@ class Library(object):
                 try:
                     self.niDigital_SetAttributeViInt32_cfunc = self._library.niDigital_SetAttributeViInt32
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_SetAttributeViInt32 was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_SetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32]  # noqa: F405
                 self.niDigital_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_SetAttributeViInt32_cfunc(vi, channel_name, attribute, value)
@@ -1081,9 +1081,9 @@ class Library(object):
                 try:
                     self.niDigital_SetAttributeViInt64_cfunc = self._library.niDigital_SetAttributeViInt64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_SetAttributeViInt64 was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_SetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt64]  # noqa: F405
                 self.niDigital_SetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_SetAttributeViInt64_cfunc(vi, channel_name, attribute, value)
@@ -1094,9 +1094,9 @@ class Library(object):
                 try:
                     self.niDigital_SetAttributeViReal64_cfunc = self._library.niDigital_SetAttributeViReal64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_SetAttributeViReal64 was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niDigital_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_SetAttributeViReal64_cfunc(vi, channel_name, attribute, value)
@@ -1107,9 +1107,9 @@ class Library(object):
                 try:
                     self.niDigital_SetAttributeViString_cfunc = self._library.niDigital_SetAttributeViString
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_SetAttributeViString was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_SetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_SetAttributeViString_cfunc(vi, channel_name, attribute, value)
@@ -1120,9 +1120,9 @@ class Library(object):
                 try:
                     self.niDigital_TDR_cfunc = self._library.niDigital_TDR
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_TDR was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_TDR_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViBoolean, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_TDR_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_TDR_cfunc(vi, channel_list, apply_offsets, offsets_buffer_size, offsets, actual_num_offsets)
@@ -1133,9 +1133,9 @@ class Library(object):
                 try:
                     self.niDigital_UnloadAllPatterns_cfunc = self._library.niDigital_UnloadAllPatterns
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_UnloadAllPatterns was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_UnloadAllPatterns_cfunc.argtypes = [ViSession, ViBoolean]  # noqa: F405
                 self.niDigital_UnloadAllPatterns_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_UnloadAllPatterns_cfunc(vi, unload_keep_alive_pattern)
@@ -1146,9 +1146,9 @@ class Library(object):
                 try:
                     self.niDigital_UnloadSpecifications_cfunc = self._library.niDigital_UnloadSpecifications
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_UnloadSpecifications was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_UnloadSpecifications_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_UnloadSpecifications_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_UnloadSpecifications_cfunc(vi, file_path)
@@ -1159,9 +1159,9 @@ class Library(object):
                 try:
                     self.niDigital_UnlockSession_cfunc = self._library.niDigital_UnlockSession
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_UnlockSession was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_UnlockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDigital_UnlockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_UnlockSession_cfunc(vi, caller_has_lock)
@@ -1172,9 +1172,9 @@ class Library(object):
                 try:
                     self.niDigital_WaitUntilDone_cfunc = self._library.niDigital_WaitUntilDone
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_WaitUntilDone was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_WaitUntilDone_cfunc.argtypes = [ViSession, ViReal64]  # noqa: F405
                 self.niDigital_WaitUntilDone_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_WaitUntilDone_cfunc(vi, timeout)
@@ -1185,9 +1185,9 @@ class Library(object):
                 try:
                     self.niDigital_WriteSequencerFlag_cfunc = self._library.niDigital_WriteSequencerFlag
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_WriteSequencerFlag was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_WriteSequencerFlag_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViBoolean]  # noqa: F405
                 self.niDigital_WriteSequencerFlag_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_WriteSequencerFlag_cfunc(vi, flag, value)
@@ -1198,9 +1198,9 @@ class Library(object):
                 try:
                     self.niDigital_WriteSequencerRegister_cfunc = self._library.niDigital_WriteSequencerRegister
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_WriteSequencerRegister was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_WriteSequencerRegister_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niDigital_WriteSequencerRegister_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_WriteSequencerRegister_cfunc(vi, reg, value)
@@ -1211,9 +1211,9 @@ class Library(object):
                 try:
                     self.niDigital_WriteSourceWaveformBroadcastU32_cfunc = self._library.niDigital_WriteSourceWaveformBroadcastU32
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_WriteSourceWaveformBroadcastU32 was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_WriteSourceWaveformBroadcastU32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViUInt32)]  # noqa: F405
                 self.niDigital_WriteSourceWaveformBroadcastU32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_WriteSourceWaveformBroadcastU32_cfunc(vi, waveform_name, waveform_size, waveform_data)
@@ -1224,9 +1224,9 @@ class Library(object):
                 try:
                     self.niDigital_WriteSourceWaveformDataFromFileTDMS_cfunc = self._library.niDigital_WriteSourceWaveformDataFromFileTDMS
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_WriteSourceWaveformDataFromFileTDMS was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_WriteSourceWaveformDataFromFileTDMS_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_WriteSourceWaveformDataFromFileTDMS_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_WriteSourceWaveformDataFromFileTDMS_cfunc(vi, waveform_name, waveform_file_path)
@@ -1237,9 +1237,9 @@ class Library(object):
                 try:
                     self.niDigital_WriteSourceWaveformSiteUniqueU32_cfunc = self._library.niDigital_WriteSourceWaveformSiteUniqueU32
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_WriteSourceWaveformSiteUniqueU32 was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_WriteSourceWaveformSiteUniqueU32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViInt32, ctypes.POINTER(ViUInt32)]  # noqa: F405
                 self.niDigital_WriteSourceWaveformSiteUniqueU32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_WriteSourceWaveformSiteUniqueU32_cfunc(vi, site_list, waveform_name, num_waveforms, samples_per_waveform, waveform_data)
@@ -1250,9 +1250,9 @@ class Library(object):
                 try:
                     self.niDigital_WriteStatic_cfunc = self._library.niDigital_WriteStatic
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_WriteStatic was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_WriteStatic_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViUInt8]  # noqa: F405
                 self.niDigital_WriteStatic_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_WriteStatic_cfunc(vi, channel_list, state)
@@ -1263,9 +1263,9 @@ class Library(object):
                 try:
                     self.niDigital_close_cfunc = self._library.niDigital_close
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_close was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_close_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_close_cfunc(vi)
@@ -1276,9 +1276,9 @@ class Library(object):
                 try:
                     self.niDigital_error_message_cfunc = self._library.niDigital_error_message
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_error_message was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_error_message_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_error_message_cfunc(vi, error_code, error_message)
@@ -1289,9 +1289,9 @@ class Library(object):
                 try:
                     self.niDigital_reset_cfunc = self._library.niDigital_reset
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_reset was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_reset_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_reset_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_reset_cfunc(vi)
@@ -1302,9 +1302,9 @@ class Library(object):
                 try:
                     self.niDigital_self_test_cfunc = self._library.niDigital_self_test
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDigital_self_test was not found in the NI-Digital Pattern Driver runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDigital_self_test_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_self_test_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_self_test_cfunc(vi, test_result, test_message)

--- a/generated/nidigital/nidigital/_library.py
+++ b/generated/nidigital/nidigital/_library.py
@@ -2,6 +2,7 @@
 # This file was generated
 
 import ctypes
+import nidigital.errors as errors
 import threading
 
 from nidigital._visatype import *  # noqa: F403,H303
@@ -113,15 +114,17 @@ class Library(object):
         self.niDigital_reset_cfunc = None
         self.niDigital_self_test_cfunc = None
 
+    def _get_library_function(self, name):
+        try:
+            function = getattr(self._library, 'fred')
+        except AttributeError as e:
+            raise errors.DriverTooOldError() from e
+        return function
+
     def niDigital_Abort(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDigital_Abort_cfunc is None:
-                try:
-                    self.niDigital_Abort_cfunc = self._library.niDigital_Abort
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_Abort was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_Abort_cfunc = self._get_library_function('niDigital_Abort')
                 self.niDigital_Abort_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_Abort_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_Abort_cfunc(vi)
@@ -129,12 +132,7 @@ class Library(object):
     def niDigital_AbortKeepAlive(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDigital_AbortKeepAlive_cfunc is None:
-                try:
-                    self.niDigital_AbortKeepAlive_cfunc = self._library.niDigital_AbortKeepAlive
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_AbortKeepAlive was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_AbortKeepAlive_cfunc = self._get_library_function('niDigital_AbortKeepAlive')
                 self.niDigital_AbortKeepAlive_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_AbortKeepAlive_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_AbortKeepAlive_cfunc(vi)
@@ -142,12 +140,7 @@ class Library(object):
     def niDigital_ApplyLevelsAndTiming(self, vi, site_list, levels_sheet, timing_sheet, initial_state_high_pins, initial_state_low_pins, initial_state_tristate_pins):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ApplyLevelsAndTiming_cfunc is None:
-                try:
-                    self.niDigital_ApplyLevelsAndTiming_cfunc = self._library.niDigital_ApplyLevelsAndTiming
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_ApplyLevelsAndTiming was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_ApplyLevelsAndTiming_cfunc = self._get_library_function('niDigital_ApplyLevelsAndTiming')
                 self.niDigital_ApplyLevelsAndTiming_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_ApplyLevelsAndTiming_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ApplyLevelsAndTiming_cfunc(vi, site_list, levels_sheet, timing_sheet, initial_state_high_pins, initial_state_low_pins, initial_state_tristate_pins)
@@ -155,12 +148,7 @@ class Library(object):
     def niDigital_ApplyTDROffsets(self, vi, channel_list, num_offsets, offsets):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ApplyTDROffsets_cfunc is None:
-                try:
-                    self.niDigital_ApplyTDROffsets_cfunc = self._library.niDigital_ApplyTDROffsets
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_ApplyTDROffsets was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_ApplyTDROffsets_cfunc = self._get_library_function('niDigital_ApplyTDROffsets')
                 self.niDigital_ApplyTDROffsets_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDigital_ApplyTDROffsets_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ApplyTDROffsets_cfunc(vi, channel_list, num_offsets, offsets)
@@ -168,12 +156,7 @@ class Library(object):
     def niDigital_BurstPattern(self, vi, site_list, start_label, select_digital_function, wait_until_done, timeout):  # noqa: N802
         with self._func_lock:
             if self.niDigital_BurstPattern_cfunc is None:
-                try:
-                    self.niDigital_BurstPattern_cfunc = self._library.niDigital_BurstPattern
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_BurstPattern was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_BurstPattern_cfunc = self._get_library_function('niDigital_BurstPattern')
                 self.niDigital_BurstPattern_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViBoolean, ViBoolean, ViReal64]  # noqa: F405
                 self.niDigital_BurstPattern_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_BurstPattern_cfunc(vi, site_list, start_label, select_digital_function, wait_until_done, timeout)
@@ -181,12 +164,7 @@ class Library(object):
     def niDigital_ClockGenerator_Abort(self, vi, channel_list):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ClockGenerator_Abort_cfunc is None:
-                try:
-                    self.niDigital_ClockGenerator_Abort_cfunc = self._library.niDigital_ClockGenerator_Abort
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_ClockGenerator_Abort was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_ClockGenerator_Abort_cfunc = self._get_library_function('niDigital_ClockGenerator_Abort')
                 self.niDigital_ClockGenerator_Abort_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_ClockGenerator_Abort_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ClockGenerator_Abort_cfunc(vi, channel_list)
@@ -194,12 +172,7 @@ class Library(object):
     def niDigital_ClockGenerator_GenerateClock(self, vi, channel_list, frequency, select_digital_function):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ClockGenerator_GenerateClock_cfunc is None:
-                try:
-                    self.niDigital_ClockGenerator_GenerateClock_cfunc = self._library.niDigital_ClockGenerator_GenerateClock
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_ClockGenerator_GenerateClock was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_ClockGenerator_GenerateClock_cfunc = self._get_library_function('niDigital_ClockGenerator_GenerateClock')
                 self.niDigital_ClockGenerator_GenerateClock_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViBoolean]  # noqa: F405
                 self.niDigital_ClockGenerator_GenerateClock_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ClockGenerator_GenerateClock_cfunc(vi, channel_list, frequency, select_digital_function)
@@ -207,12 +180,7 @@ class Library(object):
     def niDigital_Commit(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDigital_Commit_cfunc is None:
-                try:
-                    self.niDigital_Commit_cfunc = self._library.niDigital_Commit
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_Commit was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_Commit_cfunc = self._get_library_function('niDigital_Commit')
                 self.niDigital_Commit_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_Commit_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_Commit_cfunc(vi)
@@ -220,12 +188,7 @@ class Library(object):
     def niDigital_ConfigureActiveLoadLevels(self, vi, channel_list, iol, ioh, vcom):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ConfigureActiveLoadLevels_cfunc is None:
-                try:
-                    self.niDigital_ConfigureActiveLoadLevels_cfunc = self._library.niDigital_ConfigureActiveLoadLevels
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_ConfigureActiveLoadLevels was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_ConfigureActiveLoadLevels_cfunc = self._get_library_function('niDigital_ConfigureActiveLoadLevels')
                 self.niDigital_ConfigureActiveLoadLevels_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niDigital_ConfigureActiveLoadLevels_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureActiveLoadLevels_cfunc(vi, channel_list, iol, ioh, vcom)
@@ -233,12 +196,7 @@ class Library(object):
     def niDigital_ConfigurePatternBurstSites(self, vi, site_list):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ConfigurePatternBurstSites_cfunc is None:
-                try:
-                    self.niDigital_ConfigurePatternBurstSites_cfunc = self._library.niDigital_ConfigurePatternBurstSites
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_ConfigurePatternBurstSites was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_ConfigurePatternBurstSites_cfunc = self._get_library_function('niDigital_ConfigurePatternBurstSites')
                 self.niDigital_ConfigurePatternBurstSites_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_ConfigurePatternBurstSites_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigurePatternBurstSites_cfunc(vi, site_list)
@@ -246,12 +204,7 @@ class Library(object):
     def niDigital_ConfigureTimeSetCompareEdgesStrobe(self, vi, pin_list, time_set_name, strobe_edge):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ConfigureTimeSetCompareEdgesStrobe_cfunc is None:
-                try:
-                    self.niDigital_ConfigureTimeSetCompareEdgesStrobe_cfunc = self._library.niDigital_ConfigureTimeSetCompareEdgesStrobe
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_ConfigureTimeSetCompareEdgesStrobe was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_ConfigureTimeSetCompareEdgesStrobe_cfunc = self._get_library_function('niDigital_ConfigureTimeSetCompareEdgesStrobe')
                 self.niDigital_ConfigureTimeSetCompareEdgesStrobe_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViReal64]  # noqa: F405
                 self.niDigital_ConfigureTimeSetCompareEdgesStrobe_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureTimeSetCompareEdgesStrobe_cfunc(vi, pin_list, time_set_name, strobe_edge)
@@ -259,12 +212,7 @@ class Library(object):
     def niDigital_ConfigureTimeSetCompareEdgesStrobe2x(self, vi, pin_list, time_set_name, strobe_edge, strobe2_edge):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ConfigureTimeSetCompareEdgesStrobe2x_cfunc is None:
-                try:
-                    self.niDigital_ConfigureTimeSetCompareEdgesStrobe2x_cfunc = self._library.niDigital_ConfigureTimeSetCompareEdgesStrobe2x
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_ConfigureTimeSetCompareEdgesStrobe2x was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_ConfigureTimeSetCompareEdgesStrobe2x_cfunc = self._get_library_function('niDigital_ConfigureTimeSetCompareEdgesStrobe2x')
                 self.niDigital_ConfigureTimeSetCompareEdgesStrobe2x_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViReal64, ViReal64]  # noqa: F405
                 self.niDigital_ConfigureTimeSetCompareEdgesStrobe2x_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureTimeSetCompareEdgesStrobe2x_cfunc(vi, pin_list, time_set_name, strobe_edge, strobe2_edge)
@@ -272,12 +220,7 @@ class Library(object):
     def niDigital_ConfigureTimeSetDriveEdges(self, vi, pin_list, time_set_name, format, drive_on_edge, drive_data_edge, drive_return_edge, drive_off_edge):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ConfigureTimeSetDriveEdges_cfunc is None:
-                try:
-                    self.niDigital_ConfigureTimeSetDriveEdges_cfunc = self._library.niDigital_ConfigureTimeSetDriveEdges
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_ConfigureTimeSetDriveEdges was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_ConfigureTimeSetDriveEdges_cfunc = self._get_library_function('niDigital_ConfigureTimeSetDriveEdges')
                 self.niDigital_ConfigureTimeSetDriveEdges_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViReal64, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niDigital_ConfigureTimeSetDriveEdges_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureTimeSetDriveEdges_cfunc(vi, pin_list, time_set_name, format, drive_on_edge, drive_data_edge, drive_return_edge, drive_off_edge)
@@ -285,12 +228,7 @@ class Library(object):
     def niDigital_ConfigureTimeSetDriveEdges2x(self, vi, pin_list, time_set_name, format, drive_on_edge, drive_data_edge, drive_return_edge, drive_off_edge, drive_data2_edge, drive_return2_edge):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ConfigureTimeSetDriveEdges2x_cfunc is None:
-                try:
-                    self.niDigital_ConfigureTimeSetDriveEdges2x_cfunc = self._library.niDigital_ConfigureTimeSetDriveEdges2x
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_ConfigureTimeSetDriveEdges2x was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_ConfigureTimeSetDriveEdges2x_cfunc = self._get_library_function('niDigital_ConfigureTimeSetDriveEdges2x')
                 self.niDigital_ConfigureTimeSetDriveEdges2x_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViReal64, ViReal64, ViReal64, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niDigital_ConfigureTimeSetDriveEdges2x_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureTimeSetDriveEdges2x_cfunc(vi, pin_list, time_set_name, format, drive_on_edge, drive_data_edge, drive_return_edge, drive_off_edge, drive_data2_edge, drive_return2_edge)
@@ -298,12 +236,7 @@ class Library(object):
     def niDigital_ConfigureTimeSetDriveFormat(self, vi, pin_list, time_set_name, drive_format):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ConfigureTimeSetDriveFormat_cfunc is None:
-                try:
-                    self.niDigital_ConfigureTimeSetDriveFormat_cfunc = self._library.niDigital_ConfigureTimeSetDriveFormat
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_ConfigureTimeSetDriveFormat was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_ConfigureTimeSetDriveFormat_cfunc = self._get_library_function('niDigital_ConfigureTimeSetDriveFormat')
                 self.niDigital_ConfigureTimeSetDriveFormat_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niDigital_ConfigureTimeSetDriveFormat_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureTimeSetDriveFormat_cfunc(vi, pin_list, time_set_name, drive_format)
@@ -311,12 +244,7 @@ class Library(object):
     def niDigital_ConfigureTimeSetEdge(self, vi, pin_list, time_set_name, edge, time):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ConfigureTimeSetEdge_cfunc is None:
-                try:
-                    self.niDigital_ConfigureTimeSetEdge_cfunc = self._library.niDigital_ConfigureTimeSetEdge
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_ConfigureTimeSetEdge was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_ConfigureTimeSetEdge_cfunc = self._get_library_function('niDigital_ConfigureTimeSetEdge')
                 self.niDigital_ConfigureTimeSetEdge_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViReal64]  # noqa: F405
                 self.niDigital_ConfigureTimeSetEdge_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureTimeSetEdge_cfunc(vi, pin_list, time_set_name, edge, time)
@@ -324,12 +252,7 @@ class Library(object):
     def niDigital_ConfigureTimeSetEdgeMultiplier(self, vi, pin_list, time_set_name, edge_multiplier):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ConfigureTimeSetEdgeMultiplier_cfunc is None:
-                try:
-                    self.niDigital_ConfigureTimeSetEdgeMultiplier_cfunc = self._library.niDigital_ConfigureTimeSetEdgeMultiplier
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_ConfigureTimeSetEdgeMultiplier was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_ConfigureTimeSetEdgeMultiplier_cfunc = self._get_library_function('niDigital_ConfigureTimeSetEdgeMultiplier')
                 self.niDigital_ConfigureTimeSetEdgeMultiplier_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niDigital_ConfigureTimeSetEdgeMultiplier_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureTimeSetEdgeMultiplier_cfunc(vi, pin_list, time_set_name, edge_multiplier)
@@ -337,12 +260,7 @@ class Library(object):
     def niDigital_ConfigureTimeSetPeriod(self, vi, time_set_name, period):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ConfigureTimeSetPeriod_cfunc is None:
-                try:
-                    self.niDigital_ConfigureTimeSetPeriod_cfunc = self._library.niDigital_ConfigureTimeSetPeriod
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_ConfigureTimeSetPeriod was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_ConfigureTimeSetPeriod_cfunc = self._get_library_function('niDigital_ConfigureTimeSetPeriod')
                 self.niDigital_ConfigureTimeSetPeriod_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64]  # noqa: F405
                 self.niDigital_ConfigureTimeSetPeriod_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureTimeSetPeriod_cfunc(vi, time_set_name, period)
@@ -350,12 +268,7 @@ class Library(object):
     def niDigital_ConfigureVoltageLevels(self, vi, channel_list, vil, vih, vol, voh, vterm):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ConfigureVoltageLevels_cfunc is None:
-                try:
-                    self.niDigital_ConfigureVoltageLevels_cfunc = self._library.niDigital_ConfigureVoltageLevels
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_ConfigureVoltageLevels was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_ConfigureVoltageLevels_cfunc = self._get_library_function('niDigital_ConfigureVoltageLevels')
                 self.niDigital_ConfigureVoltageLevels_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViReal64, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niDigital_ConfigureVoltageLevels_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureVoltageLevels_cfunc(vi, channel_list, vil, vih, vol, voh, vterm)
@@ -363,12 +276,7 @@ class Library(object):
     def niDigital_CreateCaptureWaveformFromFileDigicapture(self, vi, waveform_name, waveform_file_path):  # noqa: N802
         with self._func_lock:
             if self.niDigital_CreateCaptureWaveformFromFileDigicapture_cfunc is None:
-                try:
-                    self.niDigital_CreateCaptureWaveformFromFileDigicapture_cfunc = self._library.niDigital_CreateCaptureWaveformFromFileDigicapture
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_CreateCaptureWaveformFromFileDigicapture was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_CreateCaptureWaveformFromFileDigicapture_cfunc = self._get_library_function('niDigital_CreateCaptureWaveformFromFileDigicapture')
                 self.niDigital_CreateCaptureWaveformFromFileDigicapture_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_CreateCaptureWaveformFromFileDigicapture_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_CreateCaptureWaveformFromFileDigicapture_cfunc(vi, waveform_name, waveform_file_path)
@@ -376,12 +284,7 @@ class Library(object):
     def niDigital_CreateCaptureWaveformParallel(self, vi, pin_list, waveform_name):  # noqa: N802
         with self._func_lock:
             if self.niDigital_CreateCaptureWaveformParallel_cfunc is None:
-                try:
-                    self.niDigital_CreateCaptureWaveformParallel_cfunc = self._library.niDigital_CreateCaptureWaveformParallel
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_CreateCaptureWaveformParallel was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_CreateCaptureWaveformParallel_cfunc = self._get_library_function('niDigital_CreateCaptureWaveformParallel')
                 self.niDigital_CreateCaptureWaveformParallel_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_CreateCaptureWaveformParallel_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_CreateCaptureWaveformParallel_cfunc(vi, pin_list, waveform_name)
@@ -389,12 +292,7 @@ class Library(object):
     def niDigital_CreateCaptureWaveformSerial(self, vi, pin_list, waveform_name, sample_width, bit_order):  # noqa: N802
         with self._func_lock:
             if self.niDigital_CreateCaptureWaveformSerial_cfunc is None:
-                try:
-                    self.niDigital_CreateCaptureWaveformSerial_cfunc = self._library.niDigital_CreateCaptureWaveformSerial
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_CreateCaptureWaveformSerial was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_CreateCaptureWaveformSerial_cfunc = self._get_library_function('niDigital_CreateCaptureWaveformSerial')
                 self.niDigital_CreateCaptureWaveformSerial_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViUInt32, ViInt32]  # noqa: F405
                 self.niDigital_CreateCaptureWaveformSerial_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_CreateCaptureWaveformSerial_cfunc(vi, pin_list, waveform_name, sample_width, bit_order)
@@ -402,12 +300,7 @@ class Library(object):
     def niDigital_CreateSourceWaveformFromFileTDMS(self, vi, waveform_name, waveform_file_path, write_waveform_data):  # noqa: N802
         with self._func_lock:
             if self.niDigital_CreateSourceWaveformFromFileTDMS_cfunc is None:
-                try:
-                    self.niDigital_CreateSourceWaveformFromFileTDMS_cfunc = self._library.niDigital_CreateSourceWaveformFromFileTDMS
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_CreateSourceWaveformFromFileTDMS was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_CreateSourceWaveformFromFileTDMS_cfunc = self._get_library_function('niDigital_CreateSourceWaveformFromFileTDMS')
                 self.niDigital_CreateSourceWaveformFromFileTDMS_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViBoolean]  # noqa: F405
                 self.niDigital_CreateSourceWaveformFromFileTDMS_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_CreateSourceWaveformFromFileTDMS_cfunc(vi, waveform_name, waveform_file_path, write_waveform_data)
@@ -415,12 +308,7 @@ class Library(object):
     def niDigital_CreateSourceWaveformParallel(self, vi, pin_list, waveform_name, data_mapping):  # noqa: N802
         with self._func_lock:
             if self.niDigital_CreateSourceWaveformParallel_cfunc is None:
-                try:
-                    self.niDigital_CreateSourceWaveformParallel_cfunc = self._library.niDigital_CreateSourceWaveformParallel
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_CreateSourceWaveformParallel was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_CreateSourceWaveformParallel_cfunc = self._get_library_function('niDigital_CreateSourceWaveformParallel')
                 self.niDigital_CreateSourceWaveformParallel_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niDigital_CreateSourceWaveformParallel_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_CreateSourceWaveformParallel_cfunc(vi, pin_list, waveform_name, data_mapping)
@@ -428,12 +316,7 @@ class Library(object):
     def niDigital_CreateSourceWaveformSerial(self, vi, pin_list, waveform_name, data_mapping, sample_width, bit_order):  # noqa: N802
         with self._func_lock:
             if self.niDigital_CreateSourceWaveformSerial_cfunc is None:
-                try:
-                    self.niDigital_CreateSourceWaveformSerial_cfunc = self._library.niDigital_CreateSourceWaveformSerial
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_CreateSourceWaveformSerial was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_CreateSourceWaveformSerial_cfunc = self._get_library_function('niDigital_CreateSourceWaveformSerial')
                 self.niDigital_CreateSourceWaveformSerial_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViUInt32, ViInt32]  # noqa: F405
                 self.niDigital_CreateSourceWaveformSerial_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_CreateSourceWaveformSerial_cfunc(vi, pin_list, waveform_name, data_mapping, sample_width, bit_order)
@@ -441,12 +324,7 @@ class Library(object):
     def niDigital_CreateTimeSet(self, vi, name):  # noqa: N802
         with self._func_lock:
             if self.niDigital_CreateTimeSet_cfunc is None:
-                try:
-                    self.niDigital_CreateTimeSet_cfunc = self._library.niDigital_CreateTimeSet
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_CreateTimeSet was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_CreateTimeSet_cfunc = self._get_library_function('niDigital_CreateTimeSet')
                 self.niDigital_CreateTimeSet_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_CreateTimeSet_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_CreateTimeSet_cfunc(vi, name)
@@ -454,12 +332,7 @@ class Library(object):
     def niDigital_DeleteAllTimeSets(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDigital_DeleteAllTimeSets_cfunc is None:
-                try:
-                    self.niDigital_DeleteAllTimeSets_cfunc = self._library.niDigital_DeleteAllTimeSets
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_DeleteAllTimeSets was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_DeleteAllTimeSets_cfunc = self._get_library_function('niDigital_DeleteAllTimeSets')
                 self.niDigital_DeleteAllTimeSets_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_DeleteAllTimeSets_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_DeleteAllTimeSets_cfunc(vi)
@@ -467,12 +340,7 @@ class Library(object):
     def niDigital_DisableSites(self, vi, site_list):  # noqa: N802
         with self._func_lock:
             if self.niDigital_DisableSites_cfunc is None:
-                try:
-                    self.niDigital_DisableSites_cfunc = self._library.niDigital_DisableSites
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_DisableSites was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_DisableSites_cfunc = self._get_library_function('niDigital_DisableSites')
                 self.niDigital_DisableSites_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_DisableSites_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_DisableSites_cfunc(vi, site_list)
@@ -480,12 +348,7 @@ class Library(object):
     def niDigital_EnableSites(self, vi, site_list):  # noqa: N802
         with self._func_lock:
             if self.niDigital_EnableSites_cfunc is None:
-                try:
-                    self.niDigital_EnableSites_cfunc = self._library.niDigital_EnableSites
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_EnableSites was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_EnableSites_cfunc = self._get_library_function('niDigital_EnableSites')
                 self.niDigital_EnableSites_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_EnableSites_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_EnableSites_cfunc(vi, site_list)
@@ -493,12 +356,7 @@ class Library(object):
     def niDigital_FetchCaptureWaveformU32(self, vi, site_list, waveform_name, samples_to_read, timeout, data_buffer_size, data, actual_num_waveforms, actual_samples_per_waveform):  # noqa: N802
         with self._func_lock:
             if self.niDigital_FetchCaptureWaveformU32_cfunc is None:
-                try:
-                    self.niDigital_FetchCaptureWaveformU32_cfunc = self._library.niDigital_FetchCaptureWaveformU32
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_FetchCaptureWaveformU32 was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_FetchCaptureWaveformU32_cfunc = self._get_library_function('niDigital_FetchCaptureWaveformU32')
                 self.niDigital_FetchCaptureWaveformU32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViReal64, ViInt32, ctypes.POINTER(ViUInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_FetchCaptureWaveformU32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_FetchCaptureWaveformU32_cfunc(vi, site_list, waveform_name, samples_to_read, timeout, data_buffer_size, data, actual_num_waveforms, actual_samples_per_waveform)
@@ -506,12 +364,7 @@ class Library(object):
     def niDigital_FetchHistoryRAMCycleInformation(self, vi, site, sample_index, pattern_index, time_set_index, vector_number, cycle_number, num_dut_cycles):  # noqa: N802
         with self._func_lock:
             if self.niDigital_FetchHistoryRAMCycleInformation_cfunc is None:
-                try:
-                    self.niDigital_FetchHistoryRAMCycleInformation_cfunc = self._library.niDigital_FetchHistoryRAMCycleInformation
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_FetchHistoryRAMCycleInformation was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_FetchHistoryRAMCycleInformation_cfunc = self._get_library_function('niDigital_FetchHistoryRAMCycleInformation')
                 self.niDigital_FetchHistoryRAMCycleInformation_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt64, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt64), ctypes.POINTER(ViInt64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_FetchHistoryRAMCycleInformation_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_FetchHistoryRAMCycleInformation_cfunc(vi, site, sample_index, pattern_index, time_set_index, vector_number, cycle_number, num_dut_cycles)
@@ -519,12 +372,7 @@ class Library(object):
     def niDigital_FetchHistoryRAMCyclePinData(self, vi, site, pin_list, sample_index, dut_cycle_index, pin_data_buffer_size, expected_pin_states, actual_pin_states, per_pin_pass_fail, actual_num_pin_data):  # noqa: N802
         with self._func_lock:
             if self.niDigital_FetchHistoryRAMCyclePinData_cfunc is None:
-                try:
-                    self.niDigital_FetchHistoryRAMCyclePinData_cfunc = self._library.niDigital_FetchHistoryRAMCyclePinData
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_FetchHistoryRAMCyclePinData was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_FetchHistoryRAMCyclePinData_cfunc = self._get_library_function('niDigital_FetchHistoryRAMCyclePinData')
                 self.niDigital_FetchHistoryRAMCyclePinData_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt64, ViInt32, ViInt32, ctypes.POINTER(ViUInt8), ctypes.POINTER(ViUInt8), ctypes.POINTER(ViBoolean), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_FetchHistoryRAMCyclePinData_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_FetchHistoryRAMCyclePinData_cfunc(vi, site, pin_list, sample_index, dut_cycle_index, pin_data_buffer_size, expected_pin_states, actual_pin_states, per_pin_pass_fail, actual_num_pin_data)
@@ -532,12 +380,7 @@ class Library(object):
     def niDigital_FetchHistoryRAMScanCycleNumber(self, vi, site, sample_index, scan_cycle_number):  # noqa: N802
         with self._func_lock:
             if self.niDigital_FetchHistoryRAMScanCycleNumber_cfunc is None:
-                try:
-                    self.niDigital_FetchHistoryRAMScanCycleNumber_cfunc = self._library.niDigital_FetchHistoryRAMScanCycleNumber
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_FetchHistoryRAMScanCycleNumber was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_FetchHistoryRAMScanCycleNumber_cfunc = self._get_library_function('niDigital_FetchHistoryRAMScanCycleNumber')
                 self.niDigital_FetchHistoryRAMScanCycleNumber_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt64, ctypes.POINTER(ViInt64)]  # noqa: F405
                 self.niDigital_FetchHistoryRAMScanCycleNumber_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_FetchHistoryRAMScanCycleNumber_cfunc(vi, site, sample_index, scan_cycle_number)
@@ -545,12 +388,7 @@ class Library(object):
     def niDigital_FrequencyCounter_MeasureFrequency(self, vi, channel_list, frequencies_buffer_size, frequencies, actual_num_frequencies):  # noqa: N802
         with self._func_lock:
             if self.niDigital_FrequencyCounter_MeasureFrequency_cfunc is None:
-                try:
-                    self.niDigital_FrequencyCounter_MeasureFrequency_cfunc = self._library.niDigital_FrequencyCounter_MeasureFrequency
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_FrequencyCounter_MeasureFrequency was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_FrequencyCounter_MeasureFrequency_cfunc = self._get_library_function('niDigital_FrequencyCounter_MeasureFrequency')
                 self.niDigital_FrequencyCounter_MeasureFrequency_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_FrequencyCounter_MeasureFrequency_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_FrequencyCounter_MeasureFrequency_cfunc(vi, channel_list, frequencies_buffer_size, frequencies, actual_num_frequencies)
@@ -558,12 +396,7 @@ class Library(object):
     def niDigital_GetAttributeViBoolean(self, vi, channel_name, attribute, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetAttributeViBoolean_cfunc is None:
-                try:
-                    self.niDigital_GetAttributeViBoolean_cfunc = self._library.niDigital_GetAttributeViBoolean
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_GetAttributeViBoolean was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_GetAttributeViBoolean_cfunc = self._get_library_function('niDigital_GetAttributeViBoolean')
                 self.niDigital_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDigital_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetAttributeViBoolean_cfunc(vi, channel_name, attribute, value)
@@ -571,12 +404,7 @@ class Library(object):
     def niDigital_GetAttributeViInt32(self, vi, channel_name, attribute, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetAttributeViInt32_cfunc is None:
-                try:
-                    self.niDigital_GetAttributeViInt32_cfunc = self._library.niDigital_GetAttributeViInt32
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_GetAttributeViInt32 was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_GetAttributeViInt32_cfunc = self._get_library_function('niDigital_GetAttributeViInt32')
                 self.niDigital_GetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetAttributeViInt32_cfunc(vi, channel_name, attribute, value)
@@ -584,12 +412,7 @@ class Library(object):
     def niDigital_GetAttributeViInt64(self, vi, channel_name, attribute, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetAttributeViInt64_cfunc is None:
-                try:
-                    self.niDigital_GetAttributeViInt64_cfunc = self._library.niDigital_GetAttributeViInt64
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_GetAttributeViInt64 was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_GetAttributeViInt64_cfunc = self._get_library_function('niDigital_GetAttributeViInt64')
                 self.niDigital_GetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt64)]  # noqa: F405
                 self.niDigital_GetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetAttributeViInt64_cfunc(vi, channel_name, attribute, value)
@@ -597,12 +420,7 @@ class Library(object):
     def niDigital_GetAttributeViReal64(self, vi, channel_name, attribute, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetAttributeViReal64_cfunc is None:
-                try:
-                    self.niDigital_GetAttributeViReal64_cfunc = self._library.niDigital_GetAttributeViReal64
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_GetAttributeViReal64 was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_GetAttributeViReal64_cfunc = self._get_library_function('niDigital_GetAttributeViReal64')
                 self.niDigital_GetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDigital_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetAttributeViReal64_cfunc(vi, channel_name, attribute, value)
@@ -610,12 +428,7 @@ class Library(object):
     def niDigital_GetAttributeViString(self, vi, channel_name, attribute, buffer_size, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetAttributeViString_cfunc is None:
-                try:
-                    self.niDigital_GetAttributeViString_cfunc = self._library.niDigital_GetAttributeViString
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_GetAttributeViString was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_GetAttributeViString_cfunc = self._get_library_function('niDigital_GetAttributeViString')
                 self.niDigital_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetAttributeViString_cfunc(vi, channel_name, attribute, buffer_size, value)
@@ -623,12 +436,7 @@ class Library(object):
     def niDigital_GetChannelNameFromString(self, vi, indices, name_buffer_size, names):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetChannelNameFromString_cfunc is None:
-                try:
-                    self.niDigital_GetChannelNameFromString_cfunc = self._library.niDigital_GetChannelNameFromString
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_GetChannelNameFromString was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_GetChannelNameFromString_cfunc = self._get_library_function('niDigital_GetChannelNameFromString')
                 self.niDigital_GetChannelNameFromString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_GetChannelNameFromString_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetChannelNameFromString_cfunc(vi, indices, name_buffer_size, names)
@@ -636,12 +444,7 @@ class Library(object):
     def niDigital_GetError(self, vi, error_code, error_description_buffer_size, error_description):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetError_cfunc is None:
-                try:
-                    self.niDigital_GetError_cfunc = self._library.niDigital_GetError
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_GetError was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_GetError_cfunc = self._get_library_function('niDigital_GetError')
                 self.niDigital_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_GetError_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetError_cfunc(vi, error_code, error_description_buffer_size, error_description)
@@ -649,12 +452,7 @@ class Library(object):
     def niDigital_GetFailCount(self, vi, channel_list, buffer_size, failure_count, actual_num_read):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetFailCount_cfunc is None:
-                try:
-                    self.niDigital_GetFailCount_cfunc = self._library.niDigital_GetFailCount
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_GetFailCount was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_GetFailCount_cfunc = self._get_library_function('niDigital_GetFailCount')
                 self.niDigital_GetFailCount_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_GetFailCount_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetFailCount_cfunc(vi, channel_list, buffer_size, failure_count, actual_num_read)
@@ -662,12 +460,7 @@ class Library(object):
     def niDigital_GetHistoryRAMSampleCount(self, vi, site, sample_count):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetHistoryRAMSampleCount_cfunc is None:
-                try:
-                    self.niDigital_GetHistoryRAMSampleCount_cfunc = self._library.niDigital_GetHistoryRAMSampleCount
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_GetHistoryRAMSampleCount was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_GetHistoryRAMSampleCount_cfunc = self._get_library_function('niDigital_GetHistoryRAMSampleCount')
                 self.niDigital_GetHistoryRAMSampleCount_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViInt64)]  # noqa: F405
                 self.niDigital_GetHistoryRAMSampleCount_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetHistoryRAMSampleCount_cfunc(vi, site, sample_count)
@@ -675,12 +468,7 @@ class Library(object):
     def niDigital_GetPatternName(self, vi, pattern_index, name_buffer_size, name):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetPatternName_cfunc is None:
-                try:
-                    self.niDigital_GetPatternName_cfunc = self._library.niDigital_GetPatternName
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_GetPatternName was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_GetPatternName_cfunc = self._get_library_function('niDigital_GetPatternName')
                 self.niDigital_GetPatternName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_GetPatternName_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetPatternName_cfunc(vi, pattern_index, name_buffer_size, name)
@@ -688,12 +476,7 @@ class Library(object):
     def niDigital_GetPatternPinList(self, vi, start_label, pin_list_buffer_size, pin_list):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetPatternPinList_cfunc is None:
-                try:
-                    self.niDigital_GetPatternPinList_cfunc = self._library.niDigital_GetPatternPinList
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_GetPatternPinList was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_GetPatternPinList_cfunc = self._get_library_function('niDigital_GetPatternPinList')
                 self.niDigital_GetPatternPinList_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_GetPatternPinList_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetPatternPinList_cfunc(vi, start_label, pin_list_buffer_size, pin_list)
@@ -701,12 +484,7 @@ class Library(object):
     def niDigital_GetPinName(self, vi, pin_index, name_buffer_size, name):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetPinName_cfunc is None:
-                try:
-                    self.niDigital_GetPinName_cfunc = self._library.niDigital_GetPinName
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_GetPinName was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_GetPinName_cfunc = self._get_library_function('niDigital_GetPinName')
                 self.niDigital_GetPinName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_GetPinName_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetPinName_cfunc(vi, pin_index, name_buffer_size, name)
@@ -714,12 +492,7 @@ class Library(object):
     def niDigital_GetPinResultsPinInformation(self, vi, channel_list, buffer_size, pin_indexes, site_numbers, channel_indexes, actual_num_values):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetPinResultsPinInformation_cfunc is None:
-                try:
-                    self.niDigital_GetPinResultsPinInformation_cfunc = self._library.niDigital_GetPinResultsPinInformation
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_GetPinResultsPinInformation was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_GetPinResultsPinInformation_cfunc = self._get_library_function('niDigital_GetPinResultsPinInformation')
                 self.niDigital_GetPinResultsPinInformation_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_GetPinResultsPinInformation_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetPinResultsPinInformation_cfunc(vi, channel_list, buffer_size, pin_indexes, site_numbers, channel_indexes, actual_num_values)
@@ -727,12 +500,7 @@ class Library(object):
     def niDigital_GetSitePassFail(self, vi, site_list, pass_fail_buffer_size, pass_fail, actual_num_sites):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetSitePassFail_cfunc is None:
-                try:
-                    self.niDigital_GetSitePassFail_cfunc = self._library.niDigital_GetSitePassFail
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_GetSitePassFail was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_GetSitePassFail_cfunc = self._get_library_function('niDigital_GetSitePassFail')
                 self.niDigital_GetSitePassFail_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViBoolean), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_GetSitePassFail_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetSitePassFail_cfunc(vi, site_list, pass_fail_buffer_size, pass_fail, actual_num_sites)
@@ -740,12 +508,7 @@ class Library(object):
     def niDigital_GetSiteResultsSiteNumbers(self, vi, site_list, site_result_type, site_numbers_buffer_size, site_numbers, actual_num_site_numbers):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetSiteResultsSiteNumbers_cfunc is None:
-                try:
-                    self.niDigital_GetSiteResultsSiteNumbers_cfunc = self._library.niDigital_GetSiteResultsSiteNumbers
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_GetSiteResultsSiteNumbers was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_GetSiteResultsSiteNumbers_cfunc = self._get_library_function('niDigital_GetSiteResultsSiteNumbers')
                 self.niDigital_GetSiteResultsSiteNumbers_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_GetSiteResultsSiteNumbers_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetSiteResultsSiteNumbers_cfunc(vi, site_list, site_result_type, site_numbers_buffer_size, site_numbers, actual_num_site_numbers)
@@ -753,12 +516,7 @@ class Library(object):
     def niDigital_GetTimeSetDriveFormat(self, vi, pin, time_set_name, format):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetTimeSetDriveFormat_cfunc is None:
-                try:
-                    self.niDigital_GetTimeSetDriveFormat_cfunc = self._library.niDigital_GetTimeSetDriveFormat
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_GetTimeSetDriveFormat was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_GetTimeSetDriveFormat_cfunc = self._get_library_function('niDigital_GetTimeSetDriveFormat')
                 self.niDigital_GetTimeSetDriveFormat_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_GetTimeSetDriveFormat_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetTimeSetDriveFormat_cfunc(vi, pin, time_set_name, format)
@@ -766,12 +524,7 @@ class Library(object):
     def niDigital_GetTimeSetEdge(self, vi, pin, time_set_name, edge, time):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetTimeSetEdge_cfunc is None:
-                try:
-                    self.niDigital_GetTimeSetEdge_cfunc = self._library.niDigital_GetTimeSetEdge
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_GetTimeSetEdge was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_GetTimeSetEdge_cfunc = self._get_library_function('niDigital_GetTimeSetEdge')
                 self.niDigital_GetTimeSetEdge_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDigital_GetTimeSetEdge_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetTimeSetEdge_cfunc(vi, pin, time_set_name, edge, time)
@@ -779,12 +532,7 @@ class Library(object):
     def niDigital_GetTimeSetEdgeMultiplier(self, vi, pin, time_set_name, edge_multiplier):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetTimeSetEdgeMultiplier_cfunc is None:
-                try:
-                    self.niDigital_GetTimeSetEdgeMultiplier_cfunc = self._library.niDigital_GetTimeSetEdgeMultiplier
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_GetTimeSetEdgeMultiplier was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_GetTimeSetEdgeMultiplier_cfunc = self._get_library_function('niDigital_GetTimeSetEdgeMultiplier')
                 self.niDigital_GetTimeSetEdgeMultiplier_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_GetTimeSetEdgeMultiplier_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetTimeSetEdgeMultiplier_cfunc(vi, pin, time_set_name, edge_multiplier)
@@ -792,12 +540,7 @@ class Library(object):
     def niDigital_GetTimeSetName(self, vi, time_set_index, name_buffer_size, name):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetTimeSetName_cfunc is None:
-                try:
-                    self.niDigital_GetTimeSetName_cfunc = self._library.niDigital_GetTimeSetName
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_GetTimeSetName was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_GetTimeSetName_cfunc = self._get_library_function('niDigital_GetTimeSetName')
                 self.niDigital_GetTimeSetName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_GetTimeSetName_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetTimeSetName_cfunc(vi, time_set_index, name_buffer_size, name)
@@ -805,12 +548,7 @@ class Library(object):
     def niDigital_GetTimeSetPeriod(self, vi, time_set_name, period):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetTimeSetPeriod_cfunc is None:
-                try:
-                    self.niDigital_GetTimeSetPeriod_cfunc = self._library.niDigital_GetTimeSetPeriod
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_GetTimeSetPeriod was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_GetTimeSetPeriod_cfunc = self._get_library_function('niDigital_GetTimeSetPeriod')
                 self.niDigital_GetTimeSetPeriod_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDigital_GetTimeSetPeriod_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetTimeSetPeriod_cfunc(vi, time_set_name, period)
@@ -818,12 +556,7 @@ class Library(object):
     def niDigital_InitWithOptions(self, resource_name, id_query, reset_device, option_string, new_vi):  # noqa: N802
         with self._func_lock:
             if self.niDigital_InitWithOptions_cfunc is None:
-                try:
-                    self.niDigital_InitWithOptions_cfunc = self._library.niDigital_InitWithOptions
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_InitWithOptions was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_InitWithOptions_cfunc = self._get_library_function('niDigital_InitWithOptions')
                 self.niDigital_InitWithOptions_cfunc.argtypes = [ctypes.POINTER(ViChar), ViBoolean, ViBoolean, ctypes.POINTER(ViChar), ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niDigital_InitWithOptions_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_InitWithOptions_cfunc(resource_name, id_query, reset_device, option_string, new_vi)
@@ -831,12 +564,7 @@ class Library(object):
     def niDigital_Initiate(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDigital_Initiate_cfunc is None:
-                try:
-                    self.niDigital_Initiate_cfunc = self._library.niDigital_Initiate
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_Initiate was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_Initiate_cfunc = self._get_library_function('niDigital_Initiate')
                 self.niDigital_Initiate_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_Initiate_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_Initiate_cfunc(vi)
@@ -844,12 +572,7 @@ class Library(object):
     def niDigital_IsDone(self, vi, done):  # noqa: N802
         with self._func_lock:
             if self.niDigital_IsDone_cfunc is None:
-                try:
-                    self.niDigital_IsDone_cfunc = self._library.niDigital_IsDone
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_IsDone was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_IsDone_cfunc = self._get_library_function('niDigital_IsDone')
                 self.niDigital_IsDone_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDigital_IsDone_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_IsDone_cfunc(vi, done)
@@ -857,12 +580,7 @@ class Library(object):
     def niDigital_IsSiteEnabled(self, vi, site, enable):  # noqa: N802
         with self._func_lock:
             if self.niDigital_IsSiteEnabled_cfunc is None:
-                try:
-                    self.niDigital_IsSiteEnabled_cfunc = self._library.niDigital_IsSiteEnabled
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_IsSiteEnabled was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_IsSiteEnabled_cfunc = self._get_library_function('niDigital_IsSiteEnabled')
                 self.niDigital_IsSiteEnabled_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDigital_IsSiteEnabled_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_IsSiteEnabled_cfunc(vi, site, enable)
@@ -870,12 +588,7 @@ class Library(object):
     def niDigital_LoadLevels(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDigital_LoadLevels_cfunc is None:
-                try:
-                    self.niDigital_LoadLevels_cfunc = self._library.niDigital_LoadLevels
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_LoadLevels was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_LoadLevels_cfunc = self._get_library_function('niDigital_LoadLevels')
                 self.niDigital_LoadLevels_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_LoadLevels_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_LoadLevels_cfunc(vi, file_path)
@@ -883,12 +596,7 @@ class Library(object):
     def niDigital_LoadPattern(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDigital_LoadPattern_cfunc is None:
-                try:
-                    self.niDigital_LoadPattern_cfunc = self._library.niDigital_LoadPattern
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_LoadPattern was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_LoadPattern_cfunc = self._get_library_function('niDigital_LoadPattern')
                 self.niDigital_LoadPattern_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_LoadPattern_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_LoadPattern_cfunc(vi, file_path)
@@ -896,12 +604,7 @@ class Library(object):
     def niDigital_LoadPinMap(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDigital_LoadPinMap_cfunc is None:
-                try:
-                    self.niDigital_LoadPinMap_cfunc = self._library.niDigital_LoadPinMap
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_LoadPinMap was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_LoadPinMap_cfunc = self._get_library_function('niDigital_LoadPinMap')
                 self.niDigital_LoadPinMap_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_LoadPinMap_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_LoadPinMap_cfunc(vi, file_path)
@@ -909,12 +612,7 @@ class Library(object):
     def niDigital_LoadSpecifications(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDigital_LoadSpecifications_cfunc is None:
-                try:
-                    self.niDigital_LoadSpecifications_cfunc = self._library.niDigital_LoadSpecifications
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_LoadSpecifications was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_LoadSpecifications_cfunc = self._get_library_function('niDigital_LoadSpecifications')
                 self.niDigital_LoadSpecifications_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_LoadSpecifications_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_LoadSpecifications_cfunc(vi, file_path)
@@ -922,12 +620,7 @@ class Library(object):
     def niDigital_LoadTiming(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDigital_LoadTiming_cfunc is None:
-                try:
-                    self.niDigital_LoadTiming_cfunc = self._library.niDigital_LoadTiming
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_LoadTiming was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_LoadTiming_cfunc = self._get_library_function('niDigital_LoadTiming')
                 self.niDigital_LoadTiming_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_LoadTiming_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_LoadTiming_cfunc(vi, file_path)
@@ -935,12 +628,7 @@ class Library(object):
     def niDigital_LockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niDigital_LockSession_cfunc is None:
-                try:
-                    self.niDigital_LockSession_cfunc = self._library.niDigital_LockSession
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_LockSession was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_LockSession_cfunc = self._get_library_function('niDigital_LockSession')
                 self.niDigital_LockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDigital_LockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_LockSession_cfunc(vi, caller_has_lock)
@@ -948,12 +636,7 @@ class Library(object):
     def niDigital_PPMU_Measure(self, vi, channel_list, measurement_type, buffer_size, measurements, actual_num_read):  # noqa: N802
         with self._func_lock:
             if self.niDigital_PPMU_Measure_cfunc is None:
-                try:
-                    self.niDigital_PPMU_Measure_cfunc = self._library.niDigital_PPMU_Measure
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_PPMU_Measure was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_PPMU_Measure_cfunc = self._get_library_function('niDigital_PPMU_Measure')
                 self.niDigital_PPMU_Measure_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_PPMU_Measure_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_PPMU_Measure_cfunc(vi, channel_list, measurement_type, buffer_size, measurements, actual_num_read)
@@ -961,12 +644,7 @@ class Library(object):
     def niDigital_PPMU_Source(self, vi, channel_list):  # noqa: N802
         with self._func_lock:
             if self.niDigital_PPMU_Source_cfunc is None:
-                try:
-                    self.niDigital_PPMU_Source_cfunc = self._library.niDigital_PPMU_Source
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_PPMU_Source was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_PPMU_Source_cfunc = self._get_library_function('niDigital_PPMU_Source')
                 self.niDigital_PPMU_Source_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_PPMU_Source_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_PPMU_Source_cfunc(vi, channel_list)
@@ -974,12 +652,7 @@ class Library(object):
     def niDigital_ReadSequencerFlag(self, vi, flag, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ReadSequencerFlag_cfunc is None:
-                try:
-                    self.niDigital_ReadSequencerFlag_cfunc = self._library.niDigital_ReadSequencerFlag
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_ReadSequencerFlag was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_ReadSequencerFlag_cfunc = self._get_library_function('niDigital_ReadSequencerFlag')
                 self.niDigital_ReadSequencerFlag_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDigital_ReadSequencerFlag_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ReadSequencerFlag_cfunc(vi, flag, value)
@@ -987,12 +660,7 @@ class Library(object):
     def niDigital_ReadSequencerRegister(self, vi, reg, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ReadSequencerRegister_cfunc is None:
-                try:
-                    self.niDigital_ReadSequencerRegister_cfunc = self._library.niDigital_ReadSequencerRegister
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_ReadSequencerRegister was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_ReadSequencerRegister_cfunc = self._get_library_function('niDigital_ReadSequencerRegister')
                 self.niDigital_ReadSequencerRegister_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_ReadSequencerRegister_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ReadSequencerRegister_cfunc(vi, reg, value)
@@ -1000,12 +668,7 @@ class Library(object):
     def niDigital_ReadStatic(self, vi, channel_list, buffer_size, data, actual_num_read):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ReadStatic_cfunc is None:
-                try:
-                    self.niDigital_ReadStatic_cfunc = self._library.niDigital_ReadStatic
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_ReadStatic was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_ReadStatic_cfunc = self._get_library_function('niDigital_ReadStatic')
                 self.niDigital_ReadStatic_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViUInt8), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_ReadStatic_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ReadStatic_cfunc(vi, channel_list, buffer_size, data, actual_num_read)
@@ -1013,12 +676,7 @@ class Library(object):
     def niDigital_ResetDevice(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ResetDevice_cfunc is None:
-                try:
-                    self.niDigital_ResetDevice_cfunc = self._library.niDigital_ResetDevice
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_ResetDevice was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_ResetDevice_cfunc = self._get_library_function('niDigital_ResetDevice')
                 self.niDigital_ResetDevice_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_ResetDevice_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ResetDevice_cfunc(vi)
@@ -1026,12 +684,7 @@ class Library(object):
     def niDigital_SelfCalibrate(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDigital_SelfCalibrate_cfunc is None:
-                try:
-                    self.niDigital_SelfCalibrate_cfunc = self._library.niDigital_SelfCalibrate
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_SelfCalibrate was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_SelfCalibrate_cfunc = self._get_library_function('niDigital_SelfCalibrate')
                 self.niDigital_SelfCalibrate_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_SelfCalibrate_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_SelfCalibrate_cfunc(vi)
@@ -1039,12 +692,7 @@ class Library(object):
     def niDigital_SendSoftwareEdgeTrigger(self, vi, trigger, trigger_identifier):  # noqa: N802
         with self._func_lock:
             if self.niDigital_SendSoftwareEdgeTrigger_cfunc is None:
-                try:
-                    self.niDigital_SendSoftwareEdgeTrigger_cfunc = self._library.niDigital_SendSoftwareEdgeTrigger
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_SendSoftwareEdgeTrigger was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_SendSoftwareEdgeTrigger_cfunc = self._get_library_function('niDigital_SendSoftwareEdgeTrigger')
                 self.niDigital_SendSoftwareEdgeTrigger_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_SendSoftwareEdgeTrigger_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_SendSoftwareEdgeTrigger_cfunc(vi, trigger, trigger_identifier)
@@ -1052,12 +700,7 @@ class Library(object):
     def niDigital_SetAttributeViBoolean(self, vi, channel_name, attribute, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_SetAttributeViBoolean_cfunc is None:
-                try:
-                    self.niDigital_SetAttributeViBoolean_cfunc = self._library.niDigital_SetAttributeViBoolean
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_SetAttributeViBoolean was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_SetAttributeViBoolean_cfunc = self._get_library_function('niDigital_SetAttributeViBoolean')
                 self.niDigital_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViBoolean]  # noqa: F405
                 self.niDigital_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_SetAttributeViBoolean_cfunc(vi, channel_name, attribute, value)
@@ -1065,12 +708,7 @@ class Library(object):
     def niDigital_SetAttributeViInt32(self, vi, channel_name, attribute, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_SetAttributeViInt32_cfunc is None:
-                try:
-                    self.niDigital_SetAttributeViInt32_cfunc = self._library.niDigital_SetAttributeViInt32
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_SetAttributeViInt32 was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_SetAttributeViInt32_cfunc = self._get_library_function('niDigital_SetAttributeViInt32')
                 self.niDigital_SetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32]  # noqa: F405
                 self.niDigital_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_SetAttributeViInt32_cfunc(vi, channel_name, attribute, value)
@@ -1078,12 +716,7 @@ class Library(object):
     def niDigital_SetAttributeViInt64(self, vi, channel_name, attribute, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_SetAttributeViInt64_cfunc is None:
-                try:
-                    self.niDigital_SetAttributeViInt64_cfunc = self._library.niDigital_SetAttributeViInt64
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_SetAttributeViInt64 was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_SetAttributeViInt64_cfunc = self._get_library_function('niDigital_SetAttributeViInt64')
                 self.niDigital_SetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt64]  # noqa: F405
                 self.niDigital_SetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_SetAttributeViInt64_cfunc(vi, channel_name, attribute, value)
@@ -1091,12 +724,7 @@ class Library(object):
     def niDigital_SetAttributeViReal64(self, vi, channel_name, attribute, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_SetAttributeViReal64_cfunc is None:
-                try:
-                    self.niDigital_SetAttributeViReal64_cfunc = self._library.niDigital_SetAttributeViReal64
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_SetAttributeViReal64 was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_SetAttributeViReal64_cfunc = self._get_library_function('niDigital_SetAttributeViReal64')
                 self.niDigital_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niDigital_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_SetAttributeViReal64_cfunc(vi, channel_name, attribute, value)
@@ -1104,12 +732,7 @@ class Library(object):
     def niDigital_SetAttributeViString(self, vi, channel_name, attribute, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_SetAttributeViString_cfunc is None:
-                try:
-                    self.niDigital_SetAttributeViString_cfunc = self._library.niDigital_SetAttributeViString
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_SetAttributeViString was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_SetAttributeViString_cfunc = self._get_library_function('niDigital_SetAttributeViString')
                 self.niDigital_SetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_SetAttributeViString_cfunc(vi, channel_name, attribute, value)
@@ -1117,12 +740,7 @@ class Library(object):
     def niDigital_TDR(self, vi, channel_list, apply_offsets, offsets_buffer_size, offsets, actual_num_offsets):  # noqa: N802
         with self._func_lock:
             if self.niDigital_TDR_cfunc is None:
-                try:
-                    self.niDigital_TDR_cfunc = self._library.niDigital_TDR
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_TDR was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_TDR_cfunc = self._get_library_function('niDigital_TDR')
                 self.niDigital_TDR_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViBoolean, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_TDR_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_TDR_cfunc(vi, channel_list, apply_offsets, offsets_buffer_size, offsets, actual_num_offsets)
@@ -1130,12 +748,7 @@ class Library(object):
     def niDigital_UnloadAllPatterns(self, vi, unload_keep_alive_pattern):  # noqa: N802
         with self._func_lock:
             if self.niDigital_UnloadAllPatterns_cfunc is None:
-                try:
-                    self.niDigital_UnloadAllPatterns_cfunc = self._library.niDigital_UnloadAllPatterns
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_UnloadAllPatterns was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_UnloadAllPatterns_cfunc = self._get_library_function('niDigital_UnloadAllPatterns')
                 self.niDigital_UnloadAllPatterns_cfunc.argtypes = [ViSession, ViBoolean]  # noqa: F405
                 self.niDigital_UnloadAllPatterns_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_UnloadAllPatterns_cfunc(vi, unload_keep_alive_pattern)
@@ -1143,12 +756,7 @@ class Library(object):
     def niDigital_UnloadSpecifications(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDigital_UnloadSpecifications_cfunc is None:
-                try:
-                    self.niDigital_UnloadSpecifications_cfunc = self._library.niDigital_UnloadSpecifications
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_UnloadSpecifications was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_UnloadSpecifications_cfunc = self._get_library_function('niDigital_UnloadSpecifications')
                 self.niDigital_UnloadSpecifications_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_UnloadSpecifications_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_UnloadSpecifications_cfunc(vi, file_path)
@@ -1156,12 +764,7 @@ class Library(object):
     def niDigital_UnlockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niDigital_UnlockSession_cfunc is None:
-                try:
-                    self.niDigital_UnlockSession_cfunc = self._library.niDigital_UnlockSession
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_UnlockSession was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_UnlockSession_cfunc = self._get_library_function('niDigital_UnlockSession')
                 self.niDigital_UnlockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDigital_UnlockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_UnlockSession_cfunc(vi, caller_has_lock)
@@ -1169,12 +772,7 @@ class Library(object):
     def niDigital_WaitUntilDone(self, vi, timeout):  # noqa: N802
         with self._func_lock:
             if self.niDigital_WaitUntilDone_cfunc is None:
-                try:
-                    self.niDigital_WaitUntilDone_cfunc = self._library.niDigital_WaitUntilDone
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_WaitUntilDone was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_WaitUntilDone_cfunc = self._get_library_function('niDigital_WaitUntilDone')
                 self.niDigital_WaitUntilDone_cfunc.argtypes = [ViSession, ViReal64]  # noqa: F405
                 self.niDigital_WaitUntilDone_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_WaitUntilDone_cfunc(vi, timeout)
@@ -1182,12 +780,7 @@ class Library(object):
     def niDigital_WriteSequencerFlag(self, vi, flag, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_WriteSequencerFlag_cfunc is None:
-                try:
-                    self.niDigital_WriteSequencerFlag_cfunc = self._library.niDigital_WriteSequencerFlag
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_WriteSequencerFlag was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_WriteSequencerFlag_cfunc = self._get_library_function('niDigital_WriteSequencerFlag')
                 self.niDigital_WriteSequencerFlag_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViBoolean]  # noqa: F405
                 self.niDigital_WriteSequencerFlag_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_WriteSequencerFlag_cfunc(vi, flag, value)
@@ -1195,12 +788,7 @@ class Library(object):
     def niDigital_WriteSequencerRegister(self, vi, reg, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_WriteSequencerRegister_cfunc is None:
-                try:
-                    self.niDigital_WriteSequencerRegister_cfunc = self._library.niDigital_WriteSequencerRegister
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_WriteSequencerRegister was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_WriteSequencerRegister_cfunc = self._get_library_function('niDigital_WriteSequencerRegister')
                 self.niDigital_WriteSequencerRegister_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niDigital_WriteSequencerRegister_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_WriteSequencerRegister_cfunc(vi, reg, value)
@@ -1208,12 +796,7 @@ class Library(object):
     def niDigital_WriteSourceWaveformBroadcastU32(self, vi, waveform_name, waveform_size, waveform_data):  # noqa: N802
         with self._func_lock:
             if self.niDigital_WriteSourceWaveformBroadcastU32_cfunc is None:
-                try:
-                    self.niDigital_WriteSourceWaveformBroadcastU32_cfunc = self._library.niDigital_WriteSourceWaveformBroadcastU32
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_WriteSourceWaveformBroadcastU32 was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_WriteSourceWaveformBroadcastU32_cfunc = self._get_library_function('niDigital_WriteSourceWaveformBroadcastU32')
                 self.niDigital_WriteSourceWaveformBroadcastU32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViUInt32)]  # noqa: F405
                 self.niDigital_WriteSourceWaveformBroadcastU32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_WriteSourceWaveformBroadcastU32_cfunc(vi, waveform_name, waveform_size, waveform_data)
@@ -1221,12 +804,7 @@ class Library(object):
     def niDigital_WriteSourceWaveformDataFromFileTDMS(self, vi, waveform_name, waveform_file_path):  # noqa: N802
         with self._func_lock:
             if self.niDigital_WriteSourceWaveformDataFromFileTDMS_cfunc is None:
-                try:
-                    self.niDigital_WriteSourceWaveformDataFromFileTDMS_cfunc = self._library.niDigital_WriteSourceWaveformDataFromFileTDMS
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_WriteSourceWaveformDataFromFileTDMS was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_WriteSourceWaveformDataFromFileTDMS_cfunc = self._get_library_function('niDigital_WriteSourceWaveformDataFromFileTDMS')
                 self.niDigital_WriteSourceWaveformDataFromFileTDMS_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_WriteSourceWaveformDataFromFileTDMS_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_WriteSourceWaveformDataFromFileTDMS_cfunc(vi, waveform_name, waveform_file_path)
@@ -1234,12 +812,7 @@ class Library(object):
     def niDigital_WriteSourceWaveformSiteUniqueU32(self, vi, site_list, waveform_name, num_waveforms, samples_per_waveform, waveform_data):  # noqa: N802
         with self._func_lock:
             if self.niDigital_WriteSourceWaveformSiteUniqueU32_cfunc is None:
-                try:
-                    self.niDigital_WriteSourceWaveformSiteUniqueU32_cfunc = self._library.niDigital_WriteSourceWaveformSiteUniqueU32
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_WriteSourceWaveformSiteUniqueU32 was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_WriteSourceWaveformSiteUniqueU32_cfunc = self._get_library_function('niDigital_WriteSourceWaveformSiteUniqueU32')
                 self.niDigital_WriteSourceWaveformSiteUniqueU32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViInt32, ctypes.POINTER(ViUInt32)]  # noqa: F405
                 self.niDigital_WriteSourceWaveformSiteUniqueU32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_WriteSourceWaveformSiteUniqueU32_cfunc(vi, site_list, waveform_name, num_waveforms, samples_per_waveform, waveform_data)
@@ -1247,12 +820,7 @@ class Library(object):
     def niDigital_WriteStatic(self, vi, channel_list, state):  # noqa: N802
         with self._func_lock:
             if self.niDigital_WriteStatic_cfunc is None:
-                try:
-                    self.niDigital_WriteStatic_cfunc = self._library.niDigital_WriteStatic
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_WriteStatic was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_WriteStatic_cfunc = self._get_library_function('niDigital_WriteStatic')
                 self.niDigital_WriteStatic_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViUInt8]  # noqa: F405
                 self.niDigital_WriteStatic_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_WriteStatic_cfunc(vi, channel_list, state)
@@ -1260,12 +828,7 @@ class Library(object):
     def niDigital_close(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDigital_close_cfunc is None:
-                try:
-                    self.niDigital_close_cfunc = self._library.niDigital_close
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_close was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_close_cfunc = self._get_library_function('niDigital_close')
                 self.niDigital_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_close_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_close_cfunc(vi)
@@ -1273,12 +836,7 @@ class Library(object):
     def niDigital_error_message(self, vi, error_code, error_message):  # noqa: N802
         with self._func_lock:
             if self.niDigital_error_message_cfunc is None:
-                try:
-                    self.niDigital_error_message_cfunc = self._library.niDigital_error_message
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_error_message was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_error_message_cfunc = self._get_library_function('niDigital_error_message')
                 self.niDigital_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_error_message_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_error_message_cfunc(vi, error_code, error_message)
@@ -1286,12 +844,7 @@ class Library(object):
     def niDigital_reset(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDigital_reset_cfunc is None:
-                try:
-                    self.niDigital_reset_cfunc = self._library.niDigital_reset
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_reset was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_reset_cfunc = self._get_library_function('niDigital_reset')
                 self.niDigital_reset_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_reset_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_reset_cfunc(vi)
@@ -1299,12 +852,7 @@ class Library(object):
     def niDigital_self_test(self, vi, test_result, test_message):  # noqa: N802
         with self._func_lock:
             if self.niDigital_self_test_cfunc is None:
-                try:
-                    self.niDigital_self_test_cfunc = self._library.niDigital_self_test
-                except AttributeError as e:
-                    raise AttributeError("Function niDigital_self_test was not found in the NI-Digital Pattern Driver runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDigital_self_test_cfunc = self._get_library_function('niDigital_self_test')
                 self.niDigital_self_test_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_self_test_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_self_test_cfunc(vi, test_result, test_message)

--- a/generated/nidigital/nidigital/_library.py
+++ b/generated/nidigital/nidigital/_library.py
@@ -116,7 +116,12 @@ class Library(object):
     def niDigital_Abort(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDigital_Abort_cfunc is None:
-                self.niDigital_Abort_cfunc = self._library.niDigital_Abort
+                try:
+                    self.niDigital_Abort_cfunc = self._library.niDigital_Abort
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_Abort_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_Abort_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_Abort_cfunc(vi)
@@ -124,7 +129,12 @@ class Library(object):
     def niDigital_AbortKeepAlive(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDigital_AbortKeepAlive_cfunc is None:
-                self.niDigital_AbortKeepAlive_cfunc = self._library.niDigital_AbortKeepAlive
+                try:
+                    self.niDigital_AbortKeepAlive_cfunc = self._library.niDigital_AbortKeepAlive
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_AbortKeepAlive_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_AbortKeepAlive_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_AbortKeepAlive_cfunc(vi)
@@ -132,7 +142,12 @@ class Library(object):
     def niDigital_ApplyLevelsAndTiming(self, vi, site_list, levels_sheet, timing_sheet, initial_state_high_pins, initial_state_low_pins, initial_state_tristate_pins):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ApplyLevelsAndTiming_cfunc is None:
-                self.niDigital_ApplyLevelsAndTiming_cfunc = self._library.niDigital_ApplyLevelsAndTiming
+                try:
+                    self.niDigital_ApplyLevelsAndTiming_cfunc = self._library.niDigital_ApplyLevelsAndTiming
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_ApplyLevelsAndTiming_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_ApplyLevelsAndTiming_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ApplyLevelsAndTiming_cfunc(vi, site_list, levels_sheet, timing_sheet, initial_state_high_pins, initial_state_low_pins, initial_state_tristate_pins)
@@ -140,7 +155,12 @@ class Library(object):
     def niDigital_ApplyTDROffsets(self, vi, channel_list, num_offsets, offsets):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ApplyTDROffsets_cfunc is None:
-                self.niDigital_ApplyTDROffsets_cfunc = self._library.niDigital_ApplyTDROffsets
+                try:
+                    self.niDigital_ApplyTDROffsets_cfunc = self._library.niDigital_ApplyTDROffsets
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_ApplyTDROffsets_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDigital_ApplyTDROffsets_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ApplyTDROffsets_cfunc(vi, channel_list, num_offsets, offsets)
@@ -148,7 +168,12 @@ class Library(object):
     def niDigital_BurstPattern(self, vi, site_list, start_label, select_digital_function, wait_until_done, timeout):  # noqa: N802
         with self._func_lock:
             if self.niDigital_BurstPattern_cfunc is None:
-                self.niDigital_BurstPattern_cfunc = self._library.niDigital_BurstPattern
+                try:
+                    self.niDigital_BurstPattern_cfunc = self._library.niDigital_BurstPattern
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_BurstPattern_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViBoolean, ViBoolean, ViReal64]  # noqa: F405
                 self.niDigital_BurstPattern_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_BurstPattern_cfunc(vi, site_list, start_label, select_digital_function, wait_until_done, timeout)
@@ -156,7 +181,12 @@ class Library(object):
     def niDigital_ClockGenerator_Abort(self, vi, channel_list):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ClockGenerator_Abort_cfunc is None:
-                self.niDigital_ClockGenerator_Abort_cfunc = self._library.niDigital_ClockGenerator_Abort
+                try:
+                    self.niDigital_ClockGenerator_Abort_cfunc = self._library.niDigital_ClockGenerator_Abort
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_ClockGenerator_Abort_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_ClockGenerator_Abort_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ClockGenerator_Abort_cfunc(vi, channel_list)
@@ -164,7 +194,12 @@ class Library(object):
     def niDigital_ClockGenerator_GenerateClock(self, vi, channel_list, frequency, select_digital_function):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ClockGenerator_GenerateClock_cfunc is None:
-                self.niDigital_ClockGenerator_GenerateClock_cfunc = self._library.niDigital_ClockGenerator_GenerateClock
+                try:
+                    self.niDigital_ClockGenerator_GenerateClock_cfunc = self._library.niDigital_ClockGenerator_GenerateClock
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_ClockGenerator_GenerateClock_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViBoolean]  # noqa: F405
                 self.niDigital_ClockGenerator_GenerateClock_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ClockGenerator_GenerateClock_cfunc(vi, channel_list, frequency, select_digital_function)
@@ -172,7 +207,12 @@ class Library(object):
     def niDigital_Commit(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDigital_Commit_cfunc is None:
-                self.niDigital_Commit_cfunc = self._library.niDigital_Commit
+                try:
+                    self.niDigital_Commit_cfunc = self._library.niDigital_Commit
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_Commit_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_Commit_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_Commit_cfunc(vi)
@@ -180,7 +220,12 @@ class Library(object):
     def niDigital_ConfigureActiveLoadLevels(self, vi, channel_list, iol, ioh, vcom):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ConfigureActiveLoadLevels_cfunc is None:
-                self.niDigital_ConfigureActiveLoadLevels_cfunc = self._library.niDigital_ConfigureActiveLoadLevels
+                try:
+                    self.niDigital_ConfigureActiveLoadLevels_cfunc = self._library.niDigital_ConfigureActiveLoadLevels
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_ConfigureActiveLoadLevels_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niDigital_ConfigureActiveLoadLevels_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureActiveLoadLevels_cfunc(vi, channel_list, iol, ioh, vcom)
@@ -188,7 +233,12 @@ class Library(object):
     def niDigital_ConfigurePatternBurstSites(self, vi, site_list):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ConfigurePatternBurstSites_cfunc is None:
-                self.niDigital_ConfigurePatternBurstSites_cfunc = self._library.niDigital_ConfigurePatternBurstSites
+                try:
+                    self.niDigital_ConfigurePatternBurstSites_cfunc = self._library.niDigital_ConfigurePatternBurstSites
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_ConfigurePatternBurstSites_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_ConfigurePatternBurstSites_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigurePatternBurstSites_cfunc(vi, site_list)
@@ -196,7 +246,12 @@ class Library(object):
     def niDigital_ConfigureTimeSetCompareEdgesStrobe(self, vi, pin_list, time_set_name, strobe_edge):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ConfigureTimeSetCompareEdgesStrobe_cfunc is None:
-                self.niDigital_ConfigureTimeSetCompareEdgesStrobe_cfunc = self._library.niDigital_ConfigureTimeSetCompareEdgesStrobe
+                try:
+                    self.niDigital_ConfigureTimeSetCompareEdgesStrobe_cfunc = self._library.niDigital_ConfigureTimeSetCompareEdgesStrobe
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_ConfigureTimeSetCompareEdgesStrobe_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViReal64]  # noqa: F405
                 self.niDigital_ConfigureTimeSetCompareEdgesStrobe_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureTimeSetCompareEdgesStrobe_cfunc(vi, pin_list, time_set_name, strobe_edge)
@@ -204,7 +259,12 @@ class Library(object):
     def niDigital_ConfigureTimeSetCompareEdgesStrobe2x(self, vi, pin_list, time_set_name, strobe_edge, strobe2_edge):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ConfigureTimeSetCompareEdgesStrobe2x_cfunc is None:
-                self.niDigital_ConfigureTimeSetCompareEdgesStrobe2x_cfunc = self._library.niDigital_ConfigureTimeSetCompareEdgesStrobe2x
+                try:
+                    self.niDigital_ConfigureTimeSetCompareEdgesStrobe2x_cfunc = self._library.niDigital_ConfigureTimeSetCompareEdgesStrobe2x
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_ConfigureTimeSetCompareEdgesStrobe2x_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViReal64, ViReal64]  # noqa: F405
                 self.niDigital_ConfigureTimeSetCompareEdgesStrobe2x_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureTimeSetCompareEdgesStrobe2x_cfunc(vi, pin_list, time_set_name, strobe_edge, strobe2_edge)
@@ -212,7 +272,12 @@ class Library(object):
     def niDigital_ConfigureTimeSetDriveEdges(self, vi, pin_list, time_set_name, format, drive_on_edge, drive_data_edge, drive_return_edge, drive_off_edge):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ConfigureTimeSetDriveEdges_cfunc is None:
-                self.niDigital_ConfigureTimeSetDriveEdges_cfunc = self._library.niDigital_ConfigureTimeSetDriveEdges
+                try:
+                    self.niDigital_ConfigureTimeSetDriveEdges_cfunc = self._library.niDigital_ConfigureTimeSetDriveEdges
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_ConfigureTimeSetDriveEdges_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViReal64, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niDigital_ConfigureTimeSetDriveEdges_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureTimeSetDriveEdges_cfunc(vi, pin_list, time_set_name, format, drive_on_edge, drive_data_edge, drive_return_edge, drive_off_edge)
@@ -220,7 +285,12 @@ class Library(object):
     def niDigital_ConfigureTimeSetDriveEdges2x(self, vi, pin_list, time_set_name, format, drive_on_edge, drive_data_edge, drive_return_edge, drive_off_edge, drive_data2_edge, drive_return2_edge):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ConfigureTimeSetDriveEdges2x_cfunc is None:
-                self.niDigital_ConfigureTimeSetDriveEdges2x_cfunc = self._library.niDigital_ConfigureTimeSetDriveEdges2x
+                try:
+                    self.niDigital_ConfigureTimeSetDriveEdges2x_cfunc = self._library.niDigital_ConfigureTimeSetDriveEdges2x
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_ConfigureTimeSetDriveEdges2x_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViReal64, ViReal64, ViReal64, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niDigital_ConfigureTimeSetDriveEdges2x_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureTimeSetDriveEdges2x_cfunc(vi, pin_list, time_set_name, format, drive_on_edge, drive_data_edge, drive_return_edge, drive_off_edge, drive_data2_edge, drive_return2_edge)
@@ -228,7 +298,12 @@ class Library(object):
     def niDigital_ConfigureTimeSetDriveFormat(self, vi, pin_list, time_set_name, drive_format):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ConfigureTimeSetDriveFormat_cfunc is None:
-                self.niDigital_ConfigureTimeSetDriveFormat_cfunc = self._library.niDigital_ConfigureTimeSetDriveFormat
+                try:
+                    self.niDigital_ConfigureTimeSetDriveFormat_cfunc = self._library.niDigital_ConfigureTimeSetDriveFormat
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_ConfigureTimeSetDriveFormat_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niDigital_ConfigureTimeSetDriveFormat_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureTimeSetDriveFormat_cfunc(vi, pin_list, time_set_name, drive_format)
@@ -236,7 +311,12 @@ class Library(object):
     def niDigital_ConfigureTimeSetEdge(self, vi, pin_list, time_set_name, edge, time):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ConfigureTimeSetEdge_cfunc is None:
-                self.niDigital_ConfigureTimeSetEdge_cfunc = self._library.niDigital_ConfigureTimeSetEdge
+                try:
+                    self.niDigital_ConfigureTimeSetEdge_cfunc = self._library.niDigital_ConfigureTimeSetEdge
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_ConfigureTimeSetEdge_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViReal64]  # noqa: F405
                 self.niDigital_ConfigureTimeSetEdge_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureTimeSetEdge_cfunc(vi, pin_list, time_set_name, edge, time)
@@ -244,7 +324,12 @@ class Library(object):
     def niDigital_ConfigureTimeSetEdgeMultiplier(self, vi, pin_list, time_set_name, edge_multiplier):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ConfigureTimeSetEdgeMultiplier_cfunc is None:
-                self.niDigital_ConfigureTimeSetEdgeMultiplier_cfunc = self._library.niDigital_ConfigureTimeSetEdgeMultiplier
+                try:
+                    self.niDigital_ConfigureTimeSetEdgeMultiplier_cfunc = self._library.niDigital_ConfigureTimeSetEdgeMultiplier
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_ConfigureTimeSetEdgeMultiplier_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niDigital_ConfigureTimeSetEdgeMultiplier_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureTimeSetEdgeMultiplier_cfunc(vi, pin_list, time_set_name, edge_multiplier)
@@ -252,7 +337,12 @@ class Library(object):
     def niDigital_ConfigureTimeSetPeriod(self, vi, time_set_name, period):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ConfigureTimeSetPeriod_cfunc is None:
-                self.niDigital_ConfigureTimeSetPeriod_cfunc = self._library.niDigital_ConfigureTimeSetPeriod
+                try:
+                    self.niDigital_ConfigureTimeSetPeriod_cfunc = self._library.niDigital_ConfigureTimeSetPeriod
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_ConfigureTimeSetPeriod_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64]  # noqa: F405
                 self.niDigital_ConfigureTimeSetPeriod_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureTimeSetPeriod_cfunc(vi, time_set_name, period)
@@ -260,7 +350,12 @@ class Library(object):
     def niDigital_ConfigureVoltageLevels(self, vi, channel_list, vil, vih, vol, voh, vterm):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ConfigureVoltageLevels_cfunc is None:
-                self.niDigital_ConfigureVoltageLevels_cfunc = self._library.niDigital_ConfigureVoltageLevels
+                try:
+                    self.niDigital_ConfigureVoltageLevels_cfunc = self._library.niDigital_ConfigureVoltageLevels
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_ConfigureVoltageLevels_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViReal64, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niDigital_ConfigureVoltageLevels_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ConfigureVoltageLevels_cfunc(vi, channel_list, vil, vih, vol, voh, vterm)
@@ -268,7 +363,12 @@ class Library(object):
     def niDigital_CreateCaptureWaveformFromFileDigicapture(self, vi, waveform_name, waveform_file_path):  # noqa: N802
         with self._func_lock:
             if self.niDigital_CreateCaptureWaveformFromFileDigicapture_cfunc is None:
-                self.niDigital_CreateCaptureWaveformFromFileDigicapture_cfunc = self._library.niDigital_CreateCaptureWaveformFromFileDigicapture
+                try:
+                    self.niDigital_CreateCaptureWaveformFromFileDigicapture_cfunc = self._library.niDigital_CreateCaptureWaveformFromFileDigicapture
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_CreateCaptureWaveformFromFileDigicapture_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_CreateCaptureWaveformFromFileDigicapture_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_CreateCaptureWaveformFromFileDigicapture_cfunc(vi, waveform_name, waveform_file_path)
@@ -276,7 +376,12 @@ class Library(object):
     def niDigital_CreateCaptureWaveformParallel(self, vi, pin_list, waveform_name):  # noqa: N802
         with self._func_lock:
             if self.niDigital_CreateCaptureWaveformParallel_cfunc is None:
-                self.niDigital_CreateCaptureWaveformParallel_cfunc = self._library.niDigital_CreateCaptureWaveformParallel
+                try:
+                    self.niDigital_CreateCaptureWaveformParallel_cfunc = self._library.niDigital_CreateCaptureWaveformParallel
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_CreateCaptureWaveformParallel_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_CreateCaptureWaveformParallel_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_CreateCaptureWaveformParallel_cfunc(vi, pin_list, waveform_name)
@@ -284,7 +389,12 @@ class Library(object):
     def niDigital_CreateCaptureWaveformSerial(self, vi, pin_list, waveform_name, sample_width, bit_order):  # noqa: N802
         with self._func_lock:
             if self.niDigital_CreateCaptureWaveformSerial_cfunc is None:
-                self.niDigital_CreateCaptureWaveformSerial_cfunc = self._library.niDigital_CreateCaptureWaveformSerial
+                try:
+                    self.niDigital_CreateCaptureWaveformSerial_cfunc = self._library.niDigital_CreateCaptureWaveformSerial
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_CreateCaptureWaveformSerial_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViUInt32, ViInt32]  # noqa: F405
                 self.niDigital_CreateCaptureWaveformSerial_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_CreateCaptureWaveformSerial_cfunc(vi, pin_list, waveform_name, sample_width, bit_order)
@@ -292,7 +402,12 @@ class Library(object):
     def niDigital_CreateSourceWaveformFromFileTDMS(self, vi, waveform_name, waveform_file_path, write_waveform_data):  # noqa: N802
         with self._func_lock:
             if self.niDigital_CreateSourceWaveformFromFileTDMS_cfunc is None:
-                self.niDigital_CreateSourceWaveformFromFileTDMS_cfunc = self._library.niDigital_CreateSourceWaveformFromFileTDMS
+                try:
+                    self.niDigital_CreateSourceWaveformFromFileTDMS_cfunc = self._library.niDigital_CreateSourceWaveformFromFileTDMS
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_CreateSourceWaveformFromFileTDMS_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViBoolean]  # noqa: F405
                 self.niDigital_CreateSourceWaveformFromFileTDMS_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_CreateSourceWaveformFromFileTDMS_cfunc(vi, waveform_name, waveform_file_path, write_waveform_data)
@@ -300,7 +415,12 @@ class Library(object):
     def niDigital_CreateSourceWaveformParallel(self, vi, pin_list, waveform_name, data_mapping):  # noqa: N802
         with self._func_lock:
             if self.niDigital_CreateSourceWaveformParallel_cfunc is None:
-                self.niDigital_CreateSourceWaveformParallel_cfunc = self._library.niDigital_CreateSourceWaveformParallel
+                try:
+                    self.niDigital_CreateSourceWaveformParallel_cfunc = self._library.niDigital_CreateSourceWaveformParallel
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_CreateSourceWaveformParallel_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niDigital_CreateSourceWaveformParallel_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_CreateSourceWaveformParallel_cfunc(vi, pin_list, waveform_name, data_mapping)
@@ -308,7 +428,12 @@ class Library(object):
     def niDigital_CreateSourceWaveformSerial(self, vi, pin_list, waveform_name, data_mapping, sample_width, bit_order):  # noqa: N802
         with self._func_lock:
             if self.niDigital_CreateSourceWaveformSerial_cfunc is None:
-                self.niDigital_CreateSourceWaveformSerial_cfunc = self._library.niDigital_CreateSourceWaveformSerial
+                try:
+                    self.niDigital_CreateSourceWaveformSerial_cfunc = self._library.niDigital_CreateSourceWaveformSerial
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_CreateSourceWaveformSerial_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViUInt32, ViInt32]  # noqa: F405
                 self.niDigital_CreateSourceWaveformSerial_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_CreateSourceWaveformSerial_cfunc(vi, pin_list, waveform_name, data_mapping, sample_width, bit_order)
@@ -316,7 +441,12 @@ class Library(object):
     def niDigital_CreateTimeSet(self, vi, name):  # noqa: N802
         with self._func_lock:
             if self.niDigital_CreateTimeSet_cfunc is None:
-                self.niDigital_CreateTimeSet_cfunc = self._library.niDigital_CreateTimeSet
+                try:
+                    self.niDigital_CreateTimeSet_cfunc = self._library.niDigital_CreateTimeSet
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_CreateTimeSet_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_CreateTimeSet_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_CreateTimeSet_cfunc(vi, name)
@@ -324,7 +454,12 @@ class Library(object):
     def niDigital_DeleteAllTimeSets(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDigital_DeleteAllTimeSets_cfunc is None:
-                self.niDigital_DeleteAllTimeSets_cfunc = self._library.niDigital_DeleteAllTimeSets
+                try:
+                    self.niDigital_DeleteAllTimeSets_cfunc = self._library.niDigital_DeleteAllTimeSets
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_DeleteAllTimeSets_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_DeleteAllTimeSets_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_DeleteAllTimeSets_cfunc(vi)
@@ -332,7 +467,12 @@ class Library(object):
     def niDigital_DisableSites(self, vi, site_list):  # noqa: N802
         with self._func_lock:
             if self.niDigital_DisableSites_cfunc is None:
-                self.niDigital_DisableSites_cfunc = self._library.niDigital_DisableSites
+                try:
+                    self.niDigital_DisableSites_cfunc = self._library.niDigital_DisableSites
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_DisableSites_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_DisableSites_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_DisableSites_cfunc(vi, site_list)
@@ -340,7 +480,12 @@ class Library(object):
     def niDigital_EnableSites(self, vi, site_list):  # noqa: N802
         with self._func_lock:
             if self.niDigital_EnableSites_cfunc is None:
-                self.niDigital_EnableSites_cfunc = self._library.niDigital_EnableSites
+                try:
+                    self.niDigital_EnableSites_cfunc = self._library.niDigital_EnableSites
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_EnableSites_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_EnableSites_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_EnableSites_cfunc(vi, site_list)
@@ -348,7 +493,12 @@ class Library(object):
     def niDigital_FetchCaptureWaveformU32(self, vi, site_list, waveform_name, samples_to_read, timeout, data_buffer_size, data, actual_num_waveforms, actual_samples_per_waveform):  # noqa: N802
         with self._func_lock:
             if self.niDigital_FetchCaptureWaveformU32_cfunc is None:
-                self.niDigital_FetchCaptureWaveformU32_cfunc = self._library.niDigital_FetchCaptureWaveformU32
+                try:
+                    self.niDigital_FetchCaptureWaveformU32_cfunc = self._library.niDigital_FetchCaptureWaveformU32
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_FetchCaptureWaveformU32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViReal64, ViInt32, ctypes.POINTER(ViUInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_FetchCaptureWaveformU32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_FetchCaptureWaveformU32_cfunc(vi, site_list, waveform_name, samples_to_read, timeout, data_buffer_size, data, actual_num_waveforms, actual_samples_per_waveform)
@@ -356,7 +506,12 @@ class Library(object):
     def niDigital_FetchHistoryRAMCycleInformation(self, vi, site, sample_index, pattern_index, time_set_index, vector_number, cycle_number, num_dut_cycles):  # noqa: N802
         with self._func_lock:
             if self.niDigital_FetchHistoryRAMCycleInformation_cfunc is None:
-                self.niDigital_FetchHistoryRAMCycleInformation_cfunc = self._library.niDigital_FetchHistoryRAMCycleInformation
+                try:
+                    self.niDigital_FetchHistoryRAMCycleInformation_cfunc = self._library.niDigital_FetchHistoryRAMCycleInformation
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_FetchHistoryRAMCycleInformation_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt64, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt64), ctypes.POINTER(ViInt64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_FetchHistoryRAMCycleInformation_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_FetchHistoryRAMCycleInformation_cfunc(vi, site, sample_index, pattern_index, time_set_index, vector_number, cycle_number, num_dut_cycles)
@@ -364,7 +519,12 @@ class Library(object):
     def niDigital_FetchHistoryRAMCyclePinData(self, vi, site, pin_list, sample_index, dut_cycle_index, pin_data_buffer_size, expected_pin_states, actual_pin_states, per_pin_pass_fail, actual_num_pin_data):  # noqa: N802
         with self._func_lock:
             if self.niDigital_FetchHistoryRAMCyclePinData_cfunc is None:
-                self.niDigital_FetchHistoryRAMCyclePinData_cfunc = self._library.niDigital_FetchHistoryRAMCyclePinData
+                try:
+                    self.niDigital_FetchHistoryRAMCyclePinData_cfunc = self._library.niDigital_FetchHistoryRAMCyclePinData
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_FetchHistoryRAMCyclePinData_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt64, ViInt32, ViInt32, ctypes.POINTER(ViUInt8), ctypes.POINTER(ViUInt8), ctypes.POINTER(ViBoolean), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_FetchHistoryRAMCyclePinData_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_FetchHistoryRAMCyclePinData_cfunc(vi, site, pin_list, sample_index, dut_cycle_index, pin_data_buffer_size, expected_pin_states, actual_pin_states, per_pin_pass_fail, actual_num_pin_data)
@@ -372,7 +532,12 @@ class Library(object):
     def niDigital_FetchHistoryRAMScanCycleNumber(self, vi, site, sample_index, scan_cycle_number):  # noqa: N802
         with self._func_lock:
             if self.niDigital_FetchHistoryRAMScanCycleNumber_cfunc is None:
-                self.niDigital_FetchHistoryRAMScanCycleNumber_cfunc = self._library.niDigital_FetchHistoryRAMScanCycleNumber
+                try:
+                    self.niDigital_FetchHistoryRAMScanCycleNumber_cfunc = self._library.niDigital_FetchHistoryRAMScanCycleNumber
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_FetchHistoryRAMScanCycleNumber_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt64, ctypes.POINTER(ViInt64)]  # noqa: F405
                 self.niDigital_FetchHistoryRAMScanCycleNumber_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_FetchHistoryRAMScanCycleNumber_cfunc(vi, site, sample_index, scan_cycle_number)
@@ -380,7 +545,12 @@ class Library(object):
     def niDigital_FrequencyCounter_MeasureFrequency(self, vi, channel_list, frequencies_buffer_size, frequencies, actual_num_frequencies):  # noqa: N802
         with self._func_lock:
             if self.niDigital_FrequencyCounter_MeasureFrequency_cfunc is None:
-                self.niDigital_FrequencyCounter_MeasureFrequency_cfunc = self._library.niDigital_FrequencyCounter_MeasureFrequency
+                try:
+                    self.niDigital_FrequencyCounter_MeasureFrequency_cfunc = self._library.niDigital_FrequencyCounter_MeasureFrequency
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_FrequencyCounter_MeasureFrequency_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_FrequencyCounter_MeasureFrequency_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_FrequencyCounter_MeasureFrequency_cfunc(vi, channel_list, frequencies_buffer_size, frequencies, actual_num_frequencies)
@@ -388,7 +558,12 @@ class Library(object):
     def niDigital_GetAttributeViBoolean(self, vi, channel_name, attribute, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetAttributeViBoolean_cfunc is None:
-                self.niDigital_GetAttributeViBoolean_cfunc = self._library.niDigital_GetAttributeViBoolean
+                try:
+                    self.niDigital_GetAttributeViBoolean_cfunc = self._library.niDigital_GetAttributeViBoolean
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDigital_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetAttributeViBoolean_cfunc(vi, channel_name, attribute, value)
@@ -396,7 +571,12 @@ class Library(object):
     def niDigital_GetAttributeViInt32(self, vi, channel_name, attribute, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetAttributeViInt32_cfunc is None:
-                self.niDigital_GetAttributeViInt32_cfunc = self._library.niDigital_GetAttributeViInt32
+                try:
+                    self.niDigital_GetAttributeViInt32_cfunc = self._library.niDigital_GetAttributeViInt32
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_GetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetAttributeViInt32_cfunc(vi, channel_name, attribute, value)
@@ -404,7 +584,12 @@ class Library(object):
     def niDigital_GetAttributeViInt64(self, vi, channel_name, attribute, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetAttributeViInt64_cfunc is None:
-                self.niDigital_GetAttributeViInt64_cfunc = self._library.niDigital_GetAttributeViInt64
+                try:
+                    self.niDigital_GetAttributeViInt64_cfunc = self._library.niDigital_GetAttributeViInt64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_GetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt64)]  # noqa: F405
                 self.niDigital_GetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetAttributeViInt64_cfunc(vi, channel_name, attribute, value)
@@ -412,7 +597,12 @@ class Library(object):
     def niDigital_GetAttributeViReal64(self, vi, channel_name, attribute, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetAttributeViReal64_cfunc is None:
-                self.niDigital_GetAttributeViReal64_cfunc = self._library.niDigital_GetAttributeViReal64
+                try:
+                    self.niDigital_GetAttributeViReal64_cfunc = self._library.niDigital_GetAttributeViReal64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_GetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDigital_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetAttributeViReal64_cfunc(vi, channel_name, attribute, value)
@@ -420,7 +610,12 @@ class Library(object):
     def niDigital_GetAttributeViString(self, vi, channel_name, attribute, buffer_size, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetAttributeViString_cfunc is None:
-                self.niDigital_GetAttributeViString_cfunc = self._library.niDigital_GetAttributeViString
+                try:
+                    self.niDigital_GetAttributeViString_cfunc = self._library.niDigital_GetAttributeViString
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetAttributeViString_cfunc(vi, channel_name, attribute, buffer_size, value)
@@ -428,7 +623,12 @@ class Library(object):
     def niDigital_GetChannelNameFromString(self, vi, indices, name_buffer_size, names):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetChannelNameFromString_cfunc is None:
-                self.niDigital_GetChannelNameFromString_cfunc = self._library.niDigital_GetChannelNameFromString
+                try:
+                    self.niDigital_GetChannelNameFromString_cfunc = self._library.niDigital_GetChannelNameFromString
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_GetChannelNameFromString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_GetChannelNameFromString_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetChannelNameFromString_cfunc(vi, indices, name_buffer_size, names)
@@ -436,7 +636,12 @@ class Library(object):
     def niDigital_GetError(self, vi, error_code, error_description_buffer_size, error_description):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetError_cfunc is None:
-                self.niDigital_GetError_cfunc = self._library.niDigital_GetError
+                try:
+                    self.niDigital_GetError_cfunc = self._library.niDigital_GetError
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_GetError_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetError_cfunc(vi, error_code, error_description_buffer_size, error_description)
@@ -444,7 +649,12 @@ class Library(object):
     def niDigital_GetFailCount(self, vi, channel_list, buffer_size, failure_count, actual_num_read):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetFailCount_cfunc is None:
-                self.niDigital_GetFailCount_cfunc = self._library.niDigital_GetFailCount
+                try:
+                    self.niDigital_GetFailCount_cfunc = self._library.niDigital_GetFailCount
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_GetFailCount_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_GetFailCount_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetFailCount_cfunc(vi, channel_list, buffer_size, failure_count, actual_num_read)
@@ -452,7 +662,12 @@ class Library(object):
     def niDigital_GetHistoryRAMSampleCount(self, vi, site, sample_count):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetHistoryRAMSampleCount_cfunc is None:
-                self.niDigital_GetHistoryRAMSampleCount_cfunc = self._library.niDigital_GetHistoryRAMSampleCount
+                try:
+                    self.niDigital_GetHistoryRAMSampleCount_cfunc = self._library.niDigital_GetHistoryRAMSampleCount
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_GetHistoryRAMSampleCount_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViInt64)]  # noqa: F405
                 self.niDigital_GetHistoryRAMSampleCount_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetHistoryRAMSampleCount_cfunc(vi, site, sample_count)
@@ -460,7 +675,12 @@ class Library(object):
     def niDigital_GetPatternName(self, vi, pattern_index, name_buffer_size, name):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetPatternName_cfunc is None:
-                self.niDigital_GetPatternName_cfunc = self._library.niDigital_GetPatternName
+                try:
+                    self.niDigital_GetPatternName_cfunc = self._library.niDigital_GetPatternName
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_GetPatternName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_GetPatternName_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetPatternName_cfunc(vi, pattern_index, name_buffer_size, name)
@@ -468,7 +688,12 @@ class Library(object):
     def niDigital_GetPatternPinList(self, vi, start_label, pin_list_buffer_size, pin_list):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetPatternPinList_cfunc is None:
-                self.niDigital_GetPatternPinList_cfunc = self._library.niDigital_GetPatternPinList
+                try:
+                    self.niDigital_GetPatternPinList_cfunc = self._library.niDigital_GetPatternPinList
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_GetPatternPinList_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_GetPatternPinList_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetPatternPinList_cfunc(vi, start_label, pin_list_buffer_size, pin_list)
@@ -476,7 +701,12 @@ class Library(object):
     def niDigital_GetPinName(self, vi, pin_index, name_buffer_size, name):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetPinName_cfunc is None:
-                self.niDigital_GetPinName_cfunc = self._library.niDigital_GetPinName
+                try:
+                    self.niDigital_GetPinName_cfunc = self._library.niDigital_GetPinName
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_GetPinName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_GetPinName_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetPinName_cfunc(vi, pin_index, name_buffer_size, name)
@@ -484,7 +714,12 @@ class Library(object):
     def niDigital_GetPinResultsPinInformation(self, vi, channel_list, buffer_size, pin_indexes, site_numbers, channel_indexes, actual_num_values):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetPinResultsPinInformation_cfunc is None:
-                self.niDigital_GetPinResultsPinInformation_cfunc = self._library.niDigital_GetPinResultsPinInformation
+                try:
+                    self.niDigital_GetPinResultsPinInformation_cfunc = self._library.niDigital_GetPinResultsPinInformation
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_GetPinResultsPinInformation_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_GetPinResultsPinInformation_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetPinResultsPinInformation_cfunc(vi, channel_list, buffer_size, pin_indexes, site_numbers, channel_indexes, actual_num_values)
@@ -492,7 +727,12 @@ class Library(object):
     def niDigital_GetSitePassFail(self, vi, site_list, pass_fail_buffer_size, pass_fail, actual_num_sites):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetSitePassFail_cfunc is None:
-                self.niDigital_GetSitePassFail_cfunc = self._library.niDigital_GetSitePassFail
+                try:
+                    self.niDigital_GetSitePassFail_cfunc = self._library.niDigital_GetSitePassFail
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_GetSitePassFail_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViBoolean), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_GetSitePassFail_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetSitePassFail_cfunc(vi, site_list, pass_fail_buffer_size, pass_fail, actual_num_sites)
@@ -500,7 +740,12 @@ class Library(object):
     def niDigital_GetSiteResultsSiteNumbers(self, vi, site_list, site_result_type, site_numbers_buffer_size, site_numbers, actual_num_site_numbers):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetSiteResultsSiteNumbers_cfunc is None:
-                self.niDigital_GetSiteResultsSiteNumbers_cfunc = self._library.niDigital_GetSiteResultsSiteNumbers
+                try:
+                    self.niDigital_GetSiteResultsSiteNumbers_cfunc = self._library.niDigital_GetSiteResultsSiteNumbers
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_GetSiteResultsSiteNumbers_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_GetSiteResultsSiteNumbers_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetSiteResultsSiteNumbers_cfunc(vi, site_list, site_result_type, site_numbers_buffer_size, site_numbers, actual_num_site_numbers)
@@ -508,7 +753,12 @@ class Library(object):
     def niDigital_GetTimeSetDriveFormat(self, vi, pin, time_set_name, format):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetTimeSetDriveFormat_cfunc is None:
-                self.niDigital_GetTimeSetDriveFormat_cfunc = self._library.niDigital_GetTimeSetDriveFormat
+                try:
+                    self.niDigital_GetTimeSetDriveFormat_cfunc = self._library.niDigital_GetTimeSetDriveFormat
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_GetTimeSetDriveFormat_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_GetTimeSetDriveFormat_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetTimeSetDriveFormat_cfunc(vi, pin, time_set_name, format)
@@ -516,7 +766,12 @@ class Library(object):
     def niDigital_GetTimeSetEdge(self, vi, pin, time_set_name, edge, time):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetTimeSetEdge_cfunc is None:
-                self.niDigital_GetTimeSetEdge_cfunc = self._library.niDigital_GetTimeSetEdge
+                try:
+                    self.niDigital_GetTimeSetEdge_cfunc = self._library.niDigital_GetTimeSetEdge
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_GetTimeSetEdge_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDigital_GetTimeSetEdge_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetTimeSetEdge_cfunc(vi, pin, time_set_name, edge, time)
@@ -524,7 +779,12 @@ class Library(object):
     def niDigital_GetTimeSetEdgeMultiplier(self, vi, pin, time_set_name, edge_multiplier):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetTimeSetEdgeMultiplier_cfunc is None:
-                self.niDigital_GetTimeSetEdgeMultiplier_cfunc = self._library.niDigital_GetTimeSetEdgeMultiplier
+                try:
+                    self.niDigital_GetTimeSetEdgeMultiplier_cfunc = self._library.niDigital_GetTimeSetEdgeMultiplier
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_GetTimeSetEdgeMultiplier_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_GetTimeSetEdgeMultiplier_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetTimeSetEdgeMultiplier_cfunc(vi, pin, time_set_name, edge_multiplier)
@@ -532,7 +792,12 @@ class Library(object):
     def niDigital_GetTimeSetName(self, vi, time_set_index, name_buffer_size, name):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetTimeSetName_cfunc is None:
-                self.niDigital_GetTimeSetName_cfunc = self._library.niDigital_GetTimeSetName
+                try:
+                    self.niDigital_GetTimeSetName_cfunc = self._library.niDigital_GetTimeSetName
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_GetTimeSetName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_GetTimeSetName_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetTimeSetName_cfunc(vi, time_set_index, name_buffer_size, name)
@@ -540,7 +805,12 @@ class Library(object):
     def niDigital_GetTimeSetPeriod(self, vi, time_set_name, period):  # noqa: N802
         with self._func_lock:
             if self.niDigital_GetTimeSetPeriod_cfunc is None:
-                self.niDigital_GetTimeSetPeriod_cfunc = self._library.niDigital_GetTimeSetPeriod
+                try:
+                    self.niDigital_GetTimeSetPeriod_cfunc = self._library.niDigital_GetTimeSetPeriod
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_GetTimeSetPeriod_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDigital_GetTimeSetPeriod_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_GetTimeSetPeriod_cfunc(vi, time_set_name, period)
@@ -548,7 +818,12 @@ class Library(object):
     def niDigital_InitWithOptions(self, resource_name, id_query, reset_device, option_string, new_vi):  # noqa: N802
         with self._func_lock:
             if self.niDigital_InitWithOptions_cfunc is None:
-                self.niDigital_InitWithOptions_cfunc = self._library.niDigital_InitWithOptions
+                try:
+                    self.niDigital_InitWithOptions_cfunc = self._library.niDigital_InitWithOptions
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_InitWithOptions_cfunc.argtypes = [ctypes.POINTER(ViChar), ViBoolean, ViBoolean, ctypes.POINTER(ViChar), ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niDigital_InitWithOptions_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_InitWithOptions_cfunc(resource_name, id_query, reset_device, option_string, new_vi)
@@ -556,7 +831,12 @@ class Library(object):
     def niDigital_Initiate(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDigital_Initiate_cfunc is None:
-                self.niDigital_Initiate_cfunc = self._library.niDigital_Initiate
+                try:
+                    self.niDigital_Initiate_cfunc = self._library.niDigital_Initiate
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_Initiate_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_Initiate_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_Initiate_cfunc(vi)
@@ -564,7 +844,12 @@ class Library(object):
     def niDigital_IsDone(self, vi, done):  # noqa: N802
         with self._func_lock:
             if self.niDigital_IsDone_cfunc is None:
-                self.niDigital_IsDone_cfunc = self._library.niDigital_IsDone
+                try:
+                    self.niDigital_IsDone_cfunc = self._library.niDigital_IsDone
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_IsDone_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDigital_IsDone_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_IsDone_cfunc(vi, done)
@@ -572,7 +857,12 @@ class Library(object):
     def niDigital_IsSiteEnabled(self, vi, site, enable):  # noqa: N802
         with self._func_lock:
             if self.niDigital_IsSiteEnabled_cfunc is None:
-                self.niDigital_IsSiteEnabled_cfunc = self._library.niDigital_IsSiteEnabled
+                try:
+                    self.niDigital_IsSiteEnabled_cfunc = self._library.niDigital_IsSiteEnabled
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_IsSiteEnabled_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDigital_IsSiteEnabled_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_IsSiteEnabled_cfunc(vi, site, enable)
@@ -580,7 +870,12 @@ class Library(object):
     def niDigital_LoadLevels(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDigital_LoadLevels_cfunc is None:
-                self.niDigital_LoadLevels_cfunc = self._library.niDigital_LoadLevels
+                try:
+                    self.niDigital_LoadLevels_cfunc = self._library.niDigital_LoadLevels
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_LoadLevels_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_LoadLevels_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_LoadLevels_cfunc(vi, file_path)
@@ -588,7 +883,12 @@ class Library(object):
     def niDigital_LoadPattern(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDigital_LoadPattern_cfunc is None:
-                self.niDigital_LoadPattern_cfunc = self._library.niDigital_LoadPattern
+                try:
+                    self.niDigital_LoadPattern_cfunc = self._library.niDigital_LoadPattern
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_LoadPattern_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_LoadPattern_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_LoadPattern_cfunc(vi, file_path)
@@ -596,7 +896,12 @@ class Library(object):
     def niDigital_LoadPinMap(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDigital_LoadPinMap_cfunc is None:
-                self.niDigital_LoadPinMap_cfunc = self._library.niDigital_LoadPinMap
+                try:
+                    self.niDigital_LoadPinMap_cfunc = self._library.niDigital_LoadPinMap
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_LoadPinMap_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_LoadPinMap_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_LoadPinMap_cfunc(vi, file_path)
@@ -604,7 +909,12 @@ class Library(object):
     def niDigital_LoadSpecifications(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDigital_LoadSpecifications_cfunc is None:
-                self.niDigital_LoadSpecifications_cfunc = self._library.niDigital_LoadSpecifications
+                try:
+                    self.niDigital_LoadSpecifications_cfunc = self._library.niDigital_LoadSpecifications
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_LoadSpecifications_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_LoadSpecifications_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_LoadSpecifications_cfunc(vi, file_path)
@@ -612,7 +922,12 @@ class Library(object):
     def niDigital_LoadTiming(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDigital_LoadTiming_cfunc is None:
-                self.niDigital_LoadTiming_cfunc = self._library.niDigital_LoadTiming
+                try:
+                    self.niDigital_LoadTiming_cfunc = self._library.niDigital_LoadTiming
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_LoadTiming_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_LoadTiming_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_LoadTiming_cfunc(vi, file_path)
@@ -620,7 +935,12 @@ class Library(object):
     def niDigital_LockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niDigital_LockSession_cfunc is None:
-                self.niDigital_LockSession_cfunc = self._library.niDigital_LockSession
+                try:
+                    self.niDigital_LockSession_cfunc = self._library.niDigital_LockSession
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_LockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDigital_LockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_LockSession_cfunc(vi, caller_has_lock)
@@ -628,7 +948,12 @@ class Library(object):
     def niDigital_PPMU_Measure(self, vi, channel_list, measurement_type, buffer_size, measurements, actual_num_read):  # noqa: N802
         with self._func_lock:
             if self.niDigital_PPMU_Measure_cfunc is None:
-                self.niDigital_PPMU_Measure_cfunc = self._library.niDigital_PPMU_Measure
+                try:
+                    self.niDigital_PPMU_Measure_cfunc = self._library.niDigital_PPMU_Measure
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_PPMU_Measure_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_PPMU_Measure_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_PPMU_Measure_cfunc(vi, channel_list, measurement_type, buffer_size, measurements, actual_num_read)
@@ -636,7 +961,12 @@ class Library(object):
     def niDigital_PPMU_Source(self, vi, channel_list):  # noqa: N802
         with self._func_lock:
             if self.niDigital_PPMU_Source_cfunc is None:
-                self.niDigital_PPMU_Source_cfunc = self._library.niDigital_PPMU_Source
+                try:
+                    self.niDigital_PPMU_Source_cfunc = self._library.niDigital_PPMU_Source
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_PPMU_Source_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_PPMU_Source_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_PPMU_Source_cfunc(vi, channel_list)
@@ -644,7 +974,12 @@ class Library(object):
     def niDigital_ReadSequencerFlag(self, vi, flag, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ReadSequencerFlag_cfunc is None:
-                self.niDigital_ReadSequencerFlag_cfunc = self._library.niDigital_ReadSequencerFlag
+                try:
+                    self.niDigital_ReadSequencerFlag_cfunc = self._library.niDigital_ReadSequencerFlag
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_ReadSequencerFlag_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDigital_ReadSequencerFlag_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ReadSequencerFlag_cfunc(vi, flag, value)
@@ -652,7 +987,12 @@ class Library(object):
     def niDigital_ReadSequencerRegister(self, vi, reg, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ReadSequencerRegister_cfunc is None:
-                self.niDigital_ReadSequencerRegister_cfunc = self._library.niDigital_ReadSequencerRegister
+                try:
+                    self.niDigital_ReadSequencerRegister_cfunc = self._library.niDigital_ReadSequencerRegister
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_ReadSequencerRegister_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_ReadSequencerRegister_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ReadSequencerRegister_cfunc(vi, reg, value)
@@ -660,7 +1000,12 @@ class Library(object):
     def niDigital_ReadStatic(self, vi, channel_list, buffer_size, data, actual_num_read):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ReadStatic_cfunc is None:
-                self.niDigital_ReadStatic_cfunc = self._library.niDigital_ReadStatic
+                try:
+                    self.niDigital_ReadStatic_cfunc = self._library.niDigital_ReadStatic
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_ReadStatic_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViUInt8), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_ReadStatic_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ReadStatic_cfunc(vi, channel_list, buffer_size, data, actual_num_read)
@@ -668,7 +1013,12 @@ class Library(object):
     def niDigital_ResetDevice(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDigital_ResetDevice_cfunc is None:
-                self.niDigital_ResetDevice_cfunc = self._library.niDigital_ResetDevice
+                try:
+                    self.niDigital_ResetDevice_cfunc = self._library.niDigital_ResetDevice
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_ResetDevice_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_ResetDevice_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_ResetDevice_cfunc(vi)
@@ -676,7 +1026,12 @@ class Library(object):
     def niDigital_SelfCalibrate(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDigital_SelfCalibrate_cfunc is None:
-                self.niDigital_SelfCalibrate_cfunc = self._library.niDigital_SelfCalibrate
+                try:
+                    self.niDigital_SelfCalibrate_cfunc = self._library.niDigital_SelfCalibrate
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_SelfCalibrate_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_SelfCalibrate_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_SelfCalibrate_cfunc(vi)
@@ -684,7 +1039,12 @@ class Library(object):
     def niDigital_SendSoftwareEdgeTrigger(self, vi, trigger, trigger_identifier):  # noqa: N802
         with self._func_lock:
             if self.niDigital_SendSoftwareEdgeTrigger_cfunc is None:
-                self.niDigital_SendSoftwareEdgeTrigger_cfunc = self._library.niDigital_SendSoftwareEdgeTrigger
+                try:
+                    self.niDigital_SendSoftwareEdgeTrigger_cfunc = self._library.niDigital_SendSoftwareEdgeTrigger
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_SendSoftwareEdgeTrigger_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_SendSoftwareEdgeTrigger_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_SendSoftwareEdgeTrigger_cfunc(vi, trigger, trigger_identifier)
@@ -692,7 +1052,12 @@ class Library(object):
     def niDigital_SetAttributeViBoolean(self, vi, channel_name, attribute, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_SetAttributeViBoolean_cfunc is None:
-                self.niDigital_SetAttributeViBoolean_cfunc = self._library.niDigital_SetAttributeViBoolean
+                try:
+                    self.niDigital_SetAttributeViBoolean_cfunc = self._library.niDigital_SetAttributeViBoolean
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViBoolean]  # noqa: F405
                 self.niDigital_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_SetAttributeViBoolean_cfunc(vi, channel_name, attribute, value)
@@ -700,7 +1065,12 @@ class Library(object):
     def niDigital_SetAttributeViInt32(self, vi, channel_name, attribute, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_SetAttributeViInt32_cfunc is None:
-                self.niDigital_SetAttributeViInt32_cfunc = self._library.niDigital_SetAttributeViInt32
+                try:
+                    self.niDigital_SetAttributeViInt32_cfunc = self._library.niDigital_SetAttributeViInt32
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_SetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32]  # noqa: F405
                 self.niDigital_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_SetAttributeViInt32_cfunc(vi, channel_name, attribute, value)
@@ -708,7 +1078,12 @@ class Library(object):
     def niDigital_SetAttributeViInt64(self, vi, channel_name, attribute, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_SetAttributeViInt64_cfunc is None:
-                self.niDigital_SetAttributeViInt64_cfunc = self._library.niDigital_SetAttributeViInt64
+                try:
+                    self.niDigital_SetAttributeViInt64_cfunc = self._library.niDigital_SetAttributeViInt64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_SetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt64]  # noqa: F405
                 self.niDigital_SetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_SetAttributeViInt64_cfunc(vi, channel_name, attribute, value)
@@ -716,7 +1091,12 @@ class Library(object):
     def niDigital_SetAttributeViReal64(self, vi, channel_name, attribute, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_SetAttributeViReal64_cfunc is None:
-                self.niDigital_SetAttributeViReal64_cfunc = self._library.niDigital_SetAttributeViReal64
+                try:
+                    self.niDigital_SetAttributeViReal64_cfunc = self._library.niDigital_SetAttributeViReal64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niDigital_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_SetAttributeViReal64_cfunc(vi, channel_name, attribute, value)
@@ -724,7 +1104,12 @@ class Library(object):
     def niDigital_SetAttributeViString(self, vi, channel_name, attribute, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_SetAttributeViString_cfunc is None:
-                self.niDigital_SetAttributeViString_cfunc = self._library.niDigital_SetAttributeViString
+                try:
+                    self.niDigital_SetAttributeViString_cfunc = self._library.niDigital_SetAttributeViString
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_SetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_SetAttributeViString_cfunc(vi, channel_name, attribute, value)
@@ -732,7 +1117,12 @@ class Library(object):
     def niDigital_TDR(self, vi, channel_list, apply_offsets, offsets_buffer_size, offsets, actual_num_offsets):  # noqa: N802
         with self._func_lock:
             if self.niDigital_TDR_cfunc is None:
-                self.niDigital_TDR_cfunc = self._library.niDigital_TDR
+                try:
+                    self.niDigital_TDR_cfunc = self._library.niDigital_TDR
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_TDR_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViBoolean, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDigital_TDR_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_TDR_cfunc(vi, channel_list, apply_offsets, offsets_buffer_size, offsets, actual_num_offsets)
@@ -740,7 +1130,12 @@ class Library(object):
     def niDigital_UnloadAllPatterns(self, vi, unload_keep_alive_pattern):  # noqa: N802
         with self._func_lock:
             if self.niDigital_UnloadAllPatterns_cfunc is None:
-                self.niDigital_UnloadAllPatterns_cfunc = self._library.niDigital_UnloadAllPatterns
+                try:
+                    self.niDigital_UnloadAllPatterns_cfunc = self._library.niDigital_UnloadAllPatterns
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_UnloadAllPatterns_cfunc.argtypes = [ViSession, ViBoolean]  # noqa: F405
                 self.niDigital_UnloadAllPatterns_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_UnloadAllPatterns_cfunc(vi, unload_keep_alive_pattern)
@@ -748,7 +1143,12 @@ class Library(object):
     def niDigital_UnloadSpecifications(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDigital_UnloadSpecifications_cfunc is None:
-                self.niDigital_UnloadSpecifications_cfunc = self._library.niDigital_UnloadSpecifications
+                try:
+                    self.niDigital_UnloadSpecifications_cfunc = self._library.niDigital_UnloadSpecifications
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_UnloadSpecifications_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_UnloadSpecifications_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_UnloadSpecifications_cfunc(vi, file_path)
@@ -756,7 +1156,12 @@ class Library(object):
     def niDigital_UnlockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niDigital_UnlockSession_cfunc is None:
-                self.niDigital_UnlockSession_cfunc = self._library.niDigital_UnlockSession
+                try:
+                    self.niDigital_UnlockSession_cfunc = self._library.niDigital_UnlockSession
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_UnlockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDigital_UnlockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_UnlockSession_cfunc(vi, caller_has_lock)
@@ -764,7 +1169,12 @@ class Library(object):
     def niDigital_WaitUntilDone(self, vi, timeout):  # noqa: N802
         with self._func_lock:
             if self.niDigital_WaitUntilDone_cfunc is None:
-                self.niDigital_WaitUntilDone_cfunc = self._library.niDigital_WaitUntilDone
+                try:
+                    self.niDigital_WaitUntilDone_cfunc = self._library.niDigital_WaitUntilDone
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_WaitUntilDone_cfunc.argtypes = [ViSession, ViReal64]  # noqa: F405
                 self.niDigital_WaitUntilDone_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_WaitUntilDone_cfunc(vi, timeout)
@@ -772,7 +1182,12 @@ class Library(object):
     def niDigital_WriteSequencerFlag(self, vi, flag, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_WriteSequencerFlag_cfunc is None:
-                self.niDigital_WriteSequencerFlag_cfunc = self._library.niDigital_WriteSequencerFlag
+                try:
+                    self.niDigital_WriteSequencerFlag_cfunc = self._library.niDigital_WriteSequencerFlag
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_WriteSequencerFlag_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViBoolean]  # noqa: F405
                 self.niDigital_WriteSequencerFlag_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_WriteSequencerFlag_cfunc(vi, flag, value)
@@ -780,7 +1195,12 @@ class Library(object):
     def niDigital_WriteSequencerRegister(self, vi, reg, value):  # noqa: N802
         with self._func_lock:
             if self.niDigital_WriteSequencerRegister_cfunc is None:
-                self.niDigital_WriteSequencerRegister_cfunc = self._library.niDigital_WriteSequencerRegister
+                try:
+                    self.niDigital_WriteSequencerRegister_cfunc = self._library.niDigital_WriteSequencerRegister
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_WriteSequencerRegister_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niDigital_WriteSequencerRegister_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_WriteSequencerRegister_cfunc(vi, reg, value)
@@ -788,7 +1208,12 @@ class Library(object):
     def niDigital_WriteSourceWaveformBroadcastU32(self, vi, waveform_name, waveform_size, waveform_data):  # noqa: N802
         with self._func_lock:
             if self.niDigital_WriteSourceWaveformBroadcastU32_cfunc is None:
-                self.niDigital_WriteSourceWaveformBroadcastU32_cfunc = self._library.niDigital_WriteSourceWaveformBroadcastU32
+                try:
+                    self.niDigital_WriteSourceWaveformBroadcastU32_cfunc = self._library.niDigital_WriteSourceWaveformBroadcastU32
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_WriteSourceWaveformBroadcastU32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViUInt32)]  # noqa: F405
                 self.niDigital_WriteSourceWaveformBroadcastU32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_WriteSourceWaveformBroadcastU32_cfunc(vi, waveform_name, waveform_size, waveform_data)
@@ -796,7 +1221,12 @@ class Library(object):
     def niDigital_WriteSourceWaveformDataFromFileTDMS(self, vi, waveform_name, waveform_file_path):  # noqa: N802
         with self._func_lock:
             if self.niDigital_WriteSourceWaveformDataFromFileTDMS_cfunc is None:
-                self.niDigital_WriteSourceWaveformDataFromFileTDMS_cfunc = self._library.niDigital_WriteSourceWaveformDataFromFileTDMS
+                try:
+                    self.niDigital_WriteSourceWaveformDataFromFileTDMS_cfunc = self._library.niDigital_WriteSourceWaveformDataFromFileTDMS
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_WriteSourceWaveformDataFromFileTDMS_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_WriteSourceWaveformDataFromFileTDMS_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_WriteSourceWaveformDataFromFileTDMS_cfunc(vi, waveform_name, waveform_file_path)
@@ -804,7 +1234,12 @@ class Library(object):
     def niDigital_WriteSourceWaveformSiteUniqueU32(self, vi, site_list, waveform_name, num_waveforms, samples_per_waveform, waveform_data):  # noqa: N802
         with self._func_lock:
             if self.niDigital_WriteSourceWaveformSiteUniqueU32_cfunc is None:
-                self.niDigital_WriteSourceWaveformSiteUniqueU32_cfunc = self._library.niDigital_WriteSourceWaveformSiteUniqueU32
+                try:
+                    self.niDigital_WriteSourceWaveformSiteUniqueU32_cfunc = self._library.niDigital_WriteSourceWaveformSiteUniqueU32
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_WriteSourceWaveformSiteUniqueU32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViInt32, ctypes.POINTER(ViUInt32)]  # noqa: F405
                 self.niDigital_WriteSourceWaveformSiteUniqueU32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_WriteSourceWaveformSiteUniqueU32_cfunc(vi, site_list, waveform_name, num_waveforms, samples_per_waveform, waveform_data)
@@ -812,7 +1247,12 @@ class Library(object):
     def niDigital_WriteStatic(self, vi, channel_list, state):  # noqa: N802
         with self._func_lock:
             if self.niDigital_WriteStatic_cfunc is None:
-                self.niDigital_WriteStatic_cfunc = self._library.niDigital_WriteStatic
+                try:
+                    self.niDigital_WriteStatic_cfunc = self._library.niDigital_WriteStatic
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_WriteStatic_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViUInt8]  # noqa: F405
                 self.niDigital_WriteStatic_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_WriteStatic_cfunc(vi, channel_list, state)
@@ -820,7 +1260,12 @@ class Library(object):
     def niDigital_close(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDigital_close_cfunc is None:
-                self.niDigital_close_cfunc = self._library.niDigital_close
+                try:
+                    self.niDigital_close_cfunc = self._library.niDigital_close
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_close_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_close_cfunc(vi)
@@ -828,7 +1273,12 @@ class Library(object):
     def niDigital_error_message(self, vi, error_code, error_message):  # noqa: N802
         with self._func_lock:
             if self.niDigital_error_message_cfunc is None:
-                self.niDigital_error_message_cfunc = self._library.niDigital_error_message
+                try:
+                    self.niDigital_error_message_cfunc = self._library.niDigital_error_message
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_error_message_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_error_message_cfunc(vi, error_code, error_message)
@@ -836,7 +1286,12 @@ class Library(object):
     def niDigital_reset(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDigital_reset_cfunc is None:
-                self.niDigital_reset_cfunc = self._library.niDigital_reset
+                try:
+                    self.niDigital_reset_cfunc = self._library.niDigital_reset
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_reset_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDigital_reset_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_reset_cfunc(vi)
@@ -844,7 +1299,12 @@ class Library(object):
     def niDigital_self_test(self, vi, test_result, test_message):  # noqa: N802
         with self._func_lock:
             if self.niDigital_self_test_cfunc is None:
-                self.niDigital_self_test_cfunc = self._library.niDigital_self_test
+                try:
+                    self.niDigital_self_test_cfunc = self._library.niDigital_self_test
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDigital_self_test_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDigital_self_test_cfunc.restype = ViStatus  # noqa: F405
         return self.niDigital_self_test_cfunc(vi, test_result, test_message)

--- a/generated/nidigital/nidigital/errors.py
+++ b/generated/nidigital/nidigital/errors.py
@@ -57,6 +57,13 @@ class DriverNotInstalledError(Error):
         super(DriverNotInstalledError, self).__init__('The NI-Digital Pattern Driver runtime could not be loaded. Make sure it is installed and its bitness matches that of your Python interpreter. Please visit http://www.ni.com/downloads/drivers/ to download and install it.')
 
 
+class DriverTooOldError(Error):
+    '''An error due to using this module with an older version of the driver runtime.'''
+
+    def __init__(self):
+        super(DriverTooOldError, self).__init__('A function was not found in the NI-Digital Pattern Driver runtime. Please visit http://www.ni.com/downloads/drivers/ to download a newer version and install it.')
+
+
 class InvalidRepeatedCapabilityError(Error):
     '''An error due to an invalid character in a repeated capability'''
 

--- a/generated/nidmm/nidmm/_library.py
+++ b/generated/nidmm/nidmm/_library.py
@@ -2,6 +2,7 @@
 # This file was generated
 
 import ctypes
+import nidmm.errors as errors
 import threading
 
 from nidmm._visatype import *  # noqa: F403,H303
@@ -68,15 +69,17 @@ class Library(object):
         self.niDMM_reset_cfunc = None
         self.niDMM_self_test_cfunc = None
 
+    def _get_library_function(self, name):
+        try:
+            function = getattr(self._library, 'fred')
+        except AttributeError as e:
+            raise errors.DriverTooOldError() from e
+        return function
+
     def niDMM_Abort(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDMM_Abort_cfunc is None:
-                try:
-                    self.niDMM_Abort_cfunc = self._library.niDMM_Abort
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_Abort was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_Abort_cfunc = self._get_library_function('niDMM_Abort')
                 self.niDMM_Abort_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_Abort_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_Abort_cfunc(vi)
@@ -84,12 +87,7 @@ class Library(object):
     def niDMM_ConfigureMeasurementAbsolute(self, vi, measurement_function, range, resolution_absolute):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ConfigureMeasurementAbsolute_cfunc is None:
-                try:
-                    self.niDMM_ConfigureMeasurementAbsolute_cfunc = self._library.niDMM_ConfigureMeasurementAbsolute
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_ConfigureMeasurementAbsolute was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_ConfigureMeasurementAbsolute_cfunc = self._get_library_function('niDMM_ConfigureMeasurementAbsolute')
                 self.niDMM_ConfigureMeasurementAbsolute_cfunc.argtypes = [ViSession, ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureMeasurementAbsolute_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureMeasurementAbsolute_cfunc(vi, measurement_function, range, resolution_absolute)
@@ -97,12 +95,7 @@ class Library(object):
     def niDMM_ConfigureMeasurementDigits(self, vi, measurement_function, range, resolution_digits):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ConfigureMeasurementDigits_cfunc is None:
-                try:
-                    self.niDMM_ConfigureMeasurementDigits_cfunc = self._library.niDMM_ConfigureMeasurementDigits
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_ConfigureMeasurementDigits was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_ConfigureMeasurementDigits_cfunc = self._get_library_function('niDMM_ConfigureMeasurementDigits')
                 self.niDMM_ConfigureMeasurementDigits_cfunc.argtypes = [ViSession, ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureMeasurementDigits_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureMeasurementDigits_cfunc(vi, measurement_function, range, resolution_digits)
@@ -110,12 +103,7 @@ class Library(object):
     def niDMM_ConfigureMultiPoint(self, vi, trigger_count, sample_count, sample_trigger, sample_interval):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ConfigureMultiPoint_cfunc is None:
-                try:
-                    self.niDMM_ConfigureMultiPoint_cfunc = self._library.niDMM_ConfigureMultiPoint
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_ConfigureMultiPoint was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_ConfigureMultiPoint_cfunc = self._get_library_function('niDMM_ConfigureMultiPoint')
                 self.niDMM_ConfigureMultiPoint_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ViInt32, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureMultiPoint_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureMultiPoint_cfunc(vi, trigger_count, sample_count, sample_trigger, sample_interval)
@@ -123,12 +111,7 @@ class Library(object):
     def niDMM_ConfigureRTDCustom(self, vi, rtd_a, rtd_b, rtd_c):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ConfigureRTDCustom_cfunc is None:
-                try:
-                    self.niDMM_ConfigureRTDCustom_cfunc = self._library.niDMM_ConfigureRTDCustom
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_ConfigureRTDCustom was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_ConfigureRTDCustom_cfunc = self._get_library_function('niDMM_ConfigureRTDCustom')
                 self.niDMM_ConfigureRTDCustom_cfunc.argtypes = [ViSession, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureRTDCustom_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureRTDCustom_cfunc(vi, rtd_a, rtd_b, rtd_c)
@@ -136,12 +119,7 @@ class Library(object):
     def niDMM_ConfigureRTDType(self, vi, rtd_type, rtd_resistance):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ConfigureRTDType_cfunc is None:
-                try:
-                    self.niDMM_ConfigureRTDType_cfunc = self._library.niDMM_ConfigureRTDType
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_ConfigureRTDType was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_ConfigureRTDType_cfunc = self._get_library_function('niDMM_ConfigureRTDType')
                 self.niDMM_ConfigureRTDType_cfunc.argtypes = [ViSession, ViInt32, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureRTDType_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureRTDType_cfunc(vi, rtd_type, rtd_resistance)
@@ -149,12 +127,7 @@ class Library(object):
     def niDMM_ConfigureThermistorCustom(self, vi, thermistor_a, thermistor_b, thermistor_c):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ConfigureThermistorCustom_cfunc is None:
-                try:
-                    self.niDMM_ConfigureThermistorCustom_cfunc = self._library.niDMM_ConfigureThermistorCustom
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_ConfigureThermistorCustom was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_ConfigureThermistorCustom_cfunc = self._get_library_function('niDMM_ConfigureThermistorCustom')
                 self.niDMM_ConfigureThermistorCustom_cfunc.argtypes = [ViSession, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureThermistorCustom_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureThermistorCustom_cfunc(vi, thermistor_a, thermistor_b, thermistor_c)
@@ -162,12 +135,7 @@ class Library(object):
     def niDMM_ConfigureThermocouple(self, vi, thermocouple_type, reference_junction_type):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ConfigureThermocouple_cfunc is None:
-                try:
-                    self.niDMM_ConfigureThermocouple_cfunc = self._library.niDMM_ConfigureThermocouple
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_ConfigureThermocouple was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_ConfigureThermocouple_cfunc = self._get_library_function('niDMM_ConfigureThermocouple')
                 self.niDMM_ConfigureThermocouple_cfunc.argtypes = [ViSession, ViInt32, ViInt32]  # noqa: F405
                 self.niDMM_ConfigureThermocouple_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureThermocouple_cfunc(vi, thermocouple_type, reference_junction_type)
@@ -175,12 +143,7 @@ class Library(object):
     def niDMM_ConfigureTrigger(self, vi, trigger_source, trigger_delay):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ConfigureTrigger_cfunc is None:
-                try:
-                    self.niDMM_ConfigureTrigger_cfunc = self._library.niDMM_ConfigureTrigger
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_ConfigureTrigger was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_ConfigureTrigger_cfunc = self._get_library_function('niDMM_ConfigureTrigger')
                 self.niDMM_ConfigureTrigger_cfunc.argtypes = [ViSession, ViInt32, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureTrigger_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureTrigger_cfunc(vi, trigger_source, trigger_delay)
@@ -188,12 +151,7 @@ class Library(object):
     def niDMM_ConfigureWaveformAcquisition(self, vi, measurement_function, range, rate, waveform_points):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ConfigureWaveformAcquisition_cfunc is None:
-                try:
-                    self.niDMM_ConfigureWaveformAcquisition_cfunc = self._library.niDMM_ConfigureWaveformAcquisition
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_ConfigureWaveformAcquisition was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_ConfigureWaveformAcquisition_cfunc = self._get_library_function('niDMM_ConfigureWaveformAcquisition')
                 self.niDMM_ConfigureWaveformAcquisition_cfunc.argtypes = [ViSession, ViInt32, ViReal64, ViReal64, ViInt32]  # noqa: F405
                 self.niDMM_ConfigureWaveformAcquisition_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureWaveformAcquisition_cfunc(vi, measurement_function, range, rate, waveform_points)
@@ -201,12 +159,7 @@ class Library(object):
     def niDMM_Disable(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDMM_Disable_cfunc is None:
-                try:
-                    self.niDMM_Disable_cfunc = self._library.niDMM_Disable
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_Disable was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_Disable_cfunc = self._get_library_function('niDMM_Disable')
                 self.niDMM_Disable_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_Disable_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_Disable_cfunc(vi)
@@ -214,12 +167,7 @@ class Library(object):
     def niDMM_ExportAttributeConfigurationBuffer(self, vi, size, configuration):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ExportAttributeConfigurationBuffer_cfunc is None:
-                try:
-                    self.niDMM_ExportAttributeConfigurationBuffer_cfunc = self._library.niDMM_ExportAttributeConfigurationBuffer
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_ExportAttributeConfigurationBuffer was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_ExportAttributeConfigurationBuffer_cfunc = self._get_library_function('niDMM_ExportAttributeConfigurationBuffer')
                 self.niDMM_ExportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niDMM_ExportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ExportAttributeConfigurationBuffer_cfunc(vi, size, configuration)
@@ -227,12 +175,7 @@ class Library(object):
     def niDMM_ExportAttributeConfigurationFile(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ExportAttributeConfigurationFile_cfunc is None:
-                try:
-                    self.niDMM_ExportAttributeConfigurationFile_cfunc = self._library.niDMM_ExportAttributeConfigurationFile
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_ExportAttributeConfigurationFile was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_ExportAttributeConfigurationFile_cfunc = self._get_library_function('niDMM_ExportAttributeConfigurationFile')
                 self.niDMM_ExportAttributeConfigurationFile_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDMM_ExportAttributeConfigurationFile_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ExportAttributeConfigurationFile_cfunc(vi, file_path)
@@ -240,12 +183,7 @@ class Library(object):
     def niDMM_Fetch(self, vi, maximum_time, reading):  # noqa: N802
         with self._func_lock:
             if self.niDMM_Fetch_cfunc is None:
-                try:
-                    self.niDMM_Fetch_cfunc = self._library.niDMM_Fetch
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_Fetch was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_Fetch_cfunc = self._get_library_function('niDMM_Fetch')
                 self.niDMM_Fetch_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_Fetch_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_Fetch_cfunc(vi, maximum_time, reading)
@@ -253,12 +191,7 @@ class Library(object):
     def niDMM_FetchMultiPoint(self, vi, maximum_time, array_size, reading_array, actual_number_of_points):  # noqa: N802
         with self._func_lock:
             if self.niDMM_FetchMultiPoint_cfunc is None:
-                try:
-                    self.niDMM_FetchMultiPoint_cfunc = self._library.niDMM_FetchMultiPoint
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_FetchMultiPoint was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_FetchMultiPoint_cfunc = self._get_library_function('niDMM_FetchMultiPoint')
                 self.niDMM_FetchMultiPoint_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_FetchMultiPoint_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_FetchMultiPoint_cfunc(vi, maximum_time, array_size, reading_array, actual_number_of_points)
@@ -266,12 +199,7 @@ class Library(object):
     def niDMM_FetchWaveform(self, vi, maximum_time, array_size, waveform_array, actual_number_of_points):  # noqa: N802
         with self._func_lock:
             if self.niDMM_FetchWaveform_cfunc is None:
-                try:
-                    self.niDMM_FetchWaveform_cfunc = self._library.niDMM_FetchWaveform
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_FetchWaveform was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_FetchWaveform_cfunc = self._get_library_function('niDMM_FetchWaveform')
                 self.niDMM_FetchWaveform_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_FetchWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_FetchWaveform_cfunc(vi, maximum_time, array_size, waveform_array, actual_number_of_points)
@@ -279,12 +207,7 @@ class Library(object):
     def niDMM_GetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDMM_GetAttributeViBoolean_cfunc is None:
-                try:
-                    self.niDMM_GetAttributeViBoolean_cfunc = self._library.niDMM_GetAttributeViBoolean
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_GetAttributeViBoolean was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_GetAttributeViBoolean_cfunc = self._get_library_function('niDMM_GetAttributeViBoolean')
                 self.niDMM_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDMM_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -292,12 +215,7 @@ class Library(object):
     def niDMM_GetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDMM_GetAttributeViInt32_cfunc is None:
-                try:
-                    self.niDMM_GetAttributeViInt32_cfunc = self._library.niDMM_GetAttributeViInt32
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_GetAttributeViInt32 was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_GetAttributeViInt32_cfunc = self._get_library_function('niDMM_GetAttributeViInt32')
                 self.niDMM_GetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -305,12 +223,7 @@ class Library(object):
     def niDMM_GetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDMM_GetAttributeViReal64_cfunc is None:
-                try:
-                    self.niDMM_GetAttributeViReal64_cfunc = self._library.niDMM_GetAttributeViReal64
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_GetAttributeViReal64 was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_GetAttributeViReal64_cfunc = self._get_library_function('niDMM_GetAttributeViReal64')
                 self.niDMM_GetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -318,12 +231,7 @@ class Library(object):
     def niDMM_GetAttributeViString(self, vi, channel_name, attribute_id, buffer_size, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDMM_GetAttributeViString_cfunc is None:
-                try:
-                    self.niDMM_GetAttributeViString_cfunc = self._library.niDMM_GetAttributeViString
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_GetAttributeViString was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_GetAttributeViString_cfunc = self._get_library_function('niDMM_GetAttributeViString')
                 self.niDMM_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDMM_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetAttributeViString_cfunc(vi, channel_name, attribute_id, buffer_size, attribute_value)
@@ -331,12 +239,7 @@ class Library(object):
     def niDMM_GetCalDateAndTime(self, vi, cal_type, month, day, year, hour, minute):  # noqa: N802
         with self._func_lock:
             if self.niDMM_GetCalDateAndTime_cfunc is None:
-                try:
-                    self.niDMM_GetCalDateAndTime_cfunc = self._library.niDMM_GetCalDateAndTime
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_GetCalDateAndTime was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_GetCalDateAndTime_cfunc = self._get_library_function('niDMM_GetCalDateAndTime')
                 self.niDMM_GetCalDateAndTime_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_GetCalDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetCalDateAndTime_cfunc(vi, cal_type, month, day, year, hour, minute)
@@ -344,12 +247,7 @@ class Library(object):
     def niDMM_GetDevTemp(self, vi, options, temperature):  # noqa: N802
         with self._func_lock:
             if self.niDMM_GetDevTemp_cfunc is None:
-                try:
-                    self.niDMM_GetDevTemp_cfunc = self._library.niDMM_GetDevTemp
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_GetDevTemp was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_GetDevTemp_cfunc = self._get_library_function('niDMM_GetDevTemp')
                 self.niDMM_GetDevTemp_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_GetDevTemp_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetDevTemp_cfunc(vi, options, temperature)
@@ -357,12 +255,7 @@ class Library(object):
     def niDMM_GetError(self, vi, error_code, buffer_size, description):  # noqa: N802
         with self._func_lock:
             if self.niDMM_GetError_cfunc is None:
-                try:
-                    self.niDMM_GetError_cfunc = self._library.niDMM_GetError
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_GetError was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_GetError_cfunc = self._get_library_function('niDMM_GetError')
                 self.niDMM_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDMM_GetError_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetError_cfunc(vi, error_code, buffer_size, description)
@@ -370,12 +263,7 @@ class Library(object):
     def niDMM_GetExtCalRecommendedInterval(self, vi, months):  # noqa: N802
         with self._func_lock:
             if self.niDMM_GetExtCalRecommendedInterval_cfunc is None:
-                try:
-                    self.niDMM_GetExtCalRecommendedInterval_cfunc = self._library.niDMM_GetExtCalRecommendedInterval
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_GetExtCalRecommendedInterval was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_GetExtCalRecommendedInterval_cfunc = self._get_library_function('niDMM_GetExtCalRecommendedInterval')
                 self.niDMM_GetExtCalRecommendedInterval_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_GetExtCalRecommendedInterval_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetExtCalRecommendedInterval_cfunc(vi, months)
@@ -383,12 +271,7 @@ class Library(object):
     def niDMM_GetLastCalTemp(self, vi, cal_type, temperature):  # noqa: N802
         with self._func_lock:
             if self.niDMM_GetLastCalTemp_cfunc is None:
-                try:
-                    self.niDMM_GetLastCalTemp_cfunc = self._library.niDMM_GetLastCalTemp
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_GetLastCalTemp was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_GetLastCalTemp_cfunc = self._get_library_function('niDMM_GetLastCalTemp')
                 self.niDMM_GetLastCalTemp_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_GetLastCalTemp_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetLastCalTemp_cfunc(vi, cal_type, temperature)
@@ -396,12 +279,7 @@ class Library(object):
     def niDMM_GetSelfCalSupported(self, vi, self_cal_supported):  # noqa: N802
         with self._func_lock:
             if self.niDMM_GetSelfCalSupported_cfunc is None:
-                try:
-                    self.niDMM_GetSelfCalSupported_cfunc = self._library.niDMM_GetSelfCalSupported
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_GetSelfCalSupported was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_GetSelfCalSupported_cfunc = self._get_library_function('niDMM_GetSelfCalSupported')
                 self.niDMM_GetSelfCalSupported_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDMM_GetSelfCalSupported_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetSelfCalSupported_cfunc(vi, self_cal_supported)
@@ -409,12 +287,7 @@ class Library(object):
     def niDMM_ImportAttributeConfigurationBuffer(self, vi, size, configuration):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ImportAttributeConfigurationBuffer_cfunc is None:
-                try:
-                    self.niDMM_ImportAttributeConfigurationBuffer_cfunc = self._library.niDMM_ImportAttributeConfigurationBuffer
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_ImportAttributeConfigurationBuffer was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_ImportAttributeConfigurationBuffer_cfunc = self._get_library_function('niDMM_ImportAttributeConfigurationBuffer')
                 self.niDMM_ImportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niDMM_ImportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ImportAttributeConfigurationBuffer_cfunc(vi, size, configuration)
@@ -422,12 +295,7 @@ class Library(object):
     def niDMM_ImportAttributeConfigurationFile(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ImportAttributeConfigurationFile_cfunc is None:
-                try:
-                    self.niDMM_ImportAttributeConfigurationFile_cfunc = self._library.niDMM_ImportAttributeConfigurationFile
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_ImportAttributeConfigurationFile was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_ImportAttributeConfigurationFile_cfunc = self._get_library_function('niDMM_ImportAttributeConfigurationFile')
                 self.niDMM_ImportAttributeConfigurationFile_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDMM_ImportAttributeConfigurationFile_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ImportAttributeConfigurationFile_cfunc(vi, file_path)
@@ -435,12 +303,7 @@ class Library(object):
     def niDMM_InitWithOptions(self, resource_name, id_query, reset_device, option_string, vi):  # noqa: N802
         with self._func_lock:
             if self.niDMM_InitWithOptions_cfunc is None:
-                try:
-                    self.niDMM_InitWithOptions_cfunc = self._library.niDMM_InitWithOptions
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_InitWithOptions was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_InitWithOptions_cfunc = self._get_library_function('niDMM_InitWithOptions')
                 self.niDMM_InitWithOptions_cfunc.argtypes = [ctypes.POINTER(ViChar), ViBoolean, ViBoolean, ctypes.POINTER(ViChar), ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niDMM_InitWithOptions_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_InitWithOptions_cfunc(resource_name, id_query, reset_device, option_string, vi)
@@ -448,12 +311,7 @@ class Library(object):
     def niDMM_Initiate(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDMM_Initiate_cfunc is None:
-                try:
-                    self.niDMM_Initiate_cfunc = self._library.niDMM_Initiate
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_Initiate was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_Initiate_cfunc = self._get_library_function('niDMM_Initiate')
                 self.niDMM_Initiate_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_Initiate_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_Initiate_cfunc(vi)
@@ -461,12 +319,7 @@ class Library(object):
     def niDMM_LockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niDMM_LockSession_cfunc is None:
-                try:
-                    self.niDMM_LockSession_cfunc = self._library.niDMM_LockSession
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_LockSession was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_LockSession_cfunc = self._get_library_function('niDMM_LockSession')
                 self.niDMM_LockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDMM_LockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_LockSession_cfunc(vi, caller_has_lock)
@@ -474,12 +327,7 @@ class Library(object):
     def niDMM_PerformOpenCableComp(self, vi, conductance, susceptance):  # noqa: N802
         with self._func_lock:
             if self.niDMM_PerformOpenCableComp_cfunc is None:
-                try:
-                    self.niDMM_PerformOpenCableComp_cfunc = self._library.niDMM_PerformOpenCableComp
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_PerformOpenCableComp was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_PerformOpenCableComp_cfunc = self._get_library_function('niDMM_PerformOpenCableComp')
                 self.niDMM_PerformOpenCableComp_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_PerformOpenCableComp_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_PerformOpenCableComp_cfunc(vi, conductance, susceptance)
@@ -487,12 +335,7 @@ class Library(object):
     def niDMM_PerformShortCableComp(self, vi, resistance, reactance):  # noqa: N802
         with self._func_lock:
             if self.niDMM_PerformShortCableComp_cfunc is None:
-                try:
-                    self.niDMM_PerformShortCableComp_cfunc = self._library.niDMM_PerformShortCableComp
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_PerformShortCableComp was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_PerformShortCableComp_cfunc = self._get_library_function('niDMM_PerformShortCableComp')
                 self.niDMM_PerformShortCableComp_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_PerformShortCableComp_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_PerformShortCableComp_cfunc(vi, resistance, reactance)
@@ -500,12 +343,7 @@ class Library(object):
     def niDMM_Read(self, vi, maximum_time, reading):  # noqa: N802
         with self._func_lock:
             if self.niDMM_Read_cfunc is None:
-                try:
-                    self.niDMM_Read_cfunc = self._library.niDMM_Read
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_Read was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_Read_cfunc = self._get_library_function('niDMM_Read')
                 self.niDMM_Read_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_Read_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_Read_cfunc(vi, maximum_time, reading)
@@ -513,12 +351,7 @@ class Library(object):
     def niDMM_ReadMultiPoint(self, vi, maximum_time, array_size, reading_array, actual_number_of_points):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ReadMultiPoint_cfunc is None:
-                try:
-                    self.niDMM_ReadMultiPoint_cfunc = self._library.niDMM_ReadMultiPoint
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_ReadMultiPoint was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_ReadMultiPoint_cfunc = self._get_library_function('niDMM_ReadMultiPoint')
                 self.niDMM_ReadMultiPoint_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_ReadMultiPoint_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ReadMultiPoint_cfunc(vi, maximum_time, array_size, reading_array, actual_number_of_points)
@@ -526,12 +359,7 @@ class Library(object):
     def niDMM_ReadStatus(self, vi, acquisition_backlog, acquisition_status):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ReadStatus_cfunc is None:
-                try:
-                    self.niDMM_ReadStatus_cfunc = self._library.niDMM_ReadStatus
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_ReadStatus was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_ReadStatus_cfunc = self._get_library_function('niDMM_ReadStatus')
                 self.niDMM_ReadStatus_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt16)]  # noqa: F405
                 self.niDMM_ReadStatus_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ReadStatus_cfunc(vi, acquisition_backlog, acquisition_status)
@@ -539,12 +367,7 @@ class Library(object):
     def niDMM_ReadWaveform(self, vi, maximum_time, array_size, waveform_array, actual_number_of_points):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ReadWaveform_cfunc is None:
-                try:
-                    self.niDMM_ReadWaveform_cfunc = self._library.niDMM_ReadWaveform
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_ReadWaveform was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_ReadWaveform_cfunc = self._get_library_function('niDMM_ReadWaveform')
                 self.niDMM_ReadWaveform_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_ReadWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ReadWaveform_cfunc(vi, maximum_time, array_size, waveform_array, actual_number_of_points)
@@ -552,12 +375,7 @@ class Library(object):
     def niDMM_ResetWithDefaults(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ResetWithDefaults_cfunc is None:
-                try:
-                    self.niDMM_ResetWithDefaults_cfunc = self._library.niDMM_ResetWithDefaults
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_ResetWithDefaults was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_ResetWithDefaults_cfunc = self._get_library_function('niDMM_ResetWithDefaults')
                 self.niDMM_ResetWithDefaults_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_ResetWithDefaults_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ResetWithDefaults_cfunc(vi)
@@ -565,12 +383,7 @@ class Library(object):
     def niDMM_SelfCal(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDMM_SelfCal_cfunc is None:
-                try:
-                    self.niDMM_SelfCal_cfunc = self._library.niDMM_SelfCal
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_SelfCal was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_SelfCal_cfunc = self._get_library_function('niDMM_SelfCal')
                 self.niDMM_SelfCal_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_SelfCal_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_SelfCal_cfunc(vi)
@@ -578,12 +391,7 @@ class Library(object):
     def niDMM_SendSoftwareTrigger(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDMM_SendSoftwareTrigger_cfunc is None:
-                try:
-                    self.niDMM_SendSoftwareTrigger_cfunc = self._library.niDMM_SendSoftwareTrigger
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_SendSoftwareTrigger was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_SendSoftwareTrigger_cfunc = self._get_library_function('niDMM_SendSoftwareTrigger')
                 self.niDMM_SendSoftwareTrigger_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_SendSoftwareTrigger_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_SendSoftwareTrigger_cfunc(vi)
@@ -591,12 +399,7 @@ class Library(object):
     def niDMM_SetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDMM_SetAttributeViBoolean_cfunc is None:
-                try:
-                    self.niDMM_SetAttributeViBoolean_cfunc = self._library.niDMM_SetAttributeViBoolean
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_SetAttributeViBoolean was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_SetAttributeViBoolean_cfunc = self._get_library_function('niDMM_SetAttributeViBoolean')
                 self.niDMM_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViBoolean]  # noqa: F405
                 self.niDMM_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_SetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -604,12 +407,7 @@ class Library(object):
     def niDMM_SetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDMM_SetAttributeViInt32_cfunc is None:
-                try:
-                    self.niDMM_SetAttributeViInt32_cfunc = self._library.niDMM_SetAttributeViInt32
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_SetAttributeViInt32 was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_SetAttributeViInt32_cfunc = self._get_library_function('niDMM_SetAttributeViInt32')
                 self.niDMM_SetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32]  # noqa: F405
                 self.niDMM_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_SetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -617,12 +415,7 @@ class Library(object):
     def niDMM_SetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDMM_SetAttributeViReal64_cfunc is None:
-                try:
-                    self.niDMM_SetAttributeViReal64_cfunc = self._library.niDMM_SetAttributeViReal64
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_SetAttributeViReal64 was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_SetAttributeViReal64_cfunc = self._get_library_function('niDMM_SetAttributeViReal64')
                 self.niDMM_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niDMM_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_SetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -630,12 +423,7 @@ class Library(object):
     def niDMM_SetAttributeViString(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDMM_SetAttributeViString_cfunc is None:
-                try:
-                    self.niDMM_SetAttributeViString_cfunc = self._library.niDMM_SetAttributeViString
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_SetAttributeViString was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_SetAttributeViString_cfunc = self._get_library_function('niDMM_SetAttributeViString')
                 self.niDMM_SetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDMM_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_SetAttributeViString_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -643,12 +431,7 @@ class Library(object):
     def niDMM_UnlockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niDMM_UnlockSession_cfunc is None:
-                try:
-                    self.niDMM_UnlockSession_cfunc = self._library.niDMM_UnlockSession
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_UnlockSession was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_UnlockSession_cfunc = self._get_library_function('niDMM_UnlockSession')
                 self.niDMM_UnlockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDMM_UnlockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_UnlockSession_cfunc(vi, caller_has_lock)
@@ -656,12 +439,7 @@ class Library(object):
     def niDMM_close(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDMM_close_cfunc is None:
-                try:
-                    self.niDMM_close_cfunc = self._library.niDMM_close
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_close was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_close_cfunc = self._get_library_function('niDMM_close')
                 self.niDMM_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_close_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_close_cfunc(vi)
@@ -669,12 +447,7 @@ class Library(object):
     def niDMM_error_message(self, vi, error_code, error_message):  # noqa: N802
         with self._func_lock:
             if self.niDMM_error_message_cfunc is None:
-                try:
-                    self.niDMM_error_message_cfunc = self._library.niDMM_error_message
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_error_message was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_error_message_cfunc = self._get_library_function('niDMM_error_message')
                 self.niDMM_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDMM_error_message_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_error_message_cfunc(vi, error_code, error_message)
@@ -682,12 +455,7 @@ class Library(object):
     def niDMM_reset(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDMM_reset_cfunc is None:
-                try:
-                    self.niDMM_reset_cfunc = self._library.niDMM_reset
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_reset was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_reset_cfunc = self._get_library_function('niDMM_reset')
                 self.niDMM_reset_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_reset_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_reset_cfunc(vi)
@@ -695,12 +463,7 @@ class Library(object):
     def niDMM_self_test(self, vi, self_test_result, self_test_message):  # noqa: N802
         with self._func_lock:
             if self.niDMM_self_test_cfunc is None:
-                try:
-                    self.niDMM_self_test_cfunc = self._library.niDMM_self_test
-                except AttributeError as e:
-                    raise AttributeError("Function niDMM_self_test was not found in the NI-DMM runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niDMM_self_test_cfunc = self._get_library_function('niDMM_self_test')
                 self.niDMM_self_test_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDMM_self_test_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_self_test_cfunc(vi, self_test_result, self_test_message)

--- a/generated/nidmm/nidmm/_library.py
+++ b/generated/nidmm/nidmm/_library.py
@@ -71,7 +71,7 @@ class Library(object):
 
     def _get_library_function(self, name):
         try:
-            function = getattr(self._library, 'fred')
+            function = getattr(self._library, name)
         except AttributeError as e:
             raise errors.DriverTooOldError() from e
         return function

--- a/generated/nidmm/nidmm/_library.py
+++ b/generated/nidmm/nidmm/_library.py
@@ -74,9 +74,9 @@ class Library(object):
                 try:
                     self.niDMM_Abort_cfunc = self._library.niDMM_Abort
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_Abort was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_Abort_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_Abort_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_Abort_cfunc(vi)
@@ -87,9 +87,9 @@ class Library(object):
                 try:
                     self.niDMM_ConfigureMeasurementAbsolute_cfunc = self._library.niDMM_ConfigureMeasurementAbsolute
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_ConfigureMeasurementAbsolute was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_ConfigureMeasurementAbsolute_cfunc.argtypes = [ViSession, ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureMeasurementAbsolute_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureMeasurementAbsolute_cfunc(vi, measurement_function, range, resolution_absolute)
@@ -100,9 +100,9 @@ class Library(object):
                 try:
                     self.niDMM_ConfigureMeasurementDigits_cfunc = self._library.niDMM_ConfigureMeasurementDigits
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_ConfigureMeasurementDigits was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_ConfigureMeasurementDigits_cfunc.argtypes = [ViSession, ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureMeasurementDigits_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureMeasurementDigits_cfunc(vi, measurement_function, range, resolution_digits)
@@ -113,9 +113,9 @@ class Library(object):
                 try:
                     self.niDMM_ConfigureMultiPoint_cfunc = self._library.niDMM_ConfigureMultiPoint
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_ConfigureMultiPoint was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_ConfigureMultiPoint_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ViInt32, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureMultiPoint_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureMultiPoint_cfunc(vi, trigger_count, sample_count, sample_trigger, sample_interval)
@@ -126,9 +126,9 @@ class Library(object):
                 try:
                     self.niDMM_ConfigureRTDCustom_cfunc = self._library.niDMM_ConfigureRTDCustom
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_ConfigureRTDCustom was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_ConfigureRTDCustom_cfunc.argtypes = [ViSession, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureRTDCustom_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureRTDCustom_cfunc(vi, rtd_a, rtd_b, rtd_c)
@@ -139,9 +139,9 @@ class Library(object):
                 try:
                     self.niDMM_ConfigureRTDType_cfunc = self._library.niDMM_ConfigureRTDType
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_ConfigureRTDType was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_ConfigureRTDType_cfunc.argtypes = [ViSession, ViInt32, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureRTDType_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureRTDType_cfunc(vi, rtd_type, rtd_resistance)
@@ -152,9 +152,9 @@ class Library(object):
                 try:
                     self.niDMM_ConfigureThermistorCustom_cfunc = self._library.niDMM_ConfigureThermistorCustom
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_ConfigureThermistorCustom was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_ConfigureThermistorCustom_cfunc.argtypes = [ViSession, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureThermistorCustom_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureThermistorCustom_cfunc(vi, thermistor_a, thermistor_b, thermistor_c)
@@ -165,9 +165,9 @@ class Library(object):
                 try:
                     self.niDMM_ConfigureThermocouple_cfunc = self._library.niDMM_ConfigureThermocouple
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_ConfigureThermocouple was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_ConfigureThermocouple_cfunc.argtypes = [ViSession, ViInt32, ViInt32]  # noqa: F405
                 self.niDMM_ConfigureThermocouple_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureThermocouple_cfunc(vi, thermocouple_type, reference_junction_type)
@@ -178,9 +178,9 @@ class Library(object):
                 try:
                     self.niDMM_ConfigureTrigger_cfunc = self._library.niDMM_ConfigureTrigger
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_ConfigureTrigger was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_ConfigureTrigger_cfunc.argtypes = [ViSession, ViInt32, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureTrigger_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureTrigger_cfunc(vi, trigger_source, trigger_delay)
@@ -191,9 +191,9 @@ class Library(object):
                 try:
                     self.niDMM_ConfigureWaveformAcquisition_cfunc = self._library.niDMM_ConfigureWaveformAcquisition
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_ConfigureWaveformAcquisition was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_ConfigureWaveformAcquisition_cfunc.argtypes = [ViSession, ViInt32, ViReal64, ViReal64, ViInt32]  # noqa: F405
                 self.niDMM_ConfigureWaveformAcquisition_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureWaveformAcquisition_cfunc(vi, measurement_function, range, rate, waveform_points)
@@ -204,9 +204,9 @@ class Library(object):
                 try:
                     self.niDMM_Disable_cfunc = self._library.niDMM_Disable
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_Disable was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_Disable_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_Disable_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_Disable_cfunc(vi)
@@ -217,9 +217,9 @@ class Library(object):
                 try:
                     self.niDMM_ExportAttributeConfigurationBuffer_cfunc = self._library.niDMM_ExportAttributeConfigurationBuffer
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_ExportAttributeConfigurationBuffer was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_ExportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niDMM_ExportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ExportAttributeConfigurationBuffer_cfunc(vi, size, configuration)
@@ -230,9 +230,9 @@ class Library(object):
                 try:
                     self.niDMM_ExportAttributeConfigurationFile_cfunc = self._library.niDMM_ExportAttributeConfigurationFile
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_ExportAttributeConfigurationFile was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_ExportAttributeConfigurationFile_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDMM_ExportAttributeConfigurationFile_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ExportAttributeConfigurationFile_cfunc(vi, file_path)
@@ -243,9 +243,9 @@ class Library(object):
                 try:
                     self.niDMM_Fetch_cfunc = self._library.niDMM_Fetch
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_Fetch was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_Fetch_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_Fetch_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_Fetch_cfunc(vi, maximum_time, reading)
@@ -256,9 +256,9 @@ class Library(object):
                 try:
                     self.niDMM_FetchMultiPoint_cfunc = self._library.niDMM_FetchMultiPoint
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_FetchMultiPoint was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_FetchMultiPoint_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_FetchMultiPoint_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_FetchMultiPoint_cfunc(vi, maximum_time, array_size, reading_array, actual_number_of_points)
@@ -269,9 +269,9 @@ class Library(object):
                 try:
                     self.niDMM_FetchWaveform_cfunc = self._library.niDMM_FetchWaveform
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_FetchWaveform was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_FetchWaveform_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_FetchWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_FetchWaveform_cfunc(vi, maximum_time, array_size, waveform_array, actual_number_of_points)
@@ -282,9 +282,9 @@ class Library(object):
                 try:
                     self.niDMM_GetAttributeViBoolean_cfunc = self._library.niDMM_GetAttributeViBoolean
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_GetAttributeViBoolean was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDMM_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -295,9 +295,9 @@ class Library(object):
                 try:
                     self.niDMM_GetAttributeViInt32_cfunc = self._library.niDMM_GetAttributeViInt32
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_GetAttributeViInt32 was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_GetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -308,9 +308,9 @@ class Library(object):
                 try:
                     self.niDMM_GetAttributeViReal64_cfunc = self._library.niDMM_GetAttributeViReal64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_GetAttributeViReal64 was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_GetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -321,9 +321,9 @@ class Library(object):
                 try:
                     self.niDMM_GetAttributeViString_cfunc = self._library.niDMM_GetAttributeViString
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_GetAttributeViString was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDMM_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetAttributeViString_cfunc(vi, channel_name, attribute_id, buffer_size, attribute_value)
@@ -334,9 +334,9 @@ class Library(object):
                 try:
                     self.niDMM_GetCalDateAndTime_cfunc = self._library.niDMM_GetCalDateAndTime
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_GetCalDateAndTime was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_GetCalDateAndTime_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_GetCalDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetCalDateAndTime_cfunc(vi, cal_type, month, day, year, hour, minute)
@@ -347,9 +347,9 @@ class Library(object):
                 try:
                     self.niDMM_GetDevTemp_cfunc = self._library.niDMM_GetDevTemp
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_GetDevTemp was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_GetDevTemp_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_GetDevTemp_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetDevTemp_cfunc(vi, options, temperature)
@@ -360,9 +360,9 @@ class Library(object):
                 try:
                     self.niDMM_GetError_cfunc = self._library.niDMM_GetError
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_GetError was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDMM_GetError_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetError_cfunc(vi, error_code, buffer_size, description)
@@ -373,9 +373,9 @@ class Library(object):
                 try:
                     self.niDMM_GetExtCalRecommendedInterval_cfunc = self._library.niDMM_GetExtCalRecommendedInterval
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_GetExtCalRecommendedInterval was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_GetExtCalRecommendedInterval_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_GetExtCalRecommendedInterval_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetExtCalRecommendedInterval_cfunc(vi, months)
@@ -386,9 +386,9 @@ class Library(object):
                 try:
                     self.niDMM_GetLastCalTemp_cfunc = self._library.niDMM_GetLastCalTemp
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_GetLastCalTemp was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_GetLastCalTemp_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_GetLastCalTemp_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetLastCalTemp_cfunc(vi, cal_type, temperature)
@@ -399,9 +399,9 @@ class Library(object):
                 try:
                     self.niDMM_GetSelfCalSupported_cfunc = self._library.niDMM_GetSelfCalSupported
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_GetSelfCalSupported was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_GetSelfCalSupported_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDMM_GetSelfCalSupported_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetSelfCalSupported_cfunc(vi, self_cal_supported)
@@ -412,9 +412,9 @@ class Library(object):
                 try:
                     self.niDMM_ImportAttributeConfigurationBuffer_cfunc = self._library.niDMM_ImportAttributeConfigurationBuffer
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_ImportAttributeConfigurationBuffer was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_ImportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niDMM_ImportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ImportAttributeConfigurationBuffer_cfunc(vi, size, configuration)
@@ -425,9 +425,9 @@ class Library(object):
                 try:
                     self.niDMM_ImportAttributeConfigurationFile_cfunc = self._library.niDMM_ImportAttributeConfigurationFile
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_ImportAttributeConfigurationFile was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_ImportAttributeConfigurationFile_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDMM_ImportAttributeConfigurationFile_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ImportAttributeConfigurationFile_cfunc(vi, file_path)
@@ -438,9 +438,9 @@ class Library(object):
                 try:
                     self.niDMM_InitWithOptions_cfunc = self._library.niDMM_InitWithOptions
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_InitWithOptions was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_InitWithOptions_cfunc.argtypes = [ctypes.POINTER(ViChar), ViBoolean, ViBoolean, ctypes.POINTER(ViChar), ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niDMM_InitWithOptions_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_InitWithOptions_cfunc(resource_name, id_query, reset_device, option_string, vi)
@@ -451,9 +451,9 @@ class Library(object):
                 try:
                     self.niDMM_Initiate_cfunc = self._library.niDMM_Initiate
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_Initiate was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_Initiate_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_Initiate_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_Initiate_cfunc(vi)
@@ -464,9 +464,9 @@ class Library(object):
                 try:
                     self.niDMM_LockSession_cfunc = self._library.niDMM_LockSession
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_LockSession was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_LockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDMM_LockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_LockSession_cfunc(vi, caller_has_lock)
@@ -477,9 +477,9 @@ class Library(object):
                 try:
                     self.niDMM_PerformOpenCableComp_cfunc = self._library.niDMM_PerformOpenCableComp
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_PerformOpenCableComp was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_PerformOpenCableComp_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_PerformOpenCableComp_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_PerformOpenCableComp_cfunc(vi, conductance, susceptance)
@@ -490,9 +490,9 @@ class Library(object):
                 try:
                     self.niDMM_PerformShortCableComp_cfunc = self._library.niDMM_PerformShortCableComp
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_PerformShortCableComp was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_PerformShortCableComp_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_PerformShortCableComp_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_PerformShortCableComp_cfunc(vi, resistance, reactance)
@@ -503,9 +503,9 @@ class Library(object):
                 try:
                     self.niDMM_Read_cfunc = self._library.niDMM_Read
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_Read was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_Read_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_Read_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_Read_cfunc(vi, maximum_time, reading)
@@ -516,9 +516,9 @@ class Library(object):
                 try:
                     self.niDMM_ReadMultiPoint_cfunc = self._library.niDMM_ReadMultiPoint
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_ReadMultiPoint was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_ReadMultiPoint_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_ReadMultiPoint_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ReadMultiPoint_cfunc(vi, maximum_time, array_size, reading_array, actual_number_of_points)
@@ -529,9 +529,9 @@ class Library(object):
                 try:
                     self.niDMM_ReadStatus_cfunc = self._library.niDMM_ReadStatus
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_ReadStatus was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_ReadStatus_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt16)]  # noqa: F405
                 self.niDMM_ReadStatus_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ReadStatus_cfunc(vi, acquisition_backlog, acquisition_status)
@@ -542,9 +542,9 @@ class Library(object):
                 try:
                     self.niDMM_ReadWaveform_cfunc = self._library.niDMM_ReadWaveform
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_ReadWaveform was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_ReadWaveform_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_ReadWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ReadWaveform_cfunc(vi, maximum_time, array_size, waveform_array, actual_number_of_points)
@@ -555,9 +555,9 @@ class Library(object):
                 try:
                     self.niDMM_ResetWithDefaults_cfunc = self._library.niDMM_ResetWithDefaults
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_ResetWithDefaults was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_ResetWithDefaults_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_ResetWithDefaults_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ResetWithDefaults_cfunc(vi)
@@ -568,9 +568,9 @@ class Library(object):
                 try:
                     self.niDMM_SelfCal_cfunc = self._library.niDMM_SelfCal
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_SelfCal was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_SelfCal_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_SelfCal_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_SelfCal_cfunc(vi)
@@ -581,9 +581,9 @@ class Library(object):
                 try:
                     self.niDMM_SendSoftwareTrigger_cfunc = self._library.niDMM_SendSoftwareTrigger
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_SendSoftwareTrigger was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_SendSoftwareTrigger_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_SendSoftwareTrigger_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_SendSoftwareTrigger_cfunc(vi)
@@ -594,9 +594,9 @@ class Library(object):
                 try:
                     self.niDMM_SetAttributeViBoolean_cfunc = self._library.niDMM_SetAttributeViBoolean
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_SetAttributeViBoolean was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViBoolean]  # noqa: F405
                 self.niDMM_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_SetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -607,9 +607,9 @@ class Library(object):
                 try:
                     self.niDMM_SetAttributeViInt32_cfunc = self._library.niDMM_SetAttributeViInt32
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_SetAttributeViInt32 was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_SetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32]  # noqa: F405
                 self.niDMM_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_SetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -620,9 +620,9 @@ class Library(object):
                 try:
                     self.niDMM_SetAttributeViReal64_cfunc = self._library.niDMM_SetAttributeViReal64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_SetAttributeViReal64 was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niDMM_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_SetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -633,9 +633,9 @@ class Library(object):
                 try:
                     self.niDMM_SetAttributeViString_cfunc = self._library.niDMM_SetAttributeViString
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_SetAttributeViString was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_SetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDMM_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_SetAttributeViString_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -646,9 +646,9 @@ class Library(object):
                 try:
                     self.niDMM_UnlockSession_cfunc = self._library.niDMM_UnlockSession
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_UnlockSession was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_UnlockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDMM_UnlockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_UnlockSession_cfunc(vi, caller_has_lock)
@@ -659,9 +659,9 @@ class Library(object):
                 try:
                     self.niDMM_close_cfunc = self._library.niDMM_close
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_close was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_close_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_close_cfunc(vi)
@@ -672,9 +672,9 @@ class Library(object):
                 try:
                     self.niDMM_error_message_cfunc = self._library.niDMM_error_message
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_error_message was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDMM_error_message_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_error_message_cfunc(vi, error_code, error_message)
@@ -685,9 +685,9 @@ class Library(object):
                 try:
                     self.niDMM_reset_cfunc = self._library.niDMM_reset
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_reset was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_reset_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_reset_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_reset_cfunc(vi)
@@ -698,9 +698,9 @@ class Library(object):
                 try:
                     self.niDMM_self_test_cfunc = self._library.niDMM_self_test
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niDMM_self_test was not found in the NI-DMM runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niDMM_self_test_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDMM_self_test_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_self_test_cfunc(vi, self_test_result, self_test_message)

--- a/generated/nidmm/nidmm/_library.py
+++ b/generated/nidmm/nidmm/_library.py
@@ -71,7 +71,12 @@ class Library(object):
     def niDMM_Abort(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDMM_Abort_cfunc is None:
-                self.niDMM_Abort_cfunc = self._library.niDMM_Abort
+                try:
+                    self.niDMM_Abort_cfunc = self._library.niDMM_Abort
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_Abort_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_Abort_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_Abort_cfunc(vi)
@@ -79,7 +84,12 @@ class Library(object):
     def niDMM_ConfigureMeasurementAbsolute(self, vi, measurement_function, range, resolution_absolute):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ConfigureMeasurementAbsolute_cfunc is None:
-                self.niDMM_ConfigureMeasurementAbsolute_cfunc = self._library.niDMM_ConfigureMeasurementAbsolute
+                try:
+                    self.niDMM_ConfigureMeasurementAbsolute_cfunc = self._library.niDMM_ConfigureMeasurementAbsolute
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_ConfigureMeasurementAbsolute_cfunc.argtypes = [ViSession, ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureMeasurementAbsolute_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureMeasurementAbsolute_cfunc(vi, measurement_function, range, resolution_absolute)
@@ -87,7 +97,12 @@ class Library(object):
     def niDMM_ConfigureMeasurementDigits(self, vi, measurement_function, range, resolution_digits):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ConfigureMeasurementDigits_cfunc is None:
-                self.niDMM_ConfigureMeasurementDigits_cfunc = self._library.niDMM_ConfigureMeasurementDigits
+                try:
+                    self.niDMM_ConfigureMeasurementDigits_cfunc = self._library.niDMM_ConfigureMeasurementDigits
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_ConfigureMeasurementDigits_cfunc.argtypes = [ViSession, ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureMeasurementDigits_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureMeasurementDigits_cfunc(vi, measurement_function, range, resolution_digits)
@@ -95,7 +110,12 @@ class Library(object):
     def niDMM_ConfigureMultiPoint(self, vi, trigger_count, sample_count, sample_trigger, sample_interval):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ConfigureMultiPoint_cfunc is None:
-                self.niDMM_ConfigureMultiPoint_cfunc = self._library.niDMM_ConfigureMultiPoint
+                try:
+                    self.niDMM_ConfigureMultiPoint_cfunc = self._library.niDMM_ConfigureMultiPoint
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_ConfigureMultiPoint_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ViInt32, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureMultiPoint_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureMultiPoint_cfunc(vi, trigger_count, sample_count, sample_trigger, sample_interval)
@@ -103,7 +123,12 @@ class Library(object):
     def niDMM_ConfigureRTDCustom(self, vi, rtd_a, rtd_b, rtd_c):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ConfigureRTDCustom_cfunc is None:
-                self.niDMM_ConfigureRTDCustom_cfunc = self._library.niDMM_ConfigureRTDCustom
+                try:
+                    self.niDMM_ConfigureRTDCustom_cfunc = self._library.niDMM_ConfigureRTDCustom
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_ConfigureRTDCustom_cfunc.argtypes = [ViSession, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureRTDCustom_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureRTDCustom_cfunc(vi, rtd_a, rtd_b, rtd_c)
@@ -111,7 +136,12 @@ class Library(object):
     def niDMM_ConfigureRTDType(self, vi, rtd_type, rtd_resistance):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ConfigureRTDType_cfunc is None:
-                self.niDMM_ConfigureRTDType_cfunc = self._library.niDMM_ConfigureRTDType
+                try:
+                    self.niDMM_ConfigureRTDType_cfunc = self._library.niDMM_ConfigureRTDType
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_ConfigureRTDType_cfunc.argtypes = [ViSession, ViInt32, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureRTDType_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureRTDType_cfunc(vi, rtd_type, rtd_resistance)
@@ -119,7 +149,12 @@ class Library(object):
     def niDMM_ConfigureThermistorCustom(self, vi, thermistor_a, thermistor_b, thermistor_c):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ConfigureThermistorCustom_cfunc is None:
-                self.niDMM_ConfigureThermistorCustom_cfunc = self._library.niDMM_ConfigureThermistorCustom
+                try:
+                    self.niDMM_ConfigureThermistorCustom_cfunc = self._library.niDMM_ConfigureThermistorCustom
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_ConfigureThermistorCustom_cfunc.argtypes = [ViSession, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureThermistorCustom_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureThermistorCustom_cfunc(vi, thermistor_a, thermistor_b, thermistor_c)
@@ -127,7 +162,12 @@ class Library(object):
     def niDMM_ConfigureThermocouple(self, vi, thermocouple_type, reference_junction_type):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ConfigureThermocouple_cfunc is None:
-                self.niDMM_ConfigureThermocouple_cfunc = self._library.niDMM_ConfigureThermocouple
+                try:
+                    self.niDMM_ConfigureThermocouple_cfunc = self._library.niDMM_ConfigureThermocouple
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_ConfigureThermocouple_cfunc.argtypes = [ViSession, ViInt32, ViInt32]  # noqa: F405
                 self.niDMM_ConfigureThermocouple_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureThermocouple_cfunc(vi, thermocouple_type, reference_junction_type)
@@ -135,7 +175,12 @@ class Library(object):
     def niDMM_ConfigureTrigger(self, vi, trigger_source, trigger_delay):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ConfigureTrigger_cfunc is None:
-                self.niDMM_ConfigureTrigger_cfunc = self._library.niDMM_ConfigureTrigger
+                try:
+                    self.niDMM_ConfigureTrigger_cfunc = self._library.niDMM_ConfigureTrigger
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_ConfigureTrigger_cfunc.argtypes = [ViSession, ViInt32, ViReal64]  # noqa: F405
                 self.niDMM_ConfigureTrigger_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureTrigger_cfunc(vi, trigger_source, trigger_delay)
@@ -143,7 +188,12 @@ class Library(object):
     def niDMM_ConfigureWaveformAcquisition(self, vi, measurement_function, range, rate, waveform_points):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ConfigureWaveformAcquisition_cfunc is None:
-                self.niDMM_ConfigureWaveformAcquisition_cfunc = self._library.niDMM_ConfigureWaveformAcquisition
+                try:
+                    self.niDMM_ConfigureWaveformAcquisition_cfunc = self._library.niDMM_ConfigureWaveformAcquisition
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_ConfigureWaveformAcquisition_cfunc.argtypes = [ViSession, ViInt32, ViReal64, ViReal64, ViInt32]  # noqa: F405
                 self.niDMM_ConfigureWaveformAcquisition_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ConfigureWaveformAcquisition_cfunc(vi, measurement_function, range, rate, waveform_points)
@@ -151,7 +201,12 @@ class Library(object):
     def niDMM_Disable(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDMM_Disable_cfunc is None:
-                self.niDMM_Disable_cfunc = self._library.niDMM_Disable
+                try:
+                    self.niDMM_Disable_cfunc = self._library.niDMM_Disable
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_Disable_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_Disable_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_Disable_cfunc(vi)
@@ -159,7 +214,12 @@ class Library(object):
     def niDMM_ExportAttributeConfigurationBuffer(self, vi, size, configuration):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ExportAttributeConfigurationBuffer_cfunc is None:
-                self.niDMM_ExportAttributeConfigurationBuffer_cfunc = self._library.niDMM_ExportAttributeConfigurationBuffer
+                try:
+                    self.niDMM_ExportAttributeConfigurationBuffer_cfunc = self._library.niDMM_ExportAttributeConfigurationBuffer
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_ExportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niDMM_ExportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ExportAttributeConfigurationBuffer_cfunc(vi, size, configuration)
@@ -167,7 +227,12 @@ class Library(object):
     def niDMM_ExportAttributeConfigurationFile(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ExportAttributeConfigurationFile_cfunc is None:
-                self.niDMM_ExportAttributeConfigurationFile_cfunc = self._library.niDMM_ExportAttributeConfigurationFile
+                try:
+                    self.niDMM_ExportAttributeConfigurationFile_cfunc = self._library.niDMM_ExportAttributeConfigurationFile
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_ExportAttributeConfigurationFile_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDMM_ExportAttributeConfigurationFile_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ExportAttributeConfigurationFile_cfunc(vi, file_path)
@@ -175,7 +240,12 @@ class Library(object):
     def niDMM_Fetch(self, vi, maximum_time, reading):  # noqa: N802
         with self._func_lock:
             if self.niDMM_Fetch_cfunc is None:
-                self.niDMM_Fetch_cfunc = self._library.niDMM_Fetch
+                try:
+                    self.niDMM_Fetch_cfunc = self._library.niDMM_Fetch
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_Fetch_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_Fetch_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_Fetch_cfunc(vi, maximum_time, reading)
@@ -183,7 +253,12 @@ class Library(object):
     def niDMM_FetchMultiPoint(self, vi, maximum_time, array_size, reading_array, actual_number_of_points):  # noqa: N802
         with self._func_lock:
             if self.niDMM_FetchMultiPoint_cfunc is None:
-                self.niDMM_FetchMultiPoint_cfunc = self._library.niDMM_FetchMultiPoint
+                try:
+                    self.niDMM_FetchMultiPoint_cfunc = self._library.niDMM_FetchMultiPoint
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_FetchMultiPoint_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_FetchMultiPoint_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_FetchMultiPoint_cfunc(vi, maximum_time, array_size, reading_array, actual_number_of_points)
@@ -191,7 +266,12 @@ class Library(object):
     def niDMM_FetchWaveform(self, vi, maximum_time, array_size, waveform_array, actual_number_of_points):  # noqa: N802
         with self._func_lock:
             if self.niDMM_FetchWaveform_cfunc is None:
-                self.niDMM_FetchWaveform_cfunc = self._library.niDMM_FetchWaveform
+                try:
+                    self.niDMM_FetchWaveform_cfunc = self._library.niDMM_FetchWaveform
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_FetchWaveform_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_FetchWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_FetchWaveform_cfunc(vi, maximum_time, array_size, waveform_array, actual_number_of_points)
@@ -199,7 +279,12 @@ class Library(object):
     def niDMM_GetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDMM_GetAttributeViBoolean_cfunc is None:
-                self.niDMM_GetAttributeViBoolean_cfunc = self._library.niDMM_GetAttributeViBoolean
+                try:
+                    self.niDMM_GetAttributeViBoolean_cfunc = self._library.niDMM_GetAttributeViBoolean
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDMM_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -207,7 +292,12 @@ class Library(object):
     def niDMM_GetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDMM_GetAttributeViInt32_cfunc is None:
-                self.niDMM_GetAttributeViInt32_cfunc = self._library.niDMM_GetAttributeViInt32
+                try:
+                    self.niDMM_GetAttributeViInt32_cfunc = self._library.niDMM_GetAttributeViInt32
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_GetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -215,7 +305,12 @@ class Library(object):
     def niDMM_GetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDMM_GetAttributeViReal64_cfunc is None:
-                self.niDMM_GetAttributeViReal64_cfunc = self._library.niDMM_GetAttributeViReal64
+                try:
+                    self.niDMM_GetAttributeViReal64_cfunc = self._library.niDMM_GetAttributeViReal64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_GetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -223,7 +318,12 @@ class Library(object):
     def niDMM_GetAttributeViString(self, vi, channel_name, attribute_id, buffer_size, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDMM_GetAttributeViString_cfunc is None:
-                self.niDMM_GetAttributeViString_cfunc = self._library.niDMM_GetAttributeViString
+                try:
+                    self.niDMM_GetAttributeViString_cfunc = self._library.niDMM_GetAttributeViString
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDMM_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetAttributeViString_cfunc(vi, channel_name, attribute_id, buffer_size, attribute_value)
@@ -231,7 +331,12 @@ class Library(object):
     def niDMM_GetCalDateAndTime(self, vi, cal_type, month, day, year, hour, minute):  # noqa: N802
         with self._func_lock:
             if self.niDMM_GetCalDateAndTime_cfunc is None:
-                self.niDMM_GetCalDateAndTime_cfunc = self._library.niDMM_GetCalDateAndTime
+                try:
+                    self.niDMM_GetCalDateAndTime_cfunc = self._library.niDMM_GetCalDateAndTime
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_GetCalDateAndTime_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_GetCalDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetCalDateAndTime_cfunc(vi, cal_type, month, day, year, hour, minute)
@@ -239,7 +344,12 @@ class Library(object):
     def niDMM_GetDevTemp(self, vi, options, temperature):  # noqa: N802
         with self._func_lock:
             if self.niDMM_GetDevTemp_cfunc is None:
-                self.niDMM_GetDevTemp_cfunc = self._library.niDMM_GetDevTemp
+                try:
+                    self.niDMM_GetDevTemp_cfunc = self._library.niDMM_GetDevTemp
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_GetDevTemp_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_GetDevTemp_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetDevTemp_cfunc(vi, options, temperature)
@@ -247,7 +357,12 @@ class Library(object):
     def niDMM_GetError(self, vi, error_code, buffer_size, description):  # noqa: N802
         with self._func_lock:
             if self.niDMM_GetError_cfunc is None:
-                self.niDMM_GetError_cfunc = self._library.niDMM_GetError
+                try:
+                    self.niDMM_GetError_cfunc = self._library.niDMM_GetError
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDMM_GetError_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetError_cfunc(vi, error_code, buffer_size, description)
@@ -255,7 +370,12 @@ class Library(object):
     def niDMM_GetExtCalRecommendedInterval(self, vi, months):  # noqa: N802
         with self._func_lock:
             if self.niDMM_GetExtCalRecommendedInterval_cfunc is None:
-                self.niDMM_GetExtCalRecommendedInterval_cfunc = self._library.niDMM_GetExtCalRecommendedInterval
+                try:
+                    self.niDMM_GetExtCalRecommendedInterval_cfunc = self._library.niDMM_GetExtCalRecommendedInterval
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_GetExtCalRecommendedInterval_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_GetExtCalRecommendedInterval_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetExtCalRecommendedInterval_cfunc(vi, months)
@@ -263,7 +383,12 @@ class Library(object):
     def niDMM_GetLastCalTemp(self, vi, cal_type, temperature):  # noqa: N802
         with self._func_lock:
             if self.niDMM_GetLastCalTemp_cfunc is None:
-                self.niDMM_GetLastCalTemp_cfunc = self._library.niDMM_GetLastCalTemp
+                try:
+                    self.niDMM_GetLastCalTemp_cfunc = self._library.niDMM_GetLastCalTemp
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_GetLastCalTemp_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_GetLastCalTemp_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetLastCalTemp_cfunc(vi, cal_type, temperature)
@@ -271,7 +396,12 @@ class Library(object):
     def niDMM_GetSelfCalSupported(self, vi, self_cal_supported):  # noqa: N802
         with self._func_lock:
             if self.niDMM_GetSelfCalSupported_cfunc is None:
-                self.niDMM_GetSelfCalSupported_cfunc = self._library.niDMM_GetSelfCalSupported
+                try:
+                    self.niDMM_GetSelfCalSupported_cfunc = self._library.niDMM_GetSelfCalSupported
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_GetSelfCalSupported_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDMM_GetSelfCalSupported_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_GetSelfCalSupported_cfunc(vi, self_cal_supported)
@@ -279,7 +409,12 @@ class Library(object):
     def niDMM_ImportAttributeConfigurationBuffer(self, vi, size, configuration):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ImportAttributeConfigurationBuffer_cfunc is None:
-                self.niDMM_ImportAttributeConfigurationBuffer_cfunc = self._library.niDMM_ImportAttributeConfigurationBuffer
+                try:
+                    self.niDMM_ImportAttributeConfigurationBuffer_cfunc = self._library.niDMM_ImportAttributeConfigurationBuffer
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_ImportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niDMM_ImportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ImportAttributeConfigurationBuffer_cfunc(vi, size, configuration)
@@ -287,7 +422,12 @@ class Library(object):
     def niDMM_ImportAttributeConfigurationFile(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ImportAttributeConfigurationFile_cfunc is None:
-                self.niDMM_ImportAttributeConfigurationFile_cfunc = self._library.niDMM_ImportAttributeConfigurationFile
+                try:
+                    self.niDMM_ImportAttributeConfigurationFile_cfunc = self._library.niDMM_ImportAttributeConfigurationFile
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_ImportAttributeConfigurationFile_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDMM_ImportAttributeConfigurationFile_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ImportAttributeConfigurationFile_cfunc(vi, file_path)
@@ -295,7 +435,12 @@ class Library(object):
     def niDMM_InitWithOptions(self, resource_name, id_query, reset_device, option_string, vi):  # noqa: N802
         with self._func_lock:
             if self.niDMM_InitWithOptions_cfunc is None:
-                self.niDMM_InitWithOptions_cfunc = self._library.niDMM_InitWithOptions
+                try:
+                    self.niDMM_InitWithOptions_cfunc = self._library.niDMM_InitWithOptions
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_InitWithOptions_cfunc.argtypes = [ctypes.POINTER(ViChar), ViBoolean, ViBoolean, ctypes.POINTER(ViChar), ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niDMM_InitWithOptions_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_InitWithOptions_cfunc(resource_name, id_query, reset_device, option_string, vi)
@@ -303,7 +448,12 @@ class Library(object):
     def niDMM_Initiate(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDMM_Initiate_cfunc is None:
-                self.niDMM_Initiate_cfunc = self._library.niDMM_Initiate
+                try:
+                    self.niDMM_Initiate_cfunc = self._library.niDMM_Initiate
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_Initiate_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_Initiate_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_Initiate_cfunc(vi)
@@ -311,7 +461,12 @@ class Library(object):
     def niDMM_LockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niDMM_LockSession_cfunc is None:
-                self.niDMM_LockSession_cfunc = self._library.niDMM_LockSession
+                try:
+                    self.niDMM_LockSession_cfunc = self._library.niDMM_LockSession
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_LockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDMM_LockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_LockSession_cfunc(vi, caller_has_lock)
@@ -319,7 +474,12 @@ class Library(object):
     def niDMM_PerformOpenCableComp(self, vi, conductance, susceptance):  # noqa: N802
         with self._func_lock:
             if self.niDMM_PerformOpenCableComp_cfunc is None:
-                self.niDMM_PerformOpenCableComp_cfunc = self._library.niDMM_PerformOpenCableComp
+                try:
+                    self.niDMM_PerformOpenCableComp_cfunc = self._library.niDMM_PerformOpenCableComp
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_PerformOpenCableComp_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_PerformOpenCableComp_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_PerformOpenCableComp_cfunc(vi, conductance, susceptance)
@@ -327,7 +487,12 @@ class Library(object):
     def niDMM_PerformShortCableComp(self, vi, resistance, reactance):  # noqa: N802
         with self._func_lock:
             if self.niDMM_PerformShortCableComp_cfunc is None:
-                self.niDMM_PerformShortCableComp_cfunc = self._library.niDMM_PerformShortCableComp
+                try:
+                    self.niDMM_PerformShortCableComp_cfunc = self._library.niDMM_PerformShortCableComp
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_PerformShortCableComp_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_PerformShortCableComp_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_PerformShortCableComp_cfunc(vi, resistance, reactance)
@@ -335,7 +500,12 @@ class Library(object):
     def niDMM_Read(self, vi, maximum_time, reading):  # noqa: N802
         with self._func_lock:
             if self.niDMM_Read_cfunc is None:
-                self.niDMM_Read_cfunc = self._library.niDMM_Read
+                try:
+                    self.niDMM_Read_cfunc = self._library.niDMM_Read
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_Read_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niDMM_Read_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_Read_cfunc(vi, maximum_time, reading)
@@ -343,7 +513,12 @@ class Library(object):
     def niDMM_ReadMultiPoint(self, vi, maximum_time, array_size, reading_array, actual_number_of_points):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ReadMultiPoint_cfunc is None:
-                self.niDMM_ReadMultiPoint_cfunc = self._library.niDMM_ReadMultiPoint
+                try:
+                    self.niDMM_ReadMultiPoint_cfunc = self._library.niDMM_ReadMultiPoint
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_ReadMultiPoint_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_ReadMultiPoint_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ReadMultiPoint_cfunc(vi, maximum_time, array_size, reading_array, actual_number_of_points)
@@ -351,7 +526,12 @@ class Library(object):
     def niDMM_ReadStatus(self, vi, acquisition_backlog, acquisition_status):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ReadStatus_cfunc is None:
-                self.niDMM_ReadStatus_cfunc = self._library.niDMM_ReadStatus
+                try:
+                    self.niDMM_ReadStatus_cfunc = self._library.niDMM_ReadStatus
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_ReadStatus_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt16)]  # noqa: F405
                 self.niDMM_ReadStatus_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ReadStatus_cfunc(vi, acquisition_backlog, acquisition_status)
@@ -359,7 +539,12 @@ class Library(object):
     def niDMM_ReadWaveform(self, vi, maximum_time, array_size, waveform_array, actual_number_of_points):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ReadWaveform_cfunc is None:
-                self.niDMM_ReadWaveform_cfunc = self._library.niDMM_ReadWaveform
+                try:
+                    self.niDMM_ReadWaveform_cfunc = self._library.niDMM_ReadWaveform
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_ReadWaveform_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niDMM_ReadWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ReadWaveform_cfunc(vi, maximum_time, array_size, waveform_array, actual_number_of_points)
@@ -367,7 +552,12 @@ class Library(object):
     def niDMM_ResetWithDefaults(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDMM_ResetWithDefaults_cfunc is None:
-                self.niDMM_ResetWithDefaults_cfunc = self._library.niDMM_ResetWithDefaults
+                try:
+                    self.niDMM_ResetWithDefaults_cfunc = self._library.niDMM_ResetWithDefaults
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_ResetWithDefaults_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_ResetWithDefaults_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_ResetWithDefaults_cfunc(vi)
@@ -375,7 +565,12 @@ class Library(object):
     def niDMM_SelfCal(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDMM_SelfCal_cfunc is None:
-                self.niDMM_SelfCal_cfunc = self._library.niDMM_SelfCal
+                try:
+                    self.niDMM_SelfCal_cfunc = self._library.niDMM_SelfCal
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_SelfCal_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_SelfCal_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_SelfCal_cfunc(vi)
@@ -383,7 +578,12 @@ class Library(object):
     def niDMM_SendSoftwareTrigger(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDMM_SendSoftwareTrigger_cfunc is None:
-                self.niDMM_SendSoftwareTrigger_cfunc = self._library.niDMM_SendSoftwareTrigger
+                try:
+                    self.niDMM_SendSoftwareTrigger_cfunc = self._library.niDMM_SendSoftwareTrigger
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_SendSoftwareTrigger_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_SendSoftwareTrigger_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_SendSoftwareTrigger_cfunc(vi)
@@ -391,7 +591,12 @@ class Library(object):
     def niDMM_SetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDMM_SetAttributeViBoolean_cfunc is None:
-                self.niDMM_SetAttributeViBoolean_cfunc = self._library.niDMM_SetAttributeViBoolean
+                try:
+                    self.niDMM_SetAttributeViBoolean_cfunc = self._library.niDMM_SetAttributeViBoolean
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViBoolean]  # noqa: F405
                 self.niDMM_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_SetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -399,7 +604,12 @@ class Library(object):
     def niDMM_SetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDMM_SetAttributeViInt32_cfunc is None:
-                self.niDMM_SetAttributeViInt32_cfunc = self._library.niDMM_SetAttributeViInt32
+                try:
+                    self.niDMM_SetAttributeViInt32_cfunc = self._library.niDMM_SetAttributeViInt32
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_SetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32]  # noqa: F405
                 self.niDMM_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_SetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -407,7 +617,12 @@ class Library(object):
     def niDMM_SetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDMM_SetAttributeViReal64_cfunc is None:
-                self.niDMM_SetAttributeViReal64_cfunc = self._library.niDMM_SetAttributeViReal64
+                try:
+                    self.niDMM_SetAttributeViReal64_cfunc = self._library.niDMM_SetAttributeViReal64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niDMM_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_SetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -415,7 +630,12 @@ class Library(object):
     def niDMM_SetAttributeViString(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niDMM_SetAttributeViString_cfunc is None:
-                self.niDMM_SetAttributeViString_cfunc = self._library.niDMM_SetAttributeViString
+                try:
+                    self.niDMM_SetAttributeViString_cfunc = self._library.niDMM_SetAttributeViString
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_SetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDMM_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_SetAttributeViString_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -423,7 +643,12 @@ class Library(object):
     def niDMM_UnlockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niDMM_UnlockSession_cfunc is None:
-                self.niDMM_UnlockSession_cfunc = self._library.niDMM_UnlockSession
+                try:
+                    self.niDMM_UnlockSession_cfunc = self._library.niDMM_UnlockSession
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_UnlockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niDMM_UnlockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_UnlockSession_cfunc(vi, caller_has_lock)
@@ -431,7 +656,12 @@ class Library(object):
     def niDMM_close(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDMM_close_cfunc is None:
-                self.niDMM_close_cfunc = self._library.niDMM_close
+                try:
+                    self.niDMM_close_cfunc = self._library.niDMM_close
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_close_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_close_cfunc(vi)
@@ -439,7 +669,12 @@ class Library(object):
     def niDMM_error_message(self, vi, error_code, error_message):  # noqa: N802
         with self._func_lock:
             if self.niDMM_error_message_cfunc is None:
-                self.niDMM_error_message_cfunc = self._library.niDMM_error_message
+                try:
+                    self.niDMM_error_message_cfunc = self._library.niDMM_error_message
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDMM_error_message_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_error_message_cfunc(vi, error_code, error_message)
@@ -447,7 +682,12 @@ class Library(object):
     def niDMM_reset(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niDMM_reset_cfunc is None:
-                self.niDMM_reset_cfunc = self._library.niDMM_reset
+                try:
+                    self.niDMM_reset_cfunc = self._library.niDMM_reset
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_reset_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niDMM_reset_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_reset_cfunc(vi)
@@ -455,7 +695,12 @@ class Library(object):
     def niDMM_self_test(self, vi, self_test_result, self_test_message):  # noqa: N802
         with self._func_lock:
             if self.niDMM_self_test_cfunc is None:
-                self.niDMM_self_test_cfunc = self._library.niDMM_self_test
+                try:
+                    self.niDMM_self_test_cfunc = self._library.niDMM_self_test
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niDMM_self_test_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niDMM_self_test_cfunc.restype = ViStatus  # noqa: F405
         return self.niDMM_self_test_cfunc(vi, self_test_result, self_test_message)

--- a/generated/nidmm/nidmm/errors.py
+++ b/generated/nidmm/nidmm/errors.py
@@ -57,6 +57,13 @@ class DriverNotInstalledError(Error):
         super(DriverNotInstalledError, self).__init__('The NI-DMM runtime could not be loaded. Make sure it is installed and its bitness matches that of your Python interpreter. Please visit http://www.ni.com/downloads/drivers/ to download and install it.')
 
 
+class DriverTooOldError(Error):
+    '''An error due to using this module with an older version of the driver runtime.'''
+
+    def __init__(self):
+        super(DriverTooOldError, self).__init__('A function was not found in the NI-DMM runtime. Please visit http://www.ni.com/downloads/drivers/ to download a newer version and install it.')
+
+
 class InvalidRepeatedCapabilityError(Error):
     '''An error due to an invalid character in a repeated capability'''
 

--- a/generated/nifake/nifake/_library.py
+++ b/generated/nifake/nifake/_library.py
@@ -83,7 +83,7 @@ class Library(object):
 
     def _get_library_function(self, name):
         try:
-            function = getattr(self._library, 'fred')
+            function = getattr(self._library, name)
         except AttributeError as e:
             raise errors.DriverTooOldError() from e
         return function

--- a/generated/nifake/nifake/_library.py
+++ b/generated/nifake/nifake/_library.py
@@ -86,9 +86,9 @@ class Library(object):
                 try:
                     self.niFake_Abort_cfunc = self._library.niFake_Abort
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_Abort was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_Abort_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFake_Abort_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_Abort_cfunc(vi)
@@ -99,9 +99,9 @@ class Library(object):
                 try:
                     self.niFake_AcceptListOfDurationsInSeconds_cfunc = self._library.niFake_AcceptListOfDurationsInSeconds
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_AcceptListOfDurationsInSeconds was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_AcceptListOfDurationsInSeconds_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_AcceptListOfDurationsInSeconds_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_AcceptListOfDurationsInSeconds_cfunc(vi, count, delays)
@@ -112,9 +112,9 @@ class Library(object):
                 try:
                     self.niFake_BoolArrayOutputFunction_cfunc = self._library.niFake_BoolArrayOutputFunction
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_BoolArrayOutputFunction was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_BoolArrayOutputFunction_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFake_BoolArrayOutputFunction_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_BoolArrayOutputFunction_cfunc(vi, number_of_elements, an_array)
@@ -125,9 +125,9 @@ class Library(object):
                 try:
                     self.niFake_DoubleAllTheNums_cfunc = self._library.niFake_DoubleAllTheNums
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_DoubleAllTheNums was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_DoubleAllTheNums_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_DoubleAllTheNums_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_DoubleAllTheNums_cfunc(vi, number_count, numbers)
@@ -138,9 +138,9 @@ class Library(object):
                 try:
                     self.niFake_EnumArrayOutputFunction_cfunc = self._library.niFake_EnumArrayOutputFunction
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_EnumArrayOutputFunction was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_EnumArrayOutputFunction_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt16)]  # noqa: F405
                 self.niFake_EnumArrayOutputFunction_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_EnumArrayOutputFunction_cfunc(vi, number_of_elements, an_array)
@@ -151,9 +151,9 @@ class Library(object):
                 try:
                     self.niFake_EnumInputFunctionWithDefaults_cfunc = self._library.niFake_EnumInputFunctionWithDefaults
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_EnumInputFunctionWithDefaults was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_EnumInputFunctionWithDefaults_cfunc.argtypes = [ViSession, ViInt16]  # noqa: F405
                 self.niFake_EnumInputFunctionWithDefaults_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_EnumInputFunctionWithDefaults_cfunc(vi, a_turtle)
@@ -164,9 +164,9 @@ class Library(object):
                 try:
                     self.niFake_ExportAttributeConfigurationBuffer_cfunc = self._library.niFake_ExportAttributeConfigurationBuffer
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_ExportAttributeConfigurationBuffer was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_ExportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niFake_ExportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ExportAttributeConfigurationBuffer_cfunc(vi, size_in_bytes, configuration)
@@ -177,9 +177,9 @@ class Library(object):
                 try:
                     self.niFake_FetchWaveform_cfunc = self._library.niFake_FetchWaveform
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_FetchWaveform was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_FetchWaveform_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFake_FetchWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_FetchWaveform_cfunc(vi, number_of_samples, waveform_data, actual_number_of_samples)
@@ -190,9 +190,9 @@ class Library(object):
                 try:
                     self.niFake_GetABoolean_cfunc = self._library.niFake_GetABoolean
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_GetABoolean was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_GetABoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFake_GetABoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetABoolean_cfunc(vi, a_boolean)
@@ -203,9 +203,9 @@ class Library(object):
                 try:
                     self.niFake_GetANumber_cfunc = self._library.niFake_GetANumber
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_GetANumber was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_GetANumber_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16)]  # noqa: F405
                 self.niFake_GetANumber_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetANumber_cfunc(vi, a_number)
@@ -216,9 +216,9 @@ class Library(object):
                 try:
                     self.niFake_GetAStringOfFixedMaximumSize_cfunc = self._library.niFake_GetAStringOfFixedMaximumSize
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_GetAStringOfFixedMaximumSize was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_GetAStringOfFixedMaximumSize_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_GetAStringOfFixedMaximumSize_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAStringOfFixedMaximumSize_cfunc(vi, a_string)
@@ -229,9 +229,9 @@ class Library(object):
                 try:
                     self.niFake_GetAStringUsingPythonCode_cfunc = self._library.niFake_GetAStringUsingPythonCode
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_GetAStringUsingPythonCode was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_GetAStringUsingPythonCode_cfunc.argtypes = [ViSession, ViInt16, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_GetAStringUsingPythonCode_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAStringUsingPythonCode_cfunc(vi, a_number, a_string)
@@ -242,9 +242,9 @@ class Library(object):
                 try:
                     self.niFake_GetAnIviDanceString_cfunc = self._library.niFake_GetAnIviDanceString
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_GetAnIviDanceString was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_GetAnIviDanceString_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_GetAnIviDanceString_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAnIviDanceString_cfunc(vi, buffer_size, a_string)
@@ -255,9 +255,9 @@ class Library(object):
                 try:
                     self.niFake_GetAnIviDanceWithATwistString_cfunc = self._library.niFake_GetAnIviDanceWithATwistString
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_GetAnIviDanceWithATwistString was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_GetAnIviDanceWithATwistString_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFake_GetAnIviDanceWithATwistString_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAnIviDanceWithATwistString_cfunc(vi, buffer_size, a_string, actual_size)
@@ -268,9 +268,9 @@ class Library(object):
                 try:
                     self.niFake_GetArrayForPythonCodeCustomType_cfunc = self._library.niFake_GetArrayForPythonCodeCustomType
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_GetArrayForPythonCodeCustomType was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_GetArrayForPythonCodeCustomType_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(custom_struct.struct_CustomStruct)]  # noqa: F405
                 self.niFake_GetArrayForPythonCodeCustomType_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetArrayForPythonCodeCustomType_cfunc(vi, number_of_elements, array_out)
@@ -281,9 +281,9 @@ class Library(object):
                 try:
                     self.niFake_GetArrayForPythonCodeDouble_cfunc = self._library.niFake_GetArrayForPythonCodeDouble
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_GetArrayForPythonCodeDouble was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_GetArrayForPythonCodeDouble_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_GetArrayForPythonCodeDouble_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetArrayForPythonCodeDouble_cfunc(vi, number_of_elements, array_out)
@@ -294,9 +294,9 @@ class Library(object):
                 try:
                     self.niFake_GetArraySizeForPythonCode_cfunc = self._library.niFake_GetArraySizeForPythonCode
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_GetArraySizeForPythonCode was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_GetArraySizeForPythonCode_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFake_GetArraySizeForPythonCode_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetArraySizeForPythonCode_cfunc(vi, size_out)
@@ -307,9 +307,9 @@ class Library(object):
                 try:
                     self.niFake_GetArrayUsingIviDance_cfunc = self._library.niFake_GetArrayUsingIviDance
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_GetArrayUsingIviDance was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_GetArrayUsingIviDance_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_GetArrayUsingIviDance_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetArrayUsingIviDance_cfunc(vi, array_size, array_out)
@@ -320,9 +320,9 @@ class Library(object):
                 try:
                     self.niFake_GetAttributeViBoolean_cfunc = self._library.niFake_GetAttributeViBoolean
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_GetAttributeViBoolean was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFake_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -333,9 +333,9 @@ class Library(object):
                 try:
                     self.niFake_GetAttributeViInt32_cfunc = self._library.niFake_GetAttributeViInt32
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_GetAttributeViInt32 was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_GetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFake_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -346,9 +346,9 @@ class Library(object):
                 try:
                     self.niFake_GetAttributeViInt64_cfunc = self._library.niFake_GetAttributeViInt64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_GetAttributeViInt64 was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_GetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt64)]  # noqa: F405
                 self.niFake_GetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAttributeViInt64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -359,9 +359,9 @@ class Library(object):
                 try:
                     self.niFake_GetAttributeViReal64_cfunc = self._library.niFake_GetAttributeViReal64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_GetAttributeViReal64 was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_GetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -372,9 +372,9 @@ class Library(object):
                 try:
                     self.niFake_GetAttributeViString_cfunc = self._library.niFake_GetAttributeViString
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_GetAttributeViString was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAttributeViString_cfunc(vi, channel_name, attribute_id, buffer_size, attribute_value)
@@ -385,9 +385,9 @@ class Library(object):
                 try:
                     self.niFake_GetCalDateAndTime_cfunc = self._library.niFake_GetCalDateAndTime
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_GetCalDateAndTime was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_GetCalDateAndTime_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFake_GetCalDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetCalDateAndTime_cfunc(vi, cal_type, month, day, year, hour, minute)
@@ -398,9 +398,9 @@ class Library(object):
                 try:
                     self.niFake_GetCalInterval_cfunc = self._library.niFake_GetCalInterval
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_GetCalInterval was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_GetCalInterval_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFake_GetCalInterval_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetCalInterval_cfunc(vi, months)
@@ -411,9 +411,9 @@ class Library(object):
                 try:
                     self.niFake_GetCustomType_cfunc = self._library.niFake_GetCustomType
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_GetCustomType was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_GetCustomType_cfunc.argtypes = [ViSession, ctypes.POINTER(custom_struct.struct_CustomStruct)]  # noqa: F405
                 self.niFake_GetCustomType_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetCustomType_cfunc(vi, cs)
@@ -424,9 +424,9 @@ class Library(object):
                 try:
                     self.niFake_GetCustomTypeArray_cfunc = self._library.niFake_GetCustomTypeArray
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_GetCustomTypeArray was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_GetCustomTypeArray_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(custom_struct.struct_CustomStruct)]  # noqa: F405
                 self.niFake_GetCustomTypeArray_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetCustomTypeArray_cfunc(vi, number_of_elements, cs)
@@ -437,9 +437,9 @@ class Library(object):
                 try:
                     self.niFake_GetEnumValue_cfunc = self._library.niFake_GetEnumValue
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_GetEnumValue was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_GetEnumValue_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt16)]  # noqa: F405
                 self.niFake_GetEnumValue_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetEnumValue_cfunc(vi, a_quantity, a_turtle)
@@ -450,9 +450,9 @@ class Library(object):
                 try:
                     self.niFake_GetError_cfunc = self._library.niFake_GetError
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_GetError was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_GetError_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetError_cfunc(vi, error_code, buffer_size, description)
@@ -463,9 +463,9 @@ class Library(object):
                 try:
                     self.niFake_ImportAttributeConfigurationBuffer_cfunc = self._library.niFake_ImportAttributeConfigurationBuffer
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_ImportAttributeConfigurationBuffer was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_ImportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niFake_ImportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ImportAttributeConfigurationBuffer_cfunc(vi, size_in_bytes, configuration)
@@ -476,9 +476,9 @@ class Library(object):
                 try:
                     self.niFake_InitWithOptions_cfunc = self._library.niFake_InitWithOptions
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_InitWithOptions was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_InitWithOptions_cfunc.argtypes = [ctypes.POINTER(ViChar), ViBoolean, ViBoolean, ctypes.POINTER(ViChar), ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niFake_InitWithOptions_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_InitWithOptions_cfunc(resource_name, id_query, reset_device, option_string, vi)
@@ -489,9 +489,9 @@ class Library(object):
                 try:
                     self.niFake_Initiate_cfunc = self._library.niFake_Initiate
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_Initiate was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_Initiate_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFake_Initiate_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_Initiate_cfunc(vi)
@@ -502,9 +502,9 @@ class Library(object):
                 try:
                     self.niFake_LockSession_cfunc = self._library.niFake_LockSession
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_LockSession was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_LockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFake_LockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_LockSession_cfunc(vi, caller_has_lock)
@@ -515,9 +515,9 @@ class Library(object):
                 try:
                     self.niFake_MultipleArrayTypes_cfunc = self._library.niFake_MultipleArrayTypes
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_MultipleArrayTypes was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_MultipleArrayTypes_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt16)]  # noqa: F405
                 self.niFake_MultipleArrayTypes_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_MultipleArrayTypes_cfunc(vi, output_array_size, output_array, output_array_of_fixed_length, input_array_sizes, input_array_of_floats, input_array_of_integers)
@@ -528,9 +528,9 @@ class Library(object):
                 try:
                     self.niFake_MultipleArraysSameSize_cfunc = self._library.niFake_MultipleArraysSameSize
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_MultipleArraysSameSize was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_MultipleArraysSameSize_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ViInt32]  # noqa: F405
                 self.niFake_MultipleArraysSameSize_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_MultipleArraysSameSize_cfunc(vi, values1, values2, values3, values4, size)
@@ -541,9 +541,9 @@ class Library(object):
                 try:
                     self.niFake_OneInputFunction_cfunc = self._library.niFake_OneInputFunction
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_OneInputFunction was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_OneInputFunction_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niFake_OneInputFunction_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_OneInputFunction_cfunc(vi, a_number)
@@ -554,9 +554,9 @@ class Library(object):
                 try:
                     self.niFake_ParametersAreMultipleTypes_cfunc = self._library.niFake_ParametersAreMultipleTypes
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_ParametersAreMultipleTypes was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_ParametersAreMultipleTypes_cfunc.argtypes = [ViSession, ViBoolean, ViInt32, ViInt64, ViInt16, ViReal64, ViReal64, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_ParametersAreMultipleTypes_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ParametersAreMultipleTypes_cfunc(vi, a_boolean, an_int32, an_int64, an_int_enum, a_float, a_float_enum, string_size, a_string)
@@ -567,9 +567,9 @@ class Library(object):
                 try:
                     self.niFake_PoorlyNamedSimpleFunction_cfunc = self._library.niFake_PoorlyNamedSimpleFunction
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_PoorlyNamedSimpleFunction was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_PoorlyNamedSimpleFunction_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFake_PoorlyNamedSimpleFunction_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_PoorlyNamedSimpleFunction_cfunc(vi)
@@ -580,9 +580,9 @@ class Library(object):
                 try:
                     self.niFake_Read_cfunc = self._library.niFake_Read
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_Read was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_Read_cfunc.argtypes = [ViSession, ViReal64, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_Read_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_Read_cfunc(vi, maximum_time, reading)
@@ -593,9 +593,9 @@ class Library(object):
                 try:
                     self.niFake_ReadFromChannel_cfunc = self._library.niFake_ReadFromChannel
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_ReadFromChannel was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_ReadFromChannel_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_ReadFromChannel_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ReadFromChannel_cfunc(vi, channel_name, maximum_time, reading)
@@ -606,9 +606,9 @@ class Library(object):
                 try:
                     self.niFake_ReturnANumberAndAString_cfunc = self._library.niFake_ReturnANumberAndAString
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_ReturnANumberAndAString was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_ReturnANumberAndAString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_ReturnANumberAndAString_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ReturnANumberAndAString_cfunc(vi, a_number, a_string)
@@ -619,9 +619,9 @@ class Library(object):
                 try:
                     self.niFake_ReturnDurationInSeconds_cfunc = self._library.niFake_ReturnDurationInSeconds
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_ReturnDurationInSeconds was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_ReturnDurationInSeconds_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_ReturnDurationInSeconds_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ReturnDurationInSeconds_cfunc(vi, timedelta)
@@ -632,9 +632,9 @@ class Library(object):
                 try:
                     self.niFake_ReturnListOfDurationsInSeconds_cfunc = self._library.niFake_ReturnListOfDurationsInSeconds
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_ReturnListOfDurationsInSeconds was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_ReturnListOfDurationsInSeconds_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_ReturnListOfDurationsInSeconds_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ReturnListOfDurationsInSeconds_cfunc(vi, number_of_elements, timedeltas)
@@ -645,9 +645,9 @@ class Library(object):
                 try:
                     self.niFake_ReturnMultipleTypes_cfunc = self._library.niFake_ReturnMultipleTypes
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_ReturnMultipleTypes was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_ReturnMultipleTypes_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt64), ctypes.POINTER(ViInt16), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ViInt32, ctypes.POINTER(ViReal64), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_ReturnMultipleTypes_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ReturnMultipleTypes_cfunc(vi, a_boolean, an_int32, an_int64, an_int_enum, a_float, a_float_enum, array_size, an_array, string_size, a_string)
@@ -658,9 +658,9 @@ class Library(object):
                 try:
                     self.niFake_SetAttributeViBoolean_cfunc = self._library.niFake_SetAttributeViBoolean
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_SetAttributeViBoolean was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViBoolean]  # noqa: F405
                 self.niFake_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_SetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -671,9 +671,9 @@ class Library(object):
                 try:
                     self.niFake_SetAttributeViInt32_cfunc = self._library.niFake_SetAttributeViInt32
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_SetAttributeViInt32 was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_SetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32]  # noqa: F405
                 self.niFake_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_SetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -684,9 +684,9 @@ class Library(object):
                 try:
                     self.niFake_SetAttributeViInt64_cfunc = self._library.niFake_SetAttributeViInt64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_SetAttributeViInt64 was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_SetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt64]  # noqa: F405
                 self.niFake_SetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_SetAttributeViInt64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -697,9 +697,9 @@ class Library(object):
                 try:
                     self.niFake_SetAttributeViReal64_cfunc = self._library.niFake_SetAttributeViReal64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_SetAttributeViReal64 was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niFake_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_SetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -710,9 +710,9 @@ class Library(object):
                 try:
                     self.niFake_SetAttributeViString_cfunc = self._library.niFake_SetAttributeViString
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_SetAttributeViString was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_SetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_SetAttributeViString_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -723,9 +723,9 @@ class Library(object):
                 try:
                     self.niFake_SetCustomType_cfunc = self._library.niFake_SetCustomType
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_SetCustomType was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_SetCustomType_cfunc.argtypes = [ViSession, custom_struct.struct_CustomStruct]  # noqa: F405
                 self.niFake_SetCustomType_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_SetCustomType_cfunc(vi, cs)
@@ -736,9 +736,9 @@ class Library(object):
                 try:
                     self.niFake_SetCustomTypeArray_cfunc = self._library.niFake_SetCustomTypeArray
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_SetCustomTypeArray was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_SetCustomTypeArray_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(custom_struct.struct_CustomStruct)]  # noqa: F405
                 self.niFake_SetCustomTypeArray_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_SetCustomTypeArray_cfunc(vi, number_of_elements, cs)
@@ -749,9 +749,9 @@ class Library(object):
                 try:
                     self.niFake_StringValuedEnumInputFunctionWithDefaults_cfunc = self._library.niFake_StringValuedEnumInputFunctionWithDefaults
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_StringValuedEnumInputFunctionWithDefaults was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_StringValuedEnumInputFunctionWithDefaults_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_StringValuedEnumInputFunctionWithDefaults_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_StringValuedEnumInputFunctionWithDefaults_cfunc(vi, a_mobile_os_name)
@@ -762,9 +762,9 @@ class Library(object):
                 try:
                     self.niFake_TwoInputFunction_cfunc = self._library.niFake_TwoInputFunction
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_TwoInputFunction was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_TwoInputFunction_cfunc.argtypes = [ViSession, ViReal64, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_TwoInputFunction_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_TwoInputFunction_cfunc(vi, a_number, a_string)
@@ -775,9 +775,9 @@ class Library(object):
                 try:
                     self.niFake_UnlockSession_cfunc = self._library.niFake_UnlockSession
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_UnlockSession was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_UnlockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFake_UnlockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_UnlockSession_cfunc(vi, caller_has_lock)
@@ -788,9 +788,9 @@ class Library(object):
                 try:
                     self.niFake_Use64BitNumber_cfunc = self._library.niFake_Use64BitNumber
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_Use64BitNumber was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_Use64BitNumber_cfunc.argtypes = [ViSession, ViInt64, ctypes.POINTER(ViInt64)]  # noqa: F405
                 self.niFake_Use64BitNumber_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_Use64BitNumber_cfunc(vi, input, output)
@@ -801,9 +801,9 @@ class Library(object):
                 try:
                     self.niFake_WriteWaveform_cfunc = self._library.niFake_WriteWaveform
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_WriteWaveform was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_WriteWaveform_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_WriteWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_WriteWaveform_cfunc(vi, number_of_samples, waveform)
@@ -814,9 +814,9 @@ class Library(object):
                 try:
                     self.niFake_close_cfunc = self._library.niFake_close
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_close was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFake_close_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_close_cfunc(vi)
@@ -827,9 +827,9 @@ class Library(object):
                 try:
                     self.niFake_error_message_cfunc = self._library.niFake_error_message
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_error_message was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_error_message_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_error_message_cfunc(vi, error_code, error_message)
@@ -840,9 +840,9 @@ class Library(object):
                 try:
                     self.niFake_self_test_cfunc = self._library.niFake_self_test
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFake_self_test was not found in the NI-FAKE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFake_self_test_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_self_test_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_self_test_cfunc(vi, self_test_result, self_test_message)

--- a/generated/nifake/nifake/_library.py
+++ b/generated/nifake/nifake/_library.py
@@ -83,7 +83,12 @@ class Library(object):
     def niFake_Abort(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFake_Abort_cfunc is None:
-                self.niFake_Abort_cfunc = self._library.niFake_Abort
+                try:
+                    self.niFake_Abort_cfunc = self._library.niFake_Abort
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_Abort_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFake_Abort_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_Abort_cfunc(vi)
@@ -91,7 +96,12 @@ class Library(object):
     def niFake_AcceptListOfDurationsInSeconds(self, vi, count, delays):  # noqa: N802
         with self._func_lock:
             if self.niFake_AcceptListOfDurationsInSeconds_cfunc is None:
-                self.niFake_AcceptListOfDurationsInSeconds_cfunc = self._library.niFake_AcceptListOfDurationsInSeconds
+                try:
+                    self.niFake_AcceptListOfDurationsInSeconds_cfunc = self._library.niFake_AcceptListOfDurationsInSeconds
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_AcceptListOfDurationsInSeconds_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_AcceptListOfDurationsInSeconds_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_AcceptListOfDurationsInSeconds_cfunc(vi, count, delays)
@@ -99,7 +109,12 @@ class Library(object):
     def niFake_BoolArrayOutputFunction(self, vi, number_of_elements, an_array):  # noqa: N802
         with self._func_lock:
             if self.niFake_BoolArrayOutputFunction_cfunc is None:
-                self.niFake_BoolArrayOutputFunction_cfunc = self._library.niFake_BoolArrayOutputFunction
+                try:
+                    self.niFake_BoolArrayOutputFunction_cfunc = self._library.niFake_BoolArrayOutputFunction
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_BoolArrayOutputFunction_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFake_BoolArrayOutputFunction_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_BoolArrayOutputFunction_cfunc(vi, number_of_elements, an_array)
@@ -107,7 +122,12 @@ class Library(object):
     def niFake_DoubleAllTheNums(self, vi, number_count, numbers):  # noqa: N802
         with self._func_lock:
             if self.niFake_DoubleAllTheNums_cfunc is None:
-                self.niFake_DoubleAllTheNums_cfunc = self._library.niFake_DoubleAllTheNums
+                try:
+                    self.niFake_DoubleAllTheNums_cfunc = self._library.niFake_DoubleAllTheNums
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_DoubleAllTheNums_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_DoubleAllTheNums_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_DoubleAllTheNums_cfunc(vi, number_count, numbers)
@@ -115,7 +135,12 @@ class Library(object):
     def niFake_EnumArrayOutputFunction(self, vi, number_of_elements, an_array):  # noqa: N802
         with self._func_lock:
             if self.niFake_EnumArrayOutputFunction_cfunc is None:
-                self.niFake_EnumArrayOutputFunction_cfunc = self._library.niFake_EnumArrayOutputFunction
+                try:
+                    self.niFake_EnumArrayOutputFunction_cfunc = self._library.niFake_EnumArrayOutputFunction
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_EnumArrayOutputFunction_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt16)]  # noqa: F405
                 self.niFake_EnumArrayOutputFunction_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_EnumArrayOutputFunction_cfunc(vi, number_of_elements, an_array)
@@ -123,7 +148,12 @@ class Library(object):
     def niFake_EnumInputFunctionWithDefaults(self, vi, a_turtle):  # noqa: N802
         with self._func_lock:
             if self.niFake_EnumInputFunctionWithDefaults_cfunc is None:
-                self.niFake_EnumInputFunctionWithDefaults_cfunc = self._library.niFake_EnumInputFunctionWithDefaults
+                try:
+                    self.niFake_EnumInputFunctionWithDefaults_cfunc = self._library.niFake_EnumInputFunctionWithDefaults
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_EnumInputFunctionWithDefaults_cfunc.argtypes = [ViSession, ViInt16]  # noqa: F405
                 self.niFake_EnumInputFunctionWithDefaults_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_EnumInputFunctionWithDefaults_cfunc(vi, a_turtle)
@@ -131,7 +161,12 @@ class Library(object):
     def niFake_ExportAttributeConfigurationBuffer(self, vi, size_in_bytes, configuration):  # noqa: N802
         with self._func_lock:
             if self.niFake_ExportAttributeConfigurationBuffer_cfunc is None:
-                self.niFake_ExportAttributeConfigurationBuffer_cfunc = self._library.niFake_ExportAttributeConfigurationBuffer
+                try:
+                    self.niFake_ExportAttributeConfigurationBuffer_cfunc = self._library.niFake_ExportAttributeConfigurationBuffer
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_ExportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niFake_ExportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ExportAttributeConfigurationBuffer_cfunc(vi, size_in_bytes, configuration)
@@ -139,7 +174,12 @@ class Library(object):
     def niFake_FetchWaveform(self, vi, number_of_samples, waveform_data, actual_number_of_samples):  # noqa: N802
         with self._func_lock:
             if self.niFake_FetchWaveform_cfunc is None:
-                self.niFake_FetchWaveform_cfunc = self._library.niFake_FetchWaveform
+                try:
+                    self.niFake_FetchWaveform_cfunc = self._library.niFake_FetchWaveform
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_FetchWaveform_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFake_FetchWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_FetchWaveform_cfunc(vi, number_of_samples, waveform_data, actual_number_of_samples)
@@ -147,7 +187,12 @@ class Library(object):
     def niFake_GetABoolean(self, vi, a_boolean):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetABoolean_cfunc is None:
-                self.niFake_GetABoolean_cfunc = self._library.niFake_GetABoolean
+                try:
+                    self.niFake_GetABoolean_cfunc = self._library.niFake_GetABoolean
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_GetABoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFake_GetABoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetABoolean_cfunc(vi, a_boolean)
@@ -155,7 +200,12 @@ class Library(object):
     def niFake_GetANumber(self, vi, a_number):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetANumber_cfunc is None:
-                self.niFake_GetANumber_cfunc = self._library.niFake_GetANumber
+                try:
+                    self.niFake_GetANumber_cfunc = self._library.niFake_GetANumber
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_GetANumber_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16)]  # noqa: F405
                 self.niFake_GetANumber_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetANumber_cfunc(vi, a_number)
@@ -163,7 +213,12 @@ class Library(object):
     def niFake_GetAStringOfFixedMaximumSize(self, vi, a_string):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetAStringOfFixedMaximumSize_cfunc is None:
-                self.niFake_GetAStringOfFixedMaximumSize_cfunc = self._library.niFake_GetAStringOfFixedMaximumSize
+                try:
+                    self.niFake_GetAStringOfFixedMaximumSize_cfunc = self._library.niFake_GetAStringOfFixedMaximumSize
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_GetAStringOfFixedMaximumSize_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_GetAStringOfFixedMaximumSize_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAStringOfFixedMaximumSize_cfunc(vi, a_string)
@@ -171,7 +226,12 @@ class Library(object):
     def niFake_GetAStringUsingPythonCode(self, vi, a_number, a_string):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetAStringUsingPythonCode_cfunc is None:
-                self.niFake_GetAStringUsingPythonCode_cfunc = self._library.niFake_GetAStringUsingPythonCode
+                try:
+                    self.niFake_GetAStringUsingPythonCode_cfunc = self._library.niFake_GetAStringUsingPythonCode
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_GetAStringUsingPythonCode_cfunc.argtypes = [ViSession, ViInt16, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_GetAStringUsingPythonCode_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAStringUsingPythonCode_cfunc(vi, a_number, a_string)
@@ -179,7 +239,12 @@ class Library(object):
     def niFake_GetAnIviDanceString(self, vi, buffer_size, a_string):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetAnIviDanceString_cfunc is None:
-                self.niFake_GetAnIviDanceString_cfunc = self._library.niFake_GetAnIviDanceString
+                try:
+                    self.niFake_GetAnIviDanceString_cfunc = self._library.niFake_GetAnIviDanceString
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_GetAnIviDanceString_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_GetAnIviDanceString_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAnIviDanceString_cfunc(vi, buffer_size, a_string)
@@ -187,7 +252,12 @@ class Library(object):
     def niFake_GetAnIviDanceWithATwistString(self, vi, buffer_size, a_string, actual_size):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetAnIviDanceWithATwistString_cfunc is None:
-                self.niFake_GetAnIviDanceWithATwistString_cfunc = self._library.niFake_GetAnIviDanceWithATwistString
+                try:
+                    self.niFake_GetAnIviDanceWithATwistString_cfunc = self._library.niFake_GetAnIviDanceWithATwistString
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_GetAnIviDanceWithATwistString_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFake_GetAnIviDanceWithATwistString_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAnIviDanceWithATwistString_cfunc(vi, buffer_size, a_string, actual_size)
@@ -195,7 +265,12 @@ class Library(object):
     def niFake_GetArrayForPythonCodeCustomType(self, vi, number_of_elements, array_out):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetArrayForPythonCodeCustomType_cfunc is None:
-                self.niFake_GetArrayForPythonCodeCustomType_cfunc = self._library.niFake_GetArrayForPythonCodeCustomType
+                try:
+                    self.niFake_GetArrayForPythonCodeCustomType_cfunc = self._library.niFake_GetArrayForPythonCodeCustomType
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_GetArrayForPythonCodeCustomType_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(custom_struct.struct_CustomStruct)]  # noqa: F405
                 self.niFake_GetArrayForPythonCodeCustomType_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetArrayForPythonCodeCustomType_cfunc(vi, number_of_elements, array_out)
@@ -203,7 +278,12 @@ class Library(object):
     def niFake_GetArrayForPythonCodeDouble(self, vi, number_of_elements, array_out):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetArrayForPythonCodeDouble_cfunc is None:
-                self.niFake_GetArrayForPythonCodeDouble_cfunc = self._library.niFake_GetArrayForPythonCodeDouble
+                try:
+                    self.niFake_GetArrayForPythonCodeDouble_cfunc = self._library.niFake_GetArrayForPythonCodeDouble
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_GetArrayForPythonCodeDouble_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_GetArrayForPythonCodeDouble_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetArrayForPythonCodeDouble_cfunc(vi, number_of_elements, array_out)
@@ -211,7 +291,12 @@ class Library(object):
     def niFake_GetArraySizeForPythonCode(self, vi, size_out):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetArraySizeForPythonCode_cfunc is None:
-                self.niFake_GetArraySizeForPythonCode_cfunc = self._library.niFake_GetArraySizeForPythonCode
+                try:
+                    self.niFake_GetArraySizeForPythonCode_cfunc = self._library.niFake_GetArraySizeForPythonCode
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_GetArraySizeForPythonCode_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFake_GetArraySizeForPythonCode_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetArraySizeForPythonCode_cfunc(vi, size_out)
@@ -219,7 +304,12 @@ class Library(object):
     def niFake_GetArrayUsingIviDance(self, vi, array_size, array_out):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetArrayUsingIviDance_cfunc is None:
-                self.niFake_GetArrayUsingIviDance_cfunc = self._library.niFake_GetArrayUsingIviDance
+                try:
+                    self.niFake_GetArrayUsingIviDance_cfunc = self._library.niFake_GetArrayUsingIviDance
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_GetArrayUsingIviDance_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_GetArrayUsingIviDance_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetArrayUsingIviDance_cfunc(vi, array_size, array_out)
@@ -227,7 +317,12 @@ class Library(object):
     def niFake_GetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetAttributeViBoolean_cfunc is None:
-                self.niFake_GetAttributeViBoolean_cfunc = self._library.niFake_GetAttributeViBoolean
+                try:
+                    self.niFake_GetAttributeViBoolean_cfunc = self._library.niFake_GetAttributeViBoolean
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFake_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -235,7 +330,12 @@ class Library(object):
     def niFake_GetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetAttributeViInt32_cfunc is None:
-                self.niFake_GetAttributeViInt32_cfunc = self._library.niFake_GetAttributeViInt32
+                try:
+                    self.niFake_GetAttributeViInt32_cfunc = self._library.niFake_GetAttributeViInt32
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_GetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFake_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -243,7 +343,12 @@ class Library(object):
     def niFake_GetAttributeViInt64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetAttributeViInt64_cfunc is None:
-                self.niFake_GetAttributeViInt64_cfunc = self._library.niFake_GetAttributeViInt64
+                try:
+                    self.niFake_GetAttributeViInt64_cfunc = self._library.niFake_GetAttributeViInt64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_GetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt64)]  # noqa: F405
                 self.niFake_GetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAttributeViInt64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -251,7 +356,12 @@ class Library(object):
     def niFake_GetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetAttributeViReal64_cfunc is None:
-                self.niFake_GetAttributeViReal64_cfunc = self._library.niFake_GetAttributeViReal64
+                try:
+                    self.niFake_GetAttributeViReal64_cfunc = self._library.niFake_GetAttributeViReal64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_GetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -259,7 +369,12 @@ class Library(object):
     def niFake_GetAttributeViString(self, vi, channel_name, attribute_id, buffer_size, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetAttributeViString_cfunc is None:
-                self.niFake_GetAttributeViString_cfunc = self._library.niFake_GetAttributeViString
+                try:
+                    self.niFake_GetAttributeViString_cfunc = self._library.niFake_GetAttributeViString
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAttributeViString_cfunc(vi, channel_name, attribute_id, buffer_size, attribute_value)
@@ -267,7 +382,12 @@ class Library(object):
     def niFake_GetCalDateAndTime(self, vi, cal_type, month, day, year, hour, minute):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetCalDateAndTime_cfunc is None:
-                self.niFake_GetCalDateAndTime_cfunc = self._library.niFake_GetCalDateAndTime
+                try:
+                    self.niFake_GetCalDateAndTime_cfunc = self._library.niFake_GetCalDateAndTime
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_GetCalDateAndTime_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFake_GetCalDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetCalDateAndTime_cfunc(vi, cal_type, month, day, year, hour, minute)
@@ -275,7 +395,12 @@ class Library(object):
     def niFake_GetCalInterval(self, vi, months):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetCalInterval_cfunc is None:
-                self.niFake_GetCalInterval_cfunc = self._library.niFake_GetCalInterval
+                try:
+                    self.niFake_GetCalInterval_cfunc = self._library.niFake_GetCalInterval
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_GetCalInterval_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFake_GetCalInterval_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetCalInterval_cfunc(vi, months)
@@ -283,7 +408,12 @@ class Library(object):
     def niFake_GetCustomType(self, vi, cs):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetCustomType_cfunc is None:
-                self.niFake_GetCustomType_cfunc = self._library.niFake_GetCustomType
+                try:
+                    self.niFake_GetCustomType_cfunc = self._library.niFake_GetCustomType
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_GetCustomType_cfunc.argtypes = [ViSession, ctypes.POINTER(custom_struct.struct_CustomStruct)]  # noqa: F405
                 self.niFake_GetCustomType_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetCustomType_cfunc(vi, cs)
@@ -291,7 +421,12 @@ class Library(object):
     def niFake_GetCustomTypeArray(self, vi, number_of_elements, cs):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetCustomTypeArray_cfunc is None:
-                self.niFake_GetCustomTypeArray_cfunc = self._library.niFake_GetCustomTypeArray
+                try:
+                    self.niFake_GetCustomTypeArray_cfunc = self._library.niFake_GetCustomTypeArray
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_GetCustomTypeArray_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(custom_struct.struct_CustomStruct)]  # noqa: F405
                 self.niFake_GetCustomTypeArray_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetCustomTypeArray_cfunc(vi, number_of_elements, cs)
@@ -299,7 +434,12 @@ class Library(object):
     def niFake_GetEnumValue(self, vi, a_quantity, a_turtle):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetEnumValue_cfunc is None:
-                self.niFake_GetEnumValue_cfunc = self._library.niFake_GetEnumValue
+                try:
+                    self.niFake_GetEnumValue_cfunc = self._library.niFake_GetEnumValue
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_GetEnumValue_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt16)]  # noqa: F405
                 self.niFake_GetEnumValue_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetEnumValue_cfunc(vi, a_quantity, a_turtle)
@@ -307,7 +447,12 @@ class Library(object):
     def niFake_GetError(self, vi, error_code, buffer_size, description):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetError_cfunc is None:
-                self.niFake_GetError_cfunc = self._library.niFake_GetError
+                try:
+                    self.niFake_GetError_cfunc = self._library.niFake_GetError
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_GetError_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetError_cfunc(vi, error_code, buffer_size, description)
@@ -315,7 +460,12 @@ class Library(object):
     def niFake_ImportAttributeConfigurationBuffer(self, vi, size_in_bytes, configuration):  # noqa: N802
         with self._func_lock:
             if self.niFake_ImportAttributeConfigurationBuffer_cfunc is None:
-                self.niFake_ImportAttributeConfigurationBuffer_cfunc = self._library.niFake_ImportAttributeConfigurationBuffer
+                try:
+                    self.niFake_ImportAttributeConfigurationBuffer_cfunc = self._library.niFake_ImportAttributeConfigurationBuffer
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_ImportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niFake_ImportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ImportAttributeConfigurationBuffer_cfunc(vi, size_in_bytes, configuration)
@@ -323,7 +473,12 @@ class Library(object):
     def niFake_InitWithOptions(self, resource_name, id_query, reset_device, option_string, vi):  # noqa: N802
         with self._func_lock:
             if self.niFake_InitWithOptions_cfunc is None:
-                self.niFake_InitWithOptions_cfunc = self._library.niFake_InitWithOptions
+                try:
+                    self.niFake_InitWithOptions_cfunc = self._library.niFake_InitWithOptions
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_InitWithOptions_cfunc.argtypes = [ctypes.POINTER(ViChar), ViBoolean, ViBoolean, ctypes.POINTER(ViChar), ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niFake_InitWithOptions_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_InitWithOptions_cfunc(resource_name, id_query, reset_device, option_string, vi)
@@ -331,7 +486,12 @@ class Library(object):
     def niFake_Initiate(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFake_Initiate_cfunc is None:
-                self.niFake_Initiate_cfunc = self._library.niFake_Initiate
+                try:
+                    self.niFake_Initiate_cfunc = self._library.niFake_Initiate
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_Initiate_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFake_Initiate_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_Initiate_cfunc(vi)
@@ -339,7 +499,12 @@ class Library(object):
     def niFake_LockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niFake_LockSession_cfunc is None:
-                self.niFake_LockSession_cfunc = self._library.niFake_LockSession
+                try:
+                    self.niFake_LockSession_cfunc = self._library.niFake_LockSession
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_LockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFake_LockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_LockSession_cfunc(vi, caller_has_lock)
@@ -347,7 +512,12 @@ class Library(object):
     def niFake_MultipleArrayTypes(self, vi, output_array_size, output_array, output_array_of_fixed_length, input_array_sizes, input_array_of_floats, input_array_of_integers):  # noqa: N802
         with self._func_lock:
             if self.niFake_MultipleArrayTypes_cfunc is None:
-                self.niFake_MultipleArrayTypes_cfunc = self._library.niFake_MultipleArrayTypes
+                try:
+                    self.niFake_MultipleArrayTypes_cfunc = self._library.niFake_MultipleArrayTypes
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_MultipleArrayTypes_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt16)]  # noqa: F405
                 self.niFake_MultipleArrayTypes_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_MultipleArrayTypes_cfunc(vi, output_array_size, output_array, output_array_of_fixed_length, input_array_sizes, input_array_of_floats, input_array_of_integers)
@@ -355,7 +525,12 @@ class Library(object):
     def niFake_MultipleArraysSameSize(self, vi, values1, values2, values3, values4, size):  # noqa: N802
         with self._func_lock:
             if self.niFake_MultipleArraysSameSize_cfunc is None:
-                self.niFake_MultipleArraysSameSize_cfunc = self._library.niFake_MultipleArraysSameSize
+                try:
+                    self.niFake_MultipleArraysSameSize_cfunc = self._library.niFake_MultipleArraysSameSize
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_MultipleArraysSameSize_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ViInt32]  # noqa: F405
                 self.niFake_MultipleArraysSameSize_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_MultipleArraysSameSize_cfunc(vi, values1, values2, values3, values4, size)
@@ -363,7 +538,12 @@ class Library(object):
     def niFake_OneInputFunction(self, vi, a_number):  # noqa: N802
         with self._func_lock:
             if self.niFake_OneInputFunction_cfunc is None:
-                self.niFake_OneInputFunction_cfunc = self._library.niFake_OneInputFunction
+                try:
+                    self.niFake_OneInputFunction_cfunc = self._library.niFake_OneInputFunction
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_OneInputFunction_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niFake_OneInputFunction_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_OneInputFunction_cfunc(vi, a_number)
@@ -371,7 +551,12 @@ class Library(object):
     def niFake_ParametersAreMultipleTypes(self, vi, a_boolean, an_int32, an_int64, an_int_enum, a_float, a_float_enum, string_size, a_string):  # noqa: N802
         with self._func_lock:
             if self.niFake_ParametersAreMultipleTypes_cfunc is None:
-                self.niFake_ParametersAreMultipleTypes_cfunc = self._library.niFake_ParametersAreMultipleTypes
+                try:
+                    self.niFake_ParametersAreMultipleTypes_cfunc = self._library.niFake_ParametersAreMultipleTypes
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_ParametersAreMultipleTypes_cfunc.argtypes = [ViSession, ViBoolean, ViInt32, ViInt64, ViInt16, ViReal64, ViReal64, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_ParametersAreMultipleTypes_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ParametersAreMultipleTypes_cfunc(vi, a_boolean, an_int32, an_int64, an_int_enum, a_float, a_float_enum, string_size, a_string)
@@ -379,7 +564,12 @@ class Library(object):
     def niFake_PoorlyNamedSimpleFunction(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFake_PoorlyNamedSimpleFunction_cfunc is None:
-                self.niFake_PoorlyNamedSimpleFunction_cfunc = self._library.niFake_PoorlyNamedSimpleFunction
+                try:
+                    self.niFake_PoorlyNamedSimpleFunction_cfunc = self._library.niFake_PoorlyNamedSimpleFunction
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_PoorlyNamedSimpleFunction_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFake_PoorlyNamedSimpleFunction_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_PoorlyNamedSimpleFunction_cfunc(vi)
@@ -387,7 +577,12 @@ class Library(object):
     def niFake_Read(self, vi, maximum_time, reading):  # noqa: N802
         with self._func_lock:
             if self.niFake_Read_cfunc is None:
-                self.niFake_Read_cfunc = self._library.niFake_Read
+                try:
+                    self.niFake_Read_cfunc = self._library.niFake_Read
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_Read_cfunc.argtypes = [ViSession, ViReal64, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_Read_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_Read_cfunc(vi, maximum_time, reading)
@@ -395,7 +590,12 @@ class Library(object):
     def niFake_ReadFromChannel(self, vi, channel_name, maximum_time, reading):  # noqa: N802
         with self._func_lock:
             if self.niFake_ReadFromChannel_cfunc is None:
-                self.niFake_ReadFromChannel_cfunc = self._library.niFake_ReadFromChannel
+                try:
+                    self.niFake_ReadFromChannel_cfunc = self._library.niFake_ReadFromChannel
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_ReadFromChannel_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_ReadFromChannel_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ReadFromChannel_cfunc(vi, channel_name, maximum_time, reading)
@@ -403,7 +603,12 @@ class Library(object):
     def niFake_ReturnANumberAndAString(self, vi, a_number, a_string):  # noqa: N802
         with self._func_lock:
             if self.niFake_ReturnANumberAndAString_cfunc is None:
-                self.niFake_ReturnANumberAndAString_cfunc = self._library.niFake_ReturnANumberAndAString
+                try:
+                    self.niFake_ReturnANumberAndAString_cfunc = self._library.niFake_ReturnANumberAndAString
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_ReturnANumberAndAString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_ReturnANumberAndAString_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ReturnANumberAndAString_cfunc(vi, a_number, a_string)
@@ -411,7 +616,12 @@ class Library(object):
     def niFake_ReturnDurationInSeconds(self, vi, timedelta):  # noqa: N802
         with self._func_lock:
             if self.niFake_ReturnDurationInSeconds_cfunc is None:
-                self.niFake_ReturnDurationInSeconds_cfunc = self._library.niFake_ReturnDurationInSeconds
+                try:
+                    self.niFake_ReturnDurationInSeconds_cfunc = self._library.niFake_ReturnDurationInSeconds
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_ReturnDurationInSeconds_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_ReturnDurationInSeconds_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ReturnDurationInSeconds_cfunc(vi, timedelta)
@@ -419,7 +629,12 @@ class Library(object):
     def niFake_ReturnListOfDurationsInSeconds(self, vi, number_of_elements, timedeltas):  # noqa: N802
         with self._func_lock:
             if self.niFake_ReturnListOfDurationsInSeconds_cfunc is None:
-                self.niFake_ReturnListOfDurationsInSeconds_cfunc = self._library.niFake_ReturnListOfDurationsInSeconds
+                try:
+                    self.niFake_ReturnListOfDurationsInSeconds_cfunc = self._library.niFake_ReturnListOfDurationsInSeconds
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_ReturnListOfDurationsInSeconds_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_ReturnListOfDurationsInSeconds_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ReturnListOfDurationsInSeconds_cfunc(vi, number_of_elements, timedeltas)
@@ -427,7 +642,12 @@ class Library(object):
     def niFake_ReturnMultipleTypes(self, vi, a_boolean, an_int32, an_int64, an_int_enum, a_float, a_float_enum, array_size, an_array, string_size, a_string):  # noqa: N802
         with self._func_lock:
             if self.niFake_ReturnMultipleTypes_cfunc is None:
-                self.niFake_ReturnMultipleTypes_cfunc = self._library.niFake_ReturnMultipleTypes
+                try:
+                    self.niFake_ReturnMultipleTypes_cfunc = self._library.niFake_ReturnMultipleTypes
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_ReturnMultipleTypes_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt64), ctypes.POINTER(ViInt16), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ViInt32, ctypes.POINTER(ViReal64), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_ReturnMultipleTypes_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ReturnMultipleTypes_cfunc(vi, a_boolean, an_int32, an_int64, an_int_enum, a_float, a_float_enum, array_size, an_array, string_size, a_string)
@@ -435,7 +655,12 @@ class Library(object):
     def niFake_SetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFake_SetAttributeViBoolean_cfunc is None:
-                self.niFake_SetAttributeViBoolean_cfunc = self._library.niFake_SetAttributeViBoolean
+                try:
+                    self.niFake_SetAttributeViBoolean_cfunc = self._library.niFake_SetAttributeViBoolean
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViBoolean]  # noqa: F405
                 self.niFake_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_SetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -443,7 +668,12 @@ class Library(object):
     def niFake_SetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFake_SetAttributeViInt32_cfunc is None:
-                self.niFake_SetAttributeViInt32_cfunc = self._library.niFake_SetAttributeViInt32
+                try:
+                    self.niFake_SetAttributeViInt32_cfunc = self._library.niFake_SetAttributeViInt32
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_SetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32]  # noqa: F405
                 self.niFake_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_SetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -451,7 +681,12 @@ class Library(object):
     def niFake_SetAttributeViInt64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFake_SetAttributeViInt64_cfunc is None:
-                self.niFake_SetAttributeViInt64_cfunc = self._library.niFake_SetAttributeViInt64
+                try:
+                    self.niFake_SetAttributeViInt64_cfunc = self._library.niFake_SetAttributeViInt64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_SetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt64]  # noqa: F405
                 self.niFake_SetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_SetAttributeViInt64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -459,7 +694,12 @@ class Library(object):
     def niFake_SetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFake_SetAttributeViReal64_cfunc is None:
-                self.niFake_SetAttributeViReal64_cfunc = self._library.niFake_SetAttributeViReal64
+                try:
+                    self.niFake_SetAttributeViReal64_cfunc = self._library.niFake_SetAttributeViReal64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niFake_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_SetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -467,7 +707,12 @@ class Library(object):
     def niFake_SetAttributeViString(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFake_SetAttributeViString_cfunc is None:
-                self.niFake_SetAttributeViString_cfunc = self._library.niFake_SetAttributeViString
+                try:
+                    self.niFake_SetAttributeViString_cfunc = self._library.niFake_SetAttributeViString
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_SetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_SetAttributeViString_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -475,7 +720,12 @@ class Library(object):
     def niFake_SetCustomType(self, vi, cs):  # noqa: N802
         with self._func_lock:
             if self.niFake_SetCustomType_cfunc is None:
-                self.niFake_SetCustomType_cfunc = self._library.niFake_SetCustomType
+                try:
+                    self.niFake_SetCustomType_cfunc = self._library.niFake_SetCustomType
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_SetCustomType_cfunc.argtypes = [ViSession, custom_struct.struct_CustomStruct]  # noqa: F405
                 self.niFake_SetCustomType_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_SetCustomType_cfunc(vi, cs)
@@ -483,7 +733,12 @@ class Library(object):
     def niFake_SetCustomTypeArray(self, vi, number_of_elements, cs):  # noqa: N802
         with self._func_lock:
             if self.niFake_SetCustomTypeArray_cfunc is None:
-                self.niFake_SetCustomTypeArray_cfunc = self._library.niFake_SetCustomTypeArray
+                try:
+                    self.niFake_SetCustomTypeArray_cfunc = self._library.niFake_SetCustomTypeArray
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_SetCustomTypeArray_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(custom_struct.struct_CustomStruct)]  # noqa: F405
                 self.niFake_SetCustomTypeArray_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_SetCustomTypeArray_cfunc(vi, number_of_elements, cs)
@@ -491,7 +746,12 @@ class Library(object):
     def niFake_StringValuedEnumInputFunctionWithDefaults(self, vi, a_mobile_os_name):  # noqa: N802
         with self._func_lock:
             if self.niFake_StringValuedEnumInputFunctionWithDefaults_cfunc is None:
-                self.niFake_StringValuedEnumInputFunctionWithDefaults_cfunc = self._library.niFake_StringValuedEnumInputFunctionWithDefaults
+                try:
+                    self.niFake_StringValuedEnumInputFunctionWithDefaults_cfunc = self._library.niFake_StringValuedEnumInputFunctionWithDefaults
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_StringValuedEnumInputFunctionWithDefaults_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_StringValuedEnumInputFunctionWithDefaults_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_StringValuedEnumInputFunctionWithDefaults_cfunc(vi, a_mobile_os_name)
@@ -499,7 +759,12 @@ class Library(object):
     def niFake_TwoInputFunction(self, vi, a_number, a_string):  # noqa: N802
         with self._func_lock:
             if self.niFake_TwoInputFunction_cfunc is None:
-                self.niFake_TwoInputFunction_cfunc = self._library.niFake_TwoInputFunction
+                try:
+                    self.niFake_TwoInputFunction_cfunc = self._library.niFake_TwoInputFunction
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_TwoInputFunction_cfunc.argtypes = [ViSession, ViReal64, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_TwoInputFunction_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_TwoInputFunction_cfunc(vi, a_number, a_string)
@@ -507,7 +772,12 @@ class Library(object):
     def niFake_UnlockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niFake_UnlockSession_cfunc is None:
-                self.niFake_UnlockSession_cfunc = self._library.niFake_UnlockSession
+                try:
+                    self.niFake_UnlockSession_cfunc = self._library.niFake_UnlockSession
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_UnlockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFake_UnlockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_UnlockSession_cfunc(vi, caller_has_lock)
@@ -515,7 +785,12 @@ class Library(object):
     def niFake_Use64BitNumber(self, vi, input, output):  # noqa: N802
         with self._func_lock:
             if self.niFake_Use64BitNumber_cfunc is None:
-                self.niFake_Use64BitNumber_cfunc = self._library.niFake_Use64BitNumber
+                try:
+                    self.niFake_Use64BitNumber_cfunc = self._library.niFake_Use64BitNumber
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_Use64BitNumber_cfunc.argtypes = [ViSession, ViInt64, ctypes.POINTER(ViInt64)]  # noqa: F405
                 self.niFake_Use64BitNumber_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_Use64BitNumber_cfunc(vi, input, output)
@@ -523,7 +798,12 @@ class Library(object):
     def niFake_WriteWaveform(self, vi, number_of_samples, waveform):  # noqa: N802
         with self._func_lock:
             if self.niFake_WriteWaveform_cfunc is None:
-                self.niFake_WriteWaveform_cfunc = self._library.niFake_WriteWaveform
+                try:
+                    self.niFake_WriteWaveform_cfunc = self._library.niFake_WriteWaveform
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_WriteWaveform_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_WriteWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_WriteWaveform_cfunc(vi, number_of_samples, waveform)
@@ -531,7 +811,12 @@ class Library(object):
     def niFake_close(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFake_close_cfunc is None:
-                self.niFake_close_cfunc = self._library.niFake_close
+                try:
+                    self.niFake_close_cfunc = self._library.niFake_close
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFake_close_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_close_cfunc(vi)
@@ -539,7 +824,12 @@ class Library(object):
     def niFake_error_message(self, vi, error_code, error_message):  # noqa: N802
         with self._func_lock:
             if self.niFake_error_message_cfunc is None:
-                self.niFake_error_message_cfunc = self._library.niFake_error_message
+                try:
+                    self.niFake_error_message_cfunc = self._library.niFake_error_message
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_error_message_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_error_message_cfunc(vi, error_code, error_message)
@@ -547,7 +837,12 @@ class Library(object):
     def niFake_self_test(self, vi, self_test_result, self_test_message):  # noqa: N802
         with self._func_lock:
             if self.niFake_self_test_cfunc is None:
-                self.niFake_self_test_cfunc = self._library.niFake_self_test
+                try:
+                    self.niFake_self_test_cfunc = self._library.niFake_self_test
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFake_self_test_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_self_test_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_self_test_cfunc(vi, self_test_result, self_test_message)

--- a/generated/nifake/nifake/_library.py
+++ b/generated/nifake/nifake/_library.py
@@ -2,6 +2,7 @@
 # This file was generated
 
 import ctypes
+import nifake.errors as errors
 import threading
 
 from nifake._visatype import *  # noqa: F403,H303
@@ -80,15 +81,17 @@ class Library(object):
         self.niFake_error_message_cfunc = None
         self.niFake_self_test_cfunc = None
 
+    def _get_library_function(self, name):
+        try:
+            function = getattr(self._library, 'fred')
+        except AttributeError as e:
+            raise errors.DriverTooOldError() from e
+        return function
+
     def niFake_Abort(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFake_Abort_cfunc is None:
-                try:
-                    self.niFake_Abort_cfunc = self._library.niFake_Abort
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_Abort was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_Abort_cfunc = self._get_library_function('niFake_Abort')
                 self.niFake_Abort_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFake_Abort_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_Abort_cfunc(vi)
@@ -96,12 +99,7 @@ class Library(object):
     def niFake_AcceptListOfDurationsInSeconds(self, vi, count, delays):  # noqa: N802
         with self._func_lock:
             if self.niFake_AcceptListOfDurationsInSeconds_cfunc is None:
-                try:
-                    self.niFake_AcceptListOfDurationsInSeconds_cfunc = self._library.niFake_AcceptListOfDurationsInSeconds
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_AcceptListOfDurationsInSeconds was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_AcceptListOfDurationsInSeconds_cfunc = self._get_library_function('niFake_AcceptListOfDurationsInSeconds')
                 self.niFake_AcceptListOfDurationsInSeconds_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_AcceptListOfDurationsInSeconds_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_AcceptListOfDurationsInSeconds_cfunc(vi, count, delays)
@@ -109,12 +107,7 @@ class Library(object):
     def niFake_BoolArrayOutputFunction(self, vi, number_of_elements, an_array):  # noqa: N802
         with self._func_lock:
             if self.niFake_BoolArrayOutputFunction_cfunc is None:
-                try:
-                    self.niFake_BoolArrayOutputFunction_cfunc = self._library.niFake_BoolArrayOutputFunction
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_BoolArrayOutputFunction was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_BoolArrayOutputFunction_cfunc = self._get_library_function('niFake_BoolArrayOutputFunction')
                 self.niFake_BoolArrayOutputFunction_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFake_BoolArrayOutputFunction_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_BoolArrayOutputFunction_cfunc(vi, number_of_elements, an_array)
@@ -122,12 +115,7 @@ class Library(object):
     def niFake_DoubleAllTheNums(self, vi, number_count, numbers):  # noqa: N802
         with self._func_lock:
             if self.niFake_DoubleAllTheNums_cfunc is None:
-                try:
-                    self.niFake_DoubleAllTheNums_cfunc = self._library.niFake_DoubleAllTheNums
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_DoubleAllTheNums was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_DoubleAllTheNums_cfunc = self._get_library_function('niFake_DoubleAllTheNums')
                 self.niFake_DoubleAllTheNums_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_DoubleAllTheNums_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_DoubleAllTheNums_cfunc(vi, number_count, numbers)
@@ -135,12 +123,7 @@ class Library(object):
     def niFake_EnumArrayOutputFunction(self, vi, number_of_elements, an_array):  # noqa: N802
         with self._func_lock:
             if self.niFake_EnumArrayOutputFunction_cfunc is None:
-                try:
-                    self.niFake_EnumArrayOutputFunction_cfunc = self._library.niFake_EnumArrayOutputFunction
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_EnumArrayOutputFunction was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_EnumArrayOutputFunction_cfunc = self._get_library_function('niFake_EnumArrayOutputFunction')
                 self.niFake_EnumArrayOutputFunction_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt16)]  # noqa: F405
                 self.niFake_EnumArrayOutputFunction_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_EnumArrayOutputFunction_cfunc(vi, number_of_elements, an_array)
@@ -148,12 +131,7 @@ class Library(object):
     def niFake_EnumInputFunctionWithDefaults(self, vi, a_turtle):  # noqa: N802
         with self._func_lock:
             if self.niFake_EnumInputFunctionWithDefaults_cfunc is None:
-                try:
-                    self.niFake_EnumInputFunctionWithDefaults_cfunc = self._library.niFake_EnumInputFunctionWithDefaults
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_EnumInputFunctionWithDefaults was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_EnumInputFunctionWithDefaults_cfunc = self._get_library_function('niFake_EnumInputFunctionWithDefaults')
                 self.niFake_EnumInputFunctionWithDefaults_cfunc.argtypes = [ViSession, ViInt16]  # noqa: F405
                 self.niFake_EnumInputFunctionWithDefaults_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_EnumInputFunctionWithDefaults_cfunc(vi, a_turtle)
@@ -161,12 +139,7 @@ class Library(object):
     def niFake_ExportAttributeConfigurationBuffer(self, vi, size_in_bytes, configuration):  # noqa: N802
         with self._func_lock:
             if self.niFake_ExportAttributeConfigurationBuffer_cfunc is None:
-                try:
-                    self.niFake_ExportAttributeConfigurationBuffer_cfunc = self._library.niFake_ExportAttributeConfigurationBuffer
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_ExportAttributeConfigurationBuffer was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_ExportAttributeConfigurationBuffer_cfunc = self._get_library_function('niFake_ExportAttributeConfigurationBuffer')
                 self.niFake_ExportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niFake_ExportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ExportAttributeConfigurationBuffer_cfunc(vi, size_in_bytes, configuration)
@@ -174,12 +147,7 @@ class Library(object):
     def niFake_FetchWaveform(self, vi, number_of_samples, waveform_data, actual_number_of_samples):  # noqa: N802
         with self._func_lock:
             if self.niFake_FetchWaveform_cfunc is None:
-                try:
-                    self.niFake_FetchWaveform_cfunc = self._library.niFake_FetchWaveform
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_FetchWaveform was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_FetchWaveform_cfunc = self._get_library_function('niFake_FetchWaveform')
                 self.niFake_FetchWaveform_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFake_FetchWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_FetchWaveform_cfunc(vi, number_of_samples, waveform_data, actual_number_of_samples)
@@ -187,12 +155,7 @@ class Library(object):
     def niFake_GetABoolean(self, vi, a_boolean):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetABoolean_cfunc is None:
-                try:
-                    self.niFake_GetABoolean_cfunc = self._library.niFake_GetABoolean
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_GetABoolean was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_GetABoolean_cfunc = self._get_library_function('niFake_GetABoolean')
                 self.niFake_GetABoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFake_GetABoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetABoolean_cfunc(vi, a_boolean)
@@ -200,12 +163,7 @@ class Library(object):
     def niFake_GetANumber(self, vi, a_number):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetANumber_cfunc is None:
-                try:
-                    self.niFake_GetANumber_cfunc = self._library.niFake_GetANumber
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_GetANumber was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_GetANumber_cfunc = self._get_library_function('niFake_GetANumber')
                 self.niFake_GetANumber_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16)]  # noqa: F405
                 self.niFake_GetANumber_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetANumber_cfunc(vi, a_number)
@@ -213,12 +171,7 @@ class Library(object):
     def niFake_GetAStringOfFixedMaximumSize(self, vi, a_string):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetAStringOfFixedMaximumSize_cfunc is None:
-                try:
-                    self.niFake_GetAStringOfFixedMaximumSize_cfunc = self._library.niFake_GetAStringOfFixedMaximumSize
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_GetAStringOfFixedMaximumSize was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_GetAStringOfFixedMaximumSize_cfunc = self._get_library_function('niFake_GetAStringOfFixedMaximumSize')
                 self.niFake_GetAStringOfFixedMaximumSize_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_GetAStringOfFixedMaximumSize_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAStringOfFixedMaximumSize_cfunc(vi, a_string)
@@ -226,12 +179,7 @@ class Library(object):
     def niFake_GetAStringUsingPythonCode(self, vi, a_number, a_string):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetAStringUsingPythonCode_cfunc is None:
-                try:
-                    self.niFake_GetAStringUsingPythonCode_cfunc = self._library.niFake_GetAStringUsingPythonCode
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_GetAStringUsingPythonCode was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_GetAStringUsingPythonCode_cfunc = self._get_library_function('niFake_GetAStringUsingPythonCode')
                 self.niFake_GetAStringUsingPythonCode_cfunc.argtypes = [ViSession, ViInt16, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_GetAStringUsingPythonCode_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAStringUsingPythonCode_cfunc(vi, a_number, a_string)
@@ -239,12 +187,7 @@ class Library(object):
     def niFake_GetAnIviDanceString(self, vi, buffer_size, a_string):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetAnIviDanceString_cfunc is None:
-                try:
-                    self.niFake_GetAnIviDanceString_cfunc = self._library.niFake_GetAnIviDanceString
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_GetAnIviDanceString was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_GetAnIviDanceString_cfunc = self._get_library_function('niFake_GetAnIviDanceString')
                 self.niFake_GetAnIviDanceString_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_GetAnIviDanceString_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAnIviDanceString_cfunc(vi, buffer_size, a_string)
@@ -252,12 +195,7 @@ class Library(object):
     def niFake_GetAnIviDanceWithATwistString(self, vi, buffer_size, a_string, actual_size):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetAnIviDanceWithATwistString_cfunc is None:
-                try:
-                    self.niFake_GetAnIviDanceWithATwistString_cfunc = self._library.niFake_GetAnIviDanceWithATwistString
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_GetAnIviDanceWithATwistString was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_GetAnIviDanceWithATwistString_cfunc = self._get_library_function('niFake_GetAnIviDanceWithATwistString')
                 self.niFake_GetAnIviDanceWithATwistString_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFake_GetAnIviDanceWithATwistString_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAnIviDanceWithATwistString_cfunc(vi, buffer_size, a_string, actual_size)
@@ -265,12 +203,7 @@ class Library(object):
     def niFake_GetArrayForPythonCodeCustomType(self, vi, number_of_elements, array_out):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetArrayForPythonCodeCustomType_cfunc is None:
-                try:
-                    self.niFake_GetArrayForPythonCodeCustomType_cfunc = self._library.niFake_GetArrayForPythonCodeCustomType
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_GetArrayForPythonCodeCustomType was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_GetArrayForPythonCodeCustomType_cfunc = self._get_library_function('niFake_GetArrayForPythonCodeCustomType')
                 self.niFake_GetArrayForPythonCodeCustomType_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(custom_struct.struct_CustomStruct)]  # noqa: F405
                 self.niFake_GetArrayForPythonCodeCustomType_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetArrayForPythonCodeCustomType_cfunc(vi, number_of_elements, array_out)
@@ -278,12 +211,7 @@ class Library(object):
     def niFake_GetArrayForPythonCodeDouble(self, vi, number_of_elements, array_out):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetArrayForPythonCodeDouble_cfunc is None:
-                try:
-                    self.niFake_GetArrayForPythonCodeDouble_cfunc = self._library.niFake_GetArrayForPythonCodeDouble
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_GetArrayForPythonCodeDouble was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_GetArrayForPythonCodeDouble_cfunc = self._get_library_function('niFake_GetArrayForPythonCodeDouble')
                 self.niFake_GetArrayForPythonCodeDouble_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_GetArrayForPythonCodeDouble_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetArrayForPythonCodeDouble_cfunc(vi, number_of_elements, array_out)
@@ -291,12 +219,7 @@ class Library(object):
     def niFake_GetArraySizeForPythonCode(self, vi, size_out):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetArraySizeForPythonCode_cfunc is None:
-                try:
-                    self.niFake_GetArraySizeForPythonCode_cfunc = self._library.niFake_GetArraySizeForPythonCode
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_GetArraySizeForPythonCode was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_GetArraySizeForPythonCode_cfunc = self._get_library_function('niFake_GetArraySizeForPythonCode')
                 self.niFake_GetArraySizeForPythonCode_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFake_GetArraySizeForPythonCode_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetArraySizeForPythonCode_cfunc(vi, size_out)
@@ -304,12 +227,7 @@ class Library(object):
     def niFake_GetArrayUsingIviDance(self, vi, array_size, array_out):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetArrayUsingIviDance_cfunc is None:
-                try:
-                    self.niFake_GetArrayUsingIviDance_cfunc = self._library.niFake_GetArrayUsingIviDance
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_GetArrayUsingIviDance was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_GetArrayUsingIviDance_cfunc = self._get_library_function('niFake_GetArrayUsingIviDance')
                 self.niFake_GetArrayUsingIviDance_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_GetArrayUsingIviDance_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetArrayUsingIviDance_cfunc(vi, array_size, array_out)
@@ -317,12 +235,7 @@ class Library(object):
     def niFake_GetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetAttributeViBoolean_cfunc is None:
-                try:
-                    self.niFake_GetAttributeViBoolean_cfunc = self._library.niFake_GetAttributeViBoolean
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_GetAttributeViBoolean was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_GetAttributeViBoolean_cfunc = self._get_library_function('niFake_GetAttributeViBoolean')
                 self.niFake_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFake_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -330,12 +243,7 @@ class Library(object):
     def niFake_GetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetAttributeViInt32_cfunc is None:
-                try:
-                    self.niFake_GetAttributeViInt32_cfunc = self._library.niFake_GetAttributeViInt32
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_GetAttributeViInt32 was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_GetAttributeViInt32_cfunc = self._get_library_function('niFake_GetAttributeViInt32')
                 self.niFake_GetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFake_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -343,12 +251,7 @@ class Library(object):
     def niFake_GetAttributeViInt64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetAttributeViInt64_cfunc is None:
-                try:
-                    self.niFake_GetAttributeViInt64_cfunc = self._library.niFake_GetAttributeViInt64
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_GetAttributeViInt64 was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_GetAttributeViInt64_cfunc = self._get_library_function('niFake_GetAttributeViInt64')
                 self.niFake_GetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt64)]  # noqa: F405
                 self.niFake_GetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAttributeViInt64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -356,12 +259,7 @@ class Library(object):
     def niFake_GetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetAttributeViReal64_cfunc is None:
-                try:
-                    self.niFake_GetAttributeViReal64_cfunc = self._library.niFake_GetAttributeViReal64
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_GetAttributeViReal64 was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_GetAttributeViReal64_cfunc = self._get_library_function('niFake_GetAttributeViReal64')
                 self.niFake_GetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -369,12 +267,7 @@ class Library(object):
     def niFake_GetAttributeViString(self, vi, channel_name, attribute_id, buffer_size, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetAttributeViString_cfunc is None:
-                try:
-                    self.niFake_GetAttributeViString_cfunc = self._library.niFake_GetAttributeViString
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_GetAttributeViString was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_GetAttributeViString_cfunc = self._get_library_function('niFake_GetAttributeViString')
                 self.niFake_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetAttributeViString_cfunc(vi, channel_name, attribute_id, buffer_size, attribute_value)
@@ -382,12 +275,7 @@ class Library(object):
     def niFake_GetCalDateAndTime(self, vi, cal_type, month, day, year, hour, minute):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetCalDateAndTime_cfunc is None:
-                try:
-                    self.niFake_GetCalDateAndTime_cfunc = self._library.niFake_GetCalDateAndTime
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_GetCalDateAndTime was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_GetCalDateAndTime_cfunc = self._get_library_function('niFake_GetCalDateAndTime')
                 self.niFake_GetCalDateAndTime_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFake_GetCalDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetCalDateAndTime_cfunc(vi, cal_type, month, day, year, hour, minute)
@@ -395,12 +283,7 @@ class Library(object):
     def niFake_GetCalInterval(self, vi, months):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetCalInterval_cfunc is None:
-                try:
-                    self.niFake_GetCalInterval_cfunc = self._library.niFake_GetCalInterval
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_GetCalInterval was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_GetCalInterval_cfunc = self._get_library_function('niFake_GetCalInterval')
                 self.niFake_GetCalInterval_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFake_GetCalInterval_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetCalInterval_cfunc(vi, months)
@@ -408,12 +291,7 @@ class Library(object):
     def niFake_GetCustomType(self, vi, cs):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetCustomType_cfunc is None:
-                try:
-                    self.niFake_GetCustomType_cfunc = self._library.niFake_GetCustomType
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_GetCustomType was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_GetCustomType_cfunc = self._get_library_function('niFake_GetCustomType')
                 self.niFake_GetCustomType_cfunc.argtypes = [ViSession, ctypes.POINTER(custom_struct.struct_CustomStruct)]  # noqa: F405
                 self.niFake_GetCustomType_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetCustomType_cfunc(vi, cs)
@@ -421,12 +299,7 @@ class Library(object):
     def niFake_GetCustomTypeArray(self, vi, number_of_elements, cs):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetCustomTypeArray_cfunc is None:
-                try:
-                    self.niFake_GetCustomTypeArray_cfunc = self._library.niFake_GetCustomTypeArray
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_GetCustomTypeArray was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_GetCustomTypeArray_cfunc = self._get_library_function('niFake_GetCustomTypeArray')
                 self.niFake_GetCustomTypeArray_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(custom_struct.struct_CustomStruct)]  # noqa: F405
                 self.niFake_GetCustomTypeArray_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetCustomTypeArray_cfunc(vi, number_of_elements, cs)
@@ -434,12 +307,7 @@ class Library(object):
     def niFake_GetEnumValue(self, vi, a_quantity, a_turtle):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetEnumValue_cfunc is None:
-                try:
-                    self.niFake_GetEnumValue_cfunc = self._library.niFake_GetEnumValue
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_GetEnumValue was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_GetEnumValue_cfunc = self._get_library_function('niFake_GetEnumValue')
                 self.niFake_GetEnumValue_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt16)]  # noqa: F405
                 self.niFake_GetEnumValue_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetEnumValue_cfunc(vi, a_quantity, a_turtle)
@@ -447,12 +315,7 @@ class Library(object):
     def niFake_GetError(self, vi, error_code, buffer_size, description):  # noqa: N802
         with self._func_lock:
             if self.niFake_GetError_cfunc is None:
-                try:
-                    self.niFake_GetError_cfunc = self._library.niFake_GetError
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_GetError was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_GetError_cfunc = self._get_library_function('niFake_GetError')
                 self.niFake_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_GetError_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetError_cfunc(vi, error_code, buffer_size, description)
@@ -460,12 +323,7 @@ class Library(object):
     def niFake_ImportAttributeConfigurationBuffer(self, vi, size_in_bytes, configuration):  # noqa: N802
         with self._func_lock:
             if self.niFake_ImportAttributeConfigurationBuffer_cfunc is None:
-                try:
-                    self.niFake_ImportAttributeConfigurationBuffer_cfunc = self._library.niFake_ImportAttributeConfigurationBuffer
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_ImportAttributeConfigurationBuffer was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_ImportAttributeConfigurationBuffer_cfunc = self._get_library_function('niFake_ImportAttributeConfigurationBuffer')
                 self.niFake_ImportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niFake_ImportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ImportAttributeConfigurationBuffer_cfunc(vi, size_in_bytes, configuration)
@@ -473,12 +331,7 @@ class Library(object):
     def niFake_InitWithOptions(self, resource_name, id_query, reset_device, option_string, vi):  # noqa: N802
         with self._func_lock:
             if self.niFake_InitWithOptions_cfunc is None:
-                try:
-                    self.niFake_InitWithOptions_cfunc = self._library.niFake_InitWithOptions
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_InitWithOptions was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_InitWithOptions_cfunc = self._get_library_function('niFake_InitWithOptions')
                 self.niFake_InitWithOptions_cfunc.argtypes = [ctypes.POINTER(ViChar), ViBoolean, ViBoolean, ctypes.POINTER(ViChar), ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niFake_InitWithOptions_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_InitWithOptions_cfunc(resource_name, id_query, reset_device, option_string, vi)
@@ -486,12 +339,7 @@ class Library(object):
     def niFake_Initiate(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFake_Initiate_cfunc is None:
-                try:
-                    self.niFake_Initiate_cfunc = self._library.niFake_Initiate
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_Initiate was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_Initiate_cfunc = self._get_library_function('niFake_Initiate')
                 self.niFake_Initiate_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFake_Initiate_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_Initiate_cfunc(vi)
@@ -499,12 +347,7 @@ class Library(object):
     def niFake_LockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niFake_LockSession_cfunc is None:
-                try:
-                    self.niFake_LockSession_cfunc = self._library.niFake_LockSession
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_LockSession was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_LockSession_cfunc = self._get_library_function('niFake_LockSession')
                 self.niFake_LockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFake_LockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_LockSession_cfunc(vi, caller_has_lock)
@@ -512,12 +355,7 @@ class Library(object):
     def niFake_MultipleArrayTypes(self, vi, output_array_size, output_array, output_array_of_fixed_length, input_array_sizes, input_array_of_floats, input_array_of_integers):  # noqa: N802
         with self._func_lock:
             if self.niFake_MultipleArrayTypes_cfunc is None:
-                try:
-                    self.niFake_MultipleArrayTypes_cfunc = self._library.niFake_MultipleArrayTypes
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_MultipleArrayTypes was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_MultipleArrayTypes_cfunc = self._get_library_function('niFake_MultipleArrayTypes')
                 self.niFake_MultipleArrayTypes_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt16)]  # noqa: F405
                 self.niFake_MultipleArrayTypes_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_MultipleArrayTypes_cfunc(vi, output_array_size, output_array, output_array_of_fixed_length, input_array_sizes, input_array_of_floats, input_array_of_integers)
@@ -525,12 +363,7 @@ class Library(object):
     def niFake_MultipleArraysSameSize(self, vi, values1, values2, values3, values4, size):  # noqa: N802
         with self._func_lock:
             if self.niFake_MultipleArraysSameSize_cfunc is None:
-                try:
-                    self.niFake_MultipleArraysSameSize_cfunc = self._library.niFake_MultipleArraysSameSize
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_MultipleArraysSameSize was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_MultipleArraysSameSize_cfunc = self._get_library_function('niFake_MultipleArraysSameSize')
                 self.niFake_MultipleArraysSameSize_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ViInt32]  # noqa: F405
                 self.niFake_MultipleArraysSameSize_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_MultipleArraysSameSize_cfunc(vi, values1, values2, values3, values4, size)
@@ -538,12 +371,7 @@ class Library(object):
     def niFake_OneInputFunction(self, vi, a_number):  # noqa: N802
         with self._func_lock:
             if self.niFake_OneInputFunction_cfunc is None:
-                try:
-                    self.niFake_OneInputFunction_cfunc = self._library.niFake_OneInputFunction
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_OneInputFunction was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_OneInputFunction_cfunc = self._get_library_function('niFake_OneInputFunction')
                 self.niFake_OneInputFunction_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niFake_OneInputFunction_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_OneInputFunction_cfunc(vi, a_number)
@@ -551,12 +379,7 @@ class Library(object):
     def niFake_ParametersAreMultipleTypes(self, vi, a_boolean, an_int32, an_int64, an_int_enum, a_float, a_float_enum, string_size, a_string):  # noqa: N802
         with self._func_lock:
             if self.niFake_ParametersAreMultipleTypes_cfunc is None:
-                try:
-                    self.niFake_ParametersAreMultipleTypes_cfunc = self._library.niFake_ParametersAreMultipleTypes
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_ParametersAreMultipleTypes was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_ParametersAreMultipleTypes_cfunc = self._get_library_function('niFake_ParametersAreMultipleTypes')
                 self.niFake_ParametersAreMultipleTypes_cfunc.argtypes = [ViSession, ViBoolean, ViInt32, ViInt64, ViInt16, ViReal64, ViReal64, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_ParametersAreMultipleTypes_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ParametersAreMultipleTypes_cfunc(vi, a_boolean, an_int32, an_int64, an_int_enum, a_float, a_float_enum, string_size, a_string)
@@ -564,12 +387,7 @@ class Library(object):
     def niFake_PoorlyNamedSimpleFunction(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFake_PoorlyNamedSimpleFunction_cfunc is None:
-                try:
-                    self.niFake_PoorlyNamedSimpleFunction_cfunc = self._library.niFake_PoorlyNamedSimpleFunction
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_PoorlyNamedSimpleFunction was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_PoorlyNamedSimpleFunction_cfunc = self._get_library_function('niFake_PoorlyNamedSimpleFunction')
                 self.niFake_PoorlyNamedSimpleFunction_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFake_PoorlyNamedSimpleFunction_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_PoorlyNamedSimpleFunction_cfunc(vi)
@@ -577,12 +395,7 @@ class Library(object):
     def niFake_Read(self, vi, maximum_time, reading):  # noqa: N802
         with self._func_lock:
             if self.niFake_Read_cfunc is None:
-                try:
-                    self.niFake_Read_cfunc = self._library.niFake_Read
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_Read was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_Read_cfunc = self._get_library_function('niFake_Read')
                 self.niFake_Read_cfunc.argtypes = [ViSession, ViReal64, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_Read_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_Read_cfunc(vi, maximum_time, reading)
@@ -590,12 +403,7 @@ class Library(object):
     def niFake_ReadFromChannel(self, vi, channel_name, maximum_time, reading):  # noqa: N802
         with self._func_lock:
             if self.niFake_ReadFromChannel_cfunc is None:
-                try:
-                    self.niFake_ReadFromChannel_cfunc = self._library.niFake_ReadFromChannel
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_ReadFromChannel was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_ReadFromChannel_cfunc = self._get_library_function('niFake_ReadFromChannel')
                 self.niFake_ReadFromChannel_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_ReadFromChannel_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ReadFromChannel_cfunc(vi, channel_name, maximum_time, reading)
@@ -603,12 +411,7 @@ class Library(object):
     def niFake_ReturnANumberAndAString(self, vi, a_number, a_string):  # noqa: N802
         with self._func_lock:
             if self.niFake_ReturnANumberAndAString_cfunc is None:
-                try:
-                    self.niFake_ReturnANumberAndAString_cfunc = self._library.niFake_ReturnANumberAndAString
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_ReturnANumberAndAString was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_ReturnANumberAndAString_cfunc = self._get_library_function('niFake_ReturnANumberAndAString')
                 self.niFake_ReturnANumberAndAString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_ReturnANumberAndAString_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ReturnANumberAndAString_cfunc(vi, a_number, a_string)
@@ -616,12 +419,7 @@ class Library(object):
     def niFake_ReturnDurationInSeconds(self, vi, timedelta):  # noqa: N802
         with self._func_lock:
             if self.niFake_ReturnDurationInSeconds_cfunc is None:
-                try:
-                    self.niFake_ReturnDurationInSeconds_cfunc = self._library.niFake_ReturnDurationInSeconds
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_ReturnDurationInSeconds was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_ReturnDurationInSeconds_cfunc = self._get_library_function('niFake_ReturnDurationInSeconds')
                 self.niFake_ReturnDurationInSeconds_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_ReturnDurationInSeconds_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ReturnDurationInSeconds_cfunc(vi, timedelta)
@@ -629,12 +427,7 @@ class Library(object):
     def niFake_ReturnListOfDurationsInSeconds(self, vi, number_of_elements, timedeltas):  # noqa: N802
         with self._func_lock:
             if self.niFake_ReturnListOfDurationsInSeconds_cfunc is None:
-                try:
-                    self.niFake_ReturnListOfDurationsInSeconds_cfunc = self._library.niFake_ReturnListOfDurationsInSeconds
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_ReturnListOfDurationsInSeconds was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_ReturnListOfDurationsInSeconds_cfunc = self._get_library_function('niFake_ReturnListOfDurationsInSeconds')
                 self.niFake_ReturnListOfDurationsInSeconds_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_ReturnListOfDurationsInSeconds_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ReturnListOfDurationsInSeconds_cfunc(vi, number_of_elements, timedeltas)
@@ -642,12 +435,7 @@ class Library(object):
     def niFake_ReturnMultipleTypes(self, vi, a_boolean, an_int32, an_int64, an_int_enum, a_float, a_float_enum, array_size, an_array, string_size, a_string):  # noqa: N802
         with self._func_lock:
             if self.niFake_ReturnMultipleTypes_cfunc is None:
-                try:
-                    self.niFake_ReturnMultipleTypes_cfunc = self._library.niFake_ReturnMultipleTypes
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_ReturnMultipleTypes was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_ReturnMultipleTypes_cfunc = self._get_library_function('niFake_ReturnMultipleTypes')
                 self.niFake_ReturnMultipleTypes_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt64), ctypes.POINTER(ViInt16), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ViInt32, ctypes.POINTER(ViReal64), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_ReturnMultipleTypes_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_ReturnMultipleTypes_cfunc(vi, a_boolean, an_int32, an_int64, an_int_enum, a_float, a_float_enum, array_size, an_array, string_size, a_string)
@@ -655,12 +443,7 @@ class Library(object):
     def niFake_SetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFake_SetAttributeViBoolean_cfunc is None:
-                try:
-                    self.niFake_SetAttributeViBoolean_cfunc = self._library.niFake_SetAttributeViBoolean
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_SetAttributeViBoolean was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_SetAttributeViBoolean_cfunc = self._get_library_function('niFake_SetAttributeViBoolean')
                 self.niFake_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViBoolean]  # noqa: F405
                 self.niFake_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_SetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -668,12 +451,7 @@ class Library(object):
     def niFake_SetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFake_SetAttributeViInt32_cfunc is None:
-                try:
-                    self.niFake_SetAttributeViInt32_cfunc = self._library.niFake_SetAttributeViInt32
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_SetAttributeViInt32 was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_SetAttributeViInt32_cfunc = self._get_library_function('niFake_SetAttributeViInt32')
                 self.niFake_SetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32]  # noqa: F405
                 self.niFake_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_SetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -681,12 +459,7 @@ class Library(object):
     def niFake_SetAttributeViInt64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFake_SetAttributeViInt64_cfunc is None:
-                try:
-                    self.niFake_SetAttributeViInt64_cfunc = self._library.niFake_SetAttributeViInt64
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_SetAttributeViInt64 was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_SetAttributeViInt64_cfunc = self._get_library_function('niFake_SetAttributeViInt64')
                 self.niFake_SetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt64]  # noqa: F405
                 self.niFake_SetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_SetAttributeViInt64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -694,12 +467,7 @@ class Library(object):
     def niFake_SetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFake_SetAttributeViReal64_cfunc is None:
-                try:
-                    self.niFake_SetAttributeViReal64_cfunc = self._library.niFake_SetAttributeViReal64
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_SetAttributeViReal64 was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_SetAttributeViReal64_cfunc = self._get_library_function('niFake_SetAttributeViReal64')
                 self.niFake_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niFake_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_SetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -707,12 +475,7 @@ class Library(object):
     def niFake_SetAttributeViString(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFake_SetAttributeViString_cfunc is None:
-                try:
-                    self.niFake_SetAttributeViString_cfunc = self._library.niFake_SetAttributeViString
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_SetAttributeViString was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_SetAttributeViString_cfunc = self._get_library_function('niFake_SetAttributeViString')
                 self.niFake_SetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_SetAttributeViString_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -720,12 +483,7 @@ class Library(object):
     def niFake_SetCustomType(self, vi, cs):  # noqa: N802
         with self._func_lock:
             if self.niFake_SetCustomType_cfunc is None:
-                try:
-                    self.niFake_SetCustomType_cfunc = self._library.niFake_SetCustomType
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_SetCustomType was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_SetCustomType_cfunc = self._get_library_function('niFake_SetCustomType')
                 self.niFake_SetCustomType_cfunc.argtypes = [ViSession, custom_struct.struct_CustomStruct]  # noqa: F405
                 self.niFake_SetCustomType_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_SetCustomType_cfunc(vi, cs)
@@ -733,12 +491,7 @@ class Library(object):
     def niFake_SetCustomTypeArray(self, vi, number_of_elements, cs):  # noqa: N802
         with self._func_lock:
             if self.niFake_SetCustomTypeArray_cfunc is None:
-                try:
-                    self.niFake_SetCustomTypeArray_cfunc = self._library.niFake_SetCustomTypeArray
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_SetCustomTypeArray was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_SetCustomTypeArray_cfunc = self._get_library_function('niFake_SetCustomTypeArray')
                 self.niFake_SetCustomTypeArray_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(custom_struct.struct_CustomStruct)]  # noqa: F405
                 self.niFake_SetCustomTypeArray_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_SetCustomTypeArray_cfunc(vi, number_of_elements, cs)
@@ -746,12 +499,7 @@ class Library(object):
     def niFake_StringValuedEnumInputFunctionWithDefaults(self, vi, a_mobile_os_name):  # noqa: N802
         with self._func_lock:
             if self.niFake_StringValuedEnumInputFunctionWithDefaults_cfunc is None:
-                try:
-                    self.niFake_StringValuedEnumInputFunctionWithDefaults_cfunc = self._library.niFake_StringValuedEnumInputFunctionWithDefaults
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_StringValuedEnumInputFunctionWithDefaults was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_StringValuedEnumInputFunctionWithDefaults_cfunc = self._get_library_function('niFake_StringValuedEnumInputFunctionWithDefaults')
                 self.niFake_StringValuedEnumInputFunctionWithDefaults_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_StringValuedEnumInputFunctionWithDefaults_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_StringValuedEnumInputFunctionWithDefaults_cfunc(vi, a_mobile_os_name)
@@ -759,12 +507,7 @@ class Library(object):
     def niFake_TwoInputFunction(self, vi, a_number, a_string):  # noqa: N802
         with self._func_lock:
             if self.niFake_TwoInputFunction_cfunc is None:
-                try:
-                    self.niFake_TwoInputFunction_cfunc = self._library.niFake_TwoInputFunction
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_TwoInputFunction was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_TwoInputFunction_cfunc = self._get_library_function('niFake_TwoInputFunction')
                 self.niFake_TwoInputFunction_cfunc.argtypes = [ViSession, ViReal64, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_TwoInputFunction_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_TwoInputFunction_cfunc(vi, a_number, a_string)
@@ -772,12 +515,7 @@ class Library(object):
     def niFake_UnlockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niFake_UnlockSession_cfunc is None:
-                try:
-                    self.niFake_UnlockSession_cfunc = self._library.niFake_UnlockSession
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_UnlockSession was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_UnlockSession_cfunc = self._get_library_function('niFake_UnlockSession')
                 self.niFake_UnlockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFake_UnlockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_UnlockSession_cfunc(vi, caller_has_lock)
@@ -785,12 +523,7 @@ class Library(object):
     def niFake_Use64BitNumber(self, vi, input, output):  # noqa: N802
         with self._func_lock:
             if self.niFake_Use64BitNumber_cfunc is None:
-                try:
-                    self.niFake_Use64BitNumber_cfunc = self._library.niFake_Use64BitNumber
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_Use64BitNumber was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_Use64BitNumber_cfunc = self._get_library_function('niFake_Use64BitNumber')
                 self.niFake_Use64BitNumber_cfunc.argtypes = [ViSession, ViInt64, ctypes.POINTER(ViInt64)]  # noqa: F405
                 self.niFake_Use64BitNumber_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_Use64BitNumber_cfunc(vi, input, output)
@@ -798,12 +531,7 @@ class Library(object):
     def niFake_WriteWaveform(self, vi, number_of_samples, waveform):  # noqa: N802
         with self._func_lock:
             if self.niFake_WriteWaveform_cfunc is None:
-                try:
-                    self.niFake_WriteWaveform_cfunc = self._library.niFake_WriteWaveform
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_WriteWaveform was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_WriteWaveform_cfunc = self._get_library_function('niFake_WriteWaveform')
                 self.niFake_WriteWaveform_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFake_WriteWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_WriteWaveform_cfunc(vi, number_of_samples, waveform)
@@ -811,12 +539,7 @@ class Library(object):
     def niFake_close(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFake_close_cfunc is None:
-                try:
-                    self.niFake_close_cfunc = self._library.niFake_close
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_close was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_close_cfunc = self._get_library_function('niFake_close')
                 self.niFake_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFake_close_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_close_cfunc(vi)
@@ -824,12 +547,7 @@ class Library(object):
     def niFake_error_message(self, vi, error_code, error_message):  # noqa: N802
         with self._func_lock:
             if self.niFake_error_message_cfunc is None:
-                try:
-                    self.niFake_error_message_cfunc = self._library.niFake_error_message
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_error_message was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_error_message_cfunc = self._get_library_function('niFake_error_message')
                 self.niFake_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_error_message_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_error_message_cfunc(vi, error_code, error_message)
@@ -837,12 +555,7 @@ class Library(object):
     def niFake_self_test(self, vi, self_test_result, self_test_message):  # noqa: N802
         with self._func_lock:
             if self.niFake_self_test_cfunc is None:
-                try:
-                    self.niFake_self_test_cfunc = self._library.niFake_self_test
-                except AttributeError as e:
-                    raise AttributeError("Function niFake_self_test was not found in the NI-FAKE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFake_self_test_cfunc = self._get_library_function('niFake_self_test')
                 self.niFake_self_test_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFake_self_test_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_self_test_cfunc(vi, self_test_result, self_test_message)

--- a/generated/nifake/nifake/errors.py
+++ b/generated/nifake/nifake/errors.py
@@ -57,6 +57,13 @@ class DriverNotInstalledError(Error):
         super(DriverNotInstalledError, self).__init__('The NI-FAKE runtime could not be loaded. Make sure it is installed and its bitness matches that of your Python interpreter. Please visit http://www.ni.com/downloads/drivers/ to download and install it.')
 
 
+class DriverTooOldError(Error):
+    '''An error due to using this module with an older version of the driver runtime.'''
+
+    def __init__(self):
+        super(DriverTooOldError, self).__init__('A function was not found in the NI-FAKE runtime. Please visit http://www.ni.com/downloads/drivers/ to download a newer version and install it.')
+
+
 class InvalidRepeatedCapabilityError(Error):
     '''An error due to an invalid character in a repeated capability'''
 

--- a/generated/nifake/nifake/unit_tests/test_session.py
+++ b/generated/nifake/nifake/unit_tests/test_session.py
@@ -9,7 +9,6 @@ import numpy
 import platform
 import warnings
 
-
 from mock import patch
 
 import _matchers
@@ -1532,12 +1531,13 @@ def test_library_error():
         ctypes_class_name = 'ctypes.WinDLL'
     mock_ctypes = patch(ctypes_class_name).start()
     mock_ctypes_instance = mock_ctypes.return_value
-    # These methods are called as part of session creation
+    # Ensure these methods return 0 because they are called in session creation
     mock_ctypes_instance.niFake_InitWithOptions.return_value = 0
     mock_ctypes_instance.niFake_LockSession.return_value = 0
     mock_ctypes_instance.niFake_UnlockSession.return_value = 0
-    # Ensure that function is not found in runtime
+    # Delete function to simulate missing function from driver runtime
     delattr(mock_ctypes_instance, 'niFake_Abort')
+
     session = nifake.Session('dev1')
 
     try:
@@ -1545,4 +1545,4 @@ def test_library_error():
         assert False
     except nifake.errors.DriverTooOldError as e:
         message = e.args[0]
-        assert message.startswith("A function was not found in the NI-FAKE runtime. Please visit http://www.ni.com/downloads/drivers/ to download a newer version and install it.")
+        assert message == 'A function was not found in the NI-FAKE runtime. Please visit http://www.ni.com/downloads/drivers/ to download a newer version and install it.'

--- a/generated/nifake/nifake/unit_tests/test_session.py
+++ b/generated/nifake/nifake/unit_tests/test_session.py
@@ -6,7 +6,9 @@ import math
 import nifake
 import nifake.errors
 import numpy
+import platform
 import warnings
+
 
 from mock import patch
 
@@ -64,6 +66,17 @@ class TestSession(object):
         ret_val = self.get_ctypes_pointer_for_buffer_side_effect_items[self.get_ctypes_pointer_for_buffer_side_effect_count]
         self.get_ctypes_pointer_for_buffer_side_effect_count += 1
         return ret_val
+
+    def test_driver_too_old_error(self):
+        if platform.architecture() == '32bit':
+            ctypes_patcher = patch('ctypes.CDLL')
+        else:
+            ctypes_patcher = patch('ctypes.WinDLL')
+
+        session = nifake.Session('dev1')
+
+        patched_ctypes = ctypes_patcher.start()
+        patched_ctypes.
 
     # Session management
 

--- a/generated/nifgen/nifgen/_library.py
+++ b/generated/nifgen/nifgen/_library.py
@@ -97,9 +97,9 @@ class Library(object):
                 try:
                     self.niFgen_AbortGeneration_cfunc = self._library.niFgen_AbortGeneration
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_AbortGeneration was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_AbortGeneration_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_AbortGeneration_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_AbortGeneration_cfunc(vi)
@@ -110,9 +110,9 @@ class Library(object):
                 try:
                     self.niFgen_AllocateNamedWaveform_cfunc = self._library.niFgen_AllocateNamedWaveform
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_AllocateNamedWaveform was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_AllocateNamedWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niFgen_AllocateNamedWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_AllocateNamedWaveform_cfunc(vi, channel_name, waveform_name, waveform_size)
@@ -123,9 +123,9 @@ class Library(object):
                 try:
                     self.niFgen_AllocateWaveform_cfunc = self._library.niFgen_AllocateWaveform
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_AllocateWaveform was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_AllocateWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_AllocateWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_AllocateWaveform_cfunc(vi, channel_name, waveform_size, waveform_handle)
@@ -136,9 +136,9 @@ class Library(object):
                 try:
                     self.niFgen_ClearArbMemory_cfunc = self._library.niFgen_ClearArbMemory
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_ClearArbMemory was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_ClearArbMemory_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_ClearArbMemory_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ClearArbMemory_cfunc(vi)
@@ -149,9 +149,9 @@ class Library(object):
                 try:
                     self.niFgen_ClearArbSequence_cfunc = self._library.niFgen_ClearArbSequence
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_ClearArbSequence was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_ClearArbSequence_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niFgen_ClearArbSequence_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ClearArbSequence_cfunc(vi, sequence_handle)
@@ -162,9 +162,9 @@ class Library(object):
                 try:
                     self.niFgen_ClearArbWaveform_cfunc = self._library.niFgen_ClearArbWaveform
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_ClearArbWaveform was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_ClearArbWaveform_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niFgen_ClearArbWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ClearArbWaveform_cfunc(vi, waveform_handle)
@@ -175,9 +175,9 @@ class Library(object):
                 try:
                     self.niFgen_ClearFreqList_cfunc = self._library.niFgen_ClearFreqList
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_ClearFreqList was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_ClearFreqList_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niFgen_ClearFreqList_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ClearFreqList_cfunc(vi, frequency_list_handle)
@@ -188,9 +188,9 @@ class Library(object):
                 try:
                     self.niFgen_ClearUserStandardWaveform_cfunc = self._library.niFgen_ClearUserStandardWaveform
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_ClearUserStandardWaveform was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_ClearUserStandardWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_ClearUserStandardWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ClearUserStandardWaveform_cfunc(vi, channel_name)
@@ -201,9 +201,9 @@ class Library(object):
                 try:
                     self.niFgen_Commit_cfunc = self._library.niFgen_Commit
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_Commit was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_Commit_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_Commit_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_Commit_cfunc(vi)
@@ -214,9 +214,9 @@ class Library(object):
                 try:
                     self.niFgen_ConfigureArbSequence_cfunc = self._library.niFgen_ConfigureArbSequence
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_ConfigureArbSequence was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_ConfigureArbSequence_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niFgen_ConfigureArbSequence_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ConfigureArbSequence_cfunc(vi, channel_name, sequence_handle, gain, offset)
@@ -227,9 +227,9 @@ class Library(object):
                 try:
                     self.niFgen_ConfigureArbWaveform_cfunc = self._library.niFgen_ConfigureArbWaveform
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_ConfigureArbWaveform was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_ConfigureArbWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niFgen_ConfigureArbWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ConfigureArbWaveform_cfunc(vi, channel_name, waveform_handle, gain, offset)
@@ -240,9 +240,9 @@ class Library(object):
                 try:
                     self.niFgen_ConfigureFreqList_cfunc = self._library.niFgen_ConfigureFreqList
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_ConfigureFreqList was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_ConfigureFreqList_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niFgen_ConfigureFreqList_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ConfigureFreqList_cfunc(vi, channel_name, frequency_list_handle, amplitude, dc_offset, start_phase)
@@ -253,9 +253,9 @@ class Library(object):
                 try:
                     self.niFgen_ConfigureStandardWaveform_cfunc = self._library.niFgen_ConfigureStandardWaveform
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_ConfigureStandardWaveform was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_ConfigureStandardWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViReal64, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niFgen_ConfigureStandardWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ConfigureStandardWaveform_cfunc(vi, channel_name, waveform, amplitude, dc_offset, frequency, start_phase)
@@ -266,9 +266,9 @@ class Library(object):
                 try:
                     self.niFgen_CreateAdvancedArbSequence_cfunc = self._library.niFgen_CreateAdvancedArbSequence
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_CreateAdvancedArbSequence was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_CreateAdvancedArbSequence_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_CreateAdvancedArbSequence_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_CreateAdvancedArbSequence_cfunc(vi, sequence_length, waveform_handles_array, loop_counts_array, sample_counts_array, marker_location_array, coerced_markers_array, sequence_handle)
@@ -279,9 +279,9 @@ class Library(object):
                 try:
                     self.niFgen_CreateArbSequence_cfunc = self._library.niFgen_CreateArbSequence
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_CreateArbSequence was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_CreateArbSequence_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_CreateArbSequence_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_CreateArbSequence_cfunc(vi, sequence_length, waveform_handles_array, loop_counts_array, sequence_handle)
@@ -292,9 +292,9 @@ class Library(object):
                 try:
                     self.niFgen_CreateFreqList_cfunc = self._library.niFgen_CreateFreqList
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_CreateFreqList was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_CreateFreqList_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_CreateFreqList_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_CreateFreqList_cfunc(vi, waveform, frequency_list_length, frequency_array, duration_array, frequency_list_handle)
@@ -305,9 +305,9 @@ class Library(object):
                 try:
                     self.niFgen_CreateWaveformF64_cfunc = self._library.niFgen_CreateWaveformF64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_CreateWaveformF64 was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_CreateWaveformF64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_CreateWaveformF64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_CreateWaveformF64_cfunc(vi, channel_name, waveform_size, waveform_data_array, waveform_handle)
@@ -318,9 +318,9 @@ class Library(object):
                 try:
                     self.niFgen_CreateWaveformFromFileF64_cfunc = self._library.niFgen_CreateWaveformFromFileF64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_CreateWaveformFromFileF64 was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_CreateWaveformFromFileF64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_CreateWaveformFromFileF64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_CreateWaveformFromFileF64_cfunc(vi, channel_name, file_name, byte_order, waveform_handle)
@@ -331,9 +331,9 @@ class Library(object):
                 try:
                     self.niFgen_CreateWaveformFromFileI16_cfunc = self._library.niFgen_CreateWaveformFromFileI16
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_CreateWaveformFromFileI16 was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_CreateWaveformFromFileI16_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_CreateWaveformFromFileI16_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_CreateWaveformFromFileI16_cfunc(vi, channel_name, file_name, byte_order, waveform_handle)
@@ -344,9 +344,9 @@ class Library(object):
                 try:
                     self.niFgen_CreateWaveformI16_cfunc = self._library.niFgen_CreateWaveformI16
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_CreateWaveformI16 was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_CreateWaveformI16_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt16), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_CreateWaveformI16_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_CreateWaveformI16_cfunc(vi, channel_name, waveform_size, waveform_data_array, waveform_handle)
@@ -357,9 +357,9 @@ class Library(object):
                 try:
                     self.niFgen_DefineUserStandardWaveform_cfunc = self._library.niFgen_DefineUserStandardWaveform
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_DefineUserStandardWaveform was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_DefineUserStandardWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_DefineUserStandardWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_DefineUserStandardWaveform_cfunc(vi, channel_name, waveform_size, waveform_data_array)
@@ -370,9 +370,9 @@ class Library(object):
                 try:
                     self.niFgen_DeleteNamedWaveform_cfunc = self._library.niFgen_DeleteNamedWaveform
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_DeleteNamedWaveform was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_DeleteNamedWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_DeleteNamedWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_DeleteNamedWaveform_cfunc(vi, channel_name, waveform_name)
@@ -383,9 +383,9 @@ class Library(object):
                 try:
                     self.niFgen_DeleteScript_cfunc = self._library.niFgen_DeleteScript
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_DeleteScript was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_DeleteScript_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_DeleteScript_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_DeleteScript_cfunc(vi, channel_name, script_name)
@@ -396,9 +396,9 @@ class Library(object):
                 try:
                     self.niFgen_Disable_cfunc = self._library.niFgen_Disable
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_Disable was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_Disable_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_Disable_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_Disable_cfunc(vi)
@@ -409,9 +409,9 @@ class Library(object):
                 try:
                     self.niFgen_ExportAttributeConfigurationBuffer_cfunc = self._library.niFgen_ExportAttributeConfigurationBuffer
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_ExportAttributeConfigurationBuffer was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_ExportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niFgen_ExportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ExportAttributeConfigurationBuffer_cfunc(vi, size_in_bytes, configuration)
@@ -422,9 +422,9 @@ class Library(object):
                 try:
                     self.niFgen_ExportAttributeConfigurationFile_cfunc = self._library.niFgen_ExportAttributeConfigurationFile
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_ExportAttributeConfigurationFile was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_ExportAttributeConfigurationFile_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_ExportAttributeConfigurationFile_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ExportAttributeConfigurationFile_cfunc(vi, file_path)
@@ -435,9 +435,9 @@ class Library(object):
                 try:
                     self.niFgen_GetAttributeViBoolean_cfunc = self._library.niFgen_GetAttributeViBoolean
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_GetAttributeViBoolean was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFgen_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -448,9 +448,9 @@ class Library(object):
                 try:
                     self.niFgen_GetAttributeViInt32_cfunc = self._library.niFgen_GetAttributeViInt32
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_GetAttributeViInt32 was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_GetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -461,9 +461,9 @@ class Library(object):
                 try:
                     self.niFgen_GetAttributeViReal64_cfunc = self._library.niFgen_GetAttributeViReal64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_GetAttributeViReal64 was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_GetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -474,9 +474,9 @@ class Library(object):
                 try:
                     self.niFgen_GetAttributeViString_cfunc = self._library.niFgen_GetAttributeViString
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_GetAttributeViString was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetAttributeViString_cfunc(vi, channel_name, attribute_id, array_size, attribute_value)
@@ -487,9 +487,9 @@ class Library(object):
                 try:
                     self.niFgen_GetChannelName_cfunc = self._library.niFgen_GetChannelName
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_GetChannelName was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_GetChannelName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_GetChannelName_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetChannelName_cfunc(vi, index, buffer_size, channel_string)
@@ -500,9 +500,9 @@ class Library(object):
                 try:
                     self.niFgen_GetError_cfunc = self._library.niFgen_GetError
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_GetError was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_GetError_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetError_cfunc(vi, error_code, error_description_buffer_size, error_description)
@@ -513,9 +513,9 @@ class Library(object):
                 try:
                     self.niFgen_GetExtCalLastDateAndTime_cfunc = self._library.niFgen_GetExtCalLastDateAndTime
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_GetExtCalLastDateAndTime was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_GetExtCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_GetExtCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetExtCalLastDateAndTime_cfunc(vi, year, month, day, hour, minute)
@@ -526,9 +526,9 @@ class Library(object):
                 try:
                     self.niFgen_GetExtCalLastTemp_cfunc = self._library.niFgen_GetExtCalLastTemp
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_GetExtCalLastTemp was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_GetExtCalLastTemp_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_GetExtCalLastTemp_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetExtCalLastTemp_cfunc(vi, temperature)
@@ -539,9 +539,9 @@ class Library(object):
                 try:
                     self.niFgen_GetExtCalRecommendedInterval_cfunc = self._library.niFgen_GetExtCalRecommendedInterval
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_GetExtCalRecommendedInterval was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_GetExtCalRecommendedInterval_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_GetExtCalRecommendedInterval_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetExtCalRecommendedInterval_cfunc(vi, months)
@@ -552,9 +552,9 @@ class Library(object):
                 try:
                     self.niFgen_GetHardwareState_cfunc = self._library.niFgen_GetHardwareState
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_GetHardwareState was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_GetHardwareState_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_GetHardwareState_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetHardwareState_cfunc(vi, state)
@@ -565,9 +565,9 @@ class Library(object):
                 try:
                     self.niFgen_GetLastExtCalLastDateAndTime_cfunc = self._library.niFgen_GetLastExtCalLastDateAndTime
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_GetLastExtCalLastDateAndTime was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_GetLastExtCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(hightime.datetime)]  # noqa: F405
                 self.niFgen_GetLastExtCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetLastExtCalLastDateAndTime_cfunc(vi, month)
@@ -578,9 +578,9 @@ class Library(object):
                 try:
                     self.niFgen_GetLastSelfCalLastDateAndTime_cfunc = self._library.niFgen_GetLastSelfCalLastDateAndTime
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_GetLastSelfCalLastDateAndTime was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_GetLastSelfCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(hightime.datetime)]  # noqa: F405
                 self.niFgen_GetLastSelfCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetLastSelfCalLastDateAndTime_cfunc(vi, month)
@@ -591,9 +591,9 @@ class Library(object):
                 try:
                     self.niFgen_GetSelfCalLastDateAndTime_cfunc = self._library.niFgen_GetSelfCalLastDateAndTime
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_GetSelfCalLastDateAndTime was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_GetSelfCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_GetSelfCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetSelfCalLastDateAndTime_cfunc(vi, year, month, day, hour, minute)
@@ -604,9 +604,9 @@ class Library(object):
                 try:
                     self.niFgen_GetSelfCalLastTemp_cfunc = self._library.niFgen_GetSelfCalLastTemp
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_GetSelfCalLastTemp was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_GetSelfCalLastTemp_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_GetSelfCalLastTemp_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetSelfCalLastTemp_cfunc(vi, temperature)
@@ -617,9 +617,9 @@ class Library(object):
                 try:
                     self.niFgen_GetSelfCalSupported_cfunc = self._library.niFgen_GetSelfCalSupported
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_GetSelfCalSupported was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_GetSelfCalSupported_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFgen_GetSelfCalSupported_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetSelfCalSupported_cfunc(vi, self_cal_supported)
@@ -630,9 +630,9 @@ class Library(object):
                 try:
                     self.niFgen_ImportAttributeConfigurationBuffer_cfunc = self._library.niFgen_ImportAttributeConfigurationBuffer
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_ImportAttributeConfigurationBuffer was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_ImportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niFgen_ImportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ImportAttributeConfigurationBuffer_cfunc(vi, size_in_bytes, configuration)
@@ -643,9 +643,9 @@ class Library(object):
                 try:
                     self.niFgen_ImportAttributeConfigurationFile_cfunc = self._library.niFgen_ImportAttributeConfigurationFile
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_ImportAttributeConfigurationFile was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_ImportAttributeConfigurationFile_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_ImportAttributeConfigurationFile_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ImportAttributeConfigurationFile_cfunc(vi, file_path)
@@ -656,9 +656,9 @@ class Library(object):
                 try:
                     self.niFgen_InitializeWithChannels_cfunc = self._library.niFgen_InitializeWithChannels
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_InitializeWithChannels was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_InitializeWithChannels_cfunc.argtypes = [ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViBoolean, ctypes.POINTER(ViChar), ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niFgen_InitializeWithChannels_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_InitializeWithChannels_cfunc(resource_name, channel_name, reset_device, option_string, vi)
@@ -669,9 +669,9 @@ class Library(object):
                 try:
                     self.niFgen_InitiateGeneration_cfunc = self._library.niFgen_InitiateGeneration
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_InitiateGeneration was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_InitiateGeneration_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_InitiateGeneration_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_InitiateGeneration_cfunc(vi)
@@ -682,9 +682,9 @@ class Library(object):
                 try:
                     self.niFgen_IsDone_cfunc = self._library.niFgen_IsDone
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_IsDone was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_IsDone_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFgen_IsDone_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_IsDone_cfunc(vi, done)
@@ -695,9 +695,9 @@ class Library(object):
                 try:
                     self.niFgen_LockSession_cfunc = self._library.niFgen_LockSession
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_LockSession was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_LockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFgen_LockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_LockSession_cfunc(vi, caller_has_lock)
@@ -708,9 +708,9 @@ class Library(object):
                 try:
                     self.niFgen_QueryArbSeqCapabilities_cfunc = self._library.niFgen_QueryArbSeqCapabilities
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_QueryArbSeqCapabilities was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_QueryArbSeqCapabilities_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_QueryArbSeqCapabilities_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_QueryArbSeqCapabilities_cfunc(vi, maximum_number_of_sequences, minimum_sequence_length, maximum_sequence_length, maximum_loop_count)
@@ -721,9 +721,9 @@ class Library(object):
                 try:
                     self.niFgen_QueryArbWfmCapabilities_cfunc = self._library.niFgen_QueryArbWfmCapabilities
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_QueryArbWfmCapabilities was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_QueryArbWfmCapabilities_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_QueryArbWfmCapabilities_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_QueryArbWfmCapabilities_cfunc(vi, maximum_number_of_waveforms, waveform_quantum, minimum_waveform_size, maximum_waveform_size)
@@ -734,9 +734,9 @@ class Library(object):
                 try:
                     self.niFgen_QueryFreqListCapabilities_cfunc = self._library.niFgen_QueryFreqListCapabilities
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_QueryFreqListCapabilities was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_QueryFreqListCapabilities_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_QueryFreqListCapabilities_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_QueryFreqListCapabilities_cfunc(vi, maximum_number_of_freq_lists, minimum_frequency_list_length, maximum_frequency_list_length, minimum_frequency_list_duration, maximum_frequency_list_duration, frequency_list_duration_quantum)
@@ -747,9 +747,9 @@ class Library(object):
                 try:
                     self.niFgen_ReadCurrentTemperature_cfunc = self._library.niFgen_ReadCurrentTemperature
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_ReadCurrentTemperature was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_ReadCurrentTemperature_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_ReadCurrentTemperature_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ReadCurrentTemperature_cfunc(vi, temperature)
@@ -760,9 +760,9 @@ class Library(object):
                 try:
                     self.niFgen_ResetDevice_cfunc = self._library.niFgen_ResetDevice
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_ResetDevice was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_ResetDevice_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_ResetDevice_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ResetDevice_cfunc(vi)
@@ -773,9 +773,9 @@ class Library(object):
                 try:
                     self.niFgen_ResetWithDefaults_cfunc = self._library.niFgen_ResetWithDefaults
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_ResetWithDefaults was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_ResetWithDefaults_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_ResetWithDefaults_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ResetWithDefaults_cfunc(vi)
@@ -786,9 +786,9 @@ class Library(object):
                 try:
                     self.niFgen_SelfCal_cfunc = self._library.niFgen_SelfCal
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_SelfCal was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_SelfCal_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_SelfCal_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SelfCal_cfunc(vi)
@@ -799,9 +799,9 @@ class Library(object):
                 try:
                     self.niFgen_SendSoftwareEdgeTrigger_cfunc = self._library.niFgen_SendSoftwareEdgeTrigger
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_SendSoftwareEdgeTrigger was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_SendSoftwareEdgeTrigger_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_SendSoftwareEdgeTrigger_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SendSoftwareEdgeTrigger_cfunc(vi, trigger, trigger_id)
@@ -812,9 +812,9 @@ class Library(object):
                 try:
                     self.niFgen_SetAttributeViBoolean_cfunc = self._library.niFgen_SetAttributeViBoolean
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_SetAttributeViBoolean was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViBoolean]  # noqa: F405
                 self.niFgen_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -825,9 +825,9 @@ class Library(object):
                 try:
                     self.niFgen_SetAttributeViInt32_cfunc = self._library.niFgen_SetAttributeViInt32
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_SetAttributeViInt32 was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_SetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32]  # noqa: F405
                 self.niFgen_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -838,9 +838,9 @@ class Library(object):
                 try:
                     self.niFgen_SetAttributeViReal64_cfunc = self._library.niFgen_SetAttributeViReal64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_SetAttributeViReal64 was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niFgen_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -851,9 +851,9 @@ class Library(object):
                 try:
                     self.niFgen_SetAttributeViString_cfunc = self._library.niFgen_SetAttributeViString
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_SetAttributeViString was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_SetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SetAttributeViString_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -864,9 +864,9 @@ class Library(object):
                 try:
                     self.niFgen_SetNamedWaveformNextWritePosition_cfunc = self._library.niFgen_SetNamedWaveformNextWritePosition
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_SetNamedWaveformNextWritePosition was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_SetNamedWaveformNextWritePosition_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViInt32]  # noqa: F405
                 self.niFgen_SetNamedWaveformNextWritePosition_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SetNamedWaveformNextWritePosition_cfunc(vi, channel_name, waveform_name, relative_to, offset)
@@ -877,9 +877,9 @@ class Library(object):
                 try:
                     self.niFgen_SetWaveformNextWritePosition_cfunc = self._library.niFgen_SetWaveformNextWritePosition
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_SetWaveformNextWritePosition was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_SetWaveformNextWritePosition_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViInt32, ViInt32]  # noqa: F405
                 self.niFgen_SetWaveformNextWritePosition_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SetWaveformNextWritePosition_cfunc(vi, channel_name, waveform_handle, relative_to, offset)
@@ -890,9 +890,9 @@ class Library(object):
                 try:
                     self.niFgen_UnlockSession_cfunc = self._library.niFgen_UnlockSession
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_UnlockSession was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_UnlockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFgen_UnlockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_UnlockSession_cfunc(vi, caller_has_lock)
@@ -903,9 +903,9 @@ class Library(object):
                 try:
                     self.niFgen_WaitUntilDone_cfunc = self._library.niFgen_WaitUntilDone
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_WaitUntilDone was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_WaitUntilDone_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niFgen_WaitUntilDone_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_WaitUntilDone_cfunc(vi, max_time)
@@ -916,9 +916,9 @@ class Library(object):
                 try:
                     self.niFgen_WriteBinary16Waveform_cfunc = self._library.niFgen_WriteBinary16Waveform
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_WriteBinary16Waveform was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_WriteBinary16Waveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViInt32, ctypes.POINTER(ViInt16)]  # noqa: F405
                 self.niFgen_WriteBinary16Waveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_WriteBinary16Waveform_cfunc(vi, channel_name, waveform_handle, size, data)
@@ -929,9 +929,9 @@ class Library(object):
                 try:
                     self.niFgen_WriteNamedWaveformF64_cfunc = self._library.niFgen_WriteNamedWaveformF64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_WriteNamedWaveformF64 was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_WriteNamedWaveformF64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_WriteNamedWaveformF64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_WriteNamedWaveformF64_cfunc(vi, channel_name, waveform_name, size, data)
@@ -942,9 +942,9 @@ class Library(object):
                 try:
                     self.niFgen_WriteNamedWaveformI16_cfunc = self._library.niFgen_WriteNamedWaveformI16
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_WriteNamedWaveformI16 was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_WriteNamedWaveformI16_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt16)]  # noqa: F405
                 self.niFgen_WriteNamedWaveformI16_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_WriteNamedWaveformI16_cfunc(vi, channel_name, waveform_name, size, data)
@@ -955,9 +955,9 @@ class Library(object):
                 try:
                     self.niFgen_WriteScript_cfunc = self._library.niFgen_WriteScript
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_WriteScript was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_WriteScript_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_WriteScript_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_WriteScript_cfunc(vi, channel_name, script)
@@ -968,9 +968,9 @@ class Library(object):
                 try:
                     self.niFgen_WriteWaveform_cfunc = self._library.niFgen_WriteWaveform
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_WriteWaveform was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_WriteWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_WriteWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_WriteWaveform_cfunc(vi, channel_name, waveform_handle, size, data)
@@ -981,9 +981,9 @@ class Library(object):
                 try:
                     self.niFgen_close_cfunc = self._library.niFgen_close
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_close was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_close_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_close_cfunc(vi)
@@ -994,9 +994,9 @@ class Library(object):
                 try:
                     self.niFgen_error_message_cfunc = self._library.niFgen_error_message
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_error_message was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_error_message_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_error_message_cfunc(vi, error_code, error_message)
@@ -1007,9 +1007,9 @@ class Library(object):
                 try:
                     self.niFgen_reset_cfunc = self._library.niFgen_reset
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_reset was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_reset_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_reset_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_reset_cfunc(vi)
@@ -1020,9 +1020,9 @@ class Library(object):
                 try:
                     self.niFgen_self_test_cfunc = self._library.niFgen_self_test
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niFgen_self_test was not found in the NI-FGEN runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niFgen_self_test_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_self_test_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_self_test_cfunc(vi, self_test_result, self_test_message)

--- a/generated/nifgen/nifgen/_library.py
+++ b/generated/nifgen/nifgen/_library.py
@@ -2,6 +2,7 @@
 # This file was generated
 
 import ctypes
+import nifgen.errors as errors
 import threading
 
 from nifgen._visatype import *  # noqa: F403,H303
@@ -91,15 +92,17 @@ class Library(object):
         self.niFgen_reset_cfunc = None
         self.niFgen_self_test_cfunc = None
 
+    def _get_library_function(self, name):
+        try:
+            function = getattr(self._library, 'fred')
+        except AttributeError as e:
+            raise errors.DriverTooOldError() from e
+        return function
+
     def niFgen_AbortGeneration(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFgen_AbortGeneration_cfunc is None:
-                try:
-                    self.niFgen_AbortGeneration_cfunc = self._library.niFgen_AbortGeneration
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_AbortGeneration was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_AbortGeneration_cfunc = self._get_library_function('niFgen_AbortGeneration')
                 self.niFgen_AbortGeneration_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_AbortGeneration_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_AbortGeneration_cfunc(vi)
@@ -107,12 +110,7 @@ class Library(object):
     def niFgen_AllocateNamedWaveform(self, vi, channel_name, waveform_name, waveform_size):  # noqa: N802
         with self._func_lock:
             if self.niFgen_AllocateNamedWaveform_cfunc is None:
-                try:
-                    self.niFgen_AllocateNamedWaveform_cfunc = self._library.niFgen_AllocateNamedWaveform
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_AllocateNamedWaveform was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_AllocateNamedWaveform_cfunc = self._get_library_function('niFgen_AllocateNamedWaveform')
                 self.niFgen_AllocateNamedWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niFgen_AllocateNamedWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_AllocateNamedWaveform_cfunc(vi, channel_name, waveform_name, waveform_size)
@@ -120,12 +118,7 @@ class Library(object):
     def niFgen_AllocateWaveform(self, vi, channel_name, waveform_size, waveform_handle):  # noqa: N802
         with self._func_lock:
             if self.niFgen_AllocateWaveform_cfunc is None:
-                try:
-                    self.niFgen_AllocateWaveform_cfunc = self._library.niFgen_AllocateWaveform
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_AllocateWaveform was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_AllocateWaveform_cfunc = self._get_library_function('niFgen_AllocateWaveform')
                 self.niFgen_AllocateWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_AllocateWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_AllocateWaveform_cfunc(vi, channel_name, waveform_size, waveform_handle)
@@ -133,12 +126,7 @@ class Library(object):
     def niFgen_ClearArbMemory(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ClearArbMemory_cfunc is None:
-                try:
-                    self.niFgen_ClearArbMemory_cfunc = self._library.niFgen_ClearArbMemory
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_ClearArbMemory was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_ClearArbMemory_cfunc = self._get_library_function('niFgen_ClearArbMemory')
                 self.niFgen_ClearArbMemory_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_ClearArbMemory_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ClearArbMemory_cfunc(vi)
@@ -146,12 +134,7 @@ class Library(object):
     def niFgen_ClearArbSequence(self, vi, sequence_handle):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ClearArbSequence_cfunc is None:
-                try:
-                    self.niFgen_ClearArbSequence_cfunc = self._library.niFgen_ClearArbSequence
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_ClearArbSequence was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_ClearArbSequence_cfunc = self._get_library_function('niFgen_ClearArbSequence')
                 self.niFgen_ClearArbSequence_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niFgen_ClearArbSequence_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ClearArbSequence_cfunc(vi, sequence_handle)
@@ -159,12 +142,7 @@ class Library(object):
     def niFgen_ClearArbWaveform(self, vi, waveform_handle):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ClearArbWaveform_cfunc is None:
-                try:
-                    self.niFgen_ClearArbWaveform_cfunc = self._library.niFgen_ClearArbWaveform
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_ClearArbWaveform was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_ClearArbWaveform_cfunc = self._get_library_function('niFgen_ClearArbWaveform')
                 self.niFgen_ClearArbWaveform_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niFgen_ClearArbWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ClearArbWaveform_cfunc(vi, waveform_handle)
@@ -172,12 +150,7 @@ class Library(object):
     def niFgen_ClearFreqList(self, vi, frequency_list_handle):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ClearFreqList_cfunc is None:
-                try:
-                    self.niFgen_ClearFreqList_cfunc = self._library.niFgen_ClearFreqList
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_ClearFreqList was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_ClearFreqList_cfunc = self._get_library_function('niFgen_ClearFreqList')
                 self.niFgen_ClearFreqList_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niFgen_ClearFreqList_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ClearFreqList_cfunc(vi, frequency_list_handle)
@@ -185,12 +158,7 @@ class Library(object):
     def niFgen_ClearUserStandardWaveform(self, vi, channel_name):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ClearUserStandardWaveform_cfunc is None:
-                try:
-                    self.niFgen_ClearUserStandardWaveform_cfunc = self._library.niFgen_ClearUserStandardWaveform
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_ClearUserStandardWaveform was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_ClearUserStandardWaveform_cfunc = self._get_library_function('niFgen_ClearUserStandardWaveform')
                 self.niFgen_ClearUserStandardWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_ClearUserStandardWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ClearUserStandardWaveform_cfunc(vi, channel_name)
@@ -198,12 +166,7 @@ class Library(object):
     def niFgen_Commit(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFgen_Commit_cfunc is None:
-                try:
-                    self.niFgen_Commit_cfunc = self._library.niFgen_Commit
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_Commit was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_Commit_cfunc = self._get_library_function('niFgen_Commit')
                 self.niFgen_Commit_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_Commit_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_Commit_cfunc(vi)
@@ -211,12 +174,7 @@ class Library(object):
     def niFgen_ConfigureArbSequence(self, vi, channel_name, sequence_handle, gain, offset):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ConfigureArbSequence_cfunc is None:
-                try:
-                    self.niFgen_ConfigureArbSequence_cfunc = self._library.niFgen_ConfigureArbSequence
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_ConfigureArbSequence was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_ConfigureArbSequence_cfunc = self._get_library_function('niFgen_ConfigureArbSequence')
                 self.niFgen_ConfigureArbSequence_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niFgen_ConfigureArbSequence_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ConfigureArbSequence_cfunc(vi, channel_name, sequence_handle, gain, offset)
@@ -224,12 +182,7 @@ class Library(object):
     def niFgen_ConfigureArbWaveform(self, vi, channel_name, waveform_handle, gain, offset):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ConfigureArbWaveform_cfunc is None:
-                try:
-                    self.niFgen_ConfigureArbWaveform_cfunc = self._library.niFgen_ConfigureArbWaveform
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_ConfigureArbWaveform was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_ConfigureArbWaveform_cfunc = self._get_library_function('niFgen_ConfigureArbWaveform')
                 self.niFgen_ConfigureArbWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niFgen_ConfigureArbWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ConfigureArbWaveform_cfunc(vi, channel_name, waveform_handle, gain, offset)
@@ -237,12 +190,7 @@ class Library(object):
     def niFgen_ConfigureFreqList(self, vi, channel_name, frequency_list_handle, amplitude, dc_offset, start_phase):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ConfigureFreqList_cfunc is None:
-                try:
-                    self.niFgen_ConfigureFreqList_cfunc = self._library.niFgen_ConfigureFreqList
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_ConfigureFreqList was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_ConfigureFreqList_cfunc = self._get_library_function('niFgen_ConfigureFreqList')
                 self.niFgen_ConfigureFreqList_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niFgen_ConfigureFreqList_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ConfigureFreqList_cfunc(vi, channel_name, frequency_list_handle, amplitude, dc_offset, start_phase)
@@ -250,12 +198,7 @@ class Library(object):
     def niFgen_ConfigureStandardWaveform(self, vi, channel_name, waveform, amplitude, dc_offset, frequency, start_phase):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ConfigureStandardWaveform_cfunc is None:
-                try:
-                    self.niFgen_ConfigureStandardWaveform_cfunc = self._library.niFgen_ConfigureStandardWaveform
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_ConfigureStandardWaveform was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_ConfigureStandardWaveform_cfunc = self._get_library_function('niFgen_ConfigureStandardWaveform')
                 self.niFgen_ConfigureStandardWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViReal64, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niFgen_ConfigureStandardWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ConfigureStandardWaveform_cfunc(vi, channel_name, waveform, amplitude, dc_offset, frequency, start_phase)
@@ -263,12 +206,7 @@ class Library(object):
     def niFgen_CreateAdvancedArbSequence(self, vi, sequence_length, waveform_handles_array, loop_counts_array, sample_counts_array, marker_location_array, coerced_markers_array, sequence_handle):  # noqa: N802
         with self._func_lock:
             if self.niFgen_CreateAdvancedArbSequence_cfunc is None:
-                try:
-                    self.niFgen_CreateAdvancedArbSequence_cfunc = self._library.niFgen_CreateAdvancedArbSequence
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_CreateAdvancedArbSequence was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_CreateAdvancedArbSequence_cfunc = self._get_library_function('niFgen_CreateAdvancedArbSequence')
                 self.niFgen_CreateAdvancedArbSequence_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_CreateAdvancedArbSequence_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_CreateAdvancedArbSequence_cfunc(vi, sequence_length, waveform_handles_array, loop_counts_array, sample_counts_array, marker_location_array, coerced_markers_array, sequence_handle)
@@ -276,12 +214,7 @@ class Library(object):
     def niFgen_CreateArbSequence(self, vi, sequence_length, waveform_handles_array, loop_counts_array, sequence_handle):  # noqa: N802
         with self._func_lock:
             if self.niFgen_CreateArbSequence_cfunc is None:
-                try:
-                    self.niFgen_CreateArbSequence_cfunc = self._library.niFgen_CreateArbSequence
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_CreateArbSequence was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_CreateArbSequence_cfunc = self._get_library_function('niFgen_CreateArbSequence')
                 self.niFgen_CreateArbSequence_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_CreateArbSequence_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_CreateArbSequence_cfunc(vi, sequence_length, waveform_handles_array, loop_counts_array, sequence_handle)
@@ -289,12 +222,7 @@ class Library(object):
     def niFgen_CreateFreqList(self, vi, waveform, frequency_list_length, frequency_array, duration_array, frequency_list_handle):  # noqa: N802
         with self._func_lock:
             if self.niFgen_CreateFreqList_cfunc is None:
-                try:
-                    self.niFgen_CreateFreqList_cfunc = self._library.niFgen_CreateFreqList
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_CreateFreqList was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_CreateFreqList_cfunc = self._get_library_function('niFgen_CreateFreqList')
                 self.niFgen_CreateFreqList_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_CreateFreqList_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_CreateFreqList_cfunc(vi, waveform, frequency_list_length, frequency_array, duration_array, frequency_list_handle)
@@ -302,12 +230,7 @@ class Library(object):
     def niFgen_CreateWaveformF64(self, vi, channel_name, waveform_size, waveform_data_array, waveform_handle):  # noqa: N802
         with self._func_lock:
             if self.niFgen_CreateWaveformF64_cfunc is None:
-                try:
-                    self.niFgen_CreateWaveformF64_cfunc = self._library.niFgen_CreateWaveformF64
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_CreateWaveformF64 was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_CreateWaveformF64_cfunc = self._get_library_function('niFgen_CreateWaveformF64')
                 self.niFgen_CreateWaveformF64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_CreateWaveformF64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_CreateWaveformF64_cfunc(vi, channel_name, waveform_size, waveform_data_array, waveform_handle)
@@ -315,12 +238,7 @@ class Library(object):
     def niFgen_CreateWaveformFromFileF64(self, vi, channel_name, file_name, byte_order, waveform_handle):  # noqa: N802
         with self._func_lock:
             if self.niFgen_CreateWaveformFromFileF64_cfunc is None:
-                try:
-                    self.niFgen_CreateWaveformFromFileF64_cfunc = self._library.niFgen_CreateWaveformFromFileF64
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_CreateWaveformFromFileF64 was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_CreateWaveformFromFileF64_cfunc = self._get_library_function('niFgen_CreateWaveformFromFileF64')
                 self.niFgen_CreateWaveformFromFileF64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_CreateWaveformFromFileF64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_CreateWaveformFromFileF64_cfunc(vi, channel_name, file_name, byte_order, waveform_handle)
@@ -328,12 +246,7 @@ class Library(object):
     def niFgen_CreateWaveformFromFileI16(self, vi, channel_name, file_name, byte_order, waveform_handle):  # noqa: N802
         with self._func_lock:
             if self.niFgen_CreateWaveformFromFileI16_cfunc is None:
-                try:
-                    self.niFgen_CreateWaveformFromFileI16_cfunc = self._library.niFgen_CreateWaveformFromFileI16
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_CreateWaveformFromFileI16 was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_CreateWaveformFromFileI16_cfunc = self._get_library_function('niFgen_CreateWaveformFromFileI16')
                 self.niFgen_CreateWaveformFromFileI16_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_CreateWaveformFromFileI16_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_CreateWaveformFromFileI16_cfunc(vi, channel_name, file_name, byte_order, waveform_handle)
@@ -341,12 +254,7 @@ class Library(object):
     def niFgen_CreateWaveformI16(self, vi, channel_name, waveform_size, waveform_data_array, waveform_handle):  # noqa: N802
         with self._func_lock:
             if self.niFgen_CreateWaveformI16_cfunc is None:
-                try:
-                    self.niFgen_CreateWaveformI16_cfunc = self._library.niFgen_CreateWaveformI16
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_CreateWaveformI16 was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_CreateWaveformI16_cfunc = self._get_library_function('niFgen_CreateWaveformI16')
                 self.niFgen_CreateWaveformI16_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt16), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_CreateWaveformI16_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_CreateWaveformI16_cfunc(vi, channel_name, waveform_size, waveform_data_array, waveform_handle)
@@ -354,12 +262,7 @@ class Library(object):
     def niFgen_DefineUserStandardWaveform(self, vi, channel_name, waveform_size, waveform_data_array):  # noqa: N802
         with self._func_lock:
             if self.niFgen_DefineUserStandardWaveform_cfunc is None:
-                try:
-                    self.niFgen_DefineUserStandardWaveform_cfunc = self._library.niFgen_DefineUserStandardWaveform
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_DefineUserStandardWaveform was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_DefineUserStandardWaveform_cfunc = self._get_library_function('niFgen_DefineUserStandardWaveform')
                 self.niFgen_DefineUserStandardWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_DefineUserStandardWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_DefineUserStandardWaveform_cfunc(vi, channel_name, waveform_size, waveform_data_array)
@@ -367,12 +270,7 @@ class Library(object):
     def niFgen_DeleteNamedWaveform(self, vi, channel_name, waveform_name):  # noqa: N802
         with self._func_lock:
             if self.niFgen_DeleteNamedWaveform_cfunc is None:
-                try:
-                    self.niFgen_DeleteNamedWaveform_cfunc = self._library.niFgen_DeleteNamedWaveform
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_DeleteNamedWaveform was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_DeleteNamedWaveform_cfunc = self._get_library_function('niFgen_DeleteNamedWaveform')
                 self.niFgen_DeleteNamedWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_DeleteNamedWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_DeleteNamedWaveform_cfunc(vi, channel_name, waveform_name)
@@ -380,12 +278,7 @@ class Library(object):
     def niFgen_DeleteScript(self, vi, channel_name, script_name):  # noqa: N802
         with self._func_lock:
             if self.niFgen_DeleteScript_cfunc is None:
-                try:
-                    self.niFgen_DeleteScript_cfunc = self._library.niFgen_DeleteScript
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_DeleteScript was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_DeleteScript_cfunc = self._get_library_function('niFgen_DeleteScript')
                 self.niFgen_DeleteScript_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_DeleteScript_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_DeleteScript_cfunc(vi, channel_name, script_name)
@@ -393,12 +286,7 @@ class Library(object):
     def niFgen_Disable(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFgen_Disable_cfunc is None:
-                try:
-                    self.niFgen_Disable_cfunc = self._library.niFgen_Disable
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_Disable was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_Disable_cfunc = self._get_library_function('niFgen_Disable')
                 self.niFgen_Disable_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_Disable_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_Disable_cfunc(vi)
@@ -406,12 +294,7 @@ class Library(object):
     def niFgen_ExportAttributeConfigurationBuffer(self, vi, size_in_bytes, configuration):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ExportAttributeConfigurationBuffer_cfunc is None:
-                try:
-                    self.niFgen_ExportAttributeConfigurationBuffer_cfunc = self._library.niFgen_ExportAttributeConfigurationBuffer
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_ExportAttributeConfigurationBuffer was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_ExportAttributeConfigurationBuffer_cfunc = self._get_library_function('niFgen_ExportAttributeConfigurationBuffer')
                 self.niFgen_ExportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niFgen_ExportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ExportAttributeConfigurationBuffer_cfunc(vi, size_in_bytes, configuration)
@@ -419,12 +302,7 @@ class Library(object):
     def niFgen_ExportAttributeConfigurationFile(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ExportAttributeConfigurationFile_cfunc is None:
-                try:
-                    self.niFgen_ExportAttributeConfigurationFile_cfunc = self._library.niFgen_ExportAttributeConfigurationFile
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_ExportAttributeConfigurationFile was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_ExportAttributeConfigurationFile_cfunc = self._get_library_function('niFgen_ExportAttributeConfigurationFile')
                 self.niFgen_ExportAttributeConfigurationFile_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_ExportAttributeConfigurationFile_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ExportAttributeConfigurationFile_cfunc(vi, file_path)
@@ -432,12 +310,7 @@ class Library(object):
     def niFgen_GetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetAttributeViBoolean_cfunc is None:
-                try:
-                    self.niFgen_GetAttributeViBoolean_cfunc = self._library.niFgen_GetAttributeViBoolean
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_GetAttributeViBoolean was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_GetAttributeViBoolean_cfunc = self._get_library_function('niFgen_GetAttributeViBoolean')
                 self.niFgen_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFgen_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -445,12 +318,7 @@ class Library(object):
     def niFgen_GetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetAttributeViInt32_cfunc is None:
-                try:
-                    self.niFgen_GetAttributeViInt32_cfunc = self._library.niFgen_GetAttributeViInt32
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_GetAttributeViInt32 was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_GetAttributeViInt32_cfunc = self._get_library_function('niFgen_GetAttributeViInt32')
                 self.niFgen_GetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -458,12 +326,7 @@ class Library(object):
     def niFgen_GetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetAttributeViReal64_cfunc is None:
-                try:
-                    self.niFgen_GetAttributeViReal64_cfunc = self._library.niFgen_GetAttributeViReal64
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_GetAttributeViReal64 was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_GetAttributeViReal64_cfunc = self._get_library_function('niFgen_GetAttributeViReal64')
                 self.niFgen_GetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -471,12 +334,7 @@ class Library(object):
     def niFgen_GetAttributeViString(self, vi, channel_name, attribute_id, array_size, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetAttributeViString_cfunc is None:
-                try:
-                    self.niFgen_GetAttributeViString_cfunc = self._library.niFgen_GetAttributeViString
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_GetAttributeViString was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_GetAttributeViString_cfunc = self._get_library_function('niFgen_GetAttributeViString')
                 self.niFgen_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetAttributeViString_cfunc(vi, channel_name, attribute_id, array_size, attribute_value)
@@ -484,12 +342,7 @@ class Library(object):
     def niFgen_GetChannelName(self, vi, index, buffer_size, channel_string):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetChannelName_cfunc is None:
-                try:
-                    self.niFgen_GetChannelName_cfunc = self._library.niFgen_GetChannelName
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_GetChannelName was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_GetChannelName_cfunc = self._get_library_function('niFgen_GetChannelName')
                 self.niFgen_GetChannelName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_GetChannelName_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetChannelName_cfunc(vi, index, buffer_size, channel_string)
@@ -497,12 +350,7 @@ class Library(object):
     def niFgen_GetError(self, vi, error_code, error_description_buffer_size, error_description):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetError_cfunc is None:
-                try:
-                    self.niFgen_GetError_cfunc = self._library.niFgen_GetError
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_GetError was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_GetError_cfunc = self._get_library_function('niFgen_GetError')
                 self.niFgen_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_GetError_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetError_cfunc(vi, error_code, error_description_buffer_size, error_description)
@@ -510,12 +358,7 @@ class Library(object):
     def niFgen_GetExtCalLastDateAndTime(self, vi, year, month, day, hour, minute):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetExtCalLastDateAndTime_cfunc is None:
-                try:
-                    self.niFgen_GetExtCalLastDateAndTime_cfunc = self._library.niFgen_GetExtCalLastDateAndTime
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_GetExtCalLastDateAndTime was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_GetExtCalLastDateAndTime_cfunc = self._get_library_function('niFgen_GetExtCalLastDateAndTime')
                 self.niFgen_GetExtCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_GetExtCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetExtCalLastDateAndTime_cfunc(vi, year, month, day, hour, minute)
@@ -523,12 +366,7 @@ class Library(object):
     def niFgen_GetExtCalLastTemp(self, vi, temperature):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetExtCalLastTemp_cfunc is None:
-                try:
-                    self.niFgen_GetExtCalLastTemp_cfunc = self._library.niFgen_GetExtCalLastTemp
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_GetExtCalLastTemp was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_GetExtCalLastTemp_cfunc = self._get_library_function('niFgen_GetExtCalLastTemp')
                 self.niFgen_GetExtCalLastTemp_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_GetExtCalLastTemp_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetExtCalLastTemp_cfunc(vi, temperature)
@@ -536,12 +374,7 @@ class Library(object):
     def niFgen_GetExtCalRecommendedInterval(self, vi, months):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetExtCalRecommendedInterval_cfunc is None:
-                try:
-                    self.niFgen_GetExtCalRecommendedInterval_cfunc = self._library.niFgen_GetExtCalRecommendedInterval
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_GetExtCalRecommendedInterval was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_GetExtCalRecommendedInterval_cfunc = self._get_library_function('niFgen_GetExtCalRecommendedInterval')
                 self.niFgen_GetExtCalRecommendedInterval_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_GetExtCalRecommendedInterval_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetExtCalRecommendedInterval_cfunc(vi, months)
@@ -549,12 +382,7 @@ class Library(object):
     def niFgen_GetHardwareState(self, vi, state):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetHardwareState_cfunc is None:
-                try:
-                    self.niFgen_GetHardwareState_cfunc = self._library.niFgen_GetHardwareState
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_GetHardwareState was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_GetHardwareState_cfunc = self._get_library_function('niFgen_GetHardwareState')
                 self.niFgen_GetHardwareState_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_GetHardwareState_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetHardwareState_cfunc(vi, state)
@@ -562,12 +390,7 @@ class Library(object):
     def niFgen_GetLastExtCalLastDateAndTime(self, vi, month):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetLastExtCalLastDateAndTime_cfunc is None:
-                try:
-                    self.niFgen_GetLastExtCalLastDateAndTime_cfunc = self._library.niFgen_GetLastExtCalLastDateAndTime
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_GetLastExtCalLastDateAndTime was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_GetLastExtCalLastDateAndTime_cfunc = self._get_library_function('niFgen_GetLastExtCalLastDateAndTime')
                 self.niFgen_GetLastExtCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(hightime.datetime)]  # noqa: F405
                 self.niFgen_GetLastExtCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetLastExtCalLastDateAndTime_cfunc(vi, month)
@@ -575,12 +398,7 @@ class Library(object):
     def niFgen_GetLastSelfCalLastDateAndTime(self, vi, month):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetLastSelfCalLastDateAndTime_cfunc is None:
-                try:
-                    self.niFgen_GetLastSelfCalLastDateAndTime_cfunc = self._library.niFgen_GetLastSelfCalLastDateAndTime
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_GetLastSelfCalLastDateAndTime was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_GetLastSelfCalLastDateAndTime_cfunc = self._get_library_function('niFgen_GetLastSelfCalLastDateAndTime')
                 self.niFgen_GetLastSelfCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(hightime.datetime)]  # noqa: F405
                 self.niFgen_GetLastSelfCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetLastSelfCalLastDateAndTime_cfunc(vi, month)
@@ -588,12 +406,7 @@ class Library(object):
     def niFgen_GetSelfCalLastDateAndTime(self, vi, year, month, day, hour, minute):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetSelfCalLastDateAndTime_cfunc is None:
-                try:
-                    self.niFgen_GetSelfCalLastDateAndTime_cfunc = self._library.niFgen_GetSelfCalLastDateAndTime
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_GetSelfCalLastDateAndTime was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_GetSelfCalLastDateAndTime_cfunc = self._get_library_function('niFgen_GetSelfCalLastDateAndTime')
                 self.niFgen_GetSelfCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_GetSelfCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetSelfCalLastDateAndTime_cfunc(vi, year, month, day, hour, minute)
@@ -601,12 +414,7 @@ class Library(object):
     def niFgen_GetSelfCalLastTemp(self, vi, temperature):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetSelfCalLastTemp_cfunc is None:
-                try:
-                    self.niFgen_GetSelfCalLastTemp_cfunc = self._library.niFgen_GetSelfCalLastTemp
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_GetSelfCalLastTemp was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_GetSelfCalLastTemp_cfunc = self._get_library_function('niFgen_GetSelfCalLastTemp')
                 self.niFgen_GetSelfCalLastTemp_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_GetSelfCalLastTemp_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetSelfCalLastTemp_cfunc(vi, temperature)
@@ -614,12 +422,7 @@ class Library(object):
     def niFgen_GetSelfCalSupported(self, vi, self_cal_supported):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetSelfCalSupported_cfunc is None:
-                try:
-                    self.niFgen_GetSelfCalSupported_cfunc = self._library.niFgen_GetSelfCalSupported
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_GetSelfCalSupported was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_GetSelfCalSupported_cfunc = self._get_library_function('niFgen_GetSelfCalSupported')
                 self.niFgen_GetSelfCalSupported_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFgen_GetSelfCalSupported_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetSelfCalSupported_cfunc(vi, self_cal_supported)
@@ -627,12 +430,7 @@ class Library(object):
     def niFgen_ImportAttributeConfigurationBuffer(self, vi, size_in_bytes, configuration):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ImportAttributeConfigurationBuffer_cfunc is None:
-                try:
-                    self.niFgen_ImportAttributeConfigurationBuffer_cfunc = self._library.niFgen_ImportAttributeConfigurationBuffer
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_ImportAttributeConfigurationBuffer was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_ImportAttributeConfigurationBuffer_cfunc = self._get_library_function('niFgen_ImportAttributeConfigurationBuffer')
                 self.niFgen_ImportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niFgen_ImportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ImportAttributeConfigurationBuffer_cfunc(vi, size_in_bytes, configuration)
@@ -640,12 +438,7 @@ class Library(object):
     def niFgen_ImportAttributeConfigurationFile(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ImportAttributeConfigurationFile_cfunc is None:
-                try:
-                    self.niFgen_ImportAttributeConfigurationFile_cfunc = self._library.niFgen_ImportAttributeConfigurationFile
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_ImportAttributeConfigurationFile was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_ImportAttributeConfigurationFile_cfunc = self._get_library_function('niFgen_ImportAttributeConfigurationFile')
                 self.niFgen_ImportAttributeConfigurationFile_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_ImportAttributeConfigurationFile_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ImportAttributeConfigurationFile_cfunc(vi, file_path)
@@ -653,12 +446,7 @@ class Library(object):
     def niFgen_InitializeWithChannels(self, resource_name, channel_name, reset_device, option_string, vi):  # noqa: N802
         with self._func_lock:
             if self.niFgen_InitializeWithChannels_cfunc is None:
-                try:
-                    self.niFgen_InitializeWithChannels_cfunc = self._library.niFgen_InitializeWithChannels
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_InitializeWithChannels was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_InitializeWithChannels_cfunc = self._get_library_function('niFgen_InitializeWithChannels')
                 self.niFgen_InitializeWithChannels_cfunc.argtypes = [ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViBoolean, ctypes.POINTER(ViChar), ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niFgen_InitializeWithChannels_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_InitializeWithChannels_cfunc(resource_name, channel_name, reset_device, option_string, vi)
@@ -666,12 +454,7 @@ class Library(object):
     def niFgen_InitiateGeneration(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFgen_InitiateGeneration_cfunc is None:
-                try:
-                    self.niFgen_InitiateGeneration_cfunc = self._library.niFgen_InitiateGeneration
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_InitiateGeneration was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_InitiateGeneration_cfunc = self._get_library_function('niFgen_InitiateGeneration')
                 self.niFgen_InitiateGeneration_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_InitiateGeneration_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_InitiateGeneration_cfunc(vi)
@@ -679,12 +462,7 @@ class Library(object):
     def niFgen_IsDone(self, vi, done):  # noqa: N802
         with self._func_lock:
             if self.niFgen_IsDone_cfunc is None:
-                try:
-                    self.niFgen_IsDone_cfunc = self._library.niFgen_IsDone
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_IsDone was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_IsDone_cfunc = self._get_library_function('niFgen_IsDone')
                 self.niFgen_IsDone_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFgen_IsDone_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_IsDone_cfunc(vi, done)
@@ -692,12 +470,7 @@ class Library(object):
     def niFgen_LockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niFgen_LockSession_cfunc is None:
-                try:
-                    self.niFgen_LockSession_cfunc = self._library.niFgen_LockSession
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_LockSession was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_LockSession_cfunc = self._get_library_function('niFgen_LockSession')
                 self.niFgen_LockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFgen_LockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_LockSession_cfunc(vi, caller_has_lock)
@@ -705,12 +478,7 @@ class Library(object):
     def niFgen_QueryArbSeqCapabilities(self, vi, maximum_number_of_sequences, minimum_sequence_length, maximum_sequence_length, maximum_loop_count):  # noqa: N802
         with self._func_lock:
             if self.niFgen_QueryArbSeqCapabilities_cfunc is None:
-                try:
-                    self.niFgen_QueryArbSeqCapabilities_cfunc = self._library.niFgen_QueryArbSeqCapabilities
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_QueryArbSeqCapabilities was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_QueryArbSeqCapabilities_cfunc = self._get_library_function('niFgen_QueryArbSeqCapabilities')
                 self.niFgen_QueryArbSeqCapabilities_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_QueryArbSeqCapabilities_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_QueryArbSeqCapabilities_cfunc(vi, maximum_number_of_sequences, minimum_sequence_length, maximum_sequence_length, maximum_loop_count)
@@ -718,12 +486,7 @@ class Library(object):
     def niFgen_QueryArbWfmCapabilities(self, vi, maximum_number_of_waveforms, waveform_quantum, minimum_waveform_size, maximum_waveform_size):  # noqa: N802
         with self._func_lock:
             if self.niFgen_QueryArbWfmCapabilities_cfunc is None:
-                try:
-                    self.niFgen_QueryArbWfmCapabilities_cfunc = self._library.niFgen_QueryArbWfmCapabilities
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_QueryArbWfmCapabilities was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_QueryArbWfmCapabilities_cfunc = self._get_library_function('niFgen_QueryArbWfmCapabilities')
                 self.niFgen_QueryArbWfmCapabilities_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_QueryArbWfmCapabilities_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_QueryArbWfmCapabilities_cfunc(vi, maximum_number_of_waveforms, waveform_quantum, minimum_waveform_size, maximum_waveform_size)
@@ -731,12 +494,7 @@ class Library(object):
     def niFgen_QueryFreqListCapabilities(self, vi, maximum_number_of_freq_lists, minimum_frequency_list_length, maximum_frequency_list_length, minimum_frequency_list_duration, maximum_frequency_list_duration, frequency_list_duration_quantum):  # noqa: N802
         with self._func_lock:
             if self.niFgen_QueryFreqListCapabilities_cfunc is None:
-                try:
-                    self.niFgen_QueryFreqListCapabilities_cfunc = self._library.niFgen_QueryFreqListCapabilities
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_QueryFreqListCapabilities was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_QueryFreqListCapabilities_cfunc = self._get_library_function('niFgen_QueryFreqListCapabilities')
                 self.niFgen_QueryFreqListCapabilities_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_QueryFreqListCapabilities_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_QueryFreqListCapabilities_cfunc(vi, maximum_number_of_freq_lists, minimum_frequency_list_length, maximum_frequency_list_length, minimum_frequency_list_duration, maximum_frequency_list_duration, frequency_list_duration_quantum)
@@ -744,12 +502,7 @@ class Library(object):
     def niFgen_ReadCurrentTemperature(self, vi, temperature):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ReadCurrentTemperature_cfunc is None:
-                try:
-                    self.niFgen_ReadCurrentTemperature_cfunc = self._library.niFgen_ReadCurrentTemperature
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_ReadCurrentTemperature was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_ReadCurrentTemperature_cfunc = self._get_library_function('niFgen_ReadCurrentTemperature')
                 self.niFgen_ReadCurrentTemperature_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_ReadCurrentTemperature_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ReadCurrentTemperature_cfunc(vi, temperature)
@@ -757,12 +510,7 @@ class Library(object):
     def niFgen_ResetDevice(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ResetDevice_cfunc is None:
-                try:
-                    self.niFgen_ResetDevice_cfunc = self._library.niFgen_ResetDevice
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_ResetDevice was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_ResetDevice_cfunc = self._get_library_function('niFgen_ResetDevice')
                 self.niFgen_ResetDevice_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_ResetDevice_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ResetDevice_cfunc(vi)
@@ -770,12 +518,7 @@ class Library(object):
     def niFgen_ResetWithDefaults(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ResetWithDefaults_cfunc is None:
-                try:
-                    self.niFgen_ResetWithDefaults_cfunc = self._library.niFgen_ResetWithDefaults
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_ResetWithDefaults was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_ResetWithDefaults_cfunc = self._get_library_function('niFgen_ResetWithDefaults')
                 self.niFgen_ResetWithDefaults_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_ResetWithDefaults_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ResetWithDefaults_cfunc(vi)
@@ -783,12 +526,7 @@ class Library(object):
     def niFgen_SelfCal(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFgen_SelfCal_cfunc is None:
-                try:
-                    self.niFgen_SelfCal_cfunc = self._library.niFgen_SelfCal
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_SelfCal was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_SelfCal_cfunc = self._get_library_function('niFgen_SelfCal')
                 self.niFgen_SelfCal_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_SelfCal_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SelfCal_cfunc(vi)
@@ -796,12 +534,7 @@ class Library(object):
     def niFgen_SendSoftwareEdgeTrigger(self, vi, trigger, trigger_id):  # noqa: N802
         with self._func_lock:
             if self.niFgen_SendSoftwareEdgeTrigger_cfunc is None:
-                try:
-                    self.niFgen_SendSoftwareEdgeTrigger_cfunc = self._library.niFgen_SendSoftwareEdgeTrigger
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_SendSoftwareEdgeTrigger was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_SendSoftwareEdgeTrigger_cfunc = self._get_library_function('niFgen_SendSoftwareEdgeTrigger')
                 self.niFgen_SendSoftwareEdgeTrigger_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_SendSoftwareEdgeTrigger_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SendSoftwareEdgeTrigger_cfunc(vi, trigger, trigger_id)
@@ -809,12 +542,7 @@ class Library(object):
     def niFgen_SetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFgen_SetAttributeViBoolean_cfunc is None:
-                try:
-                    self.niFgen_SetAttributeViBoolean_cfunc = self._library.niFgen_SetAttributeViBoolean
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_SetAttributeViBoolean was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_SetAttributeViBoolean_cfunc = self._get_library_function('niFgen_SetAttributeViBoolean')
                 self.niFgen_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViBoolean]  # noqa: F405
                 self.niFgen_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -822,12 +550,7 @@ class Library(object):
     def niFgen_SetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFgen_SetAttributeViInt32_cfunc is None:
-                try:
-                    self.niFgen_SetAttributeViInt32_cfunc = self._library.niFgen_SetAttributeViInt32
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_SetAttributeViInt32 was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_SetAttributeViInt32_cfunc = self._get_library_function('niFgen_SetAttributeViInt32')
                 self.niFgen_SetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32]  # noqa: F405
                 self.niFgen_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -835,12 +558,7 @@ class Library(object):
     def niFgen_SetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFgen_SetAttributeViReal64_cfunc is None:
-                try:
-                    self.niFgen_SetAttributeViReal64_cfunc = self._library.niFgen_SetAttributeViReal64
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_SetAttributeViReal64 was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_SetAttributeViReal64_cfunc = self._get_library_function('niFgen_SetAttributeViReal64')
                 self.niFgen_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niFgen_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -848,12 +566,7 @@ class Library(object):
     def niFgen_SetAttributeViString(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFgen_SetAttributeViString_cfunc is None:
-                try:
-                    self.niFgen_SetAttributeViString_cfunc = self._library.niFgen_SetAttributeViString
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_SetAttributeViString was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_SetAttributeViString_cfunc = self._get_library_function('niFgen_SetAttributeViString')
                 self.niFgen_SetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SetAttributeViString_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -861,12 +574,7 @@ class Library(object):
     def niFgen_SetNamedWaveformNextWritePosition(self, vi, channel_name, waveform_name, relative_to, offset):  # noqa: N802
         with self._func_lock:
             if self.niFgen_SetNamedWaveformNextWritePosition_cfunc is None:
-                try:
-                    self.niFgen_SetNamedWaveformNextWritePosition_cfunc = self._library.niFgen_SetNamedWaveformNextWritePosition
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_SetNamedWaveformNextWritePosition was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_SetNamedWaveformNextWritePosition_cfunc = self._get_library_function('niFgen_SetNamedWaveformNextWritePosition')
                 self.niFgen_SetNamedWaveformNextWritePosition_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViInt32]  # noqa: F405
                 self.niFgen_SetNamedWaveformNextWritePosition_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SetNamedWaveformNextWritePosition_cfunc(vi, channel_name, waveform_name, relative_to, offset)
@@ -874,12 +582,7 @@ class Library(object):
     def niFgen_SetWaveformNextWritePosition(self, vi, channel_name, waveform_handle, relative_to, offset):  # noqa: N802
         with self._func_lock:
             if self.niFgen_SetWaveformNextWritePosition_cfunc is None:
-                try:
-                    self.niFgen_SetWaveformNextWritePosition_cfunc = self._library.niFgen_SetWaveformNextWritePosition
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_SetWaveformNextWritePosition was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_SetWaveformNextWritePosition_cfunc = self._get_library_function('niFgen_SetWaveformNextWritePosition')
                 self.niFgen_SetWaveformNextWritePosition_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViInt32, ViInt32]  # noqa: F405
                 self.niFgen_SetWaveformNextWritePosition_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SetWaveformNextWritePosition_cfunc(vi, channel_name, waveform_handle, relative_to, offset)
@@ -887,12 +590,7 @@ class Library(object):
     def niFgen_UnlockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niFgen_UnlockSession_cfunc is None:
-                try:
-                    self.niFgen_UnlockSession_cfunc = self._library.niFgen_UnlockSession
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_UnlockSession was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_UnlockSession_cfunc = self._get_library_function('niFgen_UnlockSession')
                 self.niFgen_UnlockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFgen_UnlockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_UnlockSession_cfunc(vi, caller_has_lock)
@@ -900,12 +598,7 @@ class Library(object):
     def niFgen_WaitUntilDone(self, vi, max_time):  # noqa: N802
         with self._func_lock:
             if self.niFgen_WaitUntilDone_cfunc is None:
-                try:
-                    self.niFgen_WaitUntilDone_cfunc = self._library.niFgen_WaitUntilDone
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_WaitUntilDone was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_WaitUntilDone_cfunc = self._get_library_function('niFgen_WaitUntilDone')
                 self.niFgen_WaitUntilDone_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niFgen_WaitUntilDone_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_WaitUntilDone_cfunc(vi, max_time)
@@ -913,12 +606,7 @@ class Library(object):
     def niFgen_WriteBinary16Waveform(self, vi, channel_name, waveform_handle, size, data):  # noqa: N802
         with self._func_lock:
             if self.niFgen_WriteBinary16Waveform_cfunc is None:
-                try:
-                    self.niFgen_WriteBinary16Waveform_cfunc = self._library.niFgen_WriteBinary16Waveform
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_WriteBinary16Waveform was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_WriteBinary16Waveform_cfunc = self._get_library_function('niFgen_WriteBinary16Waveform')
                 self.niFgen_WriteBinary16Waveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViInt32, ctypes.POINTER(ViInt16)]  # noqa: F405
                 self.niFgen_WriteBinary16Waveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_WriteBinary16Waveform_cfunc(vi, channel_name, waveform_handle, size, data)
@@ -926,12 +614,7 @@ class Library(object):
     def niFgen_WriteNamedWaveformF64(self, vi, channel_name, waveform_name, size, data):  # noqa: N802
         with self._func_lock:
             if self.niFgen_WriteNamedWaveformF64_cfunc is None:
-                try:
-                    self.niFgen_WriteNamedWaveformF64_cfunc = self._library.niFgen_WriteNamedWaveformF64
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_WriteNamedWaveformF64 was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_WriteNamedWaveformF64_cfunc = self._get_library_function('niFgen_WriteNamedWaveformF64')
                 self.niFgen_WriteNamedWaveformF64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_WriteNamedWaveformF64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_WriteNamedWaveformF64_cfunc(vi, channel_name, waveform_name, size, data)
@@ -939,12 +622,7 @@ class Library(object):
     def niFgen_WriteNamedWaveformI16(self, vi, channel_name, waveform_name, size, data):  # noqa: N802
         with self._func_lock:
             if self.niFgen_WriteNamedWaveformI16_cfunc is None:
-                try:
-                    self.niFgen_WriteNamedWaveformI16_cfunc = self._library.niFgen_WriteNamedWaveformI16
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_WriteNamedWaveformI16 was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_WriteNamedWaveformI16_cfunc = self._get_library_function('niFgen_WriteNamedWaveformI16')
                 self.niFgen_WriteNamedWaveformI16_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt16)]  # noqa: F405
                 self.niFgen_WriteNamedWaveformI16_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_WriteNamedWaveformI16_cfunc(vi, channel_name, waveform_name, size, data)
@@ -952,12 +630,7 @@ class Library(object):
     def niFgen_WriteScript(self, vi, channel_name, script):  # noqa: N802
         with self._func_lock:
             if self.niFgen_WriteScript_cfunc is None:
-                try:
-                    self.niFgen_WriteScript_cfunc = self._library.niFgen_WriteScript
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_WriteScript was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_WriteScript_cfunc = self._get_library_function('niFgen_WriteScript')
                 self.niFgen_WriteScript_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_WriteScript_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_WriteScript_cfunc(vi, channel_name, script)
@@ -965,12 +638,7 @@ class Library(object):
     def niFgen_WriteWaveform(self, vi, channel_name, waveform_handle, size, data):  # noqa: N802
         with self._func_lock:
             if self.niFgen_WriteWaveform_cfunc is None:
-                try:
-                    self.niFgen_WriteWaveform_cfunc = self._library.niFgen_WriteWaveform
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_WriteWaveform was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_WriteWaveform_cfunc = self._get_library_function('niFgen_WriteWaveform')
                 self.niFgen_WriteWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_WriteWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_WriteWaveform_cfunc(vi, channel_name, waveform_handle, size, data)
@@ -978,12 +646,7 @@ class Library(object):
     def niFgen_close(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFgen_close_cfunc is None:
-                try:
-                    self.niFgen_close_cfunc = self._library.niFgen_close
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_close was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_close_cfunc = self._get_library_function('niFgen_close')
                 self.niFgen_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_close_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_close_cfunc(vi)
@@ -991,12 +654,7 @@ class Library(object):
     def niFgen_error_message(self, vi, error_code, error_message):  # noqa: N802
         with self._func_lock:
             if self.niFgen_error_message_cfunc is None:
-                try:
-                    self.niFgen_error_message_cfunc = self._library.niFgen_error_message
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_error_message was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_error_message_cfunc = self._get_library_function('niFgen_error_message')
                 self.niFgen_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_error_message_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_error_message_cfunc(vi, error_code, error_message)
@@ -1004,12 +662,7 @@ class Library(object):
     def niFgen_reset(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFgen_reset_cfunc is None:
-                try:
-                    self.niFgen_reset_cfunc = self._library.niFgen_reset
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_reset was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_reset_cfunc = self._get_library_function('niFgen_reset')
                 self.niFgen_reset_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_reset_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_reset_cfunc(vi)
@@ -1017,12 +670,7 @@ class Library(object):
     def niFgen_self_test(self, vi, self_test_result, self_test_message):  # noqa: N802
         with self._func_lock:
             if self.niFgen_self_test_cfunc is None:
-                try:
-                    self.niFgen_self_test_cfunc = self._library.niFgen_self_test
-                except AttributeError as e:
-                    raise AttributeError("Function niFgen_self_test was not found in the NI-FGEN runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niFgen_self_test_cfunc = self._get_library_function('niFgen_self_test')
                 self.niFgen_self_test_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_self_test_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_self_test_cfunc(vi, self_test_result, self_test_message)

--- a/generated/nifgen/nifgen/_library.py
+++ b/generated/nifgen/nifgen/_library.py
@@ -94,7 +94,7 @@ class Library(object):
 
     def _get_library_function(self, name):
         try:
-            function = getattr(self._library, 'fred')
+            function = getattr(self._library, name)
         except AttributeError as e:
             raise errors.DriverTooOldError() from e
         return function

--- a/generated/nifgen/nifgen/_library.py
+++ b/generated/nifgen/nifgen/_library.py
@@ -94,7 +94,12 @@ class Library(object):
     def niFgen_AbortGeneration(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFgen_AbortGeneration_cfunc is None:
-                self.niFgen_AbortGeneration_cfunc = self._library.niFgen_AbortGeneration
+                try:
+                    self.niFgen_AbortGeneration_cfunc = self._library.niFgen_AbortGeneration
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_AbortGeneration_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_AbortGeneration_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_AbortGeneration_cfunc(vi)
@@ -102,7 +107,12 @@ class Library(object):
     def niFgen_AllocateNamedWaveform(self, vi, channel_name, waveform_name, waveform_size):  # noqa: N802
         with self._func_lock:
             if self.niFgen_AllocateNamedWaveform_cfunc is None:
-                self.niFgen_AllocateNamedWaveform_cfunc = self._library.niFgen_AllocateNamedWaveform
+                try:
+                    self.niFgen_AllocateNamedWaveform_cfunc = self._library.niFgen_AllocateNamedWaveform
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_AllocateNamedWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niFgen_AllocateNamedWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_AllocateNamedWaveform_cfunc(vi, channel_name, waveform_name, waveform_size)
@@ -110,7 +120,12 @@ class Library(object):
     def niFgen_AllocateWaveform(self, vi, channel_name, waveform_size, waveform_handle):  # noqa: N802
         with self._func_lock:
             if self.niFgen_AllocateWaveform_cfunc is None:
-                self.niFgen_AllocateWaveform_cfunc = self._library.niFgen_AllocateWaveform
+                try:
+                    self.niFgen_AllocateWaveform_cfunc = self._library.niFgen_AllocateWaveform
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_AllocateWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_AllocateWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_AllocateWaveform_cfunc(vi, channel_name, waveform_size, waveform_handle)
@@ -118,7 +133,12 @@ class Library(object):
     def niFgen_ClearArbMemory(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ClearArbMemory_cfunc is None:
-                self.niFgen_ClearArbMemory_cfunc = self._library.niFgen_ClearArbMemory
+                try:
+                    self.niFgen_ClearArbMemory_cfunc = self._library.niFgen_ClearArbMemory
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_ClearArbMemory_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_ClearArbMemory_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ClearArbMemory_cfunc(vi)
@@ -126,7 +146,12 @@ class Library(object):
     def niFgen_ClearArbSequence(self, vi, sequence_handle):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ClearArbSequence_cfunc is None:
-                self.niFgen_ClearArbSequence_cfunc = self._library.niFgen_ClearArbSequence
+                try:
+                    self.niFgen_ClearArbSequence_cfunc = self._library.niFgen_ClearArbSequence
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_ClearArbSequence_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niFgen_ClearArbSequence_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ClearArbSequence_cfunc(vi, sequence_handle)
@@ -134,7 +159,12 @@ class Library(object):
     def niFgen_ClearArbWaveform(self, vi, waveform_handle):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ClearArbWaveform_cfunc is None:
-                self.niFgen_ClearArbWaveform_cfunc = self._library.niFgen_ClearArbWaveform
+                try:
+                    self.niFgen_ClearArbWaveform_cfunc = self._library.niFgen_ClearArbWaveform
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_ClearArbWaveform_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niFgen_ClearArbWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ClearArbWaveform_cfunc(vi, waveform_handle)
@@ -142,7 +172,12 @@ class Library(object):
     def niFgen_ClearFreqList(self, vi, frequency_list_handle):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ClearFreqList_cfunc is None:
-                self.niFgen_ClearFreqList_cfunc = self._library.niFgen_ClearFreqList
+                try:
+                    self.niFgen_ClearFreqList_cfunc = self._library.niFgen_ClearFreqList
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_ClearFreqList_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niFgen_ClearFreqList_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ClearFreqList_cfunc(vi, frequency_list_handle)
@@ -150,7 +185,12 @@ class Library(object):
     def niFgen_ClearUserStandardWaveform(self, vi, channel_name):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ClearUserStandardWaveform_cfunc is None:
-                self.niFgen_ClearUserStandardWaveform_cfunc = self._library.niFgen_ClearUserStandardWaveform
+                try:
+                    self.niFgen_ClearUserStandardWaveform_cfunc = self._library.niFgen_ClearUserStandardWaveform
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_ClearUserStandardWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_ClearUserStandardWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ClearUserStandardWaveform_cfunc(vi, channel_name)
@@ -158,7 +198,12 @@ class Library(object):
     def niFgen_Commit(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFgen_Commit_cfunc is None:
-                self.niFgen_Commit_cfunc = self._library.niFgen_Commit
+                try:
+                    self.niFgen_Commit_cfunc = self._library.niFgen_Commit
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_Commit_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_Commit_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_Commit_cfunc(vi)
@@ -166,7 +211,12 @@ class Library(object):
     def niFgen_ConfigureArbSequence(self, vi, channel_name, sequence_handle, gain, offset):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ConfigureArbSequence_cfunc is None:
-                self.niFgen_ConfigureArbSequence_cfunc = self._library.niFgen_ConfigureArbSequence
+                try:
+                    self.niFgen_ConfigureArbSequence_cfunc = self._library.niFgen_ConfigureArbSequence
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_ConfigureArbSequence_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niFgen_ConfigureArbSequence_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ConfigureArbSequence_cfunc(vi, channel_name, sequence_handle, gain, offset)
@@ -174,7 +224,12 @@ class Library(object):
     def niFgen_ConfigureArbWaveform(self, vi, channel_name, waveform_handle, gain, offset):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ConfigureArbWaveform_cfunc is None:
-                self.niFgen_ConfigureArbWaveform_cfunc = self._library.niFgen_ConfigureArbWaveform
+                try:
+                    self.niFgen_ConfigureArbWaveform_cfunc = self._library.niFgen_ConfigureArbWaveform
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_ConfigureArbWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niFgen_ConfigureArbWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ConfigureArbWaveform_cfunc(vi, channel_name, waveform_handle, gain, offset)
@@ -182,7 +237,12 @@ class Library(object):
     def niFgen_ConfigureFreqList(self, vi, channel_name, frequency_list_handle, amplitude, dc_offset, start_phase):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ConfigureFreqList_cfunc is None:
-                self.niFgen_ConfigureFreqList_cfunc = self._library.niFgen_ConfigureFreqList
+                try:
+                    self.niFgen_ConfigureFreqList_cfunc = self._library.niFgen_ConfigureFreqList
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_ConfigureFreqList_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niFgen_ConfigureFreqList_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ConfigureFreqList_cfunc(vi, channel_name, frequency_list_handle, amplitude, dc_offset, start_phase)
@@ -190,7 +250,12 @@ class Library(object):
     def niFgen_ConfigureStandardWaveform(self, vi, channel_name, waveform, amplitude, dc_offset, frequency, start_phase):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ConfigureStandardWaveform_cfunc is None:
-                self.niFgen_ConfigureStandardWaveform_cfunc = self._library.niFgen_ConfigureStandardWaveform
+                try:
+                    self.niFgen_ConfigureStandardWaveform_cfunc = self._library.niFgen_ConfigureStandardWaveform
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_ConfigureStandardWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViReal64, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niFgen_ConfigureStandardWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ConfigureStandardWaveform_cfunc(vi, channel_name, waveform, amplitude, dc_offset, frequency, start_phase)
@@ -198,7 +263,12 @@ class Library(object):
     def niFgen_CreateAdvancedArbSequence(self, vi, sequence_length, waveform_handles_array, loop_counts_array, sample_counts_array, marker_location_array, coerced_markers_array, sequence_handle):  # noqa: N802
         with self._func_lock:
             if self.niFgen_CreateAdvancedArbSequence_cfunc is None:
-                self.niFgen_CreateAdvancedArbSequence_cfunc = self._library.niFgen_CreateAdvancedArbSequence
+                try:
+                    self.niFgen_CreateAdvancedArbSequence_cfunc = self._library.niFgen_CreateAdvancedArbSequence
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_CreateAdvancedArbSequence_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_CreateAdvancedArbSequence_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_CreateAdvancedArbSequence_cfunc(vi, sequence_length, waveform_handles_array, loop_counts_array, sample_counts_array, marker_location_array, coerced_markers_array, sequence_handle)
@@ -206,7 +276,12 @@ class Library(object):
     def niFgen_CreateArbSequence(self, vi, sequence_length, waveform_handles_array, loop_counts_array, sequence_handle):  # noqa: N802
         with self._func_lock:
             if self.niFgen_CreateArbSequence_cfunc is None:
-                self.niFgen_CreateArbSequence_cfunc = self._library.niFgen_CreateArbSequence
+                try:
+                    self.niFgen_CreateArbSequence_cfunc = self._library.niFgen_CreateArbSequence
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_CreateArbSequence_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_CreateArbSequence_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_CreateArbSequence_cfunc(vi, sequence_length, waveform_handles_array, loop_counts_array, sequence_handle)
@@ -214,7 +289,12 @@ class Library(object):
     def niFgen_CreateFreqList(self, vi, waveform, frequency_list_length, frequency_array, duration_array, frequency_list_handle):  # noqa: N802
         with self._func_lock:
             if self.niFgen_CreateFreqList_cfunc is None:
-                self.niFgen_CreateFreqList_cfunc = self._library.niFgen_CreateFreqList
+                try:
+                    self.niFgen_CreateFreqList_cfunc = self._library.niFgen_CreateFreqList
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_CreateFreqList_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_CreateFreqList_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_CreateFreqList_cfunc(vi, waveform, frequency_list_length, frequency_array, duration_array, frequency_list_handle)
@@ -222,7 +302,12 @@ class Library(object):
     def niFgen_CreateWaveformF64(self, vi, channel_name, waveform_size, waveform_data_array, waveform_handle):  # noqa: N802
         with self._func_lock:
             if self.niFgen_CreateWaveformF64_cfunc is None:
-                self.niFgen_CreateWaveformF64_cfunc = self._library.niFgen_CreateWaveformF64
+                try:
+                    self.niFgen_CreateWaveformF64_cfunc = self._library.niFgen_CreateWaveformF64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_CreateWaveformF64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_CreateWaveformF64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_CreateWaveformF64_cfunc(vi, channel_name, waveform_size, waveform_data_array, waveform_handle)
@@ -230,7 +315,12 @@ class Library(object):
     def niFgen_CreateWaveformFromFileF64(self, vi, channel_name, file_name, byte_order, waveform_handle):  # noqa: N802
         with self._func_lock:
             if self.niFgen_CreateWaveformFromFileF64_cfunc is None:
-                self.niFgen_CreateWaveformFromFileF64_cfunc = self._library.niFgen_CreateWaveformFromFileF64
+                try:
+                    self.niFgen_CreateWaveformFromFileF64_cfunc = self._library.niFgen_CreateWaveformFromFileF64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_CreateWaveformFromFileF64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_CreateWaveformFromFileF64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_CreateWaveformFromFileF64_cfunc(vi, channel_name, file_name, byte_order, waveform_handle)
@@ -238,7 +328,12 @@ class Library(object):
     def niFgen_CreateWaveformFromFileI16(self, vi, channel_name, file_name, byte_order, waveform_handle):  # noqa: N802
         with self._func_lock:
             if self.niFgen_CreateWaveformFromFileI16_cfunc is None:
-                self.niFgen_CreateWaveformFromFileI16_cfunc = self._library.niFgen_CreateWaveformFromFileI16
+                try:
+                    self.niFgen_CreateWaveformFromFileI16_cfunc = self._library.niFgen_CreateWaveformFromFileI16
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_CreateWaveformFromFileI16_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_CreateWaveformFromFileI16_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_CreateWaveformFromFileI16_cfunc(vi, channel_name, file_name, byte_order, waveform_handle)
@@ -246,7 +341,12 @@ class Library(object):
     def niFgen_CreateWaveformI16(self, vi, channel_name, waveform_size, waveform_data_array, waveform_handle):  # noqa: N802
         with self._func_lock:
             if self.niFgen_CreateWaveformI16_cfunc is None:
-                self.niFgen_CreateWaveformI16_cfunc = self._library.niFgen_CreateWaveformI16
+                try:
+                    self.niFgen_CreateWaveformI16_cfunc = self._library.niFgen_CreateWaveformI16
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_CreateWaveformI16_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt16), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_CreateWaveformI16_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_CreateWaveformI16_cfunc(vi, channel_name, waveform_size, waveform_data_array, waveform_handle)
@@ -254,7 +354,12 @@ class Library(object):
     def niFgen_DefineUserStandardWaveform(self, vi, channel_name, waveform_size, waveform_data_array):  # noqa: N802
         with self._func_lock:
             if self.niFgen_DefineUserStandardWaveform_cfunc is None:
-                self.niFgen_DefineUserStandardWaveform_cfunc = self._library.niFgen_DefineUserStandardWaveform
+                try:
+                    self.niFgen_DefineUserStandardWaveform_cfunc = self._library.niFgen_DefineUserStandardWaveform
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_DefineUserStandardWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_DefineUserStandardWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_DefineUserStandardWaveform_cfunc(vi, channel_name, waveform_size, waveform_data_array)
@@ -262,7 +367,12 @@ class Library(object):
     def niFgen_DeleteNamedWaveform(self, vi, channel_name, waveform_name):  # noqa: N802
         with self._func_lock:
             if self.niFgen_DeleteNamedWaveform_cfunc is None:
-                self.niFgen_DeleteNamedWaveform_cfunc = self._library.niFgen_DeleteNamedWaveform
+                try:
+                    self.niFgen_DeleteNamedWaveform_cfunc = self._library.niFgen_DeleteNamedWaveform
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_DeleteNamedWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_DeleteNamedWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_DeleteNamedWaveform_cfunc(vi, channel_name, waveform_name)
@@ -270,7 +380,12 @@ class Library(object):
     def niFgen_DeleteScript(self, vi, channel_name, script_name):  # noqa: N802
         with self._func_lock:
             if self.niFgen_DeleteScript_cfunc is None:
-                self.niFgen_DeleteScript_cfunc = self._library.niFgen_DeleteScript
+                try:
+                    self.niFgen_DeleteScript_cfunc = self._library.niFgen_DeleteScript
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_DeleteScript_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_DeleteScript_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_DeleteScript_cfunc(vi, channel_name, script_name)
@@ -278,7 +393,12 @@ class Library(object):
     def niFgen_Disable(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFgen_Disable_cfunc is None:
-                self.niFgen_Disable_cfunc = self._library.niFgen_Disable
+                try:
+                    self.niFgen_Disable_cfunc = self._library.niFgen_Disable
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_Disable_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_Disable_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_Disable_cfunc(vi)
@@ -286,7 +406,12 @@ class Library(object):
     def niFgen_ExportAttributeConfigurationBuffer(self, vi, size_in_bytes, configuration):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ExportAttributeConfigurationBuffer_cfunc is None:
-                self.niFgen_ExportAttributeConfigurationBuffer_cfunc = self._library.niFgen_ExportAttributeConfigurationBuffer
+                try:
+                    self.niFgen_ExportAttributeConfigurationBuffer_cfunc = self._library.niFgen_ExportAttributeConfigurationBuffer
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_ExportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niFgen_ExportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ExportAttributeConfigurationBuffer_cfunc(vi, size_in_bytes, configuration)
@@ -294,7 +419,12 @@ class Library(object):
     def niFgen_ExportAttributeConfigurationFile(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ExportAttributeConfigurationFile_cfunc is None:
-                self.niFgen_ExportAttributeConfigurationFile_cfunc = self._library.niFgen_ExportAttributeConfigurationFile
+                try:
+                    self.niFgen_ExportAttributeConfigurationFile_cfunc = self._library.niFgen_ExportAttributeConfigurationFile
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_ExportAttributeConfigurationFile_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_ExportAttributeConfigurationFile_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ExportAttributeConfigurationFile_cfunc(vi, file_path)
@@ -302,7 +432,12 @@ class Library(object):
     def niFgen_GetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetAttributeViBoolean_cfunc is None:
-                self.niFgen_GetAttributeViBoolean_cfunc = self._library.niFgen_GetAttributeViBoolean
+                try:
+                    self.niFgen_GetAttributeViBoolean_cfunc = self._library.niFgen_GetAttributeViBoolean
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFgen_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -310,7 +445,12 @@ class Library(object):
     def niFgen_GetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetAttributeViInt32_cfunc is None:
-                self.niFgen_GetAttributeViInt32_cfunc = self._library.niFgen_GetAttributeViInt32
+                try:
+                    self.niFgen_GetAttributeViInt32_cfunc = self._library.niFgen_GetAttributeViInt32
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_GetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -318,7 +458,12 @@ class Library(object):
     def niFgen_GetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetAttributeViReal64_cfunc is None:
-                self.niFgen_GetAttributeViReal64_cfunc = self._library.niFgen_GetAttributeViReal64
+                try:
+                    self.niFgen_GetAttributeViReal64_cfunc = self._library.niFgen_GetAttributeViReal64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_GetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -326,7 +471,12 @@ class Library(object):
     def niFgen_GetAttributeViString(self, vi, channel_name, attribute_id, array_size, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetAttributeViString_cfunc is None:
-                self.niFgen_GetAttributeViString_cfunc = self._library.niFgen_GetAttributeViString
+                try:
+                    self.niFgen_GetAttributeViString_cfunc = self._library.niFgen_GetAttributeViString
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetAttributeViString_cfunc(vi, channel_name, attribute_id, array_size, attribute_value)
@@ -334,7 +484,12 @@ class Library(object):
     def niFgen_GetChannelName(self, vi, index, buffer_size, channel_string):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetChannelName_cfunc is None:
-                self.niFgen_GetChannelName_cfunc = self._library.niFgen_GetChannelName
+                try:
+                    self.niFgen_GetChannelName_cfunc = self._library.niFgen_GetChannelName
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_GetChannelName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_GetChannelName_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetChannelName_cfunc(vi, index, buffer_size, channel_string)
@@ -342,7 +497,12 @@ class Library(object):
     def niFgen_GetError(self, vi, error_code, error_description_buffer_size, error_description):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetError_cfunc is None:
-                self.niFgen_GetError_cfunc = self._library.niFgen_GetError
+                try:
+                    self.niFgen_GetError_cfunc = self._library.niFgen_GetError
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_GetError_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetError_cfunc(vi, error_code, error_description_buffer_size, error_description)
@@ -350,7 +510,12 @@ class Library(object):
     def niFgen_GetExtCalLastDateAndTime(self, vi, year, month, day, hour, minute):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetExtCalLastDateAndTime_cfunc is None:
-                self.niFgen_GetExtCalLastDateAndTime_cfunc = self._library.niFgen_GetExtCalLastDateAndTime
+                try:
+                    self.niFgen_GetExtCalLastDateAndTime_cfunc = self._library.niFgen_GetExtCalLastDateAndTime
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_GetExtCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_GetExtCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetExtCalLastDateAndTime_cfunc(vi, year, month, day, hour, minute)
@@ -358,7 +523,12 @@ class Library(object):
     def niFgen_GetExtCalLastTemp(self, vi, temperature):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetExtCalLastTemp_cfunc is None:
-                self.niFgen_GetExtCalLastTemp_cfunc = self._library.niFgen_GetExtCalLastTemp
+                try:
+                    self.niFgen_GetExtCalLastTemp_cfunc = self._library.niFgen_GetExtCalLastTemp
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_GetExtCalLastTemp_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_GetExtCalLastTemp_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetExtCalLastTemp_cfunc(vi, temperature)
@@ -366,7 +536,12 @@ class Library(object):
     def niFgen_GetExtCalRecommendedInterval(self, vi, months):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetExtCalRecommendedInterval_cfunc is None:
-                self.niFgen_GetExtCalRecommendedInterval_cfunc = self._library.niFgen_GetExtCalRecommendedInterval
+                try:
+                    self.niFgen_GetExtCalRecommendedInterval_cfunc = self._library.niFgen_GetExtCalRecommendedInterval
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_GetExtCalRecommendedInterval_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_GetExtCalRecommendedInterval_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetExtCalRecommendedInterval_cfunc(vi, months)
@@ -374,7 +549,12 @@ class Library(object):
     def niFgen_GetHardwareState(self, vi, state):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetHardwareState_cfunc is None:
-                self.niFgen_GetHardwareState_cfunc = self._library.niFgen_GetHardwareState
+                try:
+                    self.niFgen_GetHardwareState_cfunc = self._library.niFgen_GetHardwareState
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_GetHardwareState_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_GetHardwareState_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetHardwareState_cfunc(vi, state)
@@ -382,7 +562,12 @@ class Library(object):
     def niFgen_GetLastExtCalLastDateAndTime(self, vi, month):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetLastExtCalLastDateAndTime_cfunc is None:
-                self.niFgen_GetLastExtCalLastDateAndTime_cfunc = self._library.niFgen_GetLastExtCalLastDateAndTime
+                try:
+                    self.niFgen_GetLastExtCalLastDateAndTime_cfunc = self._library.niFgen_GetLastExtCalLastDateAndTime
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_GetLastExtCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(hightime.datetime)]  # noqa: F405
                 self.niFgen_GetLastExtCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetLastExtCalLastDateAndTime_cfunc(vi, month)
@@ -390,7 +575,12 @@ class Library(object):
     def niFgen_GetLastSelfCalLastDateAndTime(self, vi, month):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetLastSelfCalLastDateAndTime_cfunc is None:
-                self.niFgen_GetLastSelfCalLastDateAndTime_cfunc = self._library.niFgen_GetLastSelfCalLastDateAndTime
+                try:
+                    self.niFgen_GetLastSelfCalLastDateAndTime_cfunc = self._library.niFgen_GetLastSelfCalLastDateAndTime
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_GetLastSelfCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(hightime.datetime)]  # noqa: F405
                 self.niFgen_GetLastSelfCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetLastSelfCalLastDateAndTime_cfunc(vi, month)
@@ -398,7 +588,12 @@ class Library(object):
     def niFgen_GetSelfCalLastDateAndTime(self, vi, year, month, day, hour, minute):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetSelfCalLastDateAndTime_cfunc is None:
-                self.niFgen_GetSelfCalLastDateAndTime_cfunc = self._library.niFgen_GetSelfCalLastDateAndTime
+                try:
+                    self.niFgen_GetSelfCalLastDateAndTime_cfunc = self._library.niFgen_GetSelfCalLastDateAndTime
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_GetSelfCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_GetSelfCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetSelfCalLastDateAndTime_cfunc(vi, year, month, day, hour, minute)
@@ -406,7 +601,12 @@ class Library(object):
     def niFgen_GetSelfCalLastTemp(self, vi, temperature):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetSelfCalLastTemp_cfunc is None:
-                self.niFgen_GetSelfCalLastTemp_cfunc = self._library.niFgen_GetSelfCalLastTemp
+                try:
+                    self.niFgen_GetSelfCalLastTemp_cfunc = self._library.niFgen_GetSelfCalLastTemp
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_GetSelfCalLastTemp_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_GetSelfCalLastTemp_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetSelfCalLastTemp_cfunc(vi, temperature)
@@ -414,7 +614,12 @@ class Library(object):
     def niFgen_GetSelfCalSupported(self, vi, self_cal_supported):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetSelfCalSupported_cfunc is None:
-                self.niFgen_GetSelfCalSupported_cfunc = self._library.niFgen_GetSelfCalSupported
+                try:
+                    self.niFgen_GetSelfCalSupported_cfunc = self._library.niFgen_GetSelfCalSupported
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_GetSelfCalSupported_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFgen_GetSelfCalSupported_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetSelfCalSupported_cfunc(vi, self_cal_supported)
@@ -422,7 +627,12 @@ class Library(object):
     def niFgen_ImportAttributeConfigurationBuffer(self, vi, size_in_bytes, configuration):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ImportAttributeConfigurationBuffer_cfunc is None:
-                self.niFgen_ImportAttributeConfigurationBuffer_cfunc = self._library.niFgen_ImportAttributeConfigurationBuffer
+                try:
+                    self.niFgen_ImportAttributeConfigurationBuffer_cfunc = self._library.niFgen_ImportAttributeConfigurationBuffer
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_ImportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niFgen_ImportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ImportAttributeConfigurationBuffer_cfunc(vi, size_in_bytes, configuration)
@@ -430,7 +640,12 @@ class Library(object):
     def niFgen_ImportAttributeConfigurationFile(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ImportAttributeConfigurationFile_cfunc is None:
-                self.niFgen_ImportAttributeConfigurationFile_cfunc = self._library.niFgen_ImportAttributeConfigurationFile
+                try:
+                    self.niFgen_ImportAttributeConfigurationFile_cfunc = self._library.niFgen_ImportAttributeConfigurationFile
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_ImportAttributeConfigurationFile_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_ImportAttributeConfigurationFile_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ImportAttributeConfigurationFile_cfunc(vi, file_path)
@@ -438,7 +653,12 @@ class Library(object):
     def niFgen_InitializeWithChannels(self, resource_name, channel_name, reset_device, option_string, vi):  # noqa: N802
         with self._func_lock:
             if self.niFgen_InitializeWithChannels_cfunc is None:
-                self.niFgen_InitializeWithChannels_cfunc = self._library.niFgen_InitializeWithChannels
+                try:
+                    self.niFgen_InitializeWithChannels_cfunc = self._library.niFgen_InitializeWithChannels
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_InitializeWithChannels_cfunc.argtypes = [ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViBoolean, ctypes.POINTER(ViChar), ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niFgen_InitializeWithChannels_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_InitializeWithChannels_cfunc(resource_name, channel_name, reset_device, option_string, vi)
@@ -446,7 +666,12 @@ class Library(object):
     def niFgen_InitiateGeneration(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFgen_InitiateGeneration_cfunc is None:
-                self.niFgen_InitiateGeneration_cfunc = self._library.niFgen_InitiateGeneration
+                try:
+                    self.niFgen_InitiateGeneration_cfunc = self._library.niFgen_InitiateGeneration
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_InitiateGeneration_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_InitiateGeneration_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_InitiateGeneration_cfunc(vi)
@@ -454,7 +679,12 @@ class Library(object):
     def niFgen_IsDone(self, vi, done):  # noqa: N802
         with self._func_lock:
             if self.niFgen_IsDone_cfunc is None:
-                self.niFgen_IsDone_cfunc = self._library.niFgen_IsDone
+                try:
+                    self.niFgen_IsDone_cfunc = self._library.niFgen_IsDone
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_IsDone_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFgen_IsDone_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_IsDone_cfunc(vi, done)
@@ -462,7 +692,12 @@ class Library(object):
     def niFgen_LockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niFgen_LockSession_cfunc is None:
-                self.niFgen_LockSession_cfunc = self._library.niFgen_LockSession
+                try:
+                    self.niFgen_LockSession_cfunc = self._library.niFgen_LockSession
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_LockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFgen_LockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_LockSession_cfunc(vi, caller_has_lock)
@@ -470,7 +705,12 @@ class Library(object):
     def niFgen_QueryArbSeqCapabilities(self, vi, maximum_number_of_sequences, minimum_sequence_length, maximum_sequence_length, maximum_loop_count):  # noqa: N802
         with self._func_lock:
             if self.niFgen_QueryArbSeqCapabilities_cfunc is None:
-                self.niFgen_QueryArbSeqCapabilities_cfunc = self._library.niFgen_QueryArbSeqCapabilities
+                try:
+                    self.niFgen_QueryArbSeqCapabilities_cfunc = self._library.niFgen_QueryArbSeqCapabilities
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_QueryArbSeqCapabilities_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_QueryArbSeqCapabilities_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_QueryArbSeqCapabilities_cfunc(vi, maximum_number_of_sequences, minimum_sequence_length, maximum_sequence_length, maximum_loop_count)
@@ -478,7 +718,12 @@ class Library(object):
     def niFgen_QueryArbWfmCapabilities(self, vi, maximum_number_of_waveforms, waveform_quantum, minimum_waveform_size, maximum_waveform_size):  # noqa: N802
         with self._func_lock:
             if self.niFgen_QueryArbWfmCapabilities_cfunc is None:
-                self.niFgen_QueryArbWfmCapabilities_cfunc = self._library.niFgen_QueryArbWfmCapabilities
+                try:
+                    self.niFgen_QueryArbWfmCapabilities_cfunc = self._library.niFgen_QueryArbWfmCapabilities
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_QueryArbWfmCapabilities_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_QueryArbWfmCapabilities_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_QueryArbWfmCapabilities_cfunc(vi, maximum_number_of_waveforms, waveform_quantum, minimum_waveform_size, maximum_waveform_size)
@@ -486,7 +731,12 @@ class Library(object):
     def niFgen_QueryFreqListCapabilities(self, vi, maximum_number_of_freq_lists, minimum_frequency_list_length, maximum_frequency_list_length, minimum_frequency_list_duration, maximum_frequency_list_duration, frequency_list_duration_quantum):  # noqa: N802
         with self._func_lock:
             if self.niFgen_QueryFreqListCapabilities_cfunc is None:
-                self.niFgen_QueryFreqListCapabilities_cfunc = self._library.niFgen_QueryFreqListCapabilities
+                try:
+                    self.niFgen_QueryFreqListCapabilities_cfunc = self._library.niFgen_QueryFreqListCapabilities
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_QueryFreqListCapabilities_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_QueryFreqListCapabilities_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_QueryFreqListCapabilities_cfunc(vi, maximum_number_of_freq_lists, minimum_frequency_list_length, maximum_frequency_list_length, minimum_frequency_list_duration, maximum_frequency_list_duration, frequency_list_duration_quantum)
@@ -494,7 +744,12 @@ class Library(object):
     def niFgen_ReadCurrentTemperature(self, vi, temperature):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ReadCurrentTemperature_cfunc is None:
-                self.niFgen_ReadCurrentTemperature_cfunc = self._library.niFgen_ReadCurrentTemperature
+                try:
+                    self.niFgen_ReadCurrentTemperature_cfunc = self._library.niFgen_ReadCurrentTemperature
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_ReadCurrentTemperature_cfunc.argtypes = [ViSession, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_ReadCurrentTemperature_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ReadCurrentTemperature_cfunc(vi, temperature)
@@ -502,7 +757,12 @@ class Library(object):
     def niFgen_ResetDevice(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ResetDevice_cfunc is None:
-                self.niFgen_ResetDevice_cfunc = self._library.niFgen_ResetDevice
+                try:
+                    self.niFgen_ResetDevice_cfunc = self._library.niFgen_ResetDevice
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_ResetDevice_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_ResetDevice_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ResetDevice_cfunc(vi)
@@ -510,7 +770,12 @@ class Library(object):
     def niFgen_ResetWithDefaults(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFgen_ResetWithDefaults_cfunc is None:
-                self.niFgen_ResetWithDefaults_cfunc = self._library.niFgen_ResetWithDefaults
+                try:
+                    self.niFgen_ResetWithDefaults_cfunc = self._library.niFgen_ResetWithDefaults
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_ResetWithDefaults_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_ResetWithDefaults_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_ResetWithDefaults_cfunc(vi)
@@ -518,7 +783,12 @@ class Library(object):
     def niFgen_SelfCal(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFgen_SelfCal_cfunc is None:
-                self.niFgen_SelfCal_cfunc = self._library.niFgen_SelfCal
+                try:
+                    self.niFgen_SelfCal_cfunc = self._library.niFgen_SelfCal
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_SelfCal_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_SelfCal_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SelfCal_cfunc(vi)
@@ -526,7 +796,12 @@ class Library(object):
     def niFgen_SendSoftwareEdgeTrigger(self, vi, trigger, trigger_id):  # noqa: N802
         with self._func_lock:
             if self.niFgen_SendSoftwareEdgeTrigger_cfunc is None:
-                self.niFgen_SendSoftwareEdgeTrigger_cfunc = self._library.niFgen_SendSoftwareEdgeTrigger
+                try:
+                    self.niFgen_SendSoftwareEdgeTrigger_cfunc = self._library.niFgen_SendSoftwareEdgeTrigger
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_SendSoftwareEdgeTrigger_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_SendSoftwareEdgeTrigger_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SendSoftwareEdgeTrigger_cfunc(vi, trigger, trigger_id)
@@ -534,7 +809,12 @@ class Library(object):
     def niFgen_SetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFgen_SetAttributeViBoolean_cfunc is None:
-                self.niFgen_SetAttributeViBoolean_cfunc = self._library.niFgen_SetAttributeViBoolean
+                try:
+                    self.niFgen_SetAttributeViBoolean_cfunc = self._library.niFgen_SetAttributeViBoolean
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViBoolean]  # noqa: F405
                 self.niFgen_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -542,7 +822,12 @@ class Library(object):
     def niFgen_SetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFgen_SetAttributeViInt32_cfunc is None:
-                self.niFgen_SetAttributeViInt32_cfunc = self._library.niFgen_SetAttributeViInt32
+                try:
+                    self.niFgen_SetAttributeViInt32_cfunc = self._library.niFgen_SetAttributeViInt32
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_SetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32]  # noqa: F405
                 self.niFgen_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -550,7 +835,12 @@ class Library(object):
     def niFgen_SetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFgen_SetAttributeViReal64_cfunc is None:
-                self.niFgen_SetAttributeViReal64_cfunc = self._library.niFgen_SetAttributeViReal64
+                try:
+                    self.niFgen_SetAttributeViReal64_cfunc = self._library.niFgen_SetAttributeViReal64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niFgen_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -558,7 +848,12 @@ class Library(object):
     def niFgen_SetAttributeViString(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niFgen_SetAttributeViString_cfunc is None:
-                self.niFgen_SetAttributeViString_cfunc = self._library.niFgen_SetAttributeViString
+                try:
+                    self.niFgen_SetAttributeViString_cfunc = self._library.niFgen_SetAttributeViString
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_SetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SetAttributeViString_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -566,7 +861,12 @@ class Library(object):
     def niFgen_SetNamedWaveformNextWritePosition(self, vi, channel_name, waveform_name, relative_to, offset):  # noqa: N802
         with self._func_lock:
             if self.niFgen_SetNamedWaveformNextWritePosition_cfunc is None:
-                self.niFgen_SetNamedWaveformNextWritePosition_cfunc = self._library.niFgen_SetNamedWaveformNextWritePosition
+                try:
+                    self.niFgen_SetNamedWaveformNextWritePosition_cfunc = self._library.niFgen_SetNamedWaveformNextWritePosition
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_SetNamedWaveformNextWritePosition_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViInt32]  # noqa: F405
                 self.niFgen_SetNamedWaveformNextWritePosition_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SetNamedWaveformNextWritePosition_cfunc(vi, channel_name, waveform_name, relative_to, offset)
@@ -574,7 +874,12 @@ class Library(object):
     def niFgen_SetWaveformNextWritePosition(self, vi, channel_name, waveform_handle, relative_to, offset):  # noqa: N802
         with self._func_lock:
             if self.niFgen_SetWaveformNextWritePosition_cfunc is None:
-                self.niFgen_SetWaveformNextWritePosition_cfunc = self._library.niFgen_SetWaveformNextWritePosition
+                try:
+                    self.niFgen_SetWaveformNextWritePosition_cfunc = self._library.niFgen_SetWaveformNextWritePosition
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_SetWaveformNextWritePosition_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViInt32, ViInt32]  # noqa: F405
                 self.niFgen_SetWaveformNextWritePosition_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_SetWaveformNextWritePosition_cfunc(vi, channel_name, waveform_handle, relative_to, offset)
@@ -582,7 +887,12 @@ class Library(object):
     def niFgen_UnlockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niFgen_UnlockSession_cfunc is None:
-                self.niFgen_UnlockSession_cfunc = self._library.niFgen_UnlockSession
+                try:
+                    self.niFgen_UnlockSession_cfunc = self._library.niFgen_UnlockSession
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_UnlockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niFgen_UnlockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_UnlockSession_cfunc(vi, caller_has_lock)
@@ -590,7 +900,12 @@ class Library(object):
     def niFgen_WaitUntilDone(self, vi, max_time):  # noqa: N802
         with self._func_lock:
             if self.niFgen_WaitUntilDone_cfunc is None:
-                self.niFgen_WaitUntilDone_cfunc = self._library.niFgen_WaitUntilDone
+                try:
+                    self.niFgen_WaitUntilDone_cfunc = self._library.niFgen_WaitUntilDone
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_WaitUntilDone_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niFgen_WaitUntilDone_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_WaitUntilDone_cfunc(vi, max_time)
@@ -598,7 +913,12 @@ class Library(object):
     def niFgen_WriteBinary16Waveform(self, vi, channel_name, waveform_handle, size, data):  # noqa: N802
         with self._func_lock:
             if self.niFgen_WriteBinary16Waveform_cfunc is None:
-                self.niFgen_WriteBinary16Waveform_cfunc = self._library.niFgen_WriteBinary16Waveform
+                try:
+                    self.niFgen_WriteBinary16Waveform_cfunc = self._library.niFgen_WriteBinary16Waveform
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_WriteBinary16Waveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViInt32, ctypes.POINTER(ViInt16)]  # noqa: F405
                 self.niFgen_WriteBinary16Waveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_WriteBinary16Waveform_cfunc(vi, channel_name, waveform_handle, size, data)
@@ -606,7 +926,12 @@ class Library(object):
     def niFgen_WriteNamedWaveformF64(self, vi, channel_name, waveform_name, size, data):  # noqa: N802
         with self._func_lock:
             if self.niFgen_WriteNamedWaveformF64_cfunc is None:
-                self.niFgen_WriteNamedWaveformF64_cfunc = self._library.niFgen_WriteNamedWaveformF64
+                try:
+                    self.niFgen_WriteNamedWaveformF64_cfunc = self._library.niFgen_WriteNamedWaveformF64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_WriteNamedWaveformF64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_WriteNamedWaveformF64_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_WriteNamedWaveformF64_cfunc(vi, channel_name, waveform_name, size, data)
@@ -614,7 +939,12 @@ class Library(object):
     def niFgen_WriteNamedWaveformI16(self, vi, channel_name, waveform_name, size, data):  # noqa: N802
         with self._func_lock:
             if self.niFgen_WriteNamedWaveformI16_cfunc is None:
-                self.niFgen_WriteNamedWaveformI16_cfunc = self._library.niFgen_WriteNamedWaveformI16
+                try:
+                    self.niFgen_WriteNamedWaveformI16_cfunc = self._library.niFgen_WriteNamedWaveformI16
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_WriteNamedWaveformI16_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt16)]  # noqa: F405
                 self.niFgen_WriteNamedWaveformI16_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_WriteNamedWaveformI16_cfunc(vi, channel_name, waveform_name, size, data)
@@ -622,7 +952,12 @@ class Library(object):
     def niFgen_WriteScript(self, vi, channel_name, script):  # noqa: N802
         with self._func_lock:
             if self.niFgen_WriteScript_cfunc is None:
-                self.niFgen_WriteScript_cfunc = self._library.niFgen_WriteScript
+                try:
+                    self.niFgen_WriteScript_cfunc = self._library.niFgen_WriteScript
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_WriteScript_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_WriteScript_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_WriteScript_cfunc(vi, channel_name, script)
@@ -630,7 +965,12 @@ class Library(object):
     def niFgen_WriteWaveform(self, vi, channel_name, waveform_handle, size, data):  # noqa: N802
         with self._func_lock:
             if self.niFgen_WriteWaveform_cfunc is None:
-                self.niFgen_WriteWaveform_cfunc = self._library.niFgen_WriteWaveform
+                try:
+                    self.niFgen_WriteWaveform_cfunc = self._library.niFgen_WriteWaveform
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_WriteWaveform_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niFgen_WriteWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_WriteWaveform_cfunc(vi, channel_name, waveform_handle, size, data)
@@ -638,7 +978,12 @@ class Library(object):
     def niFgen_close(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFgen_close_cfunc is None:
-                self.niFgen_close_cfunc = self._library.niFgen_close
+                try:
+                    self.niFgen_close_cfunc = self._library.niFgen_close
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_close_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_close_cfunc(vi)
@@ -646,7 +991,12 @@ class Library(object):
     def niFgen_error_message(self, vi, error_code, error_message):  # noqa: N802
         with self._func_lock:
             if self.niFgen_error_message_cfunc is None:
-                self.niFgen_error_message_cfunc = self._library.niFgen_error_message
+                try:
+                    self.niFgen_error_message_cfunc = self._library.niFgen_error_message
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_error_message_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_error_message_cfunc(vi, error_code, error_message)
@@ -654,7 +1004,12 @@ class Library(object):
     def niFgen_reset(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niFgen_reset_cfunc is None:
-                self.niFgen_reset_cfunc = self._library.niFgen_reset
+                try:
+                    self.niFgen_reset_cfunc = self._library.niFgen_reset
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_reset_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niFgen_reset_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_reset_cfunc(vi)
@@ -662,7 +1017,12 @@ class Library(object):
     def niFgen_self_test(self, vi, self_test_result, self_test_message):  # noqa: N802
         with self._func_lock:
             if self.niFgen_self_test_cfunc is None:
-                self.niFgen_self_test_cfunc = self._library.niFgen_self_test
+                try:
+                    self.niFgen_self_test_cfunc = self._library.niFgen_self_test
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niFgen_self_test_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niFgen_self_test_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_self_test_cfunc(vi, self_test_result, self_test_message)

--- a/generated/nifgen/nifgen/errors.py
+++ b/generated/nifgen/nifgen/errors.py
@@ -57,6 +57,13 @@ class DriverNotInstalledError(Error):
         super(DriverNotInstalledError, self).__init__('The NI-FGEN runtime could not be loaded. Make sure it is installed and its bitness matches that of your Python interpreter. Please visit http://www.ni.com/downloads/drivers/ to download and install it.')
 
 
+class DriverTooOldError(Error):
+    '''An error due to using this module with an older version of the driver runtime.'''
+
+    def __init__(self):
+        super(DriverTooOldError, self).__init__('A function was not found in the NI-FGEN runtime. Please visit http://www.ni.com/downloads/drivers/ to download a newer version and install it.')
+
+
 class InvalidRepeatedCapabilityError(Error):
     '''An error due to an invalid character in a repeated capability'''
 

--- a/generated/nimodinst/nimodinst/_library.py
+++ b/generated/nimodinst/nimodinst/_library.py
@@ -30,9 +30,9 @@ class Library(object):
                 try:
                     self.niModInst_CloseInstalledDevicesSession_cfunc = self._library.niModInst_CloseInstalledDevicesSession
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niModInst_CloseInstalledDevicesSession was not found in the NI-ModInst runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niModInst_CloseInstalledDevicesSession_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niModInst_CloseInstalledDevicesSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niModInst_CloseInstalledDevicesSession_cfunc(handle)
@@ -43,9 +43,9 @@ class Library(object):
                 try:
                     self.niModInst_GetExtendedErrorInfo_cfunc = self._library.niModInst_GetExtendedErrorInfo
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niModInst_GetExtendedErrorInfo was not found in the NI-ModInst runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niModInst_GetExtendedErrorInfo_cfunc.argtypes = [ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niModInst_GetExtendedErrorInfo_cfunc.restype = ViStatus  # noqa: F405
         return self.niModInst_GetExtendedErrorInfo_cfunc(error_info_buffer_size, error_info)
@@ -56,9 +56,9 @@ class Library(object):
                 try:
                     self.niModInst_GetInstalledDeviceAttributeViInt32_cfunc = self._library.niModInst_GetInstalledDeviceAttributeViInt32
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niModInst_GetInstalledDeviceAttributeViInt32 was not found in the NI-ModInst runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niModInst_GetInstalledDeviceAttributeViInt32_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niModInst_GetInstalledDeviceAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niModInst_GetInstalledDeviceAttributeViInt32_cfunc(handle, index, attribute_id, attribute_value)
@@ -69,9 +69,9 @@ class Library(object):
                 try:
                     self.niModInst_GetInstalledDeviceAttributeViString_cfunc = self._library.niModInst_GetInstalledDeviceAttributeViString
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niModInst_GetInstalledDeviceAttributeViString was not found in the NI-ModInst runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niModInst_GetInstalledDeviceAttributeViString_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niModInst_GetInstalledDeviceAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niModInst_GetInstalledDeviceAttributeViString_cfunc(handle, index, attribute_id, attribute_value_buffer_size, attribute_value)
@@ -82,9 +82,9 @@ class Library(object):
                 try:
                     self.niModInst_OpenInstalledDevicesSession_cfunc = self._library.niModInst_OpenInstalledDevicesSession
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niModInst_OpenInstalledDevicesSession was not found in the NI-ModInst runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niModInst_OpenInstalledDevicesSession_cfunc.argtypes = [ctypes.POINTER(ViChar), ctypes.POINTER(ViSession), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niModInst_OpenInstalledDevicesSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niModInst_OpenInstalledDevicesSession_cfunc(driver, handle, device_count)

--- a/generated/nimodinst/nimodinst/_library.py
+++ b/generated/nimodinst/nimodinst/_library.py
@@ -2,6 +2,7 @@
 # This file was generated
 
 import ctypes
+import nimodinst.errors as errors
 import threading
 
 from nimodinst._visatype import *  # noqa: F403,H303
@@ -24,15 +25,17 @@ class Library(object):
         self.niModInst_GetInstalledDeviceAttributeViString_cfunc = None
         self.niModInst_OpenInstalledDevicesSession_cfunc = None
 
+    def _get_library_function(self, name):
+        try:
+            function = getattr(self._library, 'fred')
+        except AttributeError as e:
+            raise errors.DriverTooOldError() from e
+        return function
+
     def niModInst_CloseInstalledDevicesSession(self, handle):  # noqa: N802
         with self._func_lock:
             if self.niModInst_CloseInstalledDevicesSession_cfunc is None:
-                try:
-                    self.niModInst_CloseInstalledDevicesSession_cfunc = self._library.niModInst_CloseInstalledDevicesSession
-                except AttributeError as e:
-                    raise AttributeError("Function niModInst_CloseInstalledDevicesSession was not found in the NI-ModInst runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niModInst_CloseInstalledDevicesSession_cfunc = self._get_library_function('niModInst_CloseInstalledDevicesSession')
                 self.niModInst_CloseInstalledDevicesSession_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niModInst_CloseInstalledDevicesSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niModInst_CloseInstalledDevicesSession_cfunc(handle)
@@ -40,12 +43,7 @@ class Library(object):
     def niModInst_GetExtendedErrorInfo(self, error_info_buffer_size, error_info):  # noqa: N802
         with self._func_lock:
             if self.niModInst_GetExtendedErrorInfo_cfunc is None:
-                try:
-                    self.niModInst_GetExtendedErrorInfo_cfunc = self._library.niModInst_GetExtendedErrorInfo
-                except AttributeError as e:
-                    raise AttributeError("Function niModInst_GetExtendedErrorInfo was not found in the NI-ModInst runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niModInst_GetExtendedErrorInfo_cfunc = self._get_library_function('niModInst_GetExtendedErrorInfo')
                 self.niModInst_GetExtendedErrorInfo_cfunc.argtypes = [ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niModInst_GetExtendedErrorInfo_cfunc.restype = ViStatus  # noqa: F405
         return self.niModInst_GetExtendedErrorInfo_cfunc(error_info_buffer_size, error_info)
@@ -53,12 +51,7 @@ class Library(object):
     def niModInst_GetInstalledDeviceAttributeViInt32(self, handle, index, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niModInst_GetInstalledDeviceAttributeViInt32_cfunc is None:
-                try:
-                    self.niModInst_GetInstalledDeviceAttributeViInt32_cfunc = self._library.niModInst_GetInstalledDeviceAttributeViInt32
-                except AttributeError as e:
-                    raise AttributeError("Function niModInst_GetInstalledDeviceAttributeViInt32 was not found in the NI-ModInst runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niModInst_GetInstalledDeviceAttributeViInt32_cfunc = self._get_library_function('niModInst_GetInstalledDeviceAttributeViInt32')
                 self.niModInst_GetInstalledDeviceAttributeViInt32_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niModInst_GetInstalledDeviceAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niModInst_GetInstalledDeviceAttributeViInt32_cfunc(handle, index, attribute_id, attribute_value)
@@ -66,12 +59,7 @@ class Library(object):
     def niModInst_GetInstalledDeviceAttributeViString(self, handle, index, attribute_id, attribute_value_buffer_size, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niModInst_GetInstalledDeviceAttributeViString_cfunc is None:
-                try:
-                    self.niModInst_GetInstalledDeviceAttributeViString_cfunc = self._library.niModInst_GetInstalledDeviceAttributeViString
-                except AttributeError as e:
-                    raise AttributeError("Function niModInst_GetInstalledDeviceAttributeViString was not found in the NI-ModInst runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niModInst_GetInstalledDeviceAttributeViString_cfunc = self._get_library_function('niModInst_GetInstalledDeviceAttributeViString')
                 self.niModInst_GetInstalledDeviceAttributeViString_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niModInst_GetInstalledDeviceAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niModInst_GetInstalledDeviceAttributeViString_cfunc(handle, index, attribute_id, attribute_value_buffer_size, attribute_value)
@@ -79,12 +67,7 @@ class Library(object):
     def niModInst_OpenInstalledDevicesSession(self, driver, handle, device_count):  # noqa: N802
         with self._func_lock:
             if self.niModInst_OpenInstalledDevicesSession_cfunc is None:
-                try:
-                    self.niModInst_OpenInstalledDevicesSession_cfunc = self._library.niModInst_OpenInstalledDevicesSession
-                except AttributeError as e:
-                    raise AttributeError("Function niModInst_OpenInstalledDevicesSession was not found in the NI-ModInst runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niModInst_OpenInstalledDevicesSession_cfunc = self._get_library_function('niModInst_OpenInstalledDevicesSession')
                 self.niModInst_OpenInstalledDevicesSession_cfunc.argtypes = [ctypes.POINTER(ViChar), ctypes.POINTER(ViSession), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niModInst_OpenInstalledDevicesSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niModInst_OpenInstalledDevicesSession_cfunc(driver, handle, device_count)

--- a/generated/nimodinst/nimodinst/_library.py
+++ b/generated/nimodinst/nimodinst/_library.py
@@ -27,7 +27,12 @@ class Library(object):
     def niModInst_CloseInstalledDevicesSession(self, handle):  # noqa: N802
         with self._func_lock:
             if self.niModInst_CloseInstalledDevicesSession_cfunc is None:
-                self.niModInst_CloseInstalledDevicesSession_cfunc = self._library.niModInst_CloseInstalledDevicesSession
+                try:
+                    self.niModInst_CloseInstalledDevicesSession_cfunc = self._library.niModInst_CloseInstalledDevicesSession
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niModInst_CloseInstalledDevicesSession_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niModInst_CloseInstalledDevicesSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niModInst_CloseInstalledDevicesSession_cfunc(handle)
@@ -35,7 +40,12 @@ class Library(object):
     def niModInst_GetExtendedErrorInfo(self, error_info_buffer_size, error_info):  # noqa: N802
         with self._func_lock:
             if self.niModInst_GetExtendedErrorInfo_cfunc is None:
-                self.niModInst_GetExtendedErrorInfo_cfunc = self._library.niModInst_GetExtendedErrorInfo
+                try:
+                    self.niModInst_GetExtendedErrorInfo_cfunc = self._library.niModInst_GetExtendedErrorInfo
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niModInst_GetExtendedErrorInfo_cfunc.argtypes = [ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niModInst_GetExtendedErrorInfo_cfunc.restype = ViStatus  # noqa: F405
         return self.niModInst_GetExtendedErrorInfo_cfunc(error_info_buffer_size, error_info)
@@ -43,7 +53,12 @@ class Library(object):
     def niModInst_GetInstalledDeviceAttributeViInt32(self, handle, index, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niModInst_GetInstalledDeviceAttributeViInt32_cfunc is None:
-                self.niModInst_GetInstalledDeviceAttributeViInt32_cfunc = self._library.niModInst_GetInstalledDeviceAttributeViInt32
+                try:
+                    self.niModInst_GetInstalledDeviceAttributeViInt32_cfunc = self._library.niModInst_GetInstalledDeviceAttributeViInt32
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niModInst_GetInstalledDeviceAttributeViInt32_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niModInst_GetInstalledDeviceAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niModInst_GetInstalledDeviceAttributeViInt32_cfunc(handle, index, attribute_id, attribute_value)
@@ -51,7 +66,12 @@ class Library(object):
     def niModInst_GetInstalledDeviceAttributeViString(self, handle, index, attribute_id, attribute_value_buffer_size, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niModInst_GetInstalledDeviceAttributeViString_cfunc is None:
-                self.niModInst_GetInstalledDeviceAttributeViString_cfunc = self._library.niModInst_GetInstalledDeviceAttributeViString
+                try:
+                    self.niModInst_GetInstalledDeviceAttributeViString_cfunc = self._library.niModInst_GetInstalledDeviceAttributeViString
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niModInst_GetInstalledDeviceAttributeViString_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niModInst_GetInstalledDeviceAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niModInst_GetInstalledDeviceAttributeViString_cfunc(handle, index, attribute_id, attribute_value_buffer_size, attribute_value)
@@ -59,7 +79,12 @@ class Library(object):
     def niModInst_OpenInstalledDevicesSession(self, driver, handle, device_count):  # noqa: N802
         with self._func_lock:
             if self.niModInst_OpenInstalledDevicesSession_cfunc is None:
-                self.niModInst_OpenInstalledDevicesSession_cfunc = self._library.niModInst_OpenInstalledDevicesSession
+                try:
+                    self.niModInst_OpenInstalledDevicesSession_cfunc = self._library.niModInst_OpenInstalledDevicesSession
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niModInst_OpenInstalledDevicesSession_cfunc.argtypes = [ctypes.POINTER(ViChar), ctypes.POINTER(ViSession), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niModInst_OpenInstalledDevicesSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niModInst_OpenInstalledDevicesSession_cfunc(driver, handle, device_count)

--- a/generated/nimodinst/nimodinst/_library.py
+++ b/generated/nimodinst/nimodinst/_library.py
@@ -27,7 +27,7 @@ class Library(object):
 
     def _get_library_function(self, name):
         try:
-            function = getattr(self._library, 'fred')
+            function = getattr(self._library, name)
         except AttributeError as e:
             raise errors.DriverTooOldError() from e
         return function

--- a/generated/nimodinst/nimodinst/errors.py
+++ b/generated/nimodinst/nimodinst/errors.py
@@ -57,6 +57,13 @@ class DriverNotInstalledError(Error):
         super(DriverNotInstalledError, self).__init__('The NI-ModInst runtime could not be loaded. Make sure it is installed and its bitness matches that of your Python interpreter. Please visit http://www.ni.com/downloads/drivers/ to download and install it.')
 
 
+class DriverTooOldError(Error):
+    '''An error due to using this module with an older version of the driver runtime.'''
+
+    def __init__(self):
+        super(DriverTooOldError, self).__init__('A function was not found in the NI-ModInst runtime. Please visit http://www.ni.com/downloads/drivers/ to download a newer version and install it.')
+
+
 def handle_error(session, code, ignore_warnings, is_error_handling):
     '''handle_error
 

--- a/generated/niscope/niscope/_library.py
+++ b/generated/niscope/niscope/_library.py
@@ -87,7 +87,7 @@ class Library(object):
 
     def _get_library_function(self, name):
         try:
-            function = getattr(self._library, 'fred')
+            function = getattr(self._library, name)
         except AttributeError as e:
             raise errors.DriverTooOldError() from e
         return function

--- a/generated/niscope/niscope/_library.py
+++ b/generated/niscope/niscope/_library.py
@@ -87,7 +87,12 @@ class Library(object):
     def niScope_Abort(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_Abort_cfunc is None:
-                self.niScope_Abort_cfunc = self._library.niScope_Abort
+                try:
+                    self.niScope_Abort_cfunc = self._library.niScope_Abort
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_Abort_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_Abort_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_Abort_cfunc(vi)
@@ -95,7 +100,12 @@ class Library(object):
     def niScope_AcquisitionStatus(self, vi, acquisition_status):  # noqa: N802
         with self._func_lock:
             if self.niScope_AcquisitionStatus_cfunc is None:
-                self.niScope_AcquisitionStatus_cfunc = self._library.niScope_AcquisitionStatus
+                try:
+                    self.niScope_AcquisitionStatus_cfunc = self._library.niScope_AcquisitionStatus
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_AcquisitionStatus_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niScope_AcquisitionStatus_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_AcquisitionStatus_cfunc(vi, acquisition_status)
@@ -103,7 +113,12 @@ class Library(object):
     def niScope_ActualMeasWfmSize(self, vi, array_meas_function, meas_waveform_size):  # noqa: N802
         with self._func_lock:
             if self.niScope_ActualMeasWfmSize_cfunc is None:
-                self.niScope_ActualMeasWfmSize_cfunc = self._library.niScope_ActualMeasWfmSize
+                try:
+                    self.niScope_ActualMeasWfmSize_cfunc = self._library.niScope_ActualMeasWfmSize
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_ActualMeasWfmSize_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niScope_ActualMeasWfmSize_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ActualMeasWfmSize_cfunc(vi, array_meas_function, meas_waveform_size)
@@ -111,7 +126,12 @@ class Library(object):
     def niScope_ActualNumWfms(self, vi, channel_list, num_wfms):  # noqa: N802
         with self._func_lock:
             if self.niScope_ActualNumWfms_cfunc is None:
-                self.niScope_ActualNumWfms_cfunc = self._library.niScope_ActualNumWfms
+                try:
+                    self.niScope_ActualNumWfms_cfunc = self._library.niScope_ActualNumWfms
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_ActualNumWfms_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niScope_ActualNumWfms_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ActualNumWfms_cfunc(vi, channel_list, num_wfms)
@@ -119,7 +139,12 @@ class Library(object):
     def niScope_AddWaveformProcessing(self, vi, channel_list, meas_function):  # noqa: N802
         with self._func_lock:
             if self.niScope_AddWaveformProcessing_cfunc is None:
-                self.niScope_AddWaveformProcessing_cfunc = self._library.niScope_AddWaveformProcessing
+                try:
+                    self.niScope_AddWaveformProcessing_cfunc = self._library.niScope_AddWaveformProcessing
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_AddWaveformProcessing_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niScope_AddWaveformProcessing_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_AddWaveformProcessing_cfunc(vi, channel_list, meas_function)
@@ -127,7 +152,12 @@ class Library(object):
     def niScope_AutoSetup(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_AutoSetup_cfunc is None:
-                self.niScope_AutoSetup_cfunc = self._library.niScope_AutoSetup
+                try:
+                    self.niScope_AutoSetup_cfunc = self._library.niScope_AutoSetup
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_AutoSetup_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_AutoSetup_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_AutoSetup_cfunc(vi)
@@ -135,7 +165,12 @@ class Library(object):
     def niScope_CalFetchDate(self, vi, which_one, year, month, day):  # noqa: N802
         with self._func_lock:
             if self.niScope_CalFetchDate_cfunc is None:
-                self.niScope_CalFetchDate_cfunc = self._library.niScope_CalFetchDate
+                try:
+                    self.niScope_CalFetchDate_cfunc = self._library.niScope_CalFetchDate
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_CalFetchDate_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niScope_CalFetchDate_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_CalFetchDate_cfunc(vi, which_one, year, month, day)
@@ -143,7 +178,12 @@ class Library(object):
     def niScope_CalFetchTemperature(self, vi, which_one, temperature):  # noqa: N802
         with self._func_lock:
             if self.niScope_CalFetchTemperature_cfunc is None:
-                self.niScope_CalFetchTemperature_cfunc = self._library.niScope_CalFetchTemperature
+                try:
+                    self.niScope_CalFetchTemperature_cfunc = self._library.niScope_CalFetchTemperature
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_CalFetchTemperature_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niScope_CalFetchTemperature_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_CalFetchTemperature_cfunc(vi, which_one, temperature)
@@ -151,7 +191,12 @@ class Library(object):
     def niScope_CalSelfCalibrate(self, vi, channel_list, option):  # noqa: N802
         with self._func_lock:
             if self.niScope_CalSelfCalibrate_cfunc is None:
-                self.niScope_CalSelfCalibrate_cfunc = self._library.niScope_CalSelfCalibrate
+                try:
+                    self.niScope_CalSelfCalibrate_cfunc = self._library.niScope_CalSelfCalibrate
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_CalSelfCalibrate_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niScope_CalSelfCalibrate_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_CalSelfCalibrate_cfunc(vi, channel_list, option)
@@ -159,7 +204,12 @@ class Library(object):
     def niScope_ClearWaveformMeasurementStats(self, vi, channel_list, clearable_measurement_function):  # noqa: N802
         with self._func_lock:
             if self.niScope_ClearWaveformMeasurementStats_cfunc is None:
-                self.niScope_ClearWaveformMeasurementStats_cfunc = self._library.niScope_ClearWaveformMeasurementStats
+                try:
+                    self.niScope_ClearWaveformMeasurementStats_cfunc = self._library.niScope_ClearWaveformMeasurementStats
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_ClearWaveformMeasurementStats_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niScope_ClearWaveformMeasurementStats_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ClearWaveformMeasurementStats_cfunc(vi, channel_list, clearable_measurement_function)
@@ -167,7 +217,12 @@ class Library(object):
     def niScope_ClearWaveformProcessing(self, vi, channel_list):  # noqa: N802
         with self._func_lock:
             if self.niScope_ClearWaveformProcessing_cfunc is None:
-                self.niScope_ClearWaveformProcessing_cfunc = self._library.niScope_ClearWaveformProcessing
+                try:
+                    self.niScope_ClearWaveformProcessing_cfunc = self._library.niScope_ClearWaveformProcessing
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_ClearWaveformProcessing_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_ClearWaveformProcessing_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ClearWaveformProcessing_cfunc(vi, channel_list)
@@ -175,7 +230,12 @@ class Library(object):
     def niScope_Commit(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_Commit_cfunc is None:
-                self.niScope_Commit_cfunc = self._library.niScope_Commit
+                try:
+                    self.niScope_Commit_cfunc = self._library.niScope_Commit
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_Commit_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_Commit_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_Commit_cfunc(vi)
@@ -183,7 +243,12 @@ class Library(object):
     def niScope_ConfigureChanCharacteristics(self, vi, channel_list, input_impedance, max_input_frequency):  # noqa: N802
         with self._func_lock:
             if self.niScope_ConfigureChanCharacteristics_cfunc is None:
-                self.niScope_ConfigureChanCharacteristics_cfunc = self._library.niScope_ConfigureChanCharacteristics
+                try:
+                    self.niScope_ConfigureChanCharacteristics_cfunc = self._library.niScope_ConfigureChanCharacteristics
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_ConfigureChanCharacteristics_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViReal64]  # noqa: F405
                 self.niScope_ConfigureChanCharacteristics_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureChanCharacteristics_cfunc(vi, channel_list, input_impedance, max_input_frequency)
@@ -191,7 +256,12 @@ class Library(object):
     def niScope_ConfigureEqualizationFilterCoefficients(self, vi, channel_list, number_of_coefficients, coefficients):  # noqa: N802
         with self._func_lock:
             if self.niScope_ConfigureEqualizationFilterCoefficients_cfunc is None:
-                self.niScope_ConfigureEqualizationFilterCoefficients_cfunc = self._library.niScope_ConfigureEqualizationFilterCoefficients
+                try:
+                    self.niScope_ConfigureEqualizationFilterCoefficients_cfunc = self._library.niScope_ConfigureEqualizationFilterCoefficients
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_ConfigureEqualizationFilterCoefficients_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niScope_ConfigureEqualizationFilterCoefficients_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureEqualizationFilterCoefficients_cfunc(vi, channel_list, number_of_coefficients, coefficients)
@@ -199,7 +269,12 @@ class Library(object):
     def niScope_ConfigureHorizontalTiming(self, vi, min_sample_rate, min_num_pts, ref_position, num_records, enforce_realtime):  # noqa: N802
         with self._func_lock:
             if self.niScope_ConfigureHorizontalTiming_cfunc is None:
-                self.niScope_ConfigureHorizontalTiming_cfunc = self._library.niScope_ConfigureHorizontalTiming
+                try:
+                    self.niScope_ConfigureHorizontalTiming_cfunc = self._library.niScope_ConfigureHorizontalTiming
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_ConfigureHorizontalTiming_cfunc.argtypes = [ViSession, ViReal64, ViInt32, ViReal64, ViInt32, ViBoolean]  # noqa: F405
                 self.niScope_ConfigureHorizontalTiming_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureHorizontalTiming_cfunc(vi, min_sample_rate, min_num_pts, ref_position, num_records, enforce_realtime)
@@ -207,7 +282,12 @@ class Library(object):
     def niScope_ConfigureRefLevels(self, vi, low, mid, high):  # noqa: N802
         with self._func_lock:
             if self.niScope_ConfigureRefLevels_cfunc is None:
-                self.niScope_ConfigureRefLevels_cfunc = self._library.niScope_ConfigureRefLevels
+                try:
+                    self.niScope_ConfigureRefLevels_cfunc = self._library.niScope_ConfigureRefLevels
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_ConfigureRefLevels_cfunc.argtypes = [ViSession, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niScope_ConfigureRefLevels_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureRefLevels_cfunc(vi, low, mid, high)
@@ -215,7 +295,12 @@ class Library(object):
     def niScope_ConfigureTriggerDigital(self, vi, trigger_source, slope, holdoff, delay):  # noqa: N802
         with self._func_lock:
             if self.niScope_ConfigureTriggerDigital_cfunc is None:
-                self.niScope_ConfigureTriggerDigital_cfunc = self._library.niScope_ConfigureTriggerDigital
+                try:
+                    self.niScope_ConfigureTriggerDigital_cfunc = self._library.niScope_ConfigureTriggerDigital
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_ConfigureTriggerDigital_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niScope_ConfigureTriggerDigital_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureTriggerDigital_cfunc(vi, trigger_source, slope, holdoff, delay)
@@ -223,7 +308,12 @@ class Library(object):
     def niScope_ConfigureTriggerEdge(self, vi, trigger_source, level, slope, trigger_coupling, holdoff, delay):  # noqa: N802
         with self._func_lock:
             if self.niScope_ConfigureTriggerEdge_cfunc is None:
-                self.niScope_ConfigureTriggerEdge_cfunc = self._library.niScope_ConfigureTriggerEdge
+                try:
+                    self.niScope_ConfigureTriggerEdge_cfunc = self._library.niScope_ConfigureTriggerEdge
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_ConfigureTriggerEdge_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niScope_ConfigureTriggerEdge_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureTriggerEdge_cfunc(vi, trigger_source, level, slope, trigger_coupling, holdoff, delay)
@@ -231,7 +321,12 @@ class Library(object):
     def niScope_ConfigureTriggerHysteresis(self, vi, trigger_source, level, hysteresis, slope, trigger_coupling, holdoff, delay):  # noqa: N802
         with self._func_lock:
             if self.niScope_ConfigureTriggerHysteresis_cfunc is None:
-                self.niScope_ConfigureTriggerHysteresis_cfunc = self._library.niScope_ConfigureTriggerHysteresis
+                try:
+                    self.niScope_ConfigureTriggerHysteresis_cfunc = self._library.niScope_ConfigureTriggerHysteresis
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_ConfigureTriggerHysteresis_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViReal64, ViInt32, ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niScope_ConfigureTriggerHysteresis_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureTriggerHysteresis_cfunc(vi, trigger_source, level, hysteresis, slope, trigger_coupling, holdoff, delay)
@@ -239,7 +334,12 @@ class Library(object):
     def niScope_ConfigureTriggerImmediate(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_ConfigureTriggerImmediate_cfunc is None:
-                self.niScope_ConfigureTriggerImmediate_cfunc = self._library.niScope_ConfigureTriggerImmediate
+                try:
+                    self.niScope_ConfigureTriggerImmediate_cfunc = self._library.niScope_ConfigureTriggerImmediate
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_ConfigureTriggerImmediate_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_ConfigureTriggerImmediate_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureTriggerImmediate_cfunc(vi)
@@ -247,7 +347,12 @@ class Library(object):
     def niScope_ConfigureTriggerSoftware(self, vi, holdoff, delay):  # noqa: N802
         with self._func_lock:
             if self.niScope_ConfigureTriggerSoftware_cfunc is None:
-                self.niScope_ConfigureTriggerSoftware_cfunc = self._library.niScope_ConfigureTriggerSoftware
+                try:
+                    self.niScope_ConfigureTriggerSoftware_cfunc = self._library.niScope_ConfigureTriggerSoftware
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_ConfigureTriggerSoftware_cfunc.argtypes = [ViSession, ViReal64, ViReal64]  # noqa: F405
                 self.niScope_ConfigureTriggerSoftware_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureTriggerSoftware_cfunc(vi, holdoff, delay)
@@ -255,7 +360,12 @@ class Library(object):
     def niScope_ConfigureTriggerVideo(self, vi, trigger_source, enable_dc_restore, signal_format, event, line_number, polarity, trigger_coupling, holdoff, delay):  # noqa: N802
         with self._func_lock:
             if self.niScope_ConfigureTriggerVideo_cfunc is None:
-                self.niScope_ConfigureTriggerVideo_cfunc = self._library.niScope_ConfigureTriggerVideo
+                try:
+                    self.niScope_ConfigureTriggerVideo_cfunc = self._library.niScope_ConfigureTriggerVideo
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_ConfigureTriggerVideo_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViBoolean, ViInt32, ViInt32, ViInt32, ViInt32, ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niScope_ConfigureTriggerVideo_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureTriggerVideo_cfunc(vi, trigger_source, enable_dc_restore, signal_format, event, line_number, polarity, trigger_coupling, holdoff, delay)
@@ -263,7 +373,12 @@ class Library(object):
     def niScope_ConfigureTriggerWindow(self, vi, trigger_source, low_level, high_level, window_mode, trigger_coupling, holdoff, delay):  # noqa: N802
         with self._func_lock:
             if self.niScope_ConfigureTriggerWindow_cfunc is None:
-                self.niScope_ConfigureTriggerWindow_cfunc = self._library.niScope_ConfigureTriggerWindow
+                try:
+                    self.niScope_ConfigureTriggerWindow_cfunc = self._library.niScope_ConfigureTriggerWindow
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_ConfigureTriggerWindow_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViReal64, ViInt32, ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niScope_ConfigureTriggerWindow_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureTriggerWindow_cfunc(vi, trigger_source, low_level, high_level, window_mode, trigger_coupling, holdoff, delay)
@@ -271,7 +386,12 @@ class Library(object):
     def niScope_ConfigureVertical(self, vi, channel_list, range, offset, coupling, probe_attenuation, enabled):  # noqa: N802
         with self._func_lock:
             if self.niScope_ConfigureVertical_cfunc is None:
-                self.niScope_ConfigureVertical_cfunc = self._library.niScope_ConfigureVertical
+                try:
+                    self.niScope_ConfigureVertical_cfunc = self._library.niScope_ConfigureVertical
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_ConfigureVertical_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViReal64, ViInt32, ViReal64, ViBoolean]  # noqa: F405
                 self.niScope_ConfigureVertical_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureVertical_cfunc(vi, channel_list, range, offset, coupling, probe_attenuation, enabled)
@@ -279,7 +399,12 @@ class Library(object):
     def niScope_Disable(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_Disable_cfunc is None:
-                self.niScope_Disable_cfunc = self._library.niScope_Disable
+                try:
+                    self.niScope_Disable_cfunc = self._library.niScope_Disable
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_Disable_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_Disable_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_Disable_cfunc(vi)
@@ -287,7 +412,12 @@ class Library(object):
     def niScope_ExportAttributeConfigurationBuffer(self, vi, size_in_bytes, configuration):  # noqa: N802
         with self._func_lock:
             if self.niScope_ExportAttributeConfigurationBuffer_cfunc is None:
-                self.niScope_ExportAttributeConfigurationBuffer_cfunc = self._library.niScope_ExportAttributeConfigurationBuffer
+                try:
+                    self.niScope_ExportAttributeConfigurationBuffer_cfunc = self._library.niScope_ExportAttributeConfigurationBuffer
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_ExportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niScope_ExportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ExportAttributeConfigurationBuffer_cfunc(vi, size_in_bytes, configuration)
@@ -295,7 +425,12 @@ class Library(object):
     def niScope_ExportAttributeConfigurationFile(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niScope_ExportAttributeConfigurationFile_cfunc is None:
-                self.niScope_ExportAttributeConfigurationFile_cfunc = self._library.niScope_ExportAttributeConfigurationFile
+                try:
+                    self.niScope_ExportAttributeConfigurationFile_cfunc = self._library.niScope_ExportAttributeConfigurationFile
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_ExportAttributeConfigurationFile_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_ExportAttributeConfigurationFile_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ExportAttributeConfigurationFile_cfunc(vi, file_path)
@@ -303,7 +438,12 @@ class Library(object):
     def niScope_Fetch(self, vi, channel_list, timeout, num_samples, waveform, wfm_info):  # noqa: N802
         with self._func_lock:
             if self.niScope_Fetch_cfunc is None:
-                self.niScope_Fetch_cfunc = self._library.niScope_Fetch
+                try:
+                    self.niScope_Fetch_cfunc = self._library.niScope_Fetch
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_Fetch_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(waveform_info.struct_niScope_wfmInfo)]  # noqa: F405
                 self.niScope_Fetch_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_Fetch_cfunc(vi, channel_list, timeout, num_samples, waveform, wfm_info)
@@ -311,7 +451,12 @@ class Library(object):
     def niScope_FetchArrayMeasurement(self, vi, channel_list, timeout, array_meas_function, measurement_waveform_size, meas_wfm, wfm_info):  # noqa: N802
         with self._func_lock:
             if self.niScope_FetchArrayMeasurement_cfunc is None:
-                self.niScope_FetchArrayMeasurement_cfunc = self._library.niScope_FetchArrayMeasurement
+                try:
+                    self.niScope_FetchArrayMeasurement_cfunc = self._library.niScope_FetchArrayMeasurement
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_FetchArrayMeasurement_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(waveform_info.struct_niScope_wfmInfo)]  # noqa: F405
                 self.niScope_FetchArrayMeasurement_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_FetchArrayMeasurement_cfunc(vi, channel_list, timeout, array_meas_function, measurement_waveform_size, meas_wfm, wfm_info)
@@ -319,7 +464,12 @@ class Library(object):
     def niScope_FetchBinary16(self, vi, channel_list, timeout, num_samples, waveform, wfm_info):  # noqa: N802
         with self._func_lock:
             if self.niScope_FetchBinary16_cfunc is None:
-                self.niScope_FetchBinary16_cfunc = self._library.niScope_FetchBinary16
+                try:
+                    self.niScope_FetchBinary16_cfunc = self._library.niScope_FetchBinary16
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_FetchBinary16_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ctypes.POINTER(ViInt16), ctypes.POINTER(waveform_info.struct_niScope_wfmInfo)]  # noqa: F405
                 self.niScope_FetchBinary16_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_FetchBinary16_cfunc(vi, channel_list, timeout, num_samples, waveform, wfm_info)
@@ -327,7 +477,12 @@ class Library(object):
     def niScope_FetchBinary32(self, vi, channel_list, timeout, num_samples, waveform, wfm_info):  # noqa: N802
         with self._func_lock:
             if self.niScope_FetchBinary32_cfunc is None:
-                self.niScope_FetchBinary32_cfunc = self._library.niScope_FetchBinary32
+                try:
+                    self.niScope_FetchBinary32_cfunc = self._library.niScope_FetchBinary32
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_FetchBinary32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(waveform_info.struct_niScope_wfmInfo)]  # noqa: F405
                 self.niScope_FetchBinary32_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_FetchBinary32_cfunc(vi, channel_list, timeout, num_samples, waveform, wfm_info)
@@ -335,7 +490,12 @@ class Library(object):
     def niScope_FetchBinary8(self, vi, channel_list, timeout, num_samples, waveform, wfm_info):  # noqa: N802
         with self._func_lock:
             if self.niScope_FetchBinary8_cfunc is None:
-                self.niScope_FetchBinary8_cfunc = self._library.niScope_FetchBinary8
+                try:
+                    self.niScope_FetchBinary8_cfunc = self._library.niScope_FetchBinary8
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_FetchBinary8_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ctypes.POINTER(ViInt8), ctypes.POINTER(waveform_info.struct_niScope_wfmInfo)]  # noqa: F405
                 self.niScope_FetchBinary8_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_FetchBinary8_cfunc(vi, channel_list, timeout, num_samples, waveform, wfm_info)
@@ -343,7 +503,12 @@ class Library(object):
     def niScope_FetchMeasurementStats(self, vi, channel_list, timeout, scalar_meas_function, result, mean, stdev, min, max, num_in_stats):  # noqa: N802
         with self._func_lock:
             if self.niScope_FetchMeasurementStats_cfunc is None:
-                self.niScope_FetchMeasurementStats_cfunc = self._library.niScope_FetchMeasurementStats
+                try:
+                    self.niScope_FetchMeasurementStats_cfunc = self._library.niScope_FetchMeasurementStats
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_FetchMeasurementStats_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niScope_FetchMeasurementStats_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_FetchMeasurementStats_cfunc(vi, channel_list, timeout, scalar_meas_function, result, mean, stdev, min, max, num_in_stats)
@@ -351,7 +516,12 @@ class Library(object):
     def niScope_GetAttributeViBoolean(self, vi, channel_list, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niScope_GetAttributeViBoolean_cfunc is None:
-                self.niScope_GetAttributeViBoolean_cfunc = self._library.niScope_GetAttributeViBoolean
+                try:
+                    self.niScope_GetAttributeViBoolean_cfunc = self._library.niScope_GetAttributeViBoolean
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niScope_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_GetAttributeViBoolean_cfunc(vi, channel_list, attribute_id, value)
@@ -359,7 +529,12 @@ class Library(object):
     def niScope_GetAttributeViInt32(self, vi, channel_list, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niScope_GetAttributeViInt32_cfunc is None:
-                self.niScope_GetAttributeViInt32_cfunc = self._library.niScope_GetAttributeViInt32
+                try:
+                    self.niScope_GetAttributeViInt32_cfunc = self._library.niScope_GetAttributeViInt32
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_GetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niScope_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_GetAttributeViInt32_cfunc(vi, channel_list, attribute_id, value)
@@ -367,7 +542,12 @@ class Library(object):
     def niScope_GetAttributeViInt64(self, vi, channel_list, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niScope_GetAttributeViInt64_cfunc is None:
-                self.niScope_GetAttributeViInt64_cfunc = self._library.niScope_GetAttributeViInt64
+                try:
+                    self.niScope_GetAttributeViInt64_cfunc = self._library.niScope_GetAttributeViInt64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_GetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt64)]  # noqa: F405
                 self.niScope_GetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_GetAttributeViInt64_cfunc(vi, channel_list, attribute_id, value)
@@ -375,7 +555,12 @@ class Library(object):
     def niScope_GetAttributeViReal64(self, vi, channel_list, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niScope_GetAttributeViReal64_cfunc is None:
-                self.niScope_GetAttributeViReal64_cfunc = self._library.niScope_GetAttributeViReal64
+                try:
+                    self.niScope_GetAttributeViReal64_cfunc = self._library.niScope_GetAttributeViReal64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_GetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niScope_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_GetAttributeViReal64_cfunc(vi, channel_list, attribute_id, value)
@@ -383,7 +568,12 @@ class Library(object):
     def niScope_GetAttributeViString(self, vi, channel_list, attribute_id, buf_size, value):  # noqa: N802
         with self._func_lock:
             if self.niScope_GetAttributeViString_cfunc is None:
-                self.niScope_GetAttributeViString_cfunc = self._library.niScope_GetAttributeViString
+                try:
+                    self.niScope_GetAttributeViString_cfunc = self._library.niScope_GetAttributeViString
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_GetAttributeViString_cfunc(vi, channel_list, attribute_id, buf_size, value)
@@ -391,7 +581,12 @@ class Library(object):
     def niScope_GetEqualizationFilterCoefficients(self, vi, channel, number_of_coefficients, coefficients):  # noqa: N802
         with self._func_lock:
             if self.niScope_GetEqualizationFilterCoefficients_cfunc is None:
-                self.niScope_GetEqualizationFilterCoefficients_cfunc = self._library.niScope_GetEqualizationFilterCoefficients
+                try:
+                    self.niScope_GetEqualizationFilterCoefficients_cfunc = self._library.niScope_GetEqualizationFilterCoefficients
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_GetEqualizationFilterCoefficients_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niScope_GetEqualizationFilterCoefficients_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_GetEqualizationFilterCoefficients_cfunc(vi, channel, number_of_coefficients, coefficients)
@@ -399,7 +594,12 @@ class Library(object):
     def niScope_GetError(self, vi, error_code, buffer_size, description):  # noqa: N802
         with self._func_lock:
             if self.niScope_GetError_cfunc is None:
-                self.niScope_GetError_cfunc = self._library.niScope_GetError
+                try:
+                    self.niScope_GetError_cfunc = self._library.niScope_GetError
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_GetError_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_GetError_cfunc(vi, error_code, buffer_size, description)
@@ -407,7 +607,12 @@ class Library(object):
     def niScope_ImportAttributeConfigurationBuffer(self, vi, size_in_bytes, configuration):  # noqa: N802
         with self._func_lock:
             if self.niScope_ImportAttributeConfigurationBuffer_cfunc is None:
-                self.niScope_ImportAttributeConfigurationBuffer_cfunc = self._library.niScope_ImportAttributeConfigurationBuffer
+                try:
+                    self.niScope_ImportAttributeConfigurationBuffer_cfunc = self._library.niScope_ImportAttributeConfigurationBuffer
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_ImportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niScope_ImportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ImportAttributeConfigurationBuffer_cfunc(vi, size_in_bytes, configuration)
@@ -415,7 +620,12 @@ class Library(object):
     def niScope_ImportAttributeConfigurationFile(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niScope_ImportAttributeConfigurationFile_cfunc is None:
-                self.niScope_ImportAttributeConfigurationFile_cfunc = self._library.niScope_ImportAttributeConfigurationFile
+                try:
+                    self.niScope_ImportAttributeConfigurationFile_cfunc = self._library.niScope_ImportAttributeConfigurationFile
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_ImportAttributeConfigurationFile_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_ImportAttributeConfigurationFile_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ImportAttributeConfigurationFile_cfunc(vi, file_path)
@@ -423,7 +633,12 @@ class Library(object):
     def niScope_InitWithOptions(self, resource_name, id_query, reset_device, option_string, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_InitWithOptions_cfunc is None:
-                self.niScope_InitWithOptions_cfunc = self._library.niScope_InitWithOptions
+                try:
+                    self.niScope_InitWithOptions_cfunc = self._library.niScope_InitWithOptions
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_InitWithOptions_cfunc.argtypes = [ctypes.POINTER(ViChar), ViBoolean, ViBoolean, ctypes.POINTER(ViChar), ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niScope_InitWithOptions_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_InitWithOptions_cfunc(resource_name, id_query, reset_device, option_string, vi)
@@ -431,7 +646,12 @@ class Library(object):
     def niScope_InitiateAcquisition(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_InitiateAcquisition_cfunc is None:
-                self.niScope_InitiateAcquisition_cfunc = self._library.niScope_InitiateAcquisition
+                try:
+                    self.niScope_InitiateAcquisition_cfunc = self._library.niScope_InitiateAcquisition
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_InitiateAcquisition_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_InitiateAcquisition_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_InitiateAcquisition_cfunc(vi)
@@ -439,7 +659,12 @@ class Library(object):
     def niScope_LockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niScope_LockSession_cfunc is None:
-                self.niScope_LockSession_cfunc = self._library.niScope_LockSession
+                try:
+                    self.niScope_LockSession_cfunc = self._library.niScope_LockSession
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_LockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niScope_LockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_LockSession_cfunc(vi, caller_has_lock)
@@ -447,7 +672,12 @@ class Library(object):
     def niScope_ProbeCompensationSignalStart(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_ProbeCompensationSignalStart_cfunc is None:
-                self.niScope_ProbeCompensationSignalStart_cfunc = self._library.niScope_ProbeCompensationSignalStart
+                try:
+                    self.niScope_ProbeCompensationSignalStart_cfunc = self._library.niScope_ProbeCompensationSignalStart
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_ProbeCompensationSignalStart_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_ProbeCompensationSignalStart_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ProbeCompensationSignalStart_cfunc(vi)
@@ -455,7 +685,12 @@ class Library(object):
     def niScope_ProbeCompensationSignalStop(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_ProbeCompensationSignalStop_cfunc is None:
-                self.niScope_ProbeCompensationSignalStop_cfunc = self._library.niScope_ProbeCompensationSignalStop
+                try:
+                    self.niScope_ProbeCompensationSignalStop_cfunc = self._library.niScope_ProbeCompensationSignalStop
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_ProbeCompensationSignalStop_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_ProbeCompensationSignalStop_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ProbeCompensationSignalStop_cfunc(vi)
@@ -463,7 +698,12 @@ class Library(object):
     def niScope_Read(self, vi, channel_list, timeout, num_samples, waveform, wfm_info):  # noqa: N802
         with self._func_lock:
             if self.niScope_Read_cfunc is None:
-                self.niScope_Read_cfunc = self._library.niScope_Read
+                try:
+                    self.niScope_Read_cfunc = self._library.niScope_Read
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_Read_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(waveform_info.struct_niScope_wfmInfo)]  # noqa: F405
                 self.niScope_Read_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_Read_cfunc(vi, channel_list, timeout, num_samples, waveform, wfm_info)
@@ -471,7 +711,12 @@ class Library(object):
     def niScope_ResetDevice(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_ResetDevice_cfunc is None:
-                self.niScope_ResetDevice_cfunc = self._library.niScope_ResetDevice
+                try:
+                    self.niScope_ResetDevice_cfunc = self._library.niScope_ResetDevice
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_ResetDevice_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_ResetDevice_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ResetDevice_cfunc(vi)
@@ -479,7 +724,12 @@ class Library(object):
     def niScope_ResetWithDefaults(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_ResetWithDefaults_cfunc is None:
-                self.niScope_ResetWithDefaults_cfunc = self._library.niScope_ResetWithDefaults
+                try:
+                    self.niScope_ResetWithDefaults_cfunc = self._library.niScope_ResetWithDefaults
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_ResetWithDefaults_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_ResetWithDefaults_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ResetWithDefaults_cfunc(vi)
@@ -487,7 +737,12 @@ class Library(object):
     def niScope_SendSoftwareTriggerEdge(self, vi, which_trigger):  # noqa: N802
         with self._func_lock:
             if self.niScope_SendSoftwareTriggerEdge_cfunc is None:
-                self.niScope_SendSoftwareTriggerEdge_cfunc = self._library.niScope_SendSoftwareTriggerEdge
+                try:
+                    self.niScope_SendSoftwareTriggerEdge_cfunc = self._library.niScope_SendSoftwareTriggerEdge
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_SendSoftwareTriggerEdge_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niScope_SendSoftwareTriggerEdge_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_SendSoftwareTriggerEdge_cfunc(vi, which_trigger)
@@ -495,7 +750,12 @@ class Library(object):
     def niScope_SetAttributeViBoolean(self, vi, channel_list, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niScope_SetAttributeViBoolean_cfunc is None:
-                self.niScope_SetAttributeViBoolean_cfunc = self._library.niScope_SetAttributeViBoolean
+                try:
+                    self.niScope_SetAttributeViBoolean_cfunc = self._library.niScope_SetAttributeViBoolean
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViBoolean]  # noqa: F405
                 self.niScope_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_SetAttributeViBoolean_cfunc(vi, channel_list, attribute_id, value)
@@ -503,7 +763,12 @@ class Library(object):
     def niScope_SetAttributeViInt32(self, vi, channel_list, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niScope_SetAttributeViInt32_cfunc is None:
-                self.niScope_SetAttributeViInt32_cfunc = self._library.niScope_SetAttributeViInt32
+                try:
+                    self.niScope_SetAttributeViInt32_cfunc = self._library.niScope_SetAttributeViInt32
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_SetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32]  # noqa: F405
                 self.niScope_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_SetAttributeViInt32_cfunc(vi, channel_list, attribute_id, value)
@@ -511,7 +776,12 @@ class Library(object):
     def niScope_SetAttributeViInt64(self, vi, channel_list, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niScope_SetAttributeViInt64_cfunc is None:
-                self.niScope_SetAttributeViInt64_cfunc = self._library.niScope_SetAttributeViInt64
+                try:
+                    self.niScope_SetAttributeViInt64_cfunc = self._library.niScope_SetAttributeViInt64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_SetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt64]  # noqa: F405
                 self.niScope_SetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_SetAttributeViInt64_cfunc(vi, channel_list, attribute_id, value)
@@ -519,7 +789,12 @@ class Library(object):
     def niScope_SetAttributeViReal64(self, vi, channel_list, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niScope_SetAttributeViReal64_cfunc is None:
-                self.niScope_SetAttributeViReal64_cfunc = self._library.niScope_SetAttributeViReal64
+                try:
+                    self.niScope_SetAttributeViReal64_cfunc = self._library.niScope_SetAttributeViReal64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niScope_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_SetAttributeViReal64_cfunc(vi, channel_list, attribute_id, value)
@@ -527,7 +802,12 @@ class Library(object):
     def niScope_SetAttributeViString(self, vi, channel_list, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niScope_SetAttributeViString_cfunc is None:
-                self.niScope_SetAttributeViString_cfunc = self._library.niScope_SetAttributeViString
+                try:
+                    self.niScope_SetAttributeViString_cfunc = self._library.niScope_SetAttributeViString
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_SetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_SetAttributeViString_cfunc(vi, channel_list, attribute_id, value)
@@ -535,7 +815,12 @@ class Library(object):
     def niScope_UnlockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niScope_UnlockSession_cfunc is None:
-                self.niScope_UnlockSession_cfunc = self._library.niScope_UnlockSession
+                try:
+                    self.niScope_UnlockSession_cfunc = self._library.niScope_UnlockSession
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_UnlockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niScope_UnlockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_UnlockSession_cfunc(vi, caller_has_lock)
@@ -543,7 +828,12 @@ class Library(object):
     def niScope_close(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_close_cfunc is None:
-                self.niScope_close_cfunc = self._library.niScope_close
+                try:
+                    self.niScope_close_cfunc = self._library.niScope_close
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_close_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_close_cfunc(vi)
@@ -551,7 +841,12 @@ class Library(object):
     def niScope_error_message(self, vi, error_code, error_message):  # noqa: N802
         with self._func_lock:
             if self.niScope_error_message_cfunc is None:
-                self.niScope_error_message_cfunc = self._library.niScope_error_message
+                try:
+                    self.niScope_error_message_cfunc = self._library.niScope_error_message
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_error_message_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_error_message_cfunc(vi, error_code, error_message)
@@ -559,7 +854,12 @@ class Library(object):
     def niScope_reset(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_reset_cfunc is None:
-                self.niScope_reset_cfunc = self._library.niScope_reset
+                try:
+                    self.niScope_reset_cfunc = self._library.niScope_reset
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_reset_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_reset_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_reset_cfunc(vi)
@@ -567,7 +867,12 @@ class Library(object):
     def niScope_self_test(self, vi, self_test_result, self_test_message):  # noqa: N802
         with self._func_lock:
             if self.niScope_self_test_cfunc is None:
-                self.niScope_self_test_cfunc = self._library.niScope_self_test
+                try:
+                    self.niScope_self_test_cfunc = self._library.niScope_self_test
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niScope_self_test_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_self_test_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_self_test_cfunc(vi, self_test_result, self_test_message)

--- a/generated/niscope/niscope/_library.py
+++ b/generated/niscope/niscope/_library.py
@@ -2,6 +2,7 @@
 # This file was generated
 
 import ctypes
+import niscope.errors as errors
 import threading
 
 from niscope._visatype import *  # noqa: F403,H303
@@ -84,15 +85,17 @@ class Library(object):
         self.niScope_reset_cfunc = None
         self.niScope_self_test_cfunc = None
 
+    def _get_library_function(self, name):
+        try:
+            function = getattr(self._library, 'fred')
+        except AttributeError as e:
+            raise errors.DriverTooOldError() from e
+        return function
+
     def niScope_Abort(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_Abort_cfunc is None:
-                try:
-                    self.niScope_Abort_cfunc = self._library.niScope_Abort
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_Abort was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_Abort_cfunc = self._get_library_function('niScope_Abort')
                 self.niScope_Abort_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_Abort_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_Abort_cfunc(vi)
@@ -100,12 +103,7 @@ class Library(object):
     def niScope_AcquisitionStatus(self, vi, acquisition_status):  # noqa: N802
         with self._func_lock:
             if self.niScope_AcquisitionStatus_cfunc is None:
-                try:
-                    self.niScope_AcquisitionStatus_cfunc = self._library.niScope_AcquisitionStatus
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_AcquisitionStatus was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_AcquisitionStatus_cfunc = self._get_library_function('niScope_AcquisitionStatus')
                 self.niScope_AcquisitionStatus_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niScope_AcquisitionStatus_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_AcquisitionStatus_cfunc(vi, acquisition_status)
@@ -113,12 +111,7 @@ class Library(object):
     def niScope_ActualMeasWfmSize(self, vi, array_meas_function, meas_waveform_size):  # noqa: N802
         with self._func_lock:
             if self.niScope_ActualMeasWfmSize_cfunc is None:
-                try:
-                    self.niScope_ActualMeasWfmSize_cfunc = self._library.niScope_ActualMeasWfmSize
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_ActualMeasWfmSize was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_ActualMeasWfmSize_cfunc = self._get_library_function('niScope_ActualMeasWfmSize')
                 self.niScope_ActualMeasWfmSize_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niScope_ActualMeasWfmSize_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ActualMeasWfmSize_cfunc(vi, array_meas_function, meas_waveform_size)
@@ -126,12 +119,7 @@ class Library(object):
     def niScope_ActualNumWfms(self, vi, channel_list, num_wfms):  # noqa: N802
         with self._func_lock:
             if self.niScope_ActualNumWfms_cfunc is None:
-                try:
-                    self.niScope_ActualNumWfms_cfunc = self._library.niScope_ActualNumWfms
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_ActualNumWfms was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_ActualNumWfms_cfunc = self._get_library_function('niScope_ActualNumWfms')
                 self.niScope_ActualNumWfms_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niScope_ActualNumWfms_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ActualNumWfms_cfunc(vi, channel_list, num_wfms)
@@ -139,12 +127,7 @@ class Library(object):
     def niScope_AddWaveformProcessing(self, vi, channel_list, meas_function):  # noqa: N802
         with self._func_lock:
             if self.niScope_AddWaveformProcessing_cfunc is None:
-                try:
-                    self.niScope_AddWaveformProcessing_cfunc = self._library.niScope_AddWaveformProcessing
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_AddWaveformProcessing was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_AddWaveformProcessing_cfunc = self._get_library_function('niScope_AddWaveformProcessing')
                 self.niScope_AddWaveformProcessing_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niScope_AddWaveformProcessing_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_AddWaveformProcessing_cfunc(vi, channel_list, meas_function)
@@ -152,12 +135,7 @@ class Library(object):
     def niScope_AutoSetup(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_AutoSetup_cfunc is None:
-                try:
-                    self.niScope_AutoSetup_cfunc = self._library.niScope_AutoSetup
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_AutoSetup was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_AutoSetup_cfunc = self._get_library_function('niScope_AutoSetup')
                 self.niScope_AutoSetup_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_AutoSetup_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_AutoSetup_cfunc(vi)
@@ -165,12 +143,7 @@ class Library(object):
     def niScope_CalFetchDate(self, vi, which_one, year, month, day):  # noqa: N802
         with self._func_lock:
             if self.niScope_CalFetchDate_cfunc is None:
-                try:
-                    self.niScope_CalFetchDate_cfunc = self._library.niScope_CalFetchDate
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_CalFetchDate was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_CalFetchDate_cfunc = self._get_library_function('niScope_CalFetchDate')
                 self.niScope_CalFetchDate_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niScope_CalFetchDate_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_CalFetchDate_cfunc(vi, which_one, year, month, day)
@@ -178,12 +151,7 @@ class Library(object):
     def niScope_CalFetchTemperature(self, vi, which_one, temperature):  # noqa: N802
         with self._func_lock:
             if self.niScope_CalFetchTemperature_cfunc is None:
-                try:
-                    self.niScope_CalFetchTemperature_cfunc = self._library.niScope_CalFetchTemperature
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_CalFetchTemperature was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_CalFetchTemperature_cfunc = self._get_library_function('niScope_CalFetchTemperature')
                 self.niScope_CalFetchTemperature_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niScope_CalFetchTemperature_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_CalFetchTemperature_cfunc(vi, which_one, temperature)
@@ -191,12 +159,7 @@ class Library(object):
     def niScope_CalSelfCalibrate(self, vi, channel_list, option):  # noqa: N802
         with self._func_lock:
             if self.niScope_CalSelfCalibrate_cfunc is None:
-                try:
-                    self.niScope_CalSelfCalibrate_cfunc = self._library.niScope_CalSelfCalibrate
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_CalSelfCalibrate was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_CalSelfCalibrate_cfunc = self._get_library_function('niScope_CalSelfCalibrate')
                 self.niScope_CalSelfCalibrate_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niScope_CalSelfCalibrate_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_CalSelfCalibrate_cfunc(vi, channel_list, option)
@@ -204,12 +167,7 @@ class Library(object):
     def niScope_ClearWaveformMeasurementStats(self, vi, channel_list, clearable_measurement_function):  # noqa: N802
         with self._func_lock:
             if self.niScope_ClearWaveformMeasurementStats_cfunc is None:
-                try:
-                    self.niScope_ClearWaveformMeasurementStats_cfunc = self._library.niScope_ClearWaveformMeasurementStats
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_ClearWaveformMeasurementStats was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_ClearWaveformMeasurementStats_cfunc = self._get_library_function('niScope_ClearWaveformMeasurementStats')
                 self.niScope_ClearWaveformMeasurementStats_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niScope_ClearWaveformMeasurementStats_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ClearWaveformMeasurementStats_cfunc(vi, channel_list, clearable_measurement_function)
@@ -217,12 +175,7 @@ class Library(object):
     def niScope_ClearWaveformProcessing(self, vi, channel_list):  # noqa: N802
         with self._func_lock:
             if self.niScope_ClearWaveformProcessing_cfunc is None:
-                try:
-                    self.niScope_ClearWaveformProcessing_cfunc = self._library.niScope_ClearWaveformProcessing
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_ClearWaveformProcessing was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_ClearWaveformProcessing_cfunc = self._get_library_function('niScope_ClearWaveformProcessing')
                 self.niScope_ClearWaveformProcessing_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_ClearWaveformProcessing_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ClearWaveformProcessing_cfunc(vi, channel_list)
@@ -230,12 +183,7 @@ class Library(object):
     def niScope_Commit(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_Commit_cfunc is None:
-                try:
-                    self.niScope_Commit_cfunc = self._library.niScope_Commit
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_Commit was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_Commit_cfunc = self._get_library_function('niScope_Commit')
                 self.niScope_Commit_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_Commit_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_Commit_cfunc(vi)
@@ -243,12 +191,7 @@ class Library(object):
     def niScope_ConfigureChanCharacteristics(self, vi, channel_list, input_impedance, max_input_frequency):  # noqa: N802
         with self._func_lock:
             if self.niScope_ConfigureChanCharacteristics_cfunc is None:
-                try:
-                    self.niScope_ConfigureChanCharacteristics_cfunc = self._library.niScope_ConfigureChanCharacteristics
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_ConfigureChanCharacteristics was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_ConfigureChanCharacteristics_cfunc = self._get_library_function('niScope_ConfigureChanCharacteristics')
                 self.niScope_ConfigureChanCharacteristics_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViReal64]  # noqa: F405
                 self.niScope_ConfigureChanCharacteristics_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureChanCharacteristics_cfunc(vi, channel_list, input_impedance, max_input_frequency)
@@ -256,12 +199,7 @@ class Library(object):
     def niScope_ConfigureEqualizationFilterCoefficients(self, vi, channel_list, number_of_coefficients, coefficients):  # noqa: N802
         with self._func_lock:
             if self.niScope_ConfigureEqualizationFilterCoefficients_cfunc is None:
-                try:
-                    self.niScope_ConfigureEqualizationFilterCoefficients_cfunc = self._library.niScope_ConfigureEqualizationFilterCoefficients
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_ConfigureEqualizationFilterCoefficients was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_ConfigureEqualizationFilterCoefficients_cfunc = self._get_library_function('niScope_ConfigureEqualizationFilterCoefficients')
                 self.niScope_ConfigureEqualizationFilterCoefficients_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niScope_ConfigureEqualizationFilterCoefficients_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureEqualizationFilterCoefficients_cfunc(vi, channel_list, number_of_coefficients, coefficients)
@@ -269,12 +207,7 @@ class Library(object):
     def niScope_ConfigureHorizontalTiming(self, vi, min_sample_rate, min_num_pts, ref_position, num_records, enforce_realtime):  # noqa: N802
         with self._func_lock:
             if self.niScope_ConfigureHorizontalTiming_cfunc is None:
-                try:
-                    self.niScope_ConfigureHorizontalTiming_cfunc = self._library.niScope_ConfigureHorizontalTiming
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_ConfigureHorizontalTiming was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_ConfigureHorizontalTiming_cfunc = self._get_library_function('niScope_ConfigureHorizontalTiming')
                 self.niScope_ConfigureHorizontalTiming_cfunc.argtypes = [ViSession, ViReal64, ViInt32, ViReal64, ViInt32, ViBoolean]  # noqa: F405
                 self.niScope_ConfigureHorizontalTiming_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureHorizontalTiming_cfunc(vi, min_sample_rate, min_num_pts, ref_position, num_records, enforce_realtime)
@@ -282,12 +215,7 @@ class Library(object):
     def niScope_ConfigureRefLevels(self, vi, low, mid, high):  # noqa: N802
         with self._func_lock:
             if self.niScope_ConfigureRefLevels_cfunc is None:
-                try:
-                    self.niScope_ConfigureRefLevels_cfunc = self._library.niScope_ConfigureRefLevels
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_ConfigureRefLevels was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_ConfigureRefLevels_cfunc = self._get_library_function('niScope_ConfigureRefLevels')
                 self.niScope_ConfigureRefLevels_cfunc.argtypes = [ViSession, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niScope_ConfigureRefLevels_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureRefLevels_cfunc(vi, low, mid, high)
@@ -295,12 +223,7 @@ class Library(object):
     def niScope_ConfigureTriggerDigital(self, vi, trigger_source, slope, holdoff, delay):  # noqa: N802
         with self._func_lock:
             if self.niScope_ConfigureTriggerDigital_cfunc is None:
-                try:
-                    self.niScope_ConfigureTriggerDigital_cfunc = self._library.niScope_ConfigureTriggerDigital
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_ConfigureTriggerDigital was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_ConfigureTriggerDigital_cfunc = self._get_library_function('niScope_ConfigureTriggerDigital')
                 self.niScope_ConfigureTriggerDigital_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niScope_ConfigureTriggerDigital_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureTriggerDigital_cfunc(vi, trigger_source, slope, holdoff, delay)
@@ -308,12 +231,7 @@ class Library(object):
     def niScope_ConfigureTriggerEdge(self, vi, trigger_source, level, slope, trigger_coupling, holdoff, delay):  # noqa: N802
         with self._func_lock:
             if self.niScope_ConfigureTriggerEdge_cfunc is None:
-                try:
-                    self.niScope_ConfigureTriggerEdge_cfunc = self._library.niScope_ConfigureTriggerEdge
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_ConfigureTriggerEdge was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_ConfigureTriggerEdge_cfunc = self._get_library_function('niScope_ConfigureTriggerEdge')
                 self.niScope_ConfigureTriggerEdge_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niScope_ConfigureTriggerEdge_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureTriggerEdge_cfunc(vi, trigger_source, level, slope, trigger_coupling, holdoff, delay)
@@ -321,12 +239,7 @@ class Library(object):
     def niScope_ConfigureTriggerHysteresis(self, vi, trigger_source, level, hysteresis, slope, trigger_coupling, holdoff, delay):  # noqa: N802
         with self._func_lock:
             if self.niScope_ConfigureTriggerHysteresis_cfunc is None:
-                try:
-                    self.niScope_ConfigureTriggerHysteresis_cfunc = self._library.niScope_ConfigureTriggerHysteresis
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_ConfigureTriggerHysteresis was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_ConfigureTriggerHysteresis_cfunc = self._get_library_function('niScope_ConfigureTriggerHysteresis')
                 self.niScope_ConfigureTriggerHysteresis_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViReal64, ViInt32, ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niScope_ConfigureTriggerHysteresis_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureTriggerHysteresis_cfunc(vi, trigger_source, level, hysteresis, slope, trigger_coupling, holdoff, delay)
@@ -334,12 +247,7 @@ class Library(object):
     def niScope_ConfigureTriggerImmediate(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_ConfigureTriggerImmediate_cfunc is None:
-                try:
-                    self.niScope_ConfigureTriggerImmediate_cfunc = self._library.niScope_ConfigureTriggerImmediate
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_ConfigureTriggerImmediate was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_ConfigureTriggerImmediate_cfunc = self._get_library_function('niScope_ConfigureTriggerImmediate')
                 self.niScope_ConfigureTriggerImmediate_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_ConfigureTriggerImmediate_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureTriggerImmediate_cfunc(vi)
@@ -347,12 +255,7 @@ class Library(object):
     def niScope_ConfigureTriggerSoftware(self, vi, holdoff, delay):  # noqa: N802
         with self._func_lock:
             if self.niScope_ConfigureTriggerSoftware_cfunc is None:
-                try:
-                    self.niScope_ConfigureTriggerSoftware_cfunc = self._library.niScope_ConfigureTriggerSoftware
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_ConfigureTriggerSoftware was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_ConfigureTriggerSoftware_cfunc = self._get_library_function('niScope_ConfigureTriggerSoftware')
                 self.niScope_ConfigureTriggerSoftware_cfunc.argtypes = [ViSession, ViReal64, ViReal64]  # noqa: F405
                 self.niScope_ConfigureTriggerSoftware_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureTriggerSoftware_cfunc(vi, holdoff, delay)
@@ -360,12 +263,7 @@ class Library(object):
     def niScope_ConfigureTriggerVideo(self, vi, trigger_source, enable_dc_restore, signal_format, event, line_number, polarity, trigger_coupling, holdoff, delay):  # noqa: N802
         with self._func_lock:
             if self.niScope_ConfigureTriggerVideo_cfunc is None:
-                try:
-                    self.niScope_ConfigureTriggerVideo_cfunc = self._library.niScope_ConfigureTriggerVideo
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_ConfigureTriggerVideo was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_ConfigureTriggerVideo_cfunc = self._get_library_function('niScope_ConfigureTriggerVideo')
                 self.niScope_ConfigureTriggerVideo_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViBoolean, ViInt32, ViInt32, ViInt32, ViInt32, ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niScope_ConfigureTriggerVideo_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureTriggerVideo_cfunc(vi, trigger_source, enable_dc_restore, signal_format, event, line_number, polarity, trigger_coupling, holdoff, delay)
@@ -373,12 +271,7 @@ class Library(object):
     def niScope_ConfigureTriggerWindow(self, vi, trigger_source, low_level, high_level, window_mode, trigger_coupling, holdoff, delay):  # noqa: N802
         with self._func_lock:
             if self.niScope_ConfigureTriggerWindow_cfunc is None:
-                try:
-                    self.niScope_ConfigureTriggerWindow_cfunc = self._library.niScope_ConfigureTriggerWindow
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_ConfigureTriggerWindow was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_ConfigureTriggerWindow_cfunc = self._get_library_function('niScope_ConfigureTriggerWindow')
                 self.niScope_ConfigureTriggerWindow_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViReal64, ViInt32, ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niScope_ConfigureTriggerWindow_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureTriggerWindow_cfunc(vi, trigger_source, low_level, high_level, window_mode, trigger_coupling, holdoff, delay)
@@ -386,12 +279,7 @@ class Library(object):
     def niScope_ConfigureVertical(self, vi, channel_list, range, offset, coupling, probe_attenuation, enabled):  # noqa: N802
         with self._func_lock:
             if self.niScope_ConfigureVertical_cfunc is None:
-                try:
-                    self.niScope_ConfigureVertical_cfunc = self._library.niScope_ConfigureVertical
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_ConfigureVertical was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_ConfigureVertical_cfunc = self._get_library_function('niScope_ConfigureVertical')
                 self.niScope_ConfigureVertical_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViReal64, ViInt32, ViReal64, ViBoolean]  # noqa: F405
                 self.niScope_ConfigureVertical_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureVertical_cfunc(vi, channel_list, range, offset, coupling, probe_attenuation, enabled)
@@ -399,12 +287,7 @@ class Library(object):
     def niScope_Disable(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_Disable_cfunc is None:
-                try:
-                    self.niScope_Disable_cfunc = self._library.niScope_Disable
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_Disable was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_Disable_cfunc = self._get_library_function('niScope_Disable')
                 self.niScope_Disable_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_Disable_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_Disable_cfunc(vi)
@@ -412,12 +295,7 @@ class Library(object):
     def niScope_ExportAttributeConfigurationBuffer(self, vi, size_in_bytes, configuration):  # noqa: N802
         with self._func_lock:
             if self.niScope_ExportAttributeConfigurationBuffer_cfunc is None:
-                try:
-                    self.niScope_ExportAttributeConfigurationBuffer_cfunc = self._library.niScope_ExportAttributeConfigurationBuffer
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_ExportAttributeConfigurationBuffer was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_ExportAttributeConfigurationBuffer_cfunc = self._get_library_function('niScope_ExportAttributeConfigurationBuffer')
                 self.niScope_ExportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niScope_ExportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ExportAttributeConfigurationBuffer_cfunc(vi, size_in_bytes, configuration)
@@ -425,12 +303,7 @@ class Library(object):
     def niScope_ExportAttributeConfigurationFile(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niScope_ExportAttributeConfigurationFile_cfunc is None:
-                try:
-                    self.niScope_ExportAttributeConfigurationFile_cfunc = self._library.niScope_ExportAttributeConfigurationFile
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_ExportAttributeConfigurationFile was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_ExportAttributeConfigurationFile_cfunc = self._get_library_function('niScope_ExportAttributeConfigurationFile')
                 self.niScope_ExportAttributeConfigurationFile_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_ExportAttributeConfigurationFile_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ExportAttributeConfigurationFile_cfunc(vi, file_path)
@@ -438,12 +311,7 @@ class Library(object):
     def niScope_Fetch(self, vi, channel_list, timeout, num_samples, waveform, wfm_info):  # noqa: N802
         with self._func_lock:
             if self.niScope_Fetch_cfunc is None:
-                try:
-                    self.niScope_Fetch_cfunc = self._library.niScope_Fetch
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_Fetch was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_Fetch_cfunc = self._get_library_function('niScope_Fetch')
                 self.niScope_Fetch_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(waveform_info.struct_niScope_wfmInfo)]  # noqa: F405
                 self.niScope_Fetch_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_Fetch_cfunc(vi, channel_list, timeout, num_samples, waveform, wfm_info)
@@ -451,12 +319,7 @@ class Library(object):
     def niScope_FetchArrayMeasurement(self, vi, channel_list, timeout, array_meas_function, measurement_waveform_size, meas_wfm, wfm_info):  # noqa: N802
         with self._func_lock:
             if self.niScope_FetchArrayMeasurement_cfunc is None:
-                try:
-                    self.niScope_FetchArrayMeasurement_cfunc = self._library.niScope_FetchArrayMeasurement
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_FetchArrayMeasurement was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_FetchArrayMeasurement_cfunc = self._get_library_function('niScope_FetchArrayMeasurement')
                 self.niScope_FetchArrayMeasurement_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(waveform_info.struct_niScope_wfmInfo)]  # noqa: F405
                 self.niScope_FetchArrayMeasurement_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_FetchArrayMeasurement_cfunc(vi, channel_list, timeout, array_meas_function, measurement_waveform_size, meas_wfm, wfm_info)
@@ -464,12 +327,7 @@ class Library(object):
     def niScope_FetchBinary16(self, vi, channel_list, timeout, num_samples, waveform, wfm_info):  # noqa: N802
         with self._func_lock:
             if self.niScope_FetchBinary16_cfunc is None:
-                try:
-                    self.niScope_FetchBinary16_cfunc = self._library.niScope_FetchBinary16
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_FetchBinary16 was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_FetchBinary16_cfunc = self._get_library_function('niScope_FetchBinary16')
                 self.niScope_FetchBinary16_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ctypes.POINTER(ViInt16), ctypes.POINTER(waveform_info.struct_niScope_wfmInfo)]  # noqa: F405
                 self.niScope_FetchBinary16_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_FetchBinary16_cfunc(vi, channel_list, timeout, num_samples, waveform, wfm_info)
@@ -477,12 +335,7 @@ class Library(object):
     def niScope_FetchBinary32(self, vi, channel_list, timeout, num_samples, waveform, wfm_info):  # noqa: N802
         with self._func_lock:
             if self.niScope_FetchBinary32_cfunc is None:
-                try:
-                    self.niScope_FetchBinary32_cfunc = self._library.niScope_FetchBinary32
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_FetchBinary32 was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_FetchBinary32_cfunc = self._get_library_function('niScope_FetchBinary32')
                 self.niScope_FetchBinary32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(waveform_info.struct_niScope_wfmInfo)]  # noqa: F405
                 self.niScope_FetchBinary32_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_FetchBinary32_cfunc(vi, channel_list, timeout, num_samples, waveform, wfm_info)
@@ -490,12 +343,7 @@ class Library(object):
     def niScope_FetchBinary8(self, vi, channel_list, timeout, num_samples, waveform, wfm_info):  # noqa: N802
         with self._func_lock:
             if self.niScope_FetchBinary8_cfunc is None:
-                try:
-                    self.niScope_FetchBinary8_cfunc = self._library.niScope_FetchBinary8
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_FetchBinary8 was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_FetchBinary8_cfunc = self._get_library_function('niScope_FetchBinary8')
                 self.niScope_FetchBinary8_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ctypes.POINTER(ViInt8), ctypes.POINTER(waveform_info.struct_niScope_wfmInfo)]  # noqa: F405
                 self.niScope_FetchBinary8_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_FetchBinary8_cfunc(vi, channel_list, timeout, num_samples, waveform, wfm_info)
@@ -503,12 +351,7 @@ class Library(object):
     def niScope_FetchMeasurementStats(self, vi, channel_list, timeout, scalar_meas_function, result, mean, stdev, min, max, num_in_stats):  # noqa: N802
         with self._func_lock:
             if self.niScope_FetchMeasurementStats_cfunc is None:
-                try:
-                    self.niScope_FetchMeasurementStats_cfunc = self._library.niScope_FetchMeasurementStats
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_FetchMeasurementStats was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_FetchMeasurementStats_cfunc = self._get_library_function('niScope_FetchMeasurementStats')
                 self.niScope_FetchMeasurementStats_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niScope_FetchMeasurementStats_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_FetchMeasurementStats_cfunc(vi, channel_list, timeout, scalar_meas_function, result, mean, stdev, min, max, num_in_stats)
@@ -516,12 +359,7 @@ class Library(object):
     def niScope_GetAttributeViBoolean(self, vi, channel_list, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niScope_GetAttributeViBoolean_cfunc is None:
-                try:
-                    self.niScope_GetAttributeViBoolean_cfunc = self._library.niScope_GetAttributeViBoolean
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_GetAttributeViBoolean was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_GetAttributeViBoolean_cfunc = self._get_library_function('niScope_GetAttributeViBoolean')
                 self.niScope_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niScope_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_GetAttributeViBoolean_cfunc(vi, channel_list, attribute_id, value)
@@ -529,12 +367,7 @@ class Library(object):
     def niScope_GetAttributeViInt32(self, vi, channel_list, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niScope_GetAttributeViInt32_cfunc is None:
-                try:
-                    self.niScope_GetAttributeViInt32_cfunc = self._library.niScope_GetAttributeViInt32
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_GetAttributeViInt32 was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_GetAttributeViInt32_cfunc = self._get_library_function('niScope_GetAttributeViInt32')
                 self.niScope_GetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niScope_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_GetAttributeViInt32_cfunc(vi, channel_list, attribute_id, value)
@@ -542,12 +375,7 @@ class Library(object):
     def niScope_GetAttributeViInt64(self, vi, channel_list, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niScope_GetAttributeViInt64_cfunc is None:
-                try:
-                    self.niScope_GetAttributeViInt64_cfunc = self._library.niScope_GetAttributeViInt64
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_GetAttributeViInt64 was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_GetAttributeViInt64_cfunc = self._get_library_function('niScope_GetAttributeViInt64')
                 self.niScope_GetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt64)]  # noqa: F405
                 self.niScope_GetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_GetAttributeViInt64_cfunc(vi, channel_list, attribute_id, value)
@@ -555,12 +383,7 @@ class Library(object):
     def niScope_GetAttributeViReal64(self, vi, channel_list, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niScope_GetAttributeViReal64_cfunc is None:
-                try:
-                    self.niScope_GetAttributeViReal64_cfunc = self._library.niScope_GetAttributeViReal64
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_GetAttributeViReal64 was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_GetAttributeViReal64_cfunc = self._get_library_function('niScope_GetAttributeViReal64')
                 self.niScope_GetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niScope_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_GetAttributeViReal64_cfunc(vi, channel_list, attribute_id, value)
@@ -568,12 +391,7 @@ class Library(object):
     def niScope_GetAttributeViString(self, vi, channel_list, attribute_id, buf_size, value):  # noqa: N802
         with self._func_lock:
             if self.niScope_GetAttributeViString_cfunc is None:
-                try:
-                    self.niScope_GetAttributeViString_cfunc = self._library.niScope_GetAttributeViString
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_GetAttributeViString was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_GetAttributeViString_cfunc = self._get_library_function('niScope_GetAttributeViString')
                 self.niScope_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_GetAttributeViString_cfunc(vi, channel_list, attribute_id, buf_size, value)
@@ -581,12 +399,7 @@ class Library(object):
     def niScope_GetEqualizationFilterCoefficients(self, vi, channel, number_of_coefficients, coefficients):  # noqa: N802
         with self._func_lock:
             if self.niScope_GetEqualizationFilterCoefficients_cfunc is None:
-                try:
-                    self.niScope_GetEqualizationFilterCoefficients_cfunc = self._library.niScope_GetEqualizationFilterCoefficients
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_GetEqualizationFilterCoefficients was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_GetEqualizationFilterCoefficients_cfunc = self._get_library_function('niScope_GetEqualizationFilterCoefficients')
                 self.niScope_GetEqualizationFilterCoefficients_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niScope_GetEqualizationFilterCoefficients_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_GetEqualizationFilterCoefficients_cfunc(vi, channel, number_of_coefficients, coefficients)
@@ -594,12 +407,7 @@ class Library(object):
     def niScope_GetError(self, vi, error_code, buffer_size, description):  # noqa: N802
         with self._func_lock:
             if self.niScope_GetError_cfunc is None:
-                try:
-                    self.niScope_GetError_cfunc = self._library.niScope_GetError
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_GetError was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_GetError_cfunc = self._get_library_function('niScope_GetError')
                 self.niScope_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_GetError_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_GetError_cfunc(vi, error_code, buffer_size, description)
@@ -607,12 +415,7 @@ class Library(object):
     def niScope_ImportAttributeConfigurationBuffer(self, vi, size_in_bytes, configuration):  # noqa: N802
         with self._func_lock:
             if self.niScope_ImportAttributeConfigurationBuffer_cfunc is None:
-                try:
-                    self.niScope_ImportAttributeConfigurationBuffer_cfunc = self._library.niScope_ImportAttributeConfigurationBuffer
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_ImportAttributeConfigurationBuffer was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_ImportAttributeConfigurationBuffer_cfunc = self._get_library_function('niScope_ImportAttributeConfigurationBuffer')
                 self.niScope_ImportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niScope_ImportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ImportAttributeConfigurationBuffer_cfunc(vi, size_in_bytes, configuration)
@@ -620,12 +423,7 @@ class Library(object):
     def niScope_ImportAttributeConfigurationFile(self, vi, file_path):  # noqa: N802
         with self._func_lock:
             if self.niScope_ImportAttributeConfigurationFile_cfunc is None:
-                try:
-                    self.niScope_ImportAttributeConfigurationFile_cfunc = self._library.niScope_ImportAttributeConfigurationFile
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_ImportAttributeConfigurationFile was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_ImportAttributeConfigurationFile_cfunc = self._get_library_function('niScope_ImportAttributeConfigurationFile')
                 self.niScope_ImportAttributeConfigurationFile_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_ImportAttributeConfigurationFile_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ImportAttributeConfigurationFile_cfunc(vi, file_path)
@@ -633,12 +431,7 @@ class Library(object):
     def niScope_InitWithOptions(self, resource_name, id_query, reset_device, option_string, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_InitWithOptions_cfunc is None:
-                try:
-                    self.niScope_InitWithOptions_cfunc = self._library.niScope_InitWithOptions
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_InitWithOptions was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_InitWithOptions_cfunc = self._get_library_function('niScope_InitWithOptions')
                 self.niScope_InitWithOptions_cfunc.argtypes = [ctypes.POINTER(ViChar), ViBoolean, ViBoolean, ctypes.POINTER(ViChar), ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niScope_InitWithOptions_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_InitWithOptions_cfunc(resource_name, id_query, reset_device, option_string, vi)
@@ -646,12 +439,7 @@ class Library(object):
     def niScope_InitiateAcquisition(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_InitiateAcquisition_cfunc is None:
-                try:
-                    self.niScope_InitiateAcquisition_cfunc = self._library.niScope_InitiateAcquisition
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_InitiateAcquisition was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_InitiateAcquisition_cfunc = self._get_library_function('niScope_InitiateAcquisition')
                 self.niScope_InitiateAcquisition_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_InitiateAcquisition_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_InitiateAcquisition_cfunc(vi)
@@ -659,12 +447,7 @@ class Library(object):
     def niScope_LockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niScope_LockSession_cfunc is None:
-                try:
-                    self.niScope_LockSession_cfunc = self._library.niScope_LockSession
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_LockSession was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_LockSession_cfunc = self._get_library_function('niScope_LockSession')
                 self.niScope_LockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niScope_LockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_LockSession_cfunc(vi, caller_has_lock)
@@ -672,12 +455,7 @@ class Library(object):
     def niScope_ProbeCompensationSignalStart(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_ProbeCompensationSignalStart_cfunc is None:
-                try:
-                    self.niScope_ProbeCompensationSignalStart_cfunc = self._library.niScope_ProbeCompensationSignalStart
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_ProbeCompensationSignalStart was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_ProbeCompensationSignalStart_cfunc = self._get_library_function('niScope_ProbeCompensationSignalStart')
                 self.niScope_ProbeCompensationSignalStart_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_ProbeCompensationSignalStart_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ProbeCompensationSignalStart_cfunc(vi)
@@ -685,12 +463,7 @@ class Library(object):
     def niScope_ProbeCompensationSignalStop(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_ProbeCompensationSignalStop_cfunc is None:
-                try:
-                    self.niScope_ProbeCompensationSignalStop_cfunc = self._library.niScope_ProbeCompensationSignalStop
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_ProbeCompensationSignalStop was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_ProbeCompensationSignalStop_cfunc = self._get_library_function('niScope_ProbeCompensationSignalStop')
                 self.niScope_ProbeCompensationSignalStop_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_ProbeCompensationSignalStop_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ProbeCompensationSignalStop_cfunc(vi)
@@ -698,12 +471,7 @@ class Library(object):
     def niScope_Read(self, vi, channel_list, timeout, num_samples, waveform, wfm_info):  # noqa: N802
         with self._func_lock:
             if self.niScope_Read_cfunc is None:
-                try:
-                    self.niScope_Read_cfunc = self._library.niScope_Read
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_Read was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_Read_cfunc = self._get_library_function('niScope_Read')
                 self.niScope_Read_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(waveform_info.struct_niScope_wfmInfo)]  # noqa: F405
                 self.niScope_Read_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_Read_cfunc(vi, channel_list, timeout, num_samples, waveform, wfm_info)
@@ -711,12 +479,7 @@ class Library(object):
     def niScope_ResetDevice(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_ResetDevice_cfunc is None:
-                try:
-                    self.niScope_ResetDevice_cfunc = self._library.niScope_ResetDevice
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_ResetDevice was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_ResetDevice_cfunc = self._get_library_function('niScope_ResetDevice')
                 self.niScope_ResetDevice_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_ResetDevice_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ResetDevice_cfunc(vi)
@@ -724,12 +487,7 @@ class Library(object):
     def niScope_ResetWithDefaults(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_ResetWithDefaults_cfunc is None:
-                try:
-                    self.niScope_ResetWithDefaults_cfunc = self._library.niScope_ResetWithDefaults
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_ResetWithDefaults was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_ResetWithDefaults_cfunc = self._get_library_function('niScope_ResetWithDefaults')
                 self.niScope_ResetWithDefaults_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_ResetWithDefaults_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ResetWithDefaults_cfunc(vi)
@@ -737,12 +495,7 @@ class Library(object):
     def niScope_SendSoftwareTriggerEdge(self, vi, which_trigger):  # noqa: N802
         with self._func_lock:
             if self.niScope_SendSoftwareTriggerEdge_cfunc is None:
-                try:
-                    self.niScope_SendSoftwareTriggerEdge_cfunc = self._library.niScope_SendSoftwareTriggerEdge
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_SendSoftwareTriggerEdge was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_SendSoftwareTriggerEdge_cfunc = self._get_library_function('niScope_SendSoftwareTriggerEdge')
                 self.niScope_SendSoftwareTriggerEdge_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niScope_SendSoftwareTriggerEdge_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_SendSoftwareTriggerEdge_cfunc(vi, which_trigger)
@@ -750,12 +503,7 @@ class Library(object):
     def niScope_SetAttributeViBoolean(self, vi, channel_list, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niScope_SetAttributeViBoolean_cfunc is None:
-                try:
-                    self.niScope_SetAttributeViBoolean_cfunc = self._library.niScope_SetAttributeViBoolean
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_SetAttributeViBoolean was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_SetAttributeViBoolean_cfunc = self._get_library_function('niScope_SetAttributeViBoolean')
                 self.niScope_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViBoolean]  # noqa: F405
                 self.niScope_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_SetAttributeViBoolean_cfunc(vi, channel_list, attribute_id, value)
@@ -763,12 +511,7 @@ class Library(object):
     def niScope_SetAttributeViInt32(self, vi, channel_list, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niScope_SetAttributeViInt32_cfunc is None:
-                try:
-                    self.niScope_SetAttributeViInt32_cfunc = self._library.niScope_SetAttributeViInt32
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_SetAttributeViInt32 was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_SetAttributeViInt32_cfunc = self._get_library_function('niScope_SetAttributeViInt32')
                 self.niScope_SetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32]  # noqa: F405
                 self.niScope_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_SetAttributeViInt32_cfunc(vi, channel_list, attribute_id, value)
@@ -776,12 +519,7 @@ class Library(object):
     def niScope_SetAttributeViInt64(self, vi, channel_list, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niScope_SetAttributeViInt64_cfunc is None:
-                try:
-                    self.niScope_SetAttributeViInt64_cfunc = self._library.niScope_SetAttributeViInt64
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_SetAttributeViInt64 was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_SetAttributeViInt64_cfunc = self._get_library_function('niScope_SetAttributeViInt64')
                 self.niScope_SetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt64]  # noqa: F405
                 self.niScope_SetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_SetAttributeViInt64_cfunc(vi, channel_list, attribute_id, value)
@@ -789,12 +527,7 @@ class Library(object):
     def niScope_SetAttributeViReal64(self, vi, channel_list, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niScope_SetAttributeViReal64_cfunc is None:
-                try:
-                    self.niScope_SetAttributeViReal64_cfunc = self._library.niScope_SetAttributeViReal64
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_SetAttributeViReal64 was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_SetAttributeViReal64_cfunc = self._get_library_function('niScope_SetAttributeViReal64')
                 self.niScope_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niScope_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_SetAttributeViReal64_cfunc(vi, channel_list, attribute_id, value)
@@ -802,12 +535,7 @@ class Library(object):
     def niScope_SetAttributeViString(self, vi, channel_list, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niScope_SetAttributeViString_cfunc is None:
-                try:
-                    self.niScope_SetAttributeViString_cfunc = self._library.niScope_SetAttributeViString
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_SetAttributeViString was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_SetAttributeViString_cfunc = self._get_library_function('niScope_SetAttributeViString')
                 self.niScope_SetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_SetAttributeViString_cfunc(vi, channel_list, attribute_id, value)
@@ -815,12 +543,7 @@ class Library(object):
     def niScope_UnlockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niScope_UnlockSession_cfunc is None:
-                try:
-                    self.niScope_UnlockSession_cfunc = self._library.niScope_UnlockSession
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_UnlockSession was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_UnlockSession_cfunc = self._get_library_function('niScope_UnlockSession')
                 self.niScope_UnlockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niScope_UnlockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_UnlockSession_cfunc(vi, caller_has_lock)
@@ -828,12 +551,7 @@ class Library(object):
     def niScope_close(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_close_cfunc is None:
-                try:
-                    self.niScope_close_cfunc = self._library.niScope_close
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_close was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_close_cfunc = self._get_library_function('niScope_close')
                 self.niScope_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_close_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_close_cfunc(vi)
@@ -841,12 +559,7 @@ class Library(object):
     def niScope_error_message(self, vi, error_code, error_message):  # noqa: N802
         with self._func_lock:
             if self.niScope_error_message_cfunc is None:
-                try:
-                    self.niScope_error_message_cfunc = self._library.niScope_error_message
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_error_message was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_error_message_cfunc = self._get_library_function('niScope_error_message')
                 self.niScope_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_error_message_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_error_message_cfunc(vi, error_code, error_message)
@@ -854,12 +567,7 @@ class Library(object):
     def niScope_reset(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niScope_reset_cfunc is None:
-                try:
-                    self.niScope_reset_cfunc = self._library.niScope_reset
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_reset was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_reset_cfunc = self._get_library_function('niScope_reset')
                 self.niScope_reset_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_reset_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_reset_cfunc(vi)
@@ -867,12 +575,7 @@ class Library(object):
     def niScope_self_test(self, vi, self_test_result, self_test_message):  # noqa: N802
         with self._func_lock:
             if self.niScope_self_test_cfunc is None:
-                try:
-                    self.niScope_self_test_cfunc = self._library.niScope_self_test
-                except AttributeError as e:
-                    raise AttributeError("Function niScope_self_test was not found in the NI-SCOPE runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niScope_self_test_cfunc = self._get_library_function('niScope_self_test')
                 self.niScope_self_test_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_self_test_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_self_test_cfunc(vi, self_test_result, self_test_message)

--- a/generated/niscope/niscope/_library.py
+++ b/generated/niscope/niscope/_library.py
@@ -90,9 +90,9 @@ class Library(object):
                 try:
                     self.niScope_Abort_cfunc = self._library.niScope_Abort
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_Abort was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_Abort_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_Abort_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_Abort_cfunc(vi)
@@ -103,9 +103,9 @@ class Library(object):
                 try:
                     self.niScope_AcquisitionStatus_cfunc = self._library.niScope_AcquisitionStatus
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_AcquisitionStatus was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_AcquisitionStatus_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niScope_AcquisitionStatus_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_AcquisitionStatus_cfunc(vi, acquisition_status)
@@ -116,9 +116,9 @@ class Library(object):
                 try:
                     self.niScope_ActualMeasWfmSize_cfunc = self._library.niScope_ActualMeasWfmSize
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_ActualMeasWfmSize was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_ActualMeasWfmSize_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niScope_ActualMeasWfmSize_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ActualMeasWfmSize_cfunc(vi, array_meas_function, meas_waveform_size)
@@ -129,9 +129,9 @@ class Library(object):
                 try:
                     self.niScope_ActualNumWfms_cfunc = self._library.niScope_ActualNumWfms
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_ActualNumWfms was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_ActualNumWfms_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niScope_ActualNumWfms_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ActualNumWfms_cfunc(vi, channel_list, num_wfms)
@@ -142,9 +142,9 @@ class Library(object):
                 try:
                     self.niScope_AddWaveformProcessing_cfunc = self._library.niScope_AddWaveformProcessing
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_AddWaveformProcessing was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_AddWaveformProcessing_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niScope_AddWaveformProcessing_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_AddWaveformProcessing_cfunc(vi, channel_list, meas_function)
@@ -155,9 +155,9 @@ class Library(object):
                 try:
                     self.niScope_AutoSetup_cfunc = self._library.niScope_AutoSetup
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_AutoSetup was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_AutoSetup_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_AutoSetup_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_AutoSetup_cfunc(vi)
@@ -168,9 +168,9 @@ class Library(object):
                 try:
                     self.niScope_CalFetchDate_cfunc = self._library.niScope_CalFetchDate
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_CalFetchDate was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_CalFetchDate_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niScope_CalFetchDate_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_CalFetchDate_cfunc(vi, which_one, year, month, day)
@@ -181,9 +181,9 @@ class Library(object):
                 try:
                     self.niScope_CalFetchTemperature_cfunc = self._library.niScope_CalFetchTemperature
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_CalFetchTemperature was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_CalFetchTemperature_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niScope_CalFetchTemperature_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_CalFetchTemperature_cfunc(vi, which_one, temperature)
@@ -194,9 +194,9 @@ class Library(object):
                 try:
                     self.niScope_CalSelfCalibrate_cfunc = self._library.niScope_CalSelfCalibrate
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_CalSelfCalibrate was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_CalSelfCalibrate_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niScope_CalSelfCalibrate_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_CalSelfCalibrate_cfunc(vi, channel_list, option)
@@ -207,9 +207,9 @@ class Library(object):
                 try:
                     self.niScope_ClearWaveformMeasurementStats_cfunc = self._library.niScope_ClearWaveformMeasurementStats
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_ClearWaveformMeasurementStats was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_ClearWaveformMeasurementStats_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niScope_ClearWaveformMeasurementStats_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ClearWaveformMeasurementStats_cfunc(vi, channel_list, clearable_measurement_function)
@@ -220,9 +220,9 @@ class Library(object):
                 try:
                     self.niScope_ClearWaveformProcessing_cfunc = self._library.niScope_ClearWaveformProcessing
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_ClearWaveformProcessing was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_ClearWaveformProcessing_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_ClearWaveformProcessing_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ClearWaveformProcessing_cfunc(vi, channel_list)
@@ -233,9 +233,9 @@ class Library(object):
                 try:
                     self.niScope_Commit_cfunc = self._library.niScope_Commit
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_Commit was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_Commit_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_Commit_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_Commit_cfunc(vi)
@@ -246,9 +246,9 @@ class Library(object):
                 try:
                     self.niScope_ConfigureChanCharacteristics_cfunc = self._library.niScope_ConfigureChanCharacteristics
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_ConfigureChanCharacteristics was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_ConfigureChanCharacteristics_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViReal64]  # noqa: F405
                 self.niScope_ConfigureChanCharacteristics_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureChanCharacteristics_cfunc(vi, channel_list, input_impedance, max_input_frequency)
@@ -259,9 +259,9 @@ class Library(object):
                 try:
                     self.niScope_ConfigureEqualizationFilterCoefficients_cfunc = self._library.niScope_ConfigureEqualizationFilterCoefficients
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_ConfigureEqualizationFilterCoefficients was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_ConfigureEqualizationFilterCoefficients_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niScope_ConfigureEqualizationFilterCoefficients_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureEqualizationFilterCoefficients_cfunc(vi, channel_list, number_of_coefficients, coefficients)
@@ -272,9 +272,9 @@ class Library(object):
                 try:
                     self.niScope_ConfigureHorizontalTiming_cfunc = self._library.niScope_ConfigureHorizontalTiming
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_ConfigureHorizontalTiming was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_ConfigureHorizontalTiming_cfunc.argtypes = [ViSession, ViReal64, ViInt32, ViReal64, ViInt32, ViBoolean]  # noqa: F405
                 self.niScope_ConfigureHorizontalTiming_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureHorizontalTiming_cfunc(vi, min_sample_rate, min_num_pts, ref_position, num_records, enforce_realtime)
@@ -285,9 +285,9 @@ class Library(object):
                 try:
                     self.niScope_ConfigureRefLevels_cfunc = self._library.niScope_ConfigureRefLevels
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_ConfigureRefLevels was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_ConfigureRefLevels_cfunc.argtypes = [ViSession, ViReal64, ViReal64, ViReal64]  # noqa: F405
                 self.niScope_ConfigureRefLevels_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureRefLevels_cfunc(vi, low, mid, high)
@@ -298,9 +298,9 @@ class Library(object):
                 try:
                     self.niScope_ConfigureTriggerDigital_cfunc = self._library.niScope_ConfigureTriggerDigital
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_ConfigureTriggerDigital was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_ConfigureTriggerDigital_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niScope_ConfigureTriggerDigital_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureTriggerDigital_cfunc(vi, trigger_source, slope, holdoff, delay)
@@ -311,9 +311,9 @@ class Library(object):
                 try:
                     self.niScope_ConfigureTriggerEdge_cfunc = self._library.niScope_ConfigureTriggerEdge
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_ConfigureTriggerEdge was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_ConfigureTriggerEdge_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niScope_ConfigureTriggerEdge_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureTriggerEdge_cfunc(vi, trigger_source, level, slope, trigger_coupling, holdoff, delay)
@@ -324,9 +324,9 @@ class Library(object):
                 try:
                     self.niScope_ConfigureTriggerHysteresis_cfunc = self._library.niScope_ConfigureTriggerHysteresis
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_ConfigureTriggerHysteresis was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_ConfigureTriggerHysteresis_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViReal64, ViInt32, ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niScope_ConfigureTriggerHysteresis_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureTriggerHysteresis_cfunc(vi, trigger_source, level, hysteresis, slope, trigger_coupling, holdoff, delay)
@@ -337,9 +337,9 @@ class Library(object):
                 try:
                     self.niScope_ConfigureTriggerImmediate_cfunc = self._library.niScope_ConfigureTriggerImmediate
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_ConfigureTriggerImmediate was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_ConfigureTriggerImmediate_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_ConfigureTriggerImmediate_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureTriggerImmediate_cfunc(vi)
@@ -350,9 +350,9 @@ class Library(object):
                 try:
                     self.niScope_ConfigureTriggerSoftware_cfunc = self._library.niScope_ConfigureTriggerSoftware
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_ConfigureTriggerSoftware was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_ConfigureTriggerSoftware_cfunc.argtypes = [ViSession, ViReal64, ViReal64]  # noqa: F405
                 self.niScope_ConfigureTriggerSoftware_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureTriggerSoftware_cfunc(vi, holdoff, delay)
@@ -363,9 +363,9 @@ class Library(object):
                 try:
                     self.niScope_ConfigureTriggerVideo_cfunc = self._library.niScope_ConfigureTriggerVideo
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_ConfigureTriggerVideo was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_ConfigureTriggerVideo_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViBoolean, ViInt32, ViInt32, ViInt32, ViInt32, ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niScope_ConfigureTriggerVideo_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureTriggerVideo_cfunc(vi, trigger_source, enable_dc_restore, signal_format, event, line_number, polarity, trigger_coupling, holdoff, delay)
@@ -376,9 +376,9 @@ class Library(object):
                 try:
                     self.niScope_ConfigureTriggerWindow_cfunc = self._library.niScope_ConfigureTriggerWindow
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_ConfigureTriggerWindow was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_ConfigureTriggerWindow_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViReal64, ViInt32, ViInt32, ViReal64, ViReal64]  # noqa: F405
                 self.niScope_ConfigureTriggerWindow_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureTriggerWindow_cfunc(vi, trigger_source, low_level, high_level, window_mode, trigger_coupling, holdoff, delay)
@@ -389,9 +389,9 @@ class Library(object):
                 try:
                     self.niScope_ConfigureVertical_cfunc = self._library.niScope_ConfigureVertical
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_ConfigureVertical was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_ConfigureVertical_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViReal64, ViInt32, ViReal64, ViBoolean]  # noqa: F405
                 self.niScope_ConfigureVertical_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ConfigureVertical_cfunc(vi, channel_list, range, offset, coupling, probe_attenuation, enabled)
@@ -402,9 +402,9 @@ class Library(object):
                 try:
                     self.niScope_Disable_cfunc = self._library.niScope_Disable
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_Disable was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_Disable_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_Disable_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_Disable_cfunc(vi)
@@ -415,9 +415,9 @@ class Library(object):
                 try:
                     self.niScope_ExportAttributeConfigurationBuffer_cfunc = self._library.niScope_ExportAttributeConfigurationBuffer
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_ExportAttributeConfigurationBuffer was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_ExportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niScope_ExportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ExportAttributeConfigurationBuffer_cfunc(vi, size_in_bytes, configuration)
@@ -428,9 +428,9 @@ class Library(object):
                 try:
                     self.niScope_ExportAttributeConfigurationFile_cfunc = self._library.niScope_ExportAttributeConfigurationFile
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_ExportAttributeConfigurationFile was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_ExportAttributeConfigurationFile_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_ExportAttributeConfigurationFile_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ExportAttributeConfigurationFile_cfunc(vi, file_path)
@@ -441,9 +441,9 @@ class Library(object):
                 try:
                     self.niScope_Fetch_cfunc = self._library.niScope_Fetch
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_Fetch was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_Fetch_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(waveform_info.struct_niScope_wfmInfo)]  # noqa: F405
                 self.niScope_Fetch_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_Fetch_cfunc(vi, channel_list, timeout, num_samples, waveform, wfm_info)
@@ -454,9 +454,9 @@ class Library(object):
                 try:
                     self.niScope_FetchArrayMeasurement_cfunc = self._library.niScope_FetchArrayMeasurement
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_FetchArrayMeasurement was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_FetchArrayMeasurement_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(waveform_info.struct_niScope_wfmInfo)]  # noqa: F405
                 self.niScope_FetchArrayMeasurement_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_FetchArrayMeasurement_cfunc(vi, channel_list, timeout, array_meas_function, measurement_waveform_size, meas_wfm, wfm_info)
@@ -467,9 +467,9 @@ class Library(object):
                 try:
                     self.niScope_FetchBinary16_cfunc = self._library.niScope_FetchBinary16
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_FetchBinary16 was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_FetchBinary16_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ctypes.POINTER(ViInt16), ctypes.POINTER(waveform_info.struct_niScope_wfmInfo)]  # noqa: F405
                 self.niScope_FetchBinary16_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_FetchBinary16_cfunc(vi, channel_list, timeout, num_samples, waveform, wfm_info)
@@ -480,9 +480,9 @@ class Library(object):
                 try:
                     self.niScope_FetchBinary32_cfunc = self._library.niScope_FetchBinary32
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_FetchBinary32 was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_FetchBinary32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(waveform_info.struct_niScope_wfmInfo)]  # noqa: F405
                 self.niScope_FetchBinary32_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_FetchBinary32_cfunc(vi, channel_list, timeout, num_samples, waveform, wfm_info)
@@ -493,9 +493,9 @@ class Library(object):
                 try:
                     self.niScope_FetchBinary8_cfunc = self._library.niScope_FetchBinary8
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_FetchBinary8 was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_FetchBinary8_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ctypes.POINTER(ViInt8), ctypes.POINTER(waveform_info.struct_niScope_wfmInfo)]  # noqa: F405
                 self.niScope_FetchBinary8_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_FetchBinary8_cfunc(vi, channel_list, timeout, num_samples, waveform, wfm_info)
@@ -506,9 +506,9 @@ class Library(object):
                 try:
                     self.niScope_FetchMeasurementStats_cfunc = self._library.niScope_FetchMeasurementStats
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_FetchMeasurementStats was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_FetchMeasurementStats_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niScope_FetchMeasurementStats_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_FetchMeasurementStats_cfunc(vi, channel_list, timeout, scalar_meas_function, result, mean, stdev, min, max, num_in_stats)
@@ -519,9 +519,9 @@ class Library(object):
                 try:
                     self.niScope_GetAttributeViBoolean_cfunc = self._library.niScope_GetAttributeViBoolean
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_GetAttributeViBoolean was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niScope_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_GetAttributeViBoolean_cfunc(vi, channel_list, attribute_id, value)
@@ -532,9 +532,9 @@ class Library(object):
                 try:
                     self.niScope_GetAttributeViInt32_cfunc = self._library.niScope_GetAttributeViInt32
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_GetAttributeViInt32 was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_GetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niScope_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_GetAttributeViInt32_cfunc(vi, channel_list, attribute_id, value)
@@ -545,9 +545,9 @@ class Library(object):
                 try:
                     self.niScope_GetAttributeViInt64_cfunc = self._library.niScope_GetAttributeViInt64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_GetAttributeViInt64 was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_GetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt64)]  # noqa: F405
                 self.niScope_GetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_GetAttributeViInt64_cfunc(vi, channel_list, attribute_id, value)
@@ -558,9 +558,9 @@ class Library(object):
                 try:
                     self.niScope_GetAttributeViReal64_cfunc = self._library.niScope_GetAttributeViReal64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_GetAttributeViReal64 was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_GetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niScope_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_GetAttributeViReal64_cfunc(vi, channel_list, attribute_id, value)
@@ -571,9 +571,9 @@ class Library(object):
                 try:
                     self.niScope_GetAttributeViString_cfunc = self._library.niScope_GetAttributeViString
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_GetAttributeViString was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_GetAttributeViString_cfunc(vi, channel_list, attribute_id, buf_size, value)
@@ -584,9 +584,9 @@ class Library(object):
                 try:
                     self.niScope_GetEqualizationFilterCoefficients_cfunc = self._library.niScope_GetEqualizationFilterCoefficients
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_GetEqualizationFilterCoefficients was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_GetEqualizationFilterCoefficients_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niScope_GetEqualizationFilterCoefficients_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_GetEqualizationFilterCoefficients_cfunc(vi, channel, number_of_coefficients, coefficients)
@@ -597,9 +597,9 @@ class Library(object):
                 try:
                     self.niScope_GetError_cfunc = self._library.niScope_GetError
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_GetError was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_GetError_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_GetError_cfunc(vi, error_code, buffer_size, description)
@@ -610,9 +610,9 @@ class Library(object):
                 try:
                     self.niScope_ImportAttributeConfigurationBuffer_cfunc = self._library.niScope_ImportAttributeConfigurationBuffer
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_ImportAttributeConfigurationBuffer was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_ImportAttributeConfigurationBuffer_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViInt8)]  # noqa: F405
                 self.niScope_ImportAttributeConfigurationBuffer_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ImportAttributeConfigurationBuffer_cfunc(vi, size_in_bytes, configuration)
@@ -623,9 +623,9 @@ class Library(object):
                 try:
                     self.niScope_ImportAttributeConfigurationFile_cfunc = self._library.niScope_ImportAttributeConfigurationFile
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_ImportAttributeConfigurationFile was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_ImportAttributeConfigurationFile_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_ImportAttributeConfigurationFile_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ImportAttributeConfigurationFile_cfunc(vi, file_path)
@@ -636,9 +636,9 @@ class Library(object):
                 try:
                     self.niScope_InitWithOptions_cfunc = self._library.niScope_InitWithOptions
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_InitWithOptions was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_InitWithOptions_cfunc.argtypes = [ctypes.POINTER(ViChar), ViBoolean, ViBoolean, ctypes.POINTER(ViChar), ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niScope_InitWithOptions_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_InitWithOptions_cfunc(resource_name, id_query, reset_device, option_string, vi)
@@ -649,9 +649,9 @@ class Library(object):
                 try:
                     self.niScope_InitiateAcquisition_cfunc = self._library.niScope_InitiateAcquisition
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_InitiateAcquisition was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_InitiateAcquisition_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_InitiateAcquisition_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_InitiateAcquisition_cfunc(vi)
@@ -662,9 +662,9 @@ class Library(object):
                 try:
                     self.niScope_LockSession_cfunc = self._library.niScope_LockSession
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_LockSession was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_LockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niScope_LockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_LockSession_cfunc(vi, caller_has_lock)
@@ -675,9 +675,9 @@ class Library(object):
                 try:
                     self.niScope_ProbeCompensationSignalStart_cfunc = self._library.niScope_ProbeCompensationSignalStart
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_ProbeCompensationSignalStart was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_ProbeCompensationSignalStart_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_ProbeCompensationSignalStart_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ProbeCompensationSignalStart_cfunc(vi)
@@ -688,9 +688,9 @@ class Library(object):
                 try:
                     self.niScope_ProbeCompensationSignalStop_cfunc = self._library.niScope_ProbeCompensationSignalStop
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_ProbeCompensationSignalStop was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_ProbeCompensationSignalStop_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_ProbeCompensationSignalStop_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ProbeCompensationSignalStop_cfunc(vi)
@@ -701,9 +701,9 @@ class Library(object):
                 try:
                     self.niScope_Read_cfunc = self._library.niScope_Read
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_Read was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_Read_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(waveform_info.struct_niScope_wfmInfo)]  # noqa: F405
                 self.niScope_Read_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_Read_cfunc(vi, channel_list, timeout, num_samples, waveform, wfm_info)
@@ -714,9 +714,9 @@ class Library(object):
                 try:
                     self.niScope_ResetDevice_cfunc = self._library.niScope_ResetDevice
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_ResetDevice was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_ResetDevice_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_ResetDevice_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ResetDevice_cfunc(vi)
@@ -727,9 +727,9 @@ class Library(object):
                 try:
                     self.niScope_ResetWithDefaults_cfunc = self._library.niScope_ResetWithDefaults
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_ResetWithDefaults was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_ResetWithDefaults_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_ResetWithDefaults_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_ResetWithDefaults_cfunc(vi)
@@ -740,9 +740,9 @@ class Library(object):
                 try:
                     self.niScope_SendSoftwareTriggerEdge_cfunc = self._library.niScope_SendSoftwareTriggerEdge
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_SendSoftwareTriggerEdge was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_SendSoftwareTriggerEdge_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niScope_SendSoftwareTriggerEdge_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_SendSoftwareTriggerEdge_cfunc(vi, which_trigger)
@@ -753,9 +753,9 @@ class Library(object):
                 try:
                     self.niScope_SetAttributeViBoolean_cfunc = self._library.niScope_SetAttributeViBoolean
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_SetAttributeViBoolean was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViBoolean]  # noqa: F405
                 self.niScope_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_SetAttributeViBoolean_cfunc(vi, channel_list, attribute_id, value)
@@ -766,9 +766,9 @@ class Library(object):
                 try:
                     self.niScope_SetAttributeViInt32_cfunc = self._library.niScope_SetAttributeViInt32
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_SetAttributeViInt32 was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_SetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32]  # noqa: F405
                 self.niScope_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_SetAttributeViInt32_cfunc(vi, channel_list, attribute_id, value)
@@ -779,9 +779,9 @@ class Library(object):
                 try:
                     self.niScope_SetAttributeViInt64_cfunc = self._library.niScope_SetAttributeViInt64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_SetAttributeViInt64 was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_SetAttributeViInt64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt64]  # noqa: F405
                 self.niScope_SetAttributeViInt64_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_SetAttributeViInt64_cfunc(vi, channel_list, attribute_id, value)
@@ -792,9 +792,9 @@ class Library(object):
                 try:
                     self.niScope_SetAttributeViReal64_cfunc = self._library.niScope_SetAttributeViReal64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_SetAttributeViReal64 was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niScope_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_SetAttributeViReal64_cfunc(vi, channel_list, attribute_id, value)
@@ -805,9 +805,9 @@ class Library(object):
                 try:
                     self.niScope_SetAttributeViString_cfunc = self._library.niScope_SetAttributeViString
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_SetAttributeViString was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_SetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_SetAttributeViString_cfunc(vi, channel_list, attribute_id, value)
@@ -818,9 +818,9 @@ class Library(object):
                 try:
                     self.niScope_UnlockSession_cfunc = self._library.niScope_UnlockSession
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_UnlockSession was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_UnlockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niScope_UnlockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_UnlockSession_cfunc(vi, caller_has_lock)
@@ -831,9 +831,9 @@ class Library(object):
                 try:
                     self.niScope_close_cfunc = self._library.niScope_close
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_close was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_close_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_close_cfunc(vi)
@@ -844,9 +844,9 @@ class Library(object):
                 try:
                     self.niScope_error_message_cfunc = self._library.niScope_error_message
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_error_message was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_error_message_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_error_message_cfunc(vi, error_code, error_message)
@@ -857,9 +857,9 @@ class Library(object):
                 try:
                     self.niScope_reset_cfunc = self._library.niScope_reset
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_reset was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_reset_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niScope_reset_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_reset_cfunc(vi)
@@ -870,9 +870,9 @@ class Library(object):
                 try:
                     self.niScope_self_test_cfunc = self._library.niScope_self_test
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niScope_self_test was not found in the NI-SCOPE runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niScope_self_test_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_self_test_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_self_test_cfunc(vi, self_test_result, self_test_message)

--- a/generated/niscope/niscope/errors.py
+++ b/generated/niscope/niscope/errors.py
@@ -57,6 +57,13 @@ class DriverNotInstalledError(Error):
         super(DriverNotInstalledError, self).__init__('The NI-SCOPE runtime could not be loaded. Make sure it is installed and its bitness matches that of your Python interpreter. Please visit http://www.ni.com/downloads/drivers/ to download and install it.')
 
 
+class DriverTooOldError(Error):
+    '''An error due to using this module with an older version of the driver runtime.'''
+
+    def __init__(self):
+        super(DriverTooOldError, self).__init__('A function was not found in the NI-SCOPE runtime. Please visit http://www.ni.com/downloads/drivers/ to download a newer version and install it.')
+
+
 class InvalidRepeatedCapabilityError(Error):
     '''An error due to an invalid character in a repeated capability'''
 

--- a/generated/nise/nise/_library.py
+++ b/generated/nise/nise/_library.py
@@ -38,9 +38,9 @@ class Library(object):
                 try:
                     self.niSE_CloseSession_cfunc = self._library.niSE_CloseSession
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSE_CloseSession was not found in the NI Switch Executive runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSE_CloseSession_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSE_CloseSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_CloseSession_cfunc(vi)
@@ -51,9 +51,9 @@ class Library(object):
                 try:
                     self.niSE_Connect_cfunc = self._library.niSE_Connect
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSE_Connect was not found in the NI Switch Executive runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSE_Connect_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViBoolean]  # noqa: F405
                 self.niSE_Connect_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_Connect_cfunc(vi, connect_spec, multiconnect_mode, wait_for_debounce)
@@ -64,9 +64,9 @@ class Library(object):
                 try:
                     self.niSE_ConnectAndDisconnect_cfunc = self._library.niSE_ConnectAndDisconnect
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSE_ConnectAndDisconnect was not found in the NI Switch Executive runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSE_ConnectAndDisconnect_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViInt32, ViBoolean]  # noqa: F405
                 self.niSE_ConnectAndDisconnect_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_ConnectAndDisconnect_cfunc(vi, connect_spec, disconnect_spec, multiconnect_mode, operation_order, wait_for_debounce)
@@ -77,9 +77,9 @@ class Library(object):
                 try:
                     self.niSE_Disconnect_cfunc = self._library.niSE_Disconnect
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSE_Disconnect was not found in the NI Switch Executive runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSE_Disconnect_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSE_Disconnect_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_Disconnect_cfunc(vi, disconnect_spec)
@@ -90,9 +90,9 @@ class Library(object):
                 try:
                     self.niSE_DisconnectAll_cfunc = self._library.niSE_DisconnectAll
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSE_DisconnectAll was not found in the NI Switch Executive runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSE_DisconnectAll_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSE_DisconnectAll_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_DisconnectAll_cfunc(vi)
@@ -103,9 +103,9 @@ class Library(object):
                 try:
                     self.niSE_ExpandRouteSpec_cfunc = self._library.niSE_ExpandRouteSpec
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSE_ExpandRouteSpec was not found in the NI Switch Executive runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSE_ExpandRouteSpec_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSE_ExpandRouteSpec_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_ExpandRouteSpec_cfunc(vi, route_spec, expand_action, expanded_route_spec, expanded_route_spec_size)
@@ -116,9 +116,9 @@ class Library(object):
                 try:
                     self.niSE_FindRoute_cfunc = self._library.niSE_FindRoute
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSE_FindRoute was not found in the NI Switch Executive runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSE_FindRoute_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSE_FindRoute_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_FindRoute_cfunc(vi, channel1, channel2, route_spec, route_spec_size, path_capability)
@@ -129,9 +129,9 @@ class Library(object):
                 try:
                     self.niSE_GetAllConnections_cfunc = self._library.niSE_GetAllConnections
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSE_GetAllConnections was not found in the NI Switch Executive runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSE_GetAllConnections_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSE_GetAllConnections_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_GetAllConnections_cfunc(vi, route_spec, route_spec_size)
@@ -142,9 +142,9 @@ class Library(object):
                 try:
                     self.niSE_GetError_cfunc = self._library.niSE_GetError
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSE_GetError was not found in the NI Switch Executive runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSE_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSE_GetError_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_GetError_cfunc(vi, error_number, error_description, error_description_size)
@@ -155,9 +155,9 @@ class Library(object):
                 try:
                     self.niSE_IsConnected_cfunc = self._library.niSE_IsConnected
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSE_IsConnected was not found in the NI Switch Executive runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSE_IsConnected_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niSE_IsConnected_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_IsConnected_cfunc(vi, route_spec, is_connected)
@@ -168,9 +168,9 @@ class Library(object):
                 try:
                     self.niSE_IsDebounced_cfunc = self._library.niSE_IsDebounced
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSE_IsDebounced was not found in the NI Switch Executive runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSE_IsDebounced_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niSE_IsDebounced_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_IsDebounced_cfunc(vi, is_debounced)
@@ -181,9 +181,9 @@ class Library(object):
                 try:
                     self.niSE_OpenSession_cfunc = self._library.niSE_OpenSession
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSE_OpenSession was not found in the NI Switch Executive runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSE_OpenSession_cfunc.argtypes = [ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niSE_OpenSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_OpenSession_cfunc(virtual_device_name, option_string, vi)
@@ -194,9 +194,9 @@ class Library(object):
                 try:
                     self.niSE_WaitForDebounce_cfunc = self._library.niSE_WaitForDebounce
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSE_WaitForDebounce was not found in the NI Switch Executive runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSE_WaitForDebounce_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niSE_WaitForDebounce_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_WaitForDebounce_cfunc(vi, maximum_time_ms)

--- a/generated/nise/nise/_library.py
+++ b/generated/nise/nise/_library.py
@@ -2,6 +2,7 @@
 # This file was generated
 
 import ctypes
+import nise.errors as errors
 import threading
 
 from nise._visatype import *  # noqa: F403,H303
@@ -32,15 +33,17 @@ class Library(object):
         self.niSE_OpenSession_cfunc = None
         self.niSE_WaitForDebounce_cfunc = None
 
+    def _get_library_function(self, name):
+        try:
+            function = getattr(self._library, 'fred')
+        except AttributeError as e:
+            raise errors.DriverTooOldError() from e
+        return function
+
     def niSE_CloseSession(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niSE_CloseSession_cfunc is None:
-                try:
-                    self.niSE_CloseSession_cfunc = self._library.niSE_CloseSession
-                except AttributeError as e:
-                    raise AttributeError("Function niSE_CloseSession was not found in the NI Switch Executive runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSE_CloseSession_cfunc = self._get_library_function('niSE_CloseSession')
                 self.niSE_CloseSession_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSE_CloseSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_CloseSession_cfunc(vi)
@@ -48,12 +51,7 @@ class Library(object):
     def niSE_Connect(self, vi, connect_spec, multiconnect_mode, wait_for_debounce):  # noqa: N802
         with self._func_lock:
             if self.niSE_Connect_cfunc is None:
-                try:
-                    self.niSE_Connect_cfunc = self._library.niSE_Connect
-                except AttributeError as e:
-                    raise AttributeError("Function niSE_Connect was not found in the NI Switch Executive runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSE_Connect_cfunc = self._get_library_function('niSE_Connect')
                 self.niSE_Connect_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViBoolean]  # noqa: F405
                 self.niSE_Connect_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_Connect_cfunc(vi, connect_spec, multiconnect_mode, wait_for_debounce)
@@ -61,12 +59,7 @@ class Library(object):
     def niSE_ConnectAndDisconnect(self, vi, connect_spec, disconnect_spec, multiconnect_mode, operation_order, wait_for_debounce):  # noqa: N802
         with self._func_lock:
             if self.niSE_ConnectAndDisconnect_cfunc is None:
-                try:
-                    self.niSE_ConnectAndDisconnect_cfunc = self._library.niSE_ConnectAndDisconnect
-                except AttributeError as e:
-                    raise AttributeError("Function niSE_ConnectAndDisconnect was not found in the NI Switch Executive runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSE_ConnectAndDisconnect_cfunc = self._get_library_function('niSE_ConnectAndDisconnect')
                 self.niSE_ConnectAndDisconnect_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViInt32, ViBoolean]  # noqa: F405
                 self.niSE_ConnectAndDisconnect_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_ConnectAndDisconnect_cfunc(vi, connect_spec, disconnect_spec, multiconnect_mode, operation_order, wait_for_debounce)
@@ -74,12 +67,7 @@ class Library(object):
     def niSE_Disconnect(self, vi, disconnect_spec):  # noqa: N802
         with self._func_lock:
             if self.niSE_Disconnect_cfunc is None:
-                try:
-                    self.niSE_Disconnect_cfunc = self._library.niSE_Disconnect
-                except AttributeError as e:
-                    raise AttributeError("Function niSE_Disconnect was not found in the NI Switch Executive runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSE_Disconnect_cfunc = self._get_library_function('niSE_Disconnect')
                 self.niSE_Disconnect_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSE_Disconnect_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_Disconnect_cfunc(vi, disconnect_spec)
@@ -87,12 +75,7 @@ class Library(object):
     def niSE_DisconnectAll(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niSE_DisconnectAll_cfunc is None:
-                try:
-                    self.niSE_DisconnectAll_cfunc = self._library.niSE_DisconnectAll
-                except AttributeError as e:
-                    raise AttributeError("Function niSE_DisconnectAll was not found in the NI Switch Executive runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSE_DisconnectAll_cfunc = self._get_library_function('niSE_DisconnectAll')
                 self.niSE_DisconnectAll_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSE_DisconnectAll_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_DisconnectAll_cfunc(vi)
@@ -100,12 +83,7 @@ class Library(object):
     def niSE_ExpandRouteSpec(self, vi, route_spec, expand_action, expanded_route_spec, expanded_route_spec_size):  # noqa: N802
         with self._func_lock:
             if self.niSE_ExpandRouteSpec_cfunc is None:
-                try:
-                    self.niSE_ExpandRouteSpec_cfunc = self._library.niSE_ExpandRouteSpec
-                except AttributeError as e:
-                    raise AttributeError("Function niSE_ExpandRouteSpec was not found in the NI Switch Executive runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSE_ExpandRouteSpec_cfunc = self._get_library_function('niSE_ExpandRouteSpec')
                 self.niSE_ExpandRouteSpec_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSE_ExpandRouteSpec_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_ExpandRouteSpec_cfunc(vi, route_spec, expand_action, expanded_route_spec, expanded_route_spec_size)
@@ -113,12 +91,7 @@ class Library(object):
     def niSE_FindRoute(self, vi, channel1, channel2, route_spec, route_spec_size, path_capability):  # noqa: N802
         with self._func_lock:
             if self.niSE_FindRoute_cfunc is None:
-                try:
-                    self.niSE_FindRoute_cfunc = self._library.niSE_FindRoute
-                except AttributeError as e:
-                    raise AttributeError("Function niSE_FindRoute was not found in the NI Switch Executive runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSE_FindRoute_cfunc = self._get_library_function('niSE_FindRoute')
                 self.niSE_FindRoute_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSE_FindRoute_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_FindRoute_cfunc(vi, channel1, channel2, route_spec, route_spec_size, path_capability)
@@ -126,12 +99,7 @@ class Library(object):
     def niSE_GetAllConnections(self, vi, route_spec, route_spec_size):  # noqa: N802
         with self._func_lock:
             if self.niSE_GetAllConnections_cfunc is None:
-                try:
-                    self.niSE_GetAllConnections_cfunc = self._library.niSE_GetAllConnections
-                except AttributeError as e:
-                    raise AttributeError("Function niSE_GetAllConnections was not found in the NI Switch Executive runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSE_GetAllConnections_cfunc = self._get_library_function('niSE_GetAllConnections')
                 self.niSE_GetAllConnections_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSE_GetAllConnections_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_GetAllConnections_cfunc(vi, route_spec, route_spec_size)
@@ -139,12 +107,7 @@ class Library(object):
     def niSE_GetError(self, vi, error_number, error_description, error_description_size):  # noqa: N802
         with self._func_lock:
             if self.niSE_GetError_cfunc is None:
-                try:
-                    self.niSE_GetError_cfunc = self._library.niSE_GetError
-                except AttributeError as e:
-                    raise AttributeError("Function niSE_GetError was not found in the NI Switch Executive runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSE_GetError_cfunc = self._get_library_function('niSE_GetError')
                 self.niSE_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSE_GetError_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_GetError_cfunc(vi, error_number, error_description, error_description_size)
@@ -152,12 +115,7 @@ class Library(object):
     def niSE_IsConnected(self, vi, route_spec, is_connected):  # noqa: N802
         with self._func_lock:
             if self.niSE_IsConnected_cfunc is None:
-                try:
-                    self.niSE_IsConnected_cfunc = self._library.niSE_IsConnected
-                except AttributeError as e:
-                    raise AttributeError("Function niSE_IsConnected was not found in the NI Switch Executive runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSE_IsConnected_cfunc = self._get_library_function('niSE_IsConnected')
                 self.niSE_IsConnected_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niSE_IsConnected_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_IsConnected_cfunc(vi, route_spec, is_connected)
@@ -165,12 +123,7 @@ class Library(object):
     def niSE_IsDebounced(self, vi, is_debounced):  # noqa: N802
         with self._func_lock:
             if self.niSE_IsDebounced_cfunc is None:
-                try:
-                    self.niSE_IsDebounced_cfunc = self._library.niSE_IsDebounced
-                except AttributeError as e:
-                    raise AttributeError("Function niSE_IsDebounced was not found in the NI Switch Executive runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSE_IsDebounced_cfunc = self._get_library_function('niSE_IsDebounced')
                 self.niSE_IsDebounced_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niSE_IsDebounced_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_IsDebounced_cfunc(vi, is_debounced)
@@ -178,12 +131,7 @@ class Library(object):
     def niSE_OpenSession(self, virtual_device_name, option_string, vi):  # noqa: N802
         with self._func_lock:
             if self.niSE_OpenSession_cfunc is None:
-                try:
-                    self.niSE_OpenSession_cfunc = self._library.niSE_OpenSession
-                except AttributeError as e:
-                    raise AttributeError("Function niSE_OpenSession was not found in the NI Switch Executive runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSE_OpenSession_cfunc = self._get_library_function('niSE_OpenSession')
                 self.niSE_OpenSession_cfunc.argtypes = [ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niSE_OpenSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_OpenSession_cfunc(virtual_device_name, option_string, vi)
@@ -191,12 +139,7 @@ class Library(object):
     def niSE_WaitForDebounce(self, vi, maximum_time_ms):  # noqa: N802
         with self._func_lock:
             if self.niSE_WaitForDebounce_cfunc is None:
-                try:
-                    self.niSE_WaitForDebounce_cfunc = self._library.niSE_WaitForDebounce
-                except AttributeError as e:
-                    raise AttributeError("Function niSE_WaitForDebounce was not found in the NI Switch Executive runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSE_WaitForDebounce_cfunc = self._get_library_function('niSE_WaitForDebounce')
                 self.niSE_WaitForDebounce_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niSE_WaitForDebounce_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_WaitForDebounce_cfunc(vi, maximum_time_ms)

--- a/generated/nise/nise/_library.py
+++ b/generated/nise/nise/_library.py
@@ -35,7 +35,12 @@ class Library(object):
     def niSE_CloseSession(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niSE_CloseSession_cfunc is None:
-                self.niSE_CloseSession_cfunc = self._library.niSE_CloseSession
+                try:
+                    self.niSE_CloseSession_cfunc = self._library.niSE_CloseSession
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSE_CloseSession_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSE_CloseSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_CloseSession_cfunc(vi)
@@ -43,7 +48,12 @@ class Library(object):
     def niSE_Connect(self, vi, connect_spec, multiconnect_mode, wait_for_debounce):  # noqa: N802
         with self._func_lock:
             if self.niSE_Connect_cfunc is None:
-                self.niSE_Connect_cfunc = self._library.niSE_Connect
+                try:
+                    self.niSE_Connect_cfunc = self._library.niSE_Connect
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSE_Connect_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ViBoolean]  # noqa: F405
                 self.niSE_Connect_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_Connect_cfunc(vi, connect_spec, multiconnect_mode, wait_for_debounce)
@@ -51,7 +61,12 @@ class Library(object):
     def niSE_ConnectAndDisconnect(self, vi, connect_spec, disconnect_spec, multiconnect_mode, operation_order, wait_for_debounce):  # noqa: N802
         with self._func_lock:
             if self.niSE_ConnectAndDisconnect_cfunc is None:
-                self.niSE_ConnectAndDisconnect_cfunc = self._library.niSE_ConnectAndDisconnect
+                try:
+                    self.niSE_ConnectAndDisconnect_cfunc = self._library.niSE_ConnectAndDisconnect
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSE_ConnectAndDisconnect_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ViInt32, ViBoolean]  # noqa: F405
                 self.niSE_ConnectAndDisconnect_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_ConnectAndDisconnect_cfunc(vi, connect_spec, disconnect_spec, multiconnect_mode, operation_order, wait_for_debounce)
@@ -59,7 +74,12 @@ class Library(object):
     def niSE_Disconnect(self, vi, disconnect_spec):  # noqa: N802
         with self._func_lock:
             if self.niSE_Disconnect_cfunc is None:
-                self.niSE_Disconnect_cfunc = self._library.niSE_Disconnect
+                try:
+                    self.niSE_Disconnect_cfunc = self._library.niSE_Disconnect
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSE_Disconnect_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSE_Disconnect_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_Disconnect_cfunc(vi, disconnect_spec)
@@ -67,7 +87,12 @@ class Library(object):
     def niSE_DisconnectAll(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niSE_DisconnectAll_cfunc is None:
-                self.niSE_DisconnectAll_cfunc = self._library.niSE_DisconnectAll
+                try:
+                    self.niSE_DisconnectAll_cfunc = self._library.niSE_DisconnectAll
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSE_DisconnectAll_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSE_DisconnectAll_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_DisconnectAll_cfunc(vi)
@@ -75,7 +100,12 @@ class Library(object):
     def niSE_ExpandRouteSpec(self, vi, route_spec, expand_action, expanded_route_spec, expanded_route_spec_size):  # noqa: N802
         with self._func_lock:
             if self.niSE_ExpandRouteSpec_cfunc is None:
-                self.niSE_ExpandRouteSpec_cfunc = self._library.niSE_ExpandRouteSpec
+                try:
+                    self.niSE_ExpandRouteSpec_cfunc = self._library.niSE_ExpandRouteSpec
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSE_ExpandRouteSpec_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSE_ExpandRouteSpec_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_ExpandRouteSpec_cfunc(vi, route_spec, expand_action, expanded_route_spec, expanded_route_spec_size)
@@ -83,7 +113,12 @@ class Library(object):
     def niSE_FindRoute(self, vi, channel1, channel2, route_spec, route_spec_size, path_capability):  # noqa: N802
         with self._func_lock:
             if self.niSE_FindRoute_cfunc is None:
-                self.niSE_FindRoute_cfunc = self._library.niSE_FindRoute
+                try:
+                    self.niSE_FindRoute_cfunc = self._library.niSE_FindRoute
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSE_FindRoute_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSE_FindRoute_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_FindRoute_cfunc(vi, channel1, channel2, route_spec, route_spec_size, path_capability)
@@ -91,7 +126,12 @@ class Library(object):
     def niSE_GetAllConnections(self, vi, route_spec, route_spec_size):  # noqa: N802
         with self._func_lock:
             if self.niSE_GetAllConnections_cfunc is None:
-                self.niSE_GetAllConnections_cfunc = self._library.niSE_GetAllConnections
+                try:
+                    self.niSE_GetAllConnections_cfunc = self._library.niSE_GetAllConnections
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSE_GetAllConnections_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSE_GetAllConnections_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_GetAllConnections_cfunc(vi, route_spec, route_spec_size)
@@ -99,7 +139,12 @@ class Library(object):
     def niSE_GetError(self, vi, error_number, error_description, error_description_size):  # noqa: N802
         with self._func_lock:
             if self.niSE_GetError_cfunc is None:
-                self.niSE_GetError_cfunc = self._library.niSE_GetError
+                try:
+                    self.niSE_GetError_cfunc = self._library.niSE_GetError
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSE_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSE_GetError_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_GetError_cfunc(vi, error_number, error_description, error_description_size)
@@ -107,7 +152,12 @@ class Library(object):
     def niSE_IsConnected(self, vi, route_spec, is_connected):  # noqa: N802
         with self._func_lock:
             if self.niSE_IsConnected_cfunc is None:
-                self.niSE_IsConnected_cfunc = self._library.niSE_IsConnected
+                try:
+                    self.niSE_IsConnected_cfunc = self._library.niSE_IsConnected
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSE_IsConnected_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niSE_IsConnected_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_IsConnected_cfunc(vi, route_spec, is_connected)
@@ -115,7 +165,12 @@ class Library(object):
     def niSE_IsDebounced(self, vi, is_debounced):  # noqa: N802
         with self._func_lock:
             if self.niSE_IsDebounced_cfunc is None:
-                self.niSE_IsDebounced_cfunc = self._library.niSE_IsDebounced
+                try:
+                    self.niSE_IsDebounced_cfunc = self._library.niSE_IsDebounced
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSE_IsDebounced_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niSE_IsDebounced_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_IsDebounced_cfunc(vi, is_debounced)
@@ -123,7 +178,12 @@ class Library(object):
     def niSE_OpenSession(self, virtual_device_name, option_string, vi):  # noqa: N802
         with self._func_lock:
             if self.niSE_OpenSession_cfunc is None:
-                self.niSE_OpenSession_cfunc = self._library.niSE_OpenSession
+                try:
+                    self.niSE_OpenSession_cfunc = self._library.niSE_OpenSession
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSE_OpenSession_cfunc.argtypes = [ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niSE_OpenSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_OpenSession_cfunc(virtual_device_name, option_string, vi)
@@ -131,7 +191,12 @@ class Library(object):
     def niSE_WaitForDebounce(self, vi, maximum_time_ms):  # noqa: N802
         with self._func_lock:
             if self.niSE_WaitForDebounce_cfunc is None:
-                self.niSE_WaitForDebounce_cfunc = self._library.niSE_WaitForDebounce
+                try:
+                    self.niSE_WaitForDebounce_cfunc = self._library.niSE_WaitForDebounce
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSE_WaitForDebounce_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niSE_WaitForDebounce_cfunc.restype = ViStatus  # noqa: F405
         return self.niSE_WaitForDebounce_cfunc(vi, maximum_time_ms)

--- a/generated/nise/nise/_library.py
+++ b/generated/nise/nise/_library.py
@@ -35,7 +35,7 @@ class Library(object):
 
     def _get_library_function(self, name):
         try:
-            function = getattr(self._library, 'fred')
+            function = getattr(self._library, name)
         except AttributeError as e:
             raise errors.DriverTooOldError() from e
         return function

--- a/generated/nise/nise/errors.py
+++ b/generated/nise/nise/errors.py
@@ -57,6 +57,13 @@ class DriverNotInstalledError(Error):
         super(DriverNotInstalledError, self).__init__('The NI Switch Executive runtime could not be loaded. Make sure it is installed and its bitness matches that of your Python interpreter. Please visit http://www.ni.com/downloads/drivers/ to download and install it.')
 
 
+class DriverTooOldError(Error):
+    '''An error due to using this module with an older version of the driver runtime.'''
+
+    def __init__(self):
+        super(DriverTooOldError, self).__init__('A function was not found in the NI Switch Executive runtime. Please visit http://www.ni.com/downloads/drivers/ to download a newer version and install it.')
+
+
 class InvalidRepeatedCapabilityError(Error):
     '''An error due to an invalid character in a repeated capability'''
 

--- a/generated/niswitch/niswitch/_library.py
+++ b/generated/niswitch/niswitch/_library.py
@@ -2,6 +2,7 @@
 # This file was generated
 
 import ctypes
+import niswitch.errors as errors
 import threading
 
 from niswitch._visatype import *  # noqa: F403,H303
@@ -58,15 +59,17 @@ class Library(object):
         self.niSwitch_reset_cfunc = None
         self.niSwitch_self_test_cfunc = None
 
+    def _get_library_function(self, name):
+        try:
+            function = getattr(self._library, 'fred')
+        except AttributeError as e:
+            raise errors.DriverTooOldError() from e
+        return function
+
     def niSwitch_AbortScan(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_AbortScan_cfunc is None:
-                try:
-                    self.niSwitch_AbortScan_cfunc = self._library.niSwitch_AbortScan
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_AbortScan was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_AbortScan_cfunc = self._get_library_function('niSwitch_AbortScan')
                 self.niSwitch_AbortScan_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_AbortScan_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_AbortScan_cfunc(vi)
@@ -74,12 +77,7 @@ class Library(object):
     def niSwitch_CanConnect(self, vi, channel1, channel2, path_capability):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_CanConnect_cfunc is None:
-                try:
-                    self.niSwitch_CanConnect_cfunc = self._library.niSwitch_CanConnect
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_CanConnect was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_CanConnect_cfunc = self._get_library_function('niSwitch_CanConnect')
                 self.niSwitch_CanConnect_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSwitch_CanConnect_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_CanConnect_cfunc(vi, channel1, channel2, path_capability)
@@ -87,12 +85,7 @@ class Library(object):
     def niSwitch_Commit(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_Commit_cfunc is None:
-                try:
-                    self.niSwitch_Commit_cfunc = self._library.niSwitch_Commit
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_Commit was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_Commit_cfunc = self._get_library_function('niSwitch_Commit')
                 self.niSwitch_Commit_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_Commit_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_Commit_cfunc(vi)
@@ -100,12 +93,7 @@ class Library(object):
     def niSwitch_Connect(self, vi, channel1, channel2):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_Connect_cfunc is None:
-                try:
-                    self.niSwitch_Connect_cfunc = self._library.niSwitch_Connect
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_Connect was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_Connect_cfunc = self._get_library_function('niSwitch_Connect')
                 self.niSwitch_Connect_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_Connect_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_Connect_cfunc(vi, channel1, channel2)
@@ -113,12 +101,7 @@ class Library(object):
     def niSwitch_ConnectMultiple(self, vi, connection_list):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_ConnectMultiple_cfunc is None:
-                try:
-                    self.niSwitch_ConnectMultiple_cfunc = self._library.niSwitch_ConnectMultiple
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_ConnectMultiple was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_ConnectMultiple_cfunc = self._get_library_function('niSwitch_ConnectMultiple')
                 self.niSwitch_ConnectMultiple_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_ConnectMultiple_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_ConnectMultiple_cfunc(vi, connection_list)
@@ -126,12 +109,7 @@ class Library(object):
     def niSwitch_Disable(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_Disable_cfunc is None:
-                try:
-                    self.niSwitch_Disable_cfunc = self._library.niSwitch_Disable
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_Disable was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_Disable_cfunc = self._get_library_function('niSwitch_Disable')
                 self.niSwitch_Disable_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_Disable_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_Disable_cfunc(vi)
@@ -139,12 +117,7 @@ class Library(object):
     def niSwitch_Disconnect(self, vi, channel1, channel2):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_Disconnect_cfunc is None:
-                try:
-                    self.niSwitch_Disconnect_cfunc = self._library.niSwitch_Disconnect
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_Disconnect was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_Disconnect_cfunc = self._get_library_function('niSwitch_Disconnect')
                 self.niSwitch_Disconnect_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_Disconnect_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_Disconnect_cfunc(vi, channel1, channel2)
@@ -152,12 +125,7 @@ class Library(object):
     def niSwitch_DisconnectAll(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_DisconnectAll_cfunc is None:
-                try:
-                    self.niSwitch_DisconnectAll_cfunc = self._library.niSwitch_DisconnectAll
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_DisconnectAll was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_DisconnectAll_cfunc = self._get_library_function('niSwitch_DisconnectAll')
                 self.niSwitch_DisconnectAll_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_DisconnectAll_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_DisconnectAll_cfunc(vi)
@@ -165,12 +133,7 @@ class Library(object):
     def niSwitch_DisconnectMultiple(self, vi, disconnection_list):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_DisconnectMultiple_cfunc is None:
-                try:
-                    self.niSwitch_DisconnectMultiple_cfunc = self._library.niSwitch_DisconnectMultiple
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_DisconnectMultiple was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_DisconnectMultiple_cfunc = self._get_library_function('niSwitch_DisconnectMultiple')
                 self.niSwitch_DisconnectMultiple_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_DisconnectMultiple_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_DisconnectMultiple_cfunc(vi, disconnection_list)
@@ -178,12 +141,7 @@ class Library(object):
     def niSwitch_GetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_GetAttributeViBoolean_cfunc is None:
-                try:
-                    self.niSwitch_GetAttributeViBoolean_cfunc = self._library.niSwitch_GetAttributeViBoolean
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_GetAttributeViBoolean was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_GetAttributeViBoolean_cfunc = self._get_library_function('niSwitch_GetAttributeViBoolean')
                 self.niSwitch_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niSwitch_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -191,12 +149,7 @@ class Library(object):
     def niSwitch_GetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_GetAttributeViInt32_cfunc is None:
-                try:
-                    self.niSwitch_GetAttributeViInt32_cfunc = self._library.niSwitch_GetAttributeViInt32
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_GetAttributeViInt32 was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_GetAttributeViInt32_cfunc = self._get_library_function('niSwitch_GetAttributeViInt32')
                 self.niSwitch_GetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSwitch_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -204,12 +157,7 @@ class Library(object):
     def niSwitch_GetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_GetAttributeViReal64_cfunc is None:
-                try:
-                    self.niSwitch_GetAttributeViReal64_cfunc = self._library.niSwitch_GetAttributeViReal64
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_GetAttributeViReal64 was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_GetAttributeViReal64_cfunc = self._get_library_function('niSwitch_GetAttributeViReal64')
                 self.niSwitch_GetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niSwitch_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -217,12 +165,7 @@ class Library(object):
     def niSwitch_GetAttributeViString(self, vi, channel_name, attribute_id, array_size, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_GetAttributeViString_cfunc is None:
-                try:
-                    self.niSwitch_GetAttributeViString_cfunc = self._library.niSwitch_GetAttributeViString
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_GetAttributeViString was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_GetAttributeViString_cfunc = self._get_library_function('niSwitch_GetAttributeViString')
                 self.niSwitch_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetAttributeViString_cfunc(vi, channel_name, attribute_id, array_size, attribute_value)
@@ -230,12 +173,7 @@ class Library(object):
     def niSwitch_GetChannelName(self, vi, index, buffer_size, channel_name_buffer):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_GetChannelName_cfunc is None:
-                try:
-                    self.niSwitch_GetChannelName_cfunc = self._library.niSwitch_GetChannelName
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_GetChannelName was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_GetChannelName_cfunc = self._get_library_function('niSwitch_GetChannelName')
                 self.niSwitch_GetChannelName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_GetChannelName_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetChannelName_cfunc(vi, index, buffer_size, channel_name_buffer)
@@ -243,12 +181,7 @@ class Library(object):
     def niSwitch_GetError(self, vi, code, buffer_size, description):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_GetError_cfunc is None:
-                try:
-                    self.niSwitch_GetError_cfunc = self._library.niSwitch_GetError
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_GetError was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_GetError_cfunc = self._get_library_function('niSwitch_GetError')
                 self.niSwitch_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_GetError_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetError_cfunc(vi, code, buffer_size, description)
@@ -256,12 +189,7 @@ class Library(object):
     def niSwitch_GetPath(self, vi, channel1, channel2, buffer_size, path):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_GetPath_cfunc is None:
-                try:
-                    self.niSwitch_GetPath_cfunc = self._library.niSwitch_GetPath
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_GetPath was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_GetPath_cfunc = self._get_library_function('niSwitch_GetPath')
                 self.niSwitch_GetPath_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_GetPath_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetPath_cfunc(vi, channel1, channel2, buffer_size, path)
@@ -269,12 +197,7 @@ class Library(object):
     def niSwitch_GetRelayCount(self, vi, relay_name, relay_count):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_GetRelayCount_cfunc is None:
-                try:
-                    self.niSwitch_GetRelayCount_cfunc = self._library.niSwitch_GetRelayCount
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_GetRelayCount was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_GetRelayCount_cfunc = self._get_library_function('niSwitch_GetRelayCount')
                 self.niSwitch_GetRelayCount_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSwitch_GetRelayCount_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetRelayCount_cfunc(vi, relay_name, relay_count)
@@ -282,12 +205,7 @@ class Library(object):
     def niSwitch_GetRelayName(self, vi, index, relay_name_buffer_size, relay_name_buffer):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_GetRelayName_cfunc is None:
-                try:
-                    self.niSwitch_GetRelayName_cfunc = self._library.niSwitch_GetRelayName
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_GetRelayName was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_GetRelayName_cfunc = self._get_library_function('niSwitch_GetRelayName')
                 self.niSwitch_GetRelayName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_GetRelayName_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetRelayName_cfunc(vi, index, relay_name_buffer_size, relay_name_buffer)
@@ -295,12 +213,7 @@ class Library(object):
     def niSwitch_GetRelayPosition(self, vi, relay_name, relay_position):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_GetRelayPosition_cfunc is None:
-                try:
-                    self.niSwitch_GetRelayPosition_cfunc = self._library.niSwitch_GetRelayPosition
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_GetRelayPosition was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_GetRelayPosition_cfunc = self._get_library_function('niSwitch_GetRelayPosition')
                 self.niSwitch_GetRelayPosition_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSwitch_GetRelayPosition_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetRelayPosition_cfunc(vi, relay_name, relay_position)
@@ -308,12 +221,7 @@ class Library(object):
     def niSwitch_InitWithTopology(self, resource_name, topology, simulate, reset_device, vi):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_InitWithTopology_cfunc is None:
-                try:
-                    self.niSwitch_InitWithTopology_cfunc = self._library.niSwitch_InitWithTopology
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_InitWithTopology was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_InitWithTopology_cfunc = self._get_library_function('niSwitch_InitWithTopology')
                 self.niSwitch_InitWithTopology_cfunc.argtypes = [ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViBoolean, ViBoolean, ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niSwitch_InitWithTopology_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_InitWithTopology_cfunc(resource_name, topology, simulate, reset_device, vi)
@@ -321,12 +229,7 @@ class Library(object):
     def niSwitch_InitiateScan(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_InitiateScan_cfunc is None:
-                try:
-                    self.niSwitch_InitiateScan_cfunc = self._library.niSwitch_InitiateScan
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_InitiateScan was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_InitiateScan_cfunc = self._get_library_function('niSwitch_InitiateScan')
                 self.niSwitch_InitiateScan_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_InitiateScan_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_InitiateScan_cfunc(vi)
@@ -334,12 +237,7 @@ class Library(object):
     def niSwitch_LockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_LockSession_cfunc is None:
-                try:
-                    self.niSwitch_LockSession_cfunc = self._library.niSwitch_LockSession
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_LockSession was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_LockSession_cfunc = self._get_library_function('niSwitch_LockSession')
                 self.niSwitch_LockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niSwitch_LockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_LockSession_cfunc(vi, caller_has_lock)
@@ -347,12 +245,7 @@ class Library(object):
     def niSwitch_RelayControl(self, vi, relay_name, relay_action):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_RelayControl_cfunc is None:
-                try:
-                    self.niSwitch_RelayControl_cfunc = self._library.niSwitch_RelayControl
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_RelayControl was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_RelayControl_cfunc = self._get_library_function('niSwitch_RelayControl')
                 self.niSwitch_RelayControl_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niSwitch_RelayControl_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_RelayControl_cfunc(vi, relay_name, relay_action)
@@ -360,12 +253,7 @@ class Library(object):
     def niSwitch_ResetWithDefaults(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_ResetWithDefaults_cfunc is None:
-                try:
-                    self.niSwitch_ResetWithDefaults_cfunc = self._library.niSwitch_ResetWithDefaults
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_ResetWithDefaults was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_ResetWithDefaults_cfunc = self._get_library_function('niSwitch_ResetWithDefaults')
                 self.niSwitch_ResetWithDefaults_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_ResetWithDefaults_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_ResetWithDefaults_cfunc(vi)
@@ -373,12 +261,7 @@ class Library(object):
     def niSwitch_RouteScanAdvancedOutput(self, vi, scan_advanced_output_connector, scan_advanced_output_bus_line, invert):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_RouteScanAdvancedOutput_cfunc is None:
-                try:
-                    self.niSwitch_RouteScanAdvancedOutput_cfunc = self._library.niSwitch_RouteScanAdvancedOutput
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_RouteScanAdvancedOutput was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_RouteScanAdvancedOutput_cfunc = self._get_library_function('niSwitch_RouteScanAdvancedOutput')
                 self.niSwitch_RouteScanAdvancedOutput_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ViBoolean]  # noqa: F405
                 self.niSwitch_RouteScanAdvancedOutput_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_RouteScanAdvancedOutput_cfunc(vi, scan_advanced_output_connector, scan_advanced_output_bus_line, invert)
@@ -386,12 +269,7 @@ class Library(object):
     def niSwitch_RouteTriggerInput(self, vi, trigger_input_connector, trigger_input_bus_line, invert):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_RouteTriggerInput_cfunc is None:
-                try:
-                    self.niSwitch_RouteTriggerInput_cfunc = self._library.niSwitch_RouteTriggerInput
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_RouteTriggerInput was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_RouteTriggerInput_cfunc = self._get_library_function('niSwitch_RouteTriggerInput')
                 self.niSwitch_RouteTriggerInput_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ViBoolean]  # noqa: F405
                 self.niSwitch_RouteTriggerInput_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_RouteTriggerInput_cfunc(vi, trigger_input_connector, trigger_input_bus_line, invert)
@@ -399,12 +277,7 @@ class Library(object):
     def niSwitch_SendSoftwareTrigger(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_SendSoftwareTrigger_cfunc is None:
-                try:
-                    self.niSwitch_SendSoftwareTrigger_cfunc = self._library.niSwitch_SendSoftwareTrigger
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_SendSoftwareTrigger was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_SendSoftwareTrigger_cfunc = self._get_library_function('niSwitch_SendSoftwareTrigger')
                 self.niSwitch_SendSoftwareTrigger_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_SendSoftwareTrigger_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_SendSoftwareTrigger_cfunc(vi)
@@ -412,12 +285,7 @@ class Library(object):
     def niSwitch_SetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_SetAttributeViBoolean_cfunc is None:
-                try:
-                    self.niSwitch_SetAttributeViBoolean_cfunc = self._library.niSwitch_SetAttributeViBoolean
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_SetAttributeViBoolean was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_SetAttributeViBoolean_cfunc = self._get_library_function('niSwitch_SetAttributeViBoolean')
                 self.niSwitch_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViBoolean]  # noqa: F405
                 self.niSwitch_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_SetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -425,12 +293,7 @@ class Library(object):
     def niSwitch_SetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_SetAttributeViInt32_cfunc is None:
-                try:
-                    self.niSwitch_SetAttributeViInt32_cfunc = self._library.niSwitch_SetAttributeViInt32
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_SetAttributeViInt32 was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_SetAttributeViInt32_cfunc = self._get_library_function('niSwitch_SetAttributeViInt32')
                 self.niSwitch_SetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32]  # noqa: F405
                 self.niSwitch_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_SetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -438,12 +301,7 @@ class Library(object):
     def niSwitch_SetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_SetAttributeViReal64_cfunc is None:
-                try:
-                    self.niSwitch_SetAttributeViReal64_cfunc = self._library.niSwitch_SetAttributeViReal64
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_SetAttributeViReal64 was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_SetAttributeViReal64_cfunc = self._get_library_function('niSwitch_SetAttributeViReal64')
                 self.niSwitch_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niSwitch_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_SetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -451,12 +309,7 @@ class Library(object):
     def niSwitch_SetAttributeViString(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_SetAttributeViString_cfunc is None:
-                try:
-                    self.niSwitch_SetAttributeViString_cfunc = self._library.niSwitch_SetAttributeViString
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_SetAttributeViString was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_SetAttributeViString_cfunc = self._get_library_function('niSwitch_SetAttributeViString')
                 self.niSwitch_SetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_SetAttributeViString_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -464,12 +317,7 @@ class Library(object):
     def niSwitch_SetPath(self, vi, path_list):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_SetPath_cfunc is None:
-                try:
-                    self.niSwitch_SetPath_cfunc = self._library.niSwitch_SetPath
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_SetPath was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_SetPath_cfunc = self._get_library_function('niSwitch_SetPath')
                 self.niSwitch_SetPath_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_SetPath_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_SetPath_cfunc(vi, path_list)
@@ -477,12 +325,7 @@ class Library(object):
     def niSwitch_UnlockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_UnlockSession_cfunc is None:
-                try:
-                    self.niSwitch_UnlockSession_cfunc = self._library.niSwitch_UnlockSession
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_UnlockSession was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_UnlockSession_cfunc = self._get_library_function('niSwitch_UnlockSession')
                 self.niSwitch_UnlockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niSwitch_UnlockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_UnlockSession_cfunc(vi, caller_has_lock)
@@ -490,12 +333,7 @@ class Library(object):
     def niSwitch_WaitForDebounce(self, vi, maximum_time_ms):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_WaitForDebounce_cfunc is None:
-                try:
-                    self.niSwitch_WaitForDebounce_cfunc = self._library.niSwitch_WaitForDebounce
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_WaitForDebounce was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_WaitForDebounce_cfunc = self._get_library_function('niSwitch_WaitForDebounce')
                 self.niSwitch_WaitForDebounce_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niSwitch_WaitForDebounce_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_WaitForDebounce_cfunc(vi, maximum_time_ms)
@@ -503,12 +341,7 @@ class Library(object):
     def niSwitch_WaitForScanComplete(self, vi, maximum_time_ms):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_WaitForScanComplete_cfunc is None:
-                try:
-                    self.niSwitch_WaitForScanComplete_cfunc = self._library.niSwitch_WaitForScanComplete
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_WaitForScanComplete was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_WaitForScanComplete_cfunc = self._get_library_function('niSwitch_WaitForScanComplete')
                 self.niSwitch_WaitForScanComplete_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niSwitch_WaitForScanComplete_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_WaitForScanComplete_cfunc(vi, maximum_time_ms)
@@ -516,12 +349,7 @@ class Library(object):
     def niSwitch_close(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_close_cfunc is None:
-                try:
-                    self.niSwitch_close_cfunc = self._library.niSwitch_close
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_close was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_close_cfunc = self._get_library_function('niSwitch_close')
                 self.niSwitch_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_close_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_close_cfunc(vi)
@@ -529,12 +357,7 @@ class Library(object):
     def niSwitch_error_message(self, vi, error_code, error_message):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_error_message_cfunc is None:
-                try:
-                    self.niSwitch_error_message_cfunc = self._library.niSwitch_error_message
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_error_message was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_error_message_cfunc = self._get_library_function('niSwitch_error_message')
                 self.niSwitch_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_error_message_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_error_message_cfunc(vi, error_code, error_message)
@@ -542,12 +365,7 @@ class Library(object):
     def niSwitch_reset(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_reset_cfunc is None:
-                try:
-                    self.niSwitch_reset_cfunc = self._library.niSwitch_reset
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_reset was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_reset_cfunc = self._get_library_function('niSwitch_reset')
                 self.niSwitch_reset_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_reset_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_reset_cfunc(vi)
@@ -555,12 +373,7 @@ class Library(object):
     def niSwitch_self_test(self, vi, self_test_result, self_test_message):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_self_test_cfunc is None:
-                try:
-                    self.niSwitch_self_test_cfunc = self._library.niSwitch_self_test
-                except AttributeError as e:
-                    raise AttributeError("Function niSwitch_self_test was not found in the NI-SWITCH runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niSwitch_self_test_cfunc = self._get_library_function('niSwitch_self_test')
                 self.niSwitch_self_test_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_self_test_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_self_test_cfunc(vi, self_test_result, self_test_message)

--- a/generated/niswitch/niswitch/_library.py
+++ b/generated/niswitch/niswitch/_library.py
@@ -61,7 +61,7 @@ class Library(object):
 
     def _get_library_function(self, name):
         try:
-            function = getattr(self._library, 'fred')
+            function = getattr(self._library, name)
         except AttributeError as e:
             raise errors.DriverTooOldError() from e
         return function

--- a/generated/niswitch/niswitch/_library.py
+++ b/generated/niswitch/niswitch/_library.py
@@ -64,9 +64,9 @@ class Library(object):
                 try:
                     self.niSwitch_AbortScan_cfunc = self._library.niSwitch_AbortScan
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_AbortScan was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_AbortScan_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_AbortScan_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_AbortScan_cfunc(vi)
@@ -77,9 +77,9 @@ class Library(object):
                 try:
                     self.niSwitch_CanConnect_cfunc = self._library.niSwitch_CanConnect
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_CanConnect was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_CanConnect_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSwitch_CanConnect_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_CanConnect_cfunc(vi, channel1, channel2, path_capability)
@@ -90,9 +90,9 @@ class Library(object):
                 try:
                     self.niSwitch_Commit_cfunc = self._library.niSwitch_Commit
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_Commit was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_Commit_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_Commit_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_Commit_cfunc(vi)
@@ -103,9 +103,9 @@ class Library(object):
                 try:
                     self.niSwitch_Connect_cfunc = self._library.niSwitch_Connect
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_Connect was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_Connect_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_Connect_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_Connect_cfunc(vi, channel1, channel2)
@@ -116,9 +116,9 @@ class Library(object):
                 try:
                     self.niSwitch_ConnectMultiple_cfunc = self._library.niSwitch_ConnectMultiple
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_ConnectMultiple was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_ConnectMultiple_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_ConnectMultiple_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_ConnectMultiple_cfunc(vi, connection_list)
@@ -129,9 +129,9 @@ class Library(object):
                 try:
                     self.niSwitch_Disable_cfunc = self._library.niSwitch_Disable
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_Disable was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_Disable_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_Disable_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_Disable_cfunc(vi)
@@ -142,9 +142,9 @@ class Library(object):
                 try:
                     self.niSwitch_Disconnect_cfunc = self._library.niSwitch_Disconnect
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_Disconnect was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_Disconnect_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_Disconnect_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_Disconnect_cfunc(vi, channel1, channel2)
@@ -155,9 +155,9 @@ class Library(object):
                 try:
                     self.niSwitch_DisconnectAll_cfunc = self._library.niSwitch_DisconnectAll
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_DisconnectAll was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_DisconnectAll_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_DisconnectAll_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_DisconnectAll_cfunc(vi)
@@ -168,9 +168,9 @@ class Library(object):
                 try:
                     self.niSwitch_DisconnectMultiple_cfunc = self._library.niSwitch_DisconnectMultiple
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_DisconnectMultiple was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_DisconnectMultiple_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_DisconnectMultiple_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_DisconnectMultiple_cfunc(vi, disconnection_list)
@@ -181,9 +181,9 @@ class Library(object):
                 try:
                     self.niSwitch_GetAttributeViBoolean_cfunc = self._library.niSwitch_GetAttributeViBoolean
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_GetAttributeViBoolean was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niSwitch_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -194,9 +194,9 @@ class Library(object):
                 try:
                     self.niSwitch_GetAttributeViInt32_cfunc = self._library.niSwitch_GetAttributeViInt32
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_GetAttributeViInt32 was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_GetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSwitch_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -207,9 +207,9 @@ class Library(object):
                 try:
                     self.niSwitch_GetAttributeViReal64_cfunc = self._library.niSwitch_GetAttributeViReal64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_GetAttributeViReal64 was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_GetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niSwitch_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -220,9 +220,9 @@ class Library(object):
                 try:
                     self.niSwitch_GetAttributeViString_cfunc = self._library.niSwitch_GetAttributeViString
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_GetAttributeViString was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetAttributeViString_cfunc(vi, channel_name, attribute_id, array_size, attribute_value)
@@ -233,9 +233,9 @@ class Library(object):
                 try:
                     self.niSwitch_GetChannelName_cfunc = self._library.niSwitch_GetChannelName
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_GetChannelName was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_GetChannelName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_GetChannelName_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetChannelName_cfunc(vi, index, buffer_size, channel_name_buffer)
@@ -246,9 +246,9 @@ class Library(object):
                 try:
                     self.niSwitch_GetError_cfunc = self._library.niSwitch_GetError
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_GetError was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_GetError_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetError_cfunc(vi, code, buffer_size, description)
@@ -259,9 +259,9 @@ class Library(object):
                 try:
                     self.niSwitch_GetPath_cfunc = self._library.niSwitch_GetPath
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_GetPath was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_GetPath_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_GetPath_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetPath_cfunc(vi, channel1, channel2, buffer_size, path)
@@ -272,9 +272,9 @@ class Library(object):
                 try:
                     self.niSwitch_GetRelayCount_cfunc = self._library.niSwitch_GetRelayCount
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_GetRelayCount was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_GetRelayCount_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSwitch_GetRelayCount_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetRelayCount_cfunc(vi, relay_name, relay_count)
@@ -285,9 +285,9 @@ class Library(object):
                 try:
                     self.niSwitch_GetRelayName_cfunc = self._library.niSwitch_GetRelayName
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_GetRelayName was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_GetRelayName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_GetRelayName_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetRelayName_cfunc(vi, index, relay_name_buffer_size, relay_name_buffer)
@@ -298,9 +298,9 @@ class Library(object):
                 try:
                     self.niSwitch_GetRelayPosition_cfunc = self._library.niSwitch_GetRelayPosition
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_GetRelayPosition was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_GetRelayPosition_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSwitch_GetRelayPosition_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetRelayPosition_cfunc(vi, relay_name, relay_position)
@@ -311,9 +311,9 @@ class Library(object):
                 try:
                     self.niSwitch_InitWithTopology_cfunc = self._library.niSwitch_InitWithTopology
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_InitWithTopology was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_InitWithTopology_cfunc.argtypes = [ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViBoolean, ViBoolean, ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niSwitch_InitWithTopology_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_InitWithTopology_cfunc(resource_name, topology, simulate, reset_device, vi)
@@ -324,9 +324,9 @@ class Library(object):
                 try:
                     self.niSwitch_InitiateScan_cfunc = self._library.niSwitch_InitiateScan
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_InitiateScan was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_InitiateScan_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_InitiateScan_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_InitiateScan_cfunc(vi)
@@ -337,9 +337,9 @@ class Library(object):
                 try:
                     self.niSwitch_LockSession_cfunc = self._library.niSwitch_LockSession
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_LockSession was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_LockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niSwitch_LockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_LockSession_cfunc(vi, caller_has_lock)
@@ -350,9 +350,9 @@ class Library(object):
                 try:
                     self.niSwitch_RelayControl_cfunc = self._library.niSwitch_RelayControl
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_RelayControl was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_RelayControl_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niSwitch_RelayControl_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_RelayControl_cfunc(vi, relay_name, relay_action)
@@ -363,9 +363,9 @@ class Library(object):
                 try:
                     self.niSwitch_ResetWithDefaults_cfunc = self._library.niSwitch_ResetWithDefaults
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_ResetWithDefaults was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_ResetWithDefaults_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_ResetWithDefaults_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_ResetWithDefaults_cfunc(vi)
@@ -376,9 +376,9 @@ class Library(object):
                 try:
                     self.niSwitch_RouteScanAdvancedOutput_cfunc = self._library.niSwitch_RouteScanAdvancedOutput
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_RouteScanAdvancedOutput was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_RouteScanAdvancedOutput_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ViBoolean]  # noqa: F405
                 self.niSwitch_RouteScanAdvancedOutput_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_RouteScanAdvancedOutput_cfunc(vi, scan_advanced_output_connector, scan_advanced_output_bus_line, invert)
@@ -389,9 +389,9 @@ class Library(object):
                 try:
                     self.niSwitch_RouteTriggerInput_cfunc = self._library.niSwitch_RouteTriggerInput
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_RouteTriggerInput was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_RouteTriggerInput_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ViBoolean]  # noqa: F405
                 self.niSwitch_RouteTriggerInput_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_RouteTriggerInput_cfunc(vi, trigger_input_connector, trigger_input_bus_line, invert)
@@ -402,9 +402,9 @@ class Library(object):
                 try:
                     self.niSwitch_SendSoftwareTrigger_cfunc = self._library.niSwitch_SendSoftwareTrigger
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_SendSoftwareTrigger was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_SendSoftwareTrigger_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_SendSoftwareTrigger_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_SendSoftwareTrigger_cfunc(vi)
@@ -415,9 +415,9 @@ class Library(object):
                 try:
                     self.niSwitch_SetAttributeViBoolean_cfunc = self._library.niSwitch_SetAttributeViBoolean
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_SetAttributeViBoolean was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViBoolean]  # noqa: F405
                 self.niSwitch_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_SetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -428,9 +428,9 @@ class Library(object):
                 try:
                     self.niSwitch_SetAttributeViInt32_cfunc = self._library.niSwitch_SetAttributeViInt32
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_SetAttributeViInt32 was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_SetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32]  # noqa: F405
                 self.niSwitch_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_SetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -441,9 +441,9 @@ class Library(object):
                 try:
                     self.niSwitch_SetAttributeViReal64_cfunc = self._library.niSwitch_SetAttributeViReal64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_SetAttributeViReal64 was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niSwitch_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_SetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -454,9 +454,9 @@ class Library(object):
                 try:
                     self.niSwitch_SetAttributeViString_cfunc = self._library.niSwitch_SetAttributeViString
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_SetAttributeViString was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_SetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_SetAttributeViString_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -467,9 +467,9 @@ class Library(object):
                 try:
                     self.niSwitch_SetPath_cfunc = self._library.niSwitch_SetPath
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_SetPath was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_SetPath_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_SetPath_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_SetPath_cfunc(vi, path_list)
@@ -480,9 +480,9 @@ class Library(object):
                 try:
                     self.niSwitch_UnlockSession_cfunc = self._library.niSwitch_UnlockSession
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_UnlockSession was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_UnlockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niSwitch_UnlockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_UnlockSession_cfunc(vi, caller_has_lock)
@@ -493,9 +493,9 @@ class Library(object):
                 try:
                     self.niSwitch_WaitForDebounce_cfunc = self._library.niSwitch_WaitForDebounce
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_WaitForDebounce was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_WaitForDebounce_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niSwitch_WaitForDebounce_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_WaitForDebounce_cfunc(vi, maximum_time_ms)
@@ -506,9 +506,9 @@ class Library(object):
                 try:
                     self.niSwitch_WaitForScanComplete_cfunc = self._library.niSwitch_WaitForScanComplete
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_WaitForScanComplete was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_WaitForScanComplete_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niSwitch_WaitForScanComplete_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_WaitForScanComplete_cfunc(vi, maximum_time_ms)
@@ -519,9 +519,9 @@ class Library(object):
                 try:
                     self.niSwitch_close_cfunc = self._library.niSwitch_close
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_close was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_close_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_close_cfunc(vi)
@@ -532,9 +532,9 @@ class Library(object):
                 try:
                     self.niSwitch_error_message_cfunc = self._library.niSwitch_error_message
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_error_message was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_error_message_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_error_message_cfunc(vi, error_code, error_message)
@@ -545,9 +545,9 @@ class Library(object):
                 try:
                     self.niSwitch_reset_cfunc = self._library.niSwitch_reset
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_reset was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_reset_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_reset_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_reset_cfunc(vi)
@@ -558,9 +558,9 @@ class Library(object):
                 try:
                     self.niSwitch_self_test_cfunc = self._library.niSwitch_self_test
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niSwitch_self_test was not found in the NI-SWITCH runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niSwitch_self_test_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_self_test_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_self_test_cfunc(vi, self_test_result, self_test_message)

--- a/generated/niswitch/niswitch/_library.py
+++ b/generated/niswitch/niswitch/_library.py
@@ -61,7 +61,12 @@ class Library(object):
     def niSwitch_AbortScan(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_AbortScan_cfunc is None:
-                self.niSwitch_AbortScan_cfunc = self._library.niSwitch_AbortScan
+                try:
+                    self.niSwitch_AbortScan_cfunc = self._library.niSwitch_AbortScan
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_AbortScan_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_AbortScan_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_AbortScan_cfunc(vi)
@@ -69,7 +74,12 @@ class Library(object):
     def niSwitch_CanConnect(self, vi, channel1, channel2, path_capability):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_CanConnect_cfunc is None:
-                self.niSwitch_CanConnect_cfunc = self._library.niSwitch_CanConnect
+                try:
+                    self.niSwitch_CanConnect_cfunc = self._library.niSwitch_CanConnect
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_CanConnect_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSwitch_CanConnect_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_CanConnect_cfunc(vi, channel1, channel2, path_capability)
@@ -77,7 +87,12 @@ class Library(object):
     def niSwitch_Commit(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_Commit_cfunc is None:
-                self.niSwitch_Commit_cfunc = self._library.niSwitch_Commit
+                try:
+                    self.niSwitch_Commit_cfunc = self._library.niSwitch_Commit
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_Commit_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_Commit_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_Commit_cfunc(vi)
@@ -85,7 +100,12 @@ class Library(object):
     def niSwitch_Connect(self, vi, channel1, channel2):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_Connect_cfunc is None:
-                self.niSwitch_Connect_cfunc = self._library.niSwitch_Connect
+                try:
+                    self.niSwitch_Connect_cfunc = self._library.niSwitch_Connect
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_Connect_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_Connect_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_Connect_cfunc(vi, channel1, channel2)
@@ -93,7 +113,12 @@ class Library(object):
     def niSwitch_ConnectMultiple(self, vi, connection_list):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_ConnectMultiple_cfunc is None:
-                self.niSwitch_ConnectMultiple_cfunc = self._library.niSwitch_ConnectMultiple
+                try:
+                    self.niSwitch_ConnectMultiple_cfunc = self._library.niSwitch_ConnectMultiple
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_ConnectMultiple_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_ConnectMultiple_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_ConnectMultiple_cfunc(vi, connection_list)
@@ -101,7 +126,12 @@ class Library(object):
     def niSwitch_Disable(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_Disable_cfunc is None:
-                self.niSwitch_Disable_cfunc = self._library.niSwitch_Disable
+                try:
+                    self.niSwitch_Disable_cfunc = self._library.niSwitch_Disable
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_Disable_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_Disable_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_Disable_cfunc(vi)
@@ -109,7 +139,12 @@ class Library(object):
     def niSwitch_Disconnect(self, vi, channel1, channel2):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_Disconnect_cfunc is None:
-                self.niSwitch_Disconnect_cfunc = self._library.niSwitch_Disconnect
+                try:
+                    self.niSwitch_Disconnect_cfunc = self._library.niSwitch_Disconnect
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_Disconnect_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_Disconnect_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_Disconnect_cfunc(vi, channel1, channel2)
@@ -117,7 +152,12 @@ class Library(object):
     def niSwitch_DisconnectAll(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_DisconnectAll_cfunc is None:
-                self.niSwitch_DisconnectAll_cfunc = self._library.niSwitch_DisconnectAll
+                try:
+                    self.niSwitch_DisconnectAll_cfunc = self._library.niSwitch_DisconnectAll
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_DisconnectAll_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_DisconnectAll_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_DisconnectAll_cfunc(vi)
@@ -125,7 +165,12 @@ class Library(object):
     def niSwitch_DisconnectMultiple(self, vi, disconnection_list):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_DisconnectMultiple_cfunc is None:
-                self.niSwitch_DisconnectMultiple_cfunc = self._library.niSwitch_DisconnectMultiple
+                try:
+                    self.niSwitch_DisconnectMultiple_cfunc = self._library.niSwitch_DisconnectMultiple
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_DisconnectMultiple_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_DisconnectMultiple_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_DisconnectMultiple_cfunc(vi, disconnection_list)
@@ -133,7 +178,12 @@ class Library(object):
     def niSwitch_GetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_GetAttributeViBoolean_cfunc is None:
-                self.niSwitch_GetAttributeViBoolean_cfunc = self._library.niSwitch_GetAttributeViBoolean
+                try:
+                    self.niSwitch_GetAttributeViBoolean_cfunc = self._library.niSwitch_GetAttributeViBoolean
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_GetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niSwitch_GetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -141,7 +191,12 @@ class Library(object):
     def niSwitch_GetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_GetAttributeViInt32_cfunc is None:
-                self.niSwitch_GetAttributeViInt32_cfunc = self._library.niSwitch_GetAttributeViInt32
+                try:
+                    self.niSwitch_GetAttributeViInt32_cfunc = self._library.niSwitch_GetAttributeViInt32
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_GetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSwitch_GetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -149,7 +204,12 @@ class Library(object):
     def niSwitch_GetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_GetAttributeViReal64_cfunc is None:
-                self.niSwitch_GetAttributeViReal64_cfunc = self._library.niSwitch_GetAttributeViReal64
+                try:
+                    self.niSwitch_GetAttributeViReal64_cfunc = self._library.niSwitch_GetAttributeViReal64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_GetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niSwitch_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -157,7 +217,12 @@ class Library(object):
     def niSwitch_GetAttributeViString(self, vi, channel_name, attribute_id, array_size, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_GetAttributeViString_cfunc is None:
-                self.niSwitch_GetAttributeViString_cfunc = self._library.niSwitch_GetAttributeViString
+                try:
+                    self.niSwitch_GetAttributeViString_cfunc = self._library.niSwitch_GetAttributeViString
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetAttributeViString_cfunc(vi, channel_name, attribute_id, array_size, attribute_value)
@@ -165,7 +230,12 @@ class Library(object):
     def niSwitch_GetChannelName(self, vi, index, buffer_size, channel_name_buffer):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_GetChannelName_cfunc is None:
-                self.niSwitch_GetChannelName_cfunc = self._library.niSwitch_GetChannelName
+                try:
+                    self.niSwitch_GetChannelName_cfunc = self._library.niSwitch_GetChannelName
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_GetChannelName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_GetChannelName_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetChannelName_cfunc(vi, index, buffer_size, channel_name_buffer)
@@ -173,7 +243,12 @@ class Library(object):
     def niSwitch_GetError(self, vi, code, buffer_size, description):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_GetError_cfunc is None:
-                self.niSwitch_GetError_cfunc = self._library.niSwitch_GetError
+                try:
+                    self.niSwitch_GetError_cfunc = self._library.niSwitch_GetError
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_GetError_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetError_cfunc(vi, code, buffer_size, description)
@@ -181,7 +256,12 @@ class Library(object):
     def niSwitch_GetPath(self, vi, channel1, channel2, buffer_size, path):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_GetPath_cfunc is None:
-                self.niSwitch_GetPath_cfunc = self._library.niSwitch_GetPath
+                try:
+                    self.niSwitch_GetPath_cfunc = self._library.niSwitch_GetPath
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_GetPath_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_GetPath_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetPath_cfunc(vi, channel1, channel2, buffer_size, path)
@@ -189,7 +269,12 @@ class Library(object):
     def niSwitch_GetRelayCount(self, vi, relay_name, relay_count):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_GetRelayCount_cfunc is None:
-                self.niSwitch_GetRelayCount_cfunc = self._library.niSwitch_GetRelayCount
+                try:
+                    self.niSwitch_GetRelayCount_cfunc = self._library.niSwitch_GetRelayCount
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_GetRelayCount_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSwitch_GetRelayCount_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetRelayCount_cfunc(vi, relay_name, relay_count)
@@ -197,7 +282,12 @@ class Library(object):
     def niSwitch_GetRelayName(self, vi, index, relay_name_buffer_size, relay_name_buffer):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_GetRelayName_cfunc is None:
-                self.niSwitch_GetRelayName_cfunc = self._library.niSwitch_GetRelayName
+                try:
+                    self.niSwitch_GetRelayName_cfunc = self._library.niSwitch_GetRelayName
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_GetRelayName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_GetRelayName_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetRelayName_cfunc(vi, index, relay_name_buffer_size, relay_name_buffer)
@@ -205,7 +295,12 @@ class Library(object):
     def niSwitch_GetRelayPosition(self, vi, relay_name, relay_position):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_GetRelayPosition_cfunc is None:
-                self.niSwitch_GetRelayPosition_cfunc = self._library.niSwitch_GetRelayPosition
+                try:
+                    self.niSwitch_GetRelayPosition_cfunc = self._library.niSwitch_GetRelayPosition
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_GetRelayPosition_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niSwitch_GetRelayPosition_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetRelayPosition_cfunc(vi, relay_name, relay_position)
@@ -213,7 +308,12 @@ class Library(object):
     def niSwitch_InitWithTopology(self, resource_name, topology, simulate, reset_device, vi):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_InitWithTopology_cfunc is None:
-                self.niSwitch_InitWithTopology_cfunc = self._library.niSwitch_InitWithTopology
+                try:
+                    self.niSwitch_InitWithTopology_cfunc = self._library.niSwitch_InitWithTopology
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_InitWithTopology_cfunc.argtypes = [ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ViBoolean, ViBoolean, ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niSwitch_InitWithTopology_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_InitWithTopology_cfunc(resource_name, topology, simulate, reset_device, vi)
@@ -221,7 +321,12 @@ class Library(object):
     def niSwitch_InitiateScan(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_InitiateScan_cfunc is None:
-                self.niSwitch_InitiateScan_cfunc = self._library.niSwitch_InitiateScan
+                try:
+                    self.niSwitch_InitiateScan_cfunc = self._library.niSwitch_InitiateScan
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_InitiateScan_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_InitiateScan_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_InitiateScan_cfunc(vi)
@@ -229,7 +334,12 @@ class Library(object):
     def niSwitch_LockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_LockSession_cfunc is None:
-                self.niSwitch_LockSession_cfunc = self._library.niSwitch_LockSession
+                try:
+                    self.niSwitch_LockSession_cfunc = self._library.niSwitch_LockSession
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_LockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niSwitch_LockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_LockSession_cfunc(vi, caller_has_lock)
@@ -237,7 +347,12 @@ class Library(object):
     def niSwitch_RelayControl(self, vi, relay_name, relay_action):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_RelayControl_cfunc is None:
-                self.niSwitch_RelayControl_cfunc = self._library.niSwitch_RelayControl
+                try:
+                    self.niSwitch_RelayControl_cfunc = self._library.niSwitch_RelayControl
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_RelayControl_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32]  # noqa: F405
                 self.niSwitch_RelayControl_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_RelayControl_cfunc(vi, relay_name, relay_action)
@@ -245,7 +360,12 @@ class Library(object):
     def niSwitch_ResetWithDefaults(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_ResetWithDefaults_cfunc is None:
-                self.niSwitch_ResetWithDefaults_cfunc = self._library.niSwitch_ResetWithDefaults
+                try:
+                    self.niSwitch_ResetWithDefaults_cfunc = self._library.niSwitch_ResetWithDefaults
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_ResetWithDefaults_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_ResetWithDefaults_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_ResetWithDefaults_cfunc(vi)
@@ -253,7 +373,12 @@ class Library(object):
     def niSwitch_RouteScanAdvancedOutput(self, vi, scan_advanced_output_connector, scan_advanced_output_bus_line, invert):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_RouteScanAdvancedOutput_cfunc is None:
-                self.niSwitch_RouteScanAdvancedOutput_cfunc = self._library.niSwitch_RouteScanAdvancedOutput
+                try:
+                    self.niSwitch_RouteScanAdvancedOutput_cfunc = self._library.niSwitch_RouteScanAdvancedOutput
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_RouteScanAdvancedOutput_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ViBoolean]  # noqa: F405
                 self.niSwitch_RouteScanAdvancedOutput_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_RouteScanAdvancedOutput_cfunc(vi, scan_advanced_output_connector, scan_advanced_output_bus_line, invert)
@@ -261,7 +386,12 @@ class Library(object):
     def niSwitch_RouteTriggerInput(self, vi, trigger_input_connector, trigger_input_bus_line, invert):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_RouteTriggerInput_cfunc is None:
-                self.niSwitch_RouteTriggerInput_cfunc = self._library.niSwitch_RouteTriggerInput
+                try:
+                    self.niSwitch_RouteTriggerInput_cfunc = self._library.niSwitch_RouteTriggerInput
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_RouteTriggerInput_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ViBoolean]  # noqa: F405
                 self.niSwitch_RouteTriggerInput_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_RouteTriggerInput_cfunc(vi, trigger_input_connector, trigger_input_bus_line, invert)
@@ -269,7 +399,12 @@ class Library(object):
     def niSwitch_SendSoftwareTrigger(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_SendSoftwareTrigger_cfunc is None:
-                self.niSwitch_SendSoftwareTrigger_cfunc = self._library.niSwitch_SendSoftwareTrigger
+                try:
+                    self.niSwitch_SendSoftwareTrigger_cfunc = self._library.niSwitch_SendSoftwareTrigger
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_SendSoftwareTrigger_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_SendSoftwareTrigger_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_SendSoftwareTrigger_cfunc(vi)
@@ -277,7 +412,12 @@ class Library(object):
     def niSwitch_SetAttributeViBoolean(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_SetAttributeViBoolean_cfunc is None:
-                self.niSwitch_SetAttributeViBoolean_cfunc = self._library.niSwitch_SetAttributeViBoolean
+                try:
+                    self.niSwitch_SetAttributeViBoolean_cfunc = self._library.niSwitch_SetAttributeViBoolean
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_SetAttributeViBoolean_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViBoolean]  # noqa: F405
                 self.niSwitch_SetAttributeViBoolean_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_SetAttributeViBoolean_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -285,7 +425,12 @@ class Library(object):
     def niSwitch_SetAttributeViInt32(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_SetAttributeViInt32_cfunc is None:
-                self.niSwitch_SetAttributeViInt32_cfunc = self._library.niSwitch_SetAttributeViInt32
+                try:
+                    self.niSwitch_SetAttributeViInt32_cfunc = self._library.niSwitch_SetAttributeViInt32
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_SetAttributeViInt32_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32]  # noqa: F405
                 self.niSwitch_SetAttributeViInt32_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_SetAttributeViInt32_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -293,7 +438,12 @@ class Library(object):
     def niSwitch_SetAttributeViReal64(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_SetAttributeViReal64_cfunc is None:
-                self.niSwitch_SetAttributeViReal64_cfunc = self._library.niSwitch_SetAttributeViReal64
+                try:
+                    self.niSwitch_SetAttributeViReal64_cfunc = self._library.niSwitch_SetAttributeViReal64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niSwitch_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_SetAttributeViReal64_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -301,7 +451,12 @@ class Library(object):
     def niSwitch_SetAttributeViString(self, vi, channel_name, attribute_id, attribute_value):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_SetAttributeViString_cfunc is None:
-                self.niSwitch_SetAttributeViString_cfunc = self._library.niSwitch_SetAttributeViString
+                try:
+                    self.niSwitch_SetAttributeViString_cfunc = self._library.niSwitch_SetAttributeViString
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_SetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_SetAttributeViString_cfunc(vi, channel_name, attribute_id, attribute_value)
@@ -309,7 +464,12 @@ class Library(object):
     def niSwitch_SetPath(self, vi, path_list):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_SetPath_cfunc is None:
-                self.niSwitch_SetPath_cfunc = self._library.niSwitch_SetPath
+                try:
+                    self.niSwitch_SetPath_cfunc = self._library.niSwitch_SetPath
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_SetPath_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_SetPath_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_SetPath_cfunc(vi, path_list)
@@ -317,7 +477,12 @@ class Library(object):
     def niSwitch_UnlockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_UnlockSession_cfunc is None:
-                self.niSwitch_UnlockSession_cfunc = self._library.niSwitch_UnlockSession
+                try:
+                    self.niSwitch_UnlockSession_cfunc = self._library.niSwitch_UnlockSession
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_UnlockSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niSwitch_UnlockSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_UnlockSession_cfunc(vi, caller_has_lock)
@@ -325,7 +490,12 @@ class Library(object):
     def niSwitch_WaitForDebounce(self, vi, maximum_time_ms):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_WaitForDebounce_cfunc is None:
-                self.niSwitch_WaitForDebounce_cfunc = self._library.niSwitch_WaitForDebounce
+                try:
+                    self.niSwitch_WaitForDebounce_cfunc = self._library.niSwitch_WaitForDebounce
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_WaitForDebounce_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niSwitch_WaitForDebounce_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_WaitForDebounce_cfunc(vi, maximum_time_ms)
@@ -333,7 +503,12 @@ class Library(object):
     def niSwitch_WaitForScanComplete(self, vi, maximum_time_ms):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_WaitForScanComplete_cfunc is None:
-                self.niSwitch_WaitForScanComplete_cfunc = self._library.niSwitch_WaitForScanComplete
+                try:
+                    self.niSwitch_WaitForScanComplete_cfunc = self._library.niSwitch_WaitForScanComplete
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_WaitForScanComplete_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
                 self.niSwitch_WaitForScanComplete_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_WaitForScanComplete_cfunc(vi, maximum_time_ms)
@@ -341,7 +516,12 @@ class Library(object):
     def niSwitch_close(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_close_cfunc is None:
-                self.niSwitch_close_cfunc = self._library.niSwitch_close
+                try:
+                    self.niSwitch_close_cfunc = self._library.niSwitch_close
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_close_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_close_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_close_cfunc(vi)
@@ -349,7 +529,12 @@ class Library(object):
     def niSwitch_error_message(self, vi, error_code, error_message):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_error_message_cfunc is None:
-                self.niSwitch_error_message_cfunc = self._library.niSwitch_error_message
+                try:
+                    self.niSwitch_error_message_cfunc = self._library.niSwitch_error_message
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_error_message_cfunc.argtypes = [ViSession, ViStatus, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_error_message_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_error_message_cfunc(vi, error_code, error_message)
@@ -357,7 +542,12 @@ class Library(object):
     def niSwitch_reset(self, vi):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_reset_cfunc is None:
-                self.niSwitch_reset_cfunc = self._library.niSwitch_reset
+                try:
+                    self.niSwitch_reset_cfunc = self._library.niSwitch_reset
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_reset_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niSwitch_reset_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_reset_cfunc(vi)
@@ -365,7 +555,12 @@ class Library(object):
     def niSwitch_self_test(self, vi, self_test_result, self_test_message):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_self_test_cfunc is None:
-                self.niSwitch_self_test_cfunc = self._library.niSwitch_self_test
+                try:
+                    self.niSwitch_self_test_cfunc = self._library.niSwitch_self_test
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niSwitch_self_test_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt16), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_self_test_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_self_test_cfunc(vi, self_test_result, self_test_message)

--- a/generated/niswitch/niswitch/errors.py
+++ b/generated/niswitch/niswitch/errors.py
@@ -57,6 +57,13 @@ class DriverNotInstalledError(Error):
         super(DriverNotInstalledError, self).__init__('The NI-SWITCH runtime could not be loaded. Make sure it is installed and its bitness matches that of your Python interpreter. Please visit http://www.ni.com/downloads/drivers/ to download and install it.')
 
 
+class DriverTooOldError(Error):
+    '''An error due to using this module with an older version of the driver runtime.'''
+
+    def __init__(self):
+        super(DriverTooOldError, self).__init__('A function was not found in the NI-SWITCH runtime. Please visit http://www.ni.com/downloads/drivers/ to download a newer version and install it.')
+
+
 class InvalidRepeatedCapabilityError(Error):
     '''An error due to an invalid character in a repeated capability'''
 

--- a/generated/nitclk/nitclk/_library.py
+++ b/generated/nitclk/nitclk/_library.py
@@ -40,9 +40,9 @@ class Library(object):
                 try:
                     self.niTClk_ConfigureForHomogeneousTriggers_cfunc = self._library.niTClk_ConfigureForHomogeneousTriggers
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niTClk_ConfigureForHomogeneousTriggers was not found in the NI-TClk runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niTClk_ConfigureForHomogeneousTriggers_cfunc.argtypes = [ViUInt32, ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niTClk_ConfigureForHomogeneousTriggers_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_ConfigureForHomogeneousTriggers_cfunc(session_count, sessions)
@@ -53,9 +53,9 @@ class Library(object):
                 try:
                     self.niTClk_FinishSyncPulseSenderSynchronize_cfunc = self._library.niTClk_FinishSyncPulseSenderSynchronize
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niTClk_FinishSyncPulseSenderSynchronize was not found in the NI-TClk runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niTClk_FinishSyncPulseSenderSynchronize_cfunc.argtypes = [ViUInt32, ctypes.POINTER(ViSession), ViReal64]  # noqa: F405
                 self.niTClk_FinishSyncPulseSenderSynchronize_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_FinishSyncPulseSenderSynchronize_cfunc(session_count, sessions, min_time)
@@ -66,9 +66,9 @@ class Library(object):
                 try:
                     self.niTClk_GetAttributeViReal64_cfunc = self._library.niTClk_GetAttributeViReal64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niTClk_GetAttributeViReal64 was not found in the NI-TClk runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niTClk_GetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niTClk_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_GetAttributeViReal64_cfunc(session, channel_name, attribute_id, value)
@@ -79,9 +79,9 @@ class Library(object):
                 try:
                     self.niTClk_GetAttributeViSession_cfunc = self._library.niTClk_GetAttributeViSession
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niTClk_GetAttributeViSession was not found in the NI-TClk runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niTClk_GetAttributeViSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niTClk_GetAttributeViSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_GetAttributeViSession_cfunc(session, channel_name, attribute_id, value)
@@ -92,9 +92,9 @@ class Library(object):
                 try:
                     self.niTClk_GetAttributeViString_cfunc = self._library.niTClk_GetAttributeViString
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niTClk_GetAttributeViString was not found in the NI-TClk runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niTClk_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niTClk_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_GetAttributeViString_cfunc(session, channel_name, attribute_id, buf_size, value)
@@ -105,9 +105,9 @@ class Library(object):
                 try:
                     self.niTClk_GetExtendedErrorInfo_cfunc = self._library.niTClk_GetExtendedErrorInfo
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niTClk_GetExtendedErrorInfo was not found in the NI-TClk runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niTClk_GetExtendedErrorInfo_cfunc.argtypes = [ctypes.POINTER(ViChar), ViUInt32]  # noqa: F405
                 self.niTClk_GetExtendedErrorInfo_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_GetExtendedErrorInfo_cfunc(error_string, error_string_size)
@@ -118,9 +118,9 @@ class Library(object):
                 try:
                     self.niTClk_Initiate_cfunc = self._library.niTClk_Initiate
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niTClk_Initiate was not found in the NI-TClk runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niTClk_Initiate_cfunc.argtypes = [ViUInt32, ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niTClk_Initiate_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_Initiate_cfunc(session_count, sessions)
@@ -131,9 +131,9 @@ class Library(object):
                 try:
                     self.niTClk_IsDone_cfunc = self._library.niTClk_IsDone
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niTClk_IsDone was not found in the NI-TClk runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niTClk_IsDone_cfunc.argtypes = [ViUInt32, ctypes.POINTER(ViSession), ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niTClk_IsDone_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_IsDone_cfunc(session_count, sessions, done)
@@ -144,9 +144,9 @@ class Library(object):
                 try:
                     self.niTClk_SetAttributeViReal64_cfunc = self._library.niTClk_SetAttributeViReal64
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niTClk_SetAttributeViReal64 was not found in the NI-TClk runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niTClk_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niTClk_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_SetAttributeViReal64_cfunc(session, channel_name, attribute_id, value)
@@ -157,9 +157,9 @@ class Library(object):
                 try:
                     self.niTClk_SetAttributeViSession_cfunc = self._library.niTClk_SetAttributeViSession
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niTClk_SetAttributeViSession was not found in the NI-TClk runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niTClk_SetAttributeViSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViSession]  # noqa: F405
                 self.niTClk_SetAttributeViSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_SetAttributeViSession_cfunc(session, channel_name, attribute_id, value)
@@ -170,9 +170,9 @@ class Library(object):
                 try:
                     self.niTClk_SetAttributeViString_cfunc = self._library.niTClk_SetAttributeViString
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niTClk_SetAttributeViString was not found in the NI-TClk runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niTClk_SetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niTClk_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_SetAttributeViString_cfunc(session, channel_name, attribute_id, value)
@@ -183,9 +183,9 @@ class Library(object):
                 try:
                     self.niTClk_SetupForSyncPulseSenderSynchronize_cfunc = self._library.niTClk_SetupForSyncPulseSenderSynchronize
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niTClk_SetupForSyncPulseSenderSynchronize was not found in the NI-TClk runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niTClk_SetupForSyncPulseSenderSynchronize_cfunc.argtypes = [ViUInt32, ctypes.POINTER(ViSession), ViReal64]  # noqa: F405
                 self.niTClk_SetupForSyncPulseSenderSynchronize_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_SetupForSyncPulseSenderSynchronize_cfunc(session_count, sessions, min_time)
@@ -196,9 +196,9 @@ class Library(object):
                 try:
                     self.niTClk_Synchronize_cfunc = self._library.niTClk_Synchronize
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niTClk_Synchronize was not found in the NI-TClk runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niTClk_Synchronize_cfunc.argtypes = [ViUInt32, ctypes.POINTER(ViSession), ViReal64]  # noqa: F405
                 self.niTClk_Synchronize_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_Synchronize_cfunc(session_count, sessions, min_tclk_period)
@@ -209,9 +209,9 @@ class Library(object):
                 try:
                     self.niTClk_SynchronizeToSyncPulseSender_cfunc = self._library.niTClk_SynchronizeToSyncPulseSender
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niTClk_SynchronizeToSyncPulseSender was not found in the NI-TClk runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niTClk_SynchronizeToSyncPulseSender_cfunc.argtypes = [ViUInt32, ctypes.POINTER(ViSession), ViReal64]  # noqa: F405
                 self.niTClk_SynchronizeToSyncPulseSender_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_SynchronizeToSyncPulseSender_cfunc(session_count, sessions, min_time)
@@ -222,9 +222,9 @@ class Library(object):
                 try:
                     self.niTClk_WaitUntilDone_cfunc = self._library.niTClk_WaitUntilDone
                 except AttributeError as e:
-                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
-                                         "be an indication that the version of the instrument driver is too old for "
-                                         "this version of the python API. Upgrade your instrument driver.") from e
+                    raise AttributeError("Function niTClk_WaitUntilDone was not found in the NI-TClk runtime. Please visit "
+                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
+                                         "install it.") from e
                 self.niTClk_WaitUntilDone_cfunc.argtypes = [ViUInt32, ctypes.POINTER(ViSession), ViReal64]  # noqa: F405
                 self.niTClk_WaitUntilDone_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_WaitUntilDone_cfunc(session_count, sessions, timeout)

--- a/generated/nitclk/nitclk/_library.py
+++ b/generated/nitclk/nitclk/_library.py
@@ -37,7 +37,12 @@ class Library(object):
     def niTClk_ConfigureForHomogeneousTriggers(self, session_count, sessions):  # noqa: N802
         with self._func_lock:
             if self.niTClk_ConfigureForHomogeneousTriggers_cfunc is None:
-                self.niTClk_ConfigureForHomogeneousTriggers_cfunc = self._library.niTClk_ConfigureForHomogeneousTriggers
+                try:
+                    self.niTClk_ConfigureForHomogeneousTriggers_cfunc = self._library.niTClk_ConfigureForHomogeneousTriggers
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niTClk_ConfigureForHomogeneousTriggers_cfunc.argtypes = [ViUInt32, ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niTClk_ConfigureForHomogeneousTriggers_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_ConfigureForHomogeneousTriggers_cfunc(session_count, sessions)
@@ -45,7 +50,12 @@ class Library(object):
     def niTClk_FinishSyncPulseSenderSynchronize(self, session_count, sessions, min_time):  # noqa: N802
         with self._func_lock:
             if self.niTClk_FinishSyncPulseSenderSynchronize_cfunc is None:
-                self.niTClk_FinishSyncPulseSenderSynchronize_cfunc = self._library.niTClk_FinishSyncPulseSenderSynchronize
+                try:
+                    self.niTClk_FinishSyncPulseSenderSynchronize_cfunc = self._library.niTClk_FinishSyncPulseSenderSynchronize
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niTClk_FinishSyncPulseSenderSynchronize_cfunc.argtypes = [ViUInt32, ctypes.POINTER(ViSession), ViReal64]  # noqa: F405
                 self.niTClk_FinishSyncPulseSenderSynchronize_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_FinishSyncPulseSenderSynchronize_cfunc(session_count, sessions, min_time)
@@ -53,7 +63,12 @@ class Library(object):
     def niTClk_GetAttributeViReal64(self, session, channel_name, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niTClk_GetAttributeViReal64_cfunc is None:
-                self.niTClk_GetAttributeViReal64_cfunc = self._library.niTClk_GetAttributeViReal64
+                try:
+                    self.niTClk_GetAttributeViReal64_cfunc = self._library.niTClk_GetAttributeViReal64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niTClk_GetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niTClk_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_GetAttributeViReal64_cfunc(session, channel_name, attribute_id, value)
@@ -61,7 +76,12 @@ class Library(object):
     def niTClk_GetAttributeViSession(self, session, channel_name, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niTClk_GetAttributeViSession_cfunc is None:
-                self.niTClk_GetAttributeViSession_cfunc = self._library.niTClk_GetAttributeViSession
+                try:
+                    self.niTClk_GetAttributeViSession_cfunc = self._library.niTClk_GetAttributeViSession
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niTClk_GetAttributeViSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niTClk_GetAttributeViSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_GetAttributeViSession_cfunc(session, channel_name, attribute_id, value)
@@ -69,7 +89,12 @@ class Library(object):
     def niTClk_GetAttributeViString(self, session, channel_name, attribute_id, buf_size, value):  # noqa: N802
         with self._func_lock:
             if self.niTClk_GetAttributeViString_cfunc is None:
-                self.niTClk_GetAttributeViString_cfunc = self._library.niTClk_GetAttributeViString
+                try:
+                    self.niTClk_GetAttributeViString_cfunc = self._library.niTClk_GetAttributeViString
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niTClk_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niTClk_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_GetAttributeViString_cfunc(session, channel_name, attribute_id, buf_size, value)
@@ -77,7 +102,12 @@ class Library(object):
     def niTClk_GetExtendedErrorInfo(self, error_string, error_string_size):  # noqa: N802
         with self._func_lock:
             if self.niTClk_GetExtendedErrorInfo_cfunc is None:
-                self.niTClk_GetExtendedErrorInfo_cfunc = self._library.niTClk_GetExtendedErrorInfo
+                try:
+                    self.niTClk_GetExtendedErrorInfo_cfunc = self._library.niTClk_GetExtendedErrorInfo
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niTClk_GetExtendedErrorInfo_cfunc.argtypes = [ctypes.POINTER(ViChar), ViUInt32]  # noqa: F405
                 self.niTClk_GetExtendedErrorInfo_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_GetExtendedErrorInfo_cfunc(error_string, error_string_size)
@@ -85,7 +115,12 @@ class Library(object):
     def niTClk_Initiate(self, session_count, sessions):  # noqa: N802
         with self._func_lock:
             if self.niTClk_Initiate_cfunc is None:
-                self.niTClk_Initiate_cfunc = self._library.niTClk_Initiate
+                try:
+                    self.niTClk_Initiate_cfunc = self._library.niTClk_Initiate
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niTClk_Initiate_cfunc.argtypes = [ViUInt32, ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niTClk_Initiate_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_Initiate_cfunc(session_count, sessions)
@@ -93,7 +128,12 @@ class Library(object):
     def niTClk_IsDone(self, session_count, sessions, done):  # noqa: N802
         with self._func_lock:
             if self.niTClk_IsDone_cfunc is None:
-                self.niTClk_IsDone_cfunc = self._library.niTClk_IsDone
+                try:
+                    self.niTClk_IsDone_cfunc = self._library.niTClk_IsDone
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niTClk_IsDone_cfunc.argtypes = [ViUInt32, ctypes.POINTER(ViSession), ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niTClk_IsDone_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_IsDone_cfunc(session_count, sessions, done)
@@ -101,7 +141,12 @@ class Library(object):
     def niTClk_SetAttributeViReal64(self, session, channel_name, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niTClk_SetAttributeViReal64_cfunc is None:
-                self.niTClk_SetAttributeViReal64_cfunc = self._library.niTClk_SetAttributeViReal64
+                try:
+                    self.niTClk_SetAttributeViReal64_cfunc = self._library.niTClk_SetAttributeViReal64
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niTClk_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niTClk_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_SetAttributeViReal64_cfunc(session, channel_name, attribute_id, value)
@@ -109,7 +154,12 @@ class Library(object):
     def niTClk_SetAttributeViSession(self, session, channel_name, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niTClk_SetAttributeViSession_cfunc is None:
-                self.niTClk_SetAttributeViSession_cfunc = self._library.niTClk_SetAttributeViSession
+                try:
+                    self.niTClk_SetAttributeViSession_cfunc = self._library.niTClk_SetAttributeViSession
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niTClk_SetAttributeViSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViSession]  # noqa: F405
                 self.niTClk_SetAttributeViSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_SetAttributeViSession_cfunc(session, channel_name, attribute_id, value)
@@ -117,7 +167,12 @@ class Library(object):
     def niTClk_SetAttributeViString(self, session, channel_name, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niTClk_SetAttributeViString_cfunc is None:
-                self.niTClk_SetAttributeViString_cfunc = self._library.niTClk_SetAttributeViString
+                try:
+                    self.niTClk_SetAttributeViString_cfunc = self._library.niTClk_SetAttributeViString
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niTClk_SetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niTClk_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_SetAttributeViString_cfunc(session, channel_name, attribute_id, value)
@@ -125,7 +180,12 @@ class Library(object):
     def niTClk_SetupForSyncPulseSenderSynchronize(self, session_count, sessions, min_time):  # noqa: N802
         with self._func_lock:
             if self.niTClk_SetupForSyncPulseSenderSynchronize_cfunc is None:
-                self.niTClk_SetupForSyncPulseSenderSynchronize_cfunc = self._library.niTClk_SetupForSyncPulseSenderSynchronize
+                try:
+                    self.niTClk_SetupForSyncPulseSenderSynchronize_cfunc = self._library.niTClk_SetupForSyncPulseSenderSynchronize
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niTClk_SetupForSyncPulseSenderSynchronize_cfunc.argtypes = [ViUInt32, ctypes.POINTER(ViSession), ViReal64]  # noqa: F405
                 self.niTClk_SetupForSyncPulseSenderSynchronize_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_SetupForSyncPulseSenderSynchronize_cfunc(session_count, sessions, min_time)
@@ -133,7 +193,12 @@ class Library(object):
     def niTClk_Synchronize(self, session_count, sessions, min_tclk_period):  # noqa: N802
         with self._func_lock:
             if self.niTClk_Synchronize_cfunc is None:
-                self.niTClk_Synchronize_cfunc = self._library.niTClk_Synchronize
+                try:
+                    self.niTClk_Synchronize_cfunc = self._library.niTClk_Synchronize
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niTClk_Synchronize_cfunc.argtypes = [ViUInt32, ctypes.POINTER(ViSession), ViReal64]  # noqa: F405
                 self.niTClk_Synchronize_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_Synchronize_cfunc(session_count, sessions, min_tclk_period)
@@ -141,7 +206,12 @@ class Library(object):
     def niTClk_SynchronizeToSyncPulseSender(self, session_count, sessions, min_time):  # noqa: N802
         with self._func_lock:
             if self.niTClk_SynchronizeToSyncPulseSender_cfunc is None:
-                self.niTClk_SynchronizeToSyncPulseSender_cfunc = self._library.niTClk_SynchronizeToSyncPulseSender
+                try:
+                    self.niTClk_SynchronizeToSyncPulseSender_cfunc = self._library.niTClk_SynchronizeToSyncPulseSender
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niTClk_SynchronizeToSyncPulseSender_cfunc.argtypes = [ViUInt32, ctypes.POINTER(ViSession), ViReal64]  # noqa: F405
                 self.niTClk_SynchronizeToSyncPulseSender_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_SynchronizeToSyncPulseSender_cfunc(session_count, sessions, min_time)
@@ -149,7 +219,12 @@ class Library(object):
     def niTClk_WaitUntilDone(self, session_count, sessions, timeout):  # noqa: N802
         with self._func_lock:
             if self.niTClk_WaitUntilDone_cfunc is None:
-                self.niTClk_WaitUntilDone_cfunc = self._library.niTClk_WaitUntilDone
+                try:
+                    self.niTClk_WaitUntilDone_cfunc = self._library.niTClk_WaitUntilDone
+                except AttributeError as e:
+                    raise AttributeError("A required function was not found in the instrument driver DLL. This might "
+                                         "be an indication that the version of the instrument driver is too old for "
+                                         "this version of the python API. Upgrade your instrument driver.") from e
                 self.niTClk_WaitUntilDone_cfunc.argtypes = [ViUInt32, ctypes.POINTER(ViSession), ViReal64]  # noqa: F405
                 self.niTClk_WaitUntilDone_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_WaitUntilDone_cfunc(session_count, sessions, timeout)

--- a/generated/nitclk/nitclk/_library.py
+++ b/generated/nitclk/nitclk/_library.py
@@ -37,7 +37,7 @@ class Library(object):
 
     def _get_library_function(self, name):
         try:
-            function = getattr(self._library, 'fred')
+            function = getattr(self._library, name)
         except AttributeError as e:
             raise errors.DriverTooOldError() from e
         return function

--- a/generated/nitclk/nitclk/_library.py
+++ b/generated/nitclk/nitclk/_library.py
@@ -2,6 +2,7 @@
 # This file was generated
 
 import ctypes
+import nitclk.errors as errors
 import threading
 
 from nitclk._visatype import *  # noqa: F403,H303
@@ -34,15 +35,17 @@ class Library(object):
         self.niTClk_SynchronizeToSyncPulseSender_cfunc = None
         self.niTClk_WaitUntilDone_cfunc = None
 
+    def _get_library_function(self, name):
+        try:
+            function = getattr(self._library, 'fred')
+        except AttributeError as e:
+            raise errors.DriverTooOldError() from e
+        return function
+
     def niTClk_ConfigureForHomogeneousTriggers(self, session_count, sessions):  # noqa: N802
         with self._func_lock:
             if self.niTClk_ConfigureForHomogeneousTriggers_cfunc is None:
-                try:
-                    self.niTClk_ConfigureForHomogeneousTriggers_cfunc = self._library.niTClk_ConfigureForHomogeneousTriggers
-                except AttributeError as e:
-                    raise AttributeError("Function niTClk_ConfigureForHomogeneousTriggers was not found in the NI-TClk runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niTClk_ConfigureForHomogeneousTriggers_cfunc = self._get_library_function('niTClk_ConfigureForHomogeneousTriggers')
                 self.niTClk_ConfigureForHomogeneousTriggers_cfunc.argtypes = [ViUInt32, ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niTClk_ConfigureForHomogeneousTriggers_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_ConfigureForHomogeneousTriggers_cfunc(session_count, sessions)
@@ -50,12 +53,7 @@ class Library(object):
     def niTClk_FinishSyncPulseSenderSynchronize(self, session_count, sessions, min_time):  # noqa: N802
         with self._func_lock:
             if self.niTClk_FinishSyncPulseSenderSynchronize_cfunc is None:
-                try:
-                    self.niTClk_FinishSyncPulseSenderSynchronize_cfunc = self._library.niTClk_FinishSyncPulseSenderSynchronize
-                except AttributeError as e:
-                    raise AttributeError("Function niTClk_FinishSyncPulseSenderSynchronize was not found in the NI-TClk runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niTClk_FinishSyncPulseSenderSynchronize_cfunc = self._get_library_function('niTClk_FinishSyncPulseSenderSynchronize')
                 self.niTClk_FinishSyncPulseSenderSynchronize_cfunc.argtypes = [ViUInt32, ctypes.POINTER(ViSession), ViReal64]  # noqa: F405
                 self.niTClk_FinishSyncPulseSenderSynchronize_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_FinishSyncPulseSenderSynchronize_cfunc(session_count, sessions, min_time)
@@ -63,12 +61,7 @@ class Library(object):
     def niTClk_GetAttributeViReal64(self, session, channel_name, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niTClk_GetAttributeViReal64_cfunc is None:
-                try:
-                    self.niTClk_GetAttributeViReal64_cfunc = self._library.niTClk_GetAttributeViReal64
-                except AttributeError as e:
-                    raise AttributeError("Function niTClk_GetAttributeViReal64 was not found in the NI-TClk runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niTClk_GetAttributeViReal64_cfunc = self._get_library_function('niTClk_GetAttributeViReal64')
                 self.niTClk_GetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViReal64)]  # noqa: F405
                 self.niTClk_GetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_GetAttributeViReal64_cfunc(session, channel_name, attribute_id, value)
@@ -76,12 +69,7 @@ class Library(object):
     def niTClk_GetAttributeViSession(self, session, channel_name, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niTClk_GetAttributeViSession_cfunc is None:
-                try:
-                    self.niTClk_GetAttributeViSession_cfunc = self._library.niTClk_GetAttributeViSession
-                except AttributeError as e:
-                    raise AttributeError("Function niTClk_GetAttributeViSession was not found in the NI-TClk runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niTClk_GetAttributeViSession_cfunc = self._get_library_function('niTClk_GetAttributeViSession')
                 self.niTClk_GetAttributeViSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niTClk_GetAttributeViSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_GetAttributeViSession_cfunc(session, channel_name, attribute_id, value)
@@ -89,12 +77,7 @@ class Library(object):
     def niTClk_GetAttributeViString(self, session, channel_name, attribute_id, buf_size, value):  # noqa: N802
         with self._func_lock:
             if self.niTClk_GetAttributeViString_cfunc is None:
-                try:
-                    self.niTClk_GetAttributeViString_cfunc = self._library.niTClk_GetAttributeViString
-                except AttributeError as e:
-                    raise AttributeError("Function niTClk_GetAttributeViString was not found in the NI-TClk runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niTClk_GetAttributeViString_cfunc = self._get_library_function('niTClk_GetAttributeViString')
                 self.niTClk_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niTClk_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_GetAttributeViString_cfunc(session, channel_name, attribute_id, buf_size, value)
@@ -102,12 +85,7 @@ class Library(object):
     def niTClk_GetExtendedErrorInfo(self, error_string, error_string_size):  # noqa: N802
         with self._func_lock:
             if self.niTClk_GetExtendedErrorInfo_cfunc is None:
-                try:
-                    self.niTClk_GetExtendedErrorInfo_cfunc = self._library.niTClk_GetExtendedErrorInfo
-                except AttributeError as e:
-                    raise AttributeError("Function niTClk_GetExtendedErrorInfo was not found in the NI-TClk runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niTClk_GetExtendedErrorInfo_cfunc = self._get_library_function('niTClk_GetExtendedErrorInfo')
                 self.niTClk_GetExtendedErrorInfo_cfunc.argtypes = [ctypes.POINTER(ViChar), ViUInt32]  # noqa: F405
                 self.niTClk_GetExtendedErrorInfo_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_GetExtendedErrorInfo_cfunc(error_string, error_string_size)
@@ -115,12 +93,7 @@ class Library(object):
     def niTClk_Initiate(self, session_count, sessions):  # noqa: N802
         with self._func_lock:
             if self.niTClk_Initiate_cfunc is None:
-                try:
-                    self.niTClk_Initiate_cfunc = self._library.niTClk_Initiate
-                except AttributeError as e:
-                    raise AttributeError("Function niTClk_Initiate was not found in the NI-TClk runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niTClk_Initiate_cfunc = self._get_library_function('niTClk_Initiate')
                 self.niTClk_Initiate_cfunc.argtypes = [ViUInt32, ctypes.POINTER(ViSession)]  # noqa: F405
                 self.niTClk_Initiate_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_Initiate_cfunc(session_count, sessions)
@@ -128,12 +101,7 @@ class Library(object):
     def niTClk_IsDone(self, session_count, sessions, done):  # noqa: N802
         with self._func_lock:
             if self.niTClk_IsDone_cfunc is None:
-                try:
-                    self.niTClk_IsDone_cfunc = self._library.niTClk_IsDone
-                except AttributeError as e:
-                    raise AttributeError("Function niTClk_IsDone was not found in the NI-TClk runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niTClk_IsDone_cfunc = self._get_library_function('niTClk_IsDone')
                 self.niTClk_IsDone_cfunc.argtypes = [ViUInt32, ctypes.POINTER(ViSession), ctypes.POINTER(ViBoolean)]  # noqa: F405
                 self.niTClk_IsDone_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_IsDone_cfunc(session_count, sessions, done)
@@ -141,12 +109,7 @@ class Library(object):
     def niTClk_SetAttributeViReal64(self, session, channel_name, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niTClk_SetAttributeViReal64_cfunc is None:
-                try:
-                    self.niTClk_SetAttributeViReal64_cfunc = self._library.niTClk_SetAttributeViReal64
-                except AttributeError as e:
-                    raise AttributeError("Function niTClk_SetAttributeViReal64 was not found in the NI-TClk runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niTClk_SetAttributeViReal64_cfunc = self._get_library_function('niTClk_SetAttributeViReal64')
                 self.niTClk_SetAttributeViReal64_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViReal64]  # noqa: F405
                 self.niTClk_SetAttributeViReal64_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_SetAttributeViReal64_cfunc(session, channel_name, attribute_id, value)
@@ -154,12 +117,7 @@ class Library(object):
     def niTClk_SetAttributeViSession(self, session, channel_name, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niTClk_SetAttributeViSession_cfunc is None:
-                try:
-                    self.niTClk_SetAttributeViSession_cfunc = self._library.niTClk_SetAttributeViSession
-                except AttributeError as e:
-                    raise AttributeError("Function niTClk_SetAttributeViSession was not found in the NI-TClk runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niTClk_SetAttributeViSession_cfunc = self._get_library_function('niTClk_SetAttributeViSession')
                 self.niTClk_SetAttributeViSession_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViSession]  # noqa: F405
                 self.niTClk_SetAttributeViSession_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_SetAttributeViSession_cfunc(session, channel_name, attribute_id, value)
@@ -167,12 +125,7 @@ class Library(object):
     def niTClk_SetAttributeViString(self, session, channel_name, attribute_id, value):  # noqa: N802
         with self._func_lock:
             if self.niTClk_SetAttributeViString_cfunc is None:
-                try:
-                    self.niTClk_SetAttributeViString_cfunc = self._library.niTClk_SetAttributeViString
-                except AttributeError as e:
-                    raise AttributeError("Function niTClk_SetAttributeViString was not found in the NI-TClk runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niTClk_SetAttributeViString_cfunc = self._get_library_function('niTClk_SetAttributeViString')
                 self.niTClk_SetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niTClk_SetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_SetAttributeViString_cfunc(session, channel_name, attribute_id, value)
@@ -180,12 +133,7 @@ class Library(object):
     def niTClk_SetupForSyncPulseSenderSynchronize(self, session_count, sessions, min_time):  # noqa: N802
         with self._func_lock:
             if self.niTClk_SetupForSyncPulseSenderSynchronize_cfunc is None:
-                try:
-                    self.niTClk_SetupForSyncPulseSenderSynchronize_cfunc = self._library.niTClk_SetupForSyncPulseSenderSynchronize
-                except AttributeError as e:
-                    raise AttributeError("Function niTClk_SetupForSyncPulseSenderSynchronize was not found in the NI-TClk runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niTClk_SetupForSyncPulseSenderSynchronize_cfunc = self._get_library_function('niTClk_SetupForSyncPulseSenderSynchronize')
                 self.niTClk_SetupForSyncPulseSenderSynchronize_cfunc.argtypes = [ViUInt32, ctypes.POINTER(ViSession), ViReal64]  # noqa: F405
                 self.niTClk_SetupForSyncPulseSenderSynchronize_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_SetupForSyncPulseSenderSynchronize_cfunc(session_count, sessions, min_time)
@@ -193,12 +141,7 @@ class Library(object):
     def niTClk_Synchronize(self, session_count, sessions, min_tclk_period):  # noqa: N802
         with self._func_lock:
             if self.niTClk_Synchronize_cfunc is None:
-                try:
-                    self.niTClk_Synchronize_cfunc = self._library.niTClk_Synchronize
-                except AttributeError as e:
-                    raise AttributeError("Function niTClk_Synchronize was not found in the NI-TClk runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niTClk_Synchronize_cfunc = self._get_library_function('niTClk_Synchronize')
                 self.niTClk_Synchronize_cfunc.argtypes = [ViUInt32, ctypes.POINTER(ViSession), ViReal64]  # noqa: F405
                 self.niTClk_Synchronize_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_Synchronize_cfunc(session_count, sessions, min_tclk_period)
@@ -206,12 +149,7 @@ class Library(object):
     def niTClk_SynchronizeToSyncPulseSender(self, session_count, sessions, min_time):  # noqa: N802
         with self._func_lock:
             if self.niTClk_SynchronizeToSyncPulseSender_cfunc is None:
-                try:
-                    self.niTClk_SynchronizeToSyncPulseSender_cfunc = self._library.niTClk_SynchronizeToSyncPulseSender
-                except AttributeError as e:
-                    raise AttributeError("Function niTClk_SynchronizeToSyncPulseSender was not found in the NI-TClk runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niTClk_SynchronizeToSyncPulseSender_cfunc = self._get_library_function('niTClk_SynchronizeToSyncPulseSender')
                 self.niTClk_SynchronizeToSyncPulseSender_cfunc.argtypes = [ViUInt32, ctypes.POINTER(ViSession), ViReal64]  # noqa: F405
                 self.niTClk_SynchronizeToSyncPulseSender_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_SynchronizeToSyncPulseSender_cfunc(session_count, sessions, min_time)
@@ -219,12 +157,7 @@ class Library(object):
     def niTClk_WaitUntilDone(self, session_count, sessions, timeout):  # noqa: N802
         with self._func_lock:
             if self.niTClk_WaitUntilDone_cfunc is None:
-                try:
-                    self.niTClk_WaitUntilDone_cfunc = self._library.niTClk_WaitUntilDone
-                except AttributeError as e:
-                    raise AttributeError("Function niTClk_WaitUntilDone was not found in the NI-TClk runtime. Please visit "
-                                         "http://www.ni.com/downloads/drivers/ to download a newer version and "
-                                         "install it.") from e
+                self.niTClk_WaitUntilDone_cfunc = self._get_library_function('niTClk_WaitUntilDone')
                 self.niTClk_WaitUntilDone_cfunc.argtypes = [ViUInt32, ctypes.POINTER(ViSession), ViReal64]  # noqa: F405
                 self.niTClk_WaitUntilDone_cfunc.restype = ViStatus  # noqa: F405
         return self.niTClk_WaitUntilDone_cfunc(session_count, sessions, timeout)

--- a/generated/nitclk/nitclk/errors.py
+++ b/generated/nitclk/nitclk/errors.py
@@ -57,6 +57,13 @@ class DriverNotInstalledError(Error):
         super(DriverNotInstalledError, self).__init__('The NI-TClk runtime could not be loaded. Make sure it is installed and its bitness matches that of your Python interpreter. Please visit http://www.ni.com/downloads/drivers/ to download and install it.')
 
 
+class DriverTooOldError(Error):
+    '''An error due to using this module with an older version of the driver runtime.'''
+
+    def __init__(self):
+        super(DriverTooOldError, self).__init__('A function was not found in the NI-TClk runtime. Please visit http://www.ni.com/downloads/drivers/ to download a newer version and install it.')
+
+
 def handle_error(session, code, ignore_warnings, is_error_handling):
     '''handle_error
 

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -9,7 +9,6 @@ import numpy
 import platform
 import warnings
 
-
 from mock import patch
 
 import _matchers
@@ -1532,9 +1531,11 @@ def test_library_error():
         ctypes_class_name = 'ctypes.WinDLL'
     mock_ctypes = patch(ctypes_class_name).start()
     mock_ctypes_instance = mock_ctypes.return_value
+    # Ensure these methods return 0 because they are called in session creation
     mock_ctypes_instance.niFake_InitWithOptions.return_value = 0
     mock_ctypes_instance.niFake_LockSession.return_value = 0
     mock_ctypes_instance.niFake_UnlockSession.return_value = 0
+    # Delete function to simulate missing function from driver runtime
     delattr(mock_ctypes_instance, 'niFake_Abort')
 
     session = nifake.Session('dev1')
@@ -1544,4 +1545,4 @@ def test_library_error():
         assert False
     except nifake.errors.DriverTooOldError as e:
         message = e.args[0]
-        assert message.startswith("A function was not found in the NI-FAKE runtime. Please visit http://www.ni.com/downloads/drivers/ to download a newer version and install it.")
+        assert message == 'A function was not found in the NI-FAKE runtime. Please visit http://www.ni.com/downloads/drivers/ to download a newer version and install it.'

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -6,7 +6,9 @@ import math
 import nifake
 import nifake.errors
 import numpy
+import platform
 import warnings
+
 
 from mock import patch
 
@@ -1522,3 +1524,24 @@ def test_dunder_version():
     print('Version = {}'.format(nifake.__version__))
     assert type(nifake.__version__) is str
 
+
+def test_library_error():
+    if platform.architecture()[0] == '64bit':
+        ctypes_class_name = 'ctypes.CDLL'
+    else:
+        ctypes_class_name = 'ctypes.WinDLL'
+    mock_ctypes = patch(ctypes_class_name).start()
+    mock_ctypes_instance = mock_ctypes.return_value
+    mock_ctypes_instance.niFake_InitWithOptions.return_value = 0
+    mock_ctypes_instance.niFake_LockSession.return_value = 0
+    mock_ctypes_instance.niFake_UnlockSession.return_value = 0
+    delattr(mock_ctypes_instance, 'niFake_Abort')
+
+    session = nifake.Session('dev1')
+
+    try:
+        session.abort()
+        assert False
+    except nifake.errors.DriverTooOldError as e:
+        message = e.args[0]
+        assert message.startswith("A function was not found in the NI-FAKE runtime. Please visit http://www.ni.com/downloads/drivers/ to download a newer version and install it.")


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [ ] ~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- [ ] ~I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

When a required function (e.g. CommitWithChannels) is missing from the driver runtime, nimi-python adds an error description that is more descriptive than "function not found" to instruct the user to upgrade to a newer version of the driver.

### List issues fixed by this Pull Request below, if any.

- Fix #1585 

### What testing has been done?

Called abort and commit methods on a system with NI-DCPower 20.5 instrument driver and confirmed that the error message is displayed in the exception information at runtime.
