### PR TITLE
Use explicit metadata attribute to avoid adding repeated capability

### DIFF
--- a/build/helper/metadata_add_all.py
+++ b/build/helper/metadata_add_all.py
@@ -691,6 +691,8 @@ functions_input = {
                 'direction': 'in',
                 'enum': None,
                 'name': 'channelName',
+                'python_name': 'name',
+                'is_repeated_capability': False,
                 'type': 'ViString',
                 'documentation': {
                     'description': 'The channel to call this on.',
@@ -793,10 +795,9 @@ functions_expected = {
         'documentation': {
             'description': 'Performs a foo, and performs it well.'
         },
-        'has_repeated_capability': True,
-        'repeated_capability_type': 'channels',
+        'has_repeated_capability': False,
         'is_error_handling': False,
-        'render_in_session_base': True,
+        'render_in_session_base': False,
         'method_templates': [{'session_filename': '/cool_template', 'documentation_filename': '/cool_template', 'method_python_name_suffix': '', }, ],
         'parameters': [
             {
@@ -833,14 +834,13 @@ functions_expected = {
             },
             {
                 'ctypes_type': 'ViString',
-                'ctypes_variable_name': 'channel_name_ctype',
+                'ctypes_variable_name': 'name_ctype',
                 'ctypes_type_library_call': 'ctypes.POINTER(ViChar)',
                 'direction': 'in',
                 'documentation': {
                     'description': 'The channel to call this on.'
                 },
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'channels',
+                'is_repeated_capability': False,
                 'is_session_handle': False,
                 'enum': None,
                 'numpy': False,
@@ -852,14 +852,14 @@ functions_expected = {
                 'use_list': False,
                 'is_string': True,
                 'name': 'channelName',
-                'python_name': 'channel_name',
-                'python_name_with_default': 'channel_name',
-                'python_name_with_doc_default': 'channel_name',
+                'python_name': 'name',
+                'python_name_with_default': 'name',
+                'python_name_with_doc_default': 'name',
                 'size': {'mechanism': 'fixed', 'value': 1},
                 'type': 'ViString',
-                'library_method_call_snippet': 'channel_name_ctype',
+                'library_method_call_snippet': 'name_ctype',
                 'use_in_python_api': True,
-                'python_name_or_default_for_init': 'channel_name',
+                'python_name_or_default_for_init': 'name',
             },
             {
                 'ctypes_type': 'ViInt32',

--- a/docs/nidcpower/class.rst
+++ b/docs/nidcpower/class.rst
@@ -870,11 +870,6 @@ get_channel_names
             
 
 
-            .. tip:: This method requires repeated capabilities. If called directly on the
-                nidcpower.Session object, then the method will use all repeated capabilities in the session.
-                You can specify a subset of repeated capabilities using the Python index notation on an
-                nidcpower.Session repeated capabilities container, and calling this method on the result.
-
 
             :param indices:
 

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -3692,44 +3692,6 @@ class _SessionBase(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return attribute_value_ctype.value.decode(self._encoding)
 
-    @ivi_synchronized
-    def get_channel_names(self, indices):
-        r'''get_channel_names
-
-        Returns a list of channel names for given channel indices.
-
-        Tip:
-        This method requires repeated capabilities. If called directly on the
-        nidcpower.Session object, then the method will use all repeated capabilities in the session.
-        You can specify a subset of repeated capabilities using the Python index notation on an
-        nidcpower.Session repeated capabilities container, and calling this method on the result.
-
-        Args:
-            indices (basic sequence types or str or int): Index list for the channels in the session. Valid values are from zero to the total number of channels in the session minus one. The index string can be one of the following formats:
-
-                -   A comma-separated list—for example, "0,2,3,1"
-                -   A range using a hyphen—for example, "0-3"
-                -   A range using a colon—for example, "0:3 "
-
-                You can combine comma-separated lists and ranges that use a hyphen or colon. Both out-of-order and repeated indices are supported ("2,3,0," "1,2,2,3"). White space characters, including spaces, tabs, feeds, and carriage returns, are allowed between characters. Ranges can be incrementing or decrementing.
-
-
-        Returns:
-            names (list of str): The channel name(s) at the specified indices.
-
-        '''
-        vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        indices_ctype = ctypes.create_string_buffer(_converters.convert_repeated_capabilities_without_prefix(indices).encode(self._encoding))  # case C040
-        buffer_size_ctype = _visatype.ViInt32()  # case S170
-        names_ctype = None  # case C050
-        error_code = self._library.niDCPower_GetChannelNameFromString(vi_ctype, indices_ctype, buffer_size_ctype, names_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
-        buffer_size_ctype = _visatype.ViInt32(error_code)  # case S180
-        names_ctype = (_visatype.ViChar * buffer_size_ctype.value)()  # case C060
-        error_code = self._library.niDCPower_GetChannelNameFromString(vi_ctype, indices_ctype, buffer_size_ctype, names_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return _converters.convert_comma_separated_string_to_list(names_ctype.value.decode(self._encoding))
-
     def _get_error(self):
         r'''_get_error
 
@@ -5222,6 +5184,38 @@ class Session(_SessionBase):
         error_code = self._library.niDCPower_GetChannelName(vi_ctype, index_ctype, buffer_size_ctype, channel_name_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return channel_name_ctype.value.decode(self._encoding)
+
+    @ivi_synchronized
+    def get_channel_names(self, indices):
+        r'''get_channel_names
+
+        Returns a list of channel names for given channel indices.
+
+        Args:
+            indices (basic sequence types or str or int): Index list for the channels in the session. Valid values are from zero to the total number of channels in the session minus one. The index string can be one of the following formats:
+
+                -   A comma-separated list—for example, "0,2,3,1"
+                -   A range using a hyphen—for example, "0-3"
+                -   A range using a colon—for example, "0:3 "
+
+                You can combine comma-separated lists and ranges that use a hyphen or colon. Both out-of-order and repeated indices are supported ("2,3,0," "1,2,2,3"). White space characters, including spaces, tabs, feeds, and carriage returns, are allowed between characters. Ranges can be incrementing or decrementing.
+
+
+        Returns:
+            names (list of str): The channel name(s) at the specified indices.
+
+        '''
+        vi_ctype = _visatype.ViSession(self._vi)  # case S110
+        indices_ctype = ctypes.create_string_buffer(_converters.convert_repeated_capabilities_without_prefix(indices).encode(self._encoding))  # case C040
+        buffer_size_ctype = _visatype.ViInt32()  # case S170
+        names_ctype = None  # case C050
+        error_code = self._library.niDCPower_GetChannelNameFromString(vi_ctype, indices_ctype, buffer_size_ctype, names_ctype)
+        errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
+        buffer_size_ctype = _visatype.ViInt32(error_code)  # case S180
+        names_ctype = (_visatype.ViChar * buffer_size_ctype.value)()  # case C060
+        error_code = self._library.niDCPower_GetChannelNameFromString(vi_ctype, indices_ctype, buffer_size_ctype, names_ctype)
+        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
+        return _converters.convert_comma_separated_string_to_list(names_ctype.value.decode(self._encoding))
 
     @ivi_synchronized
     def _get_ext_cal_last_date_and_time(self):

--- a/src/nidcpower/metadata/functions.py
+++ b/src/nidcpower/metadata/functions.py
@@ -1490,6 +1490,7 @@ functions = {
                 'documentation': {
                     'description': 'The channel name(s) at the specified indices.'
                 },
+                'is_repeated_capability': False,
                 'name': 'channelName',
                 'python_api_converter_name': 'convert_comma_separated_string_to_list',
                 'python_name': 'names',


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [ ] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

Uses an explicit metadata attribute (`is_repeated_capability`) to avoid adding repeated capability in a parameter for which its `name` would otherwise require it, but for which its `python_name` might not (e.g. get_channel_names)

This is a (lower priority) continuation of #1578 

### What testing has been done?

Ensured unit test passes. Performed code generation locally to verify that the repeated capability is correctly removed from the `get_channel_names` function.
