### PR TITLE
Replace the Sphinx library call `add_stylesheet` with `add_css_file`

### DIFF
--- a/build/templates/conf.py.mako
+++ b/build/templates/conf.py.mako
@@ -116,7 +116,7 @@ html_static_path = ['_static']
 
 # Fix wide tables of RTD per https://github.com/rtfd/sphinx_rtd_theme/issues/117#issuecomment-41571653
 def setup(app):
-    app.add_stylesheet('theme_overrides.css')
+    app.add_css_file('theme_overrides.css')
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,7 +108,7 @@ html_static_path = ['_static']
 
 # Fix wide tables of RTD per https://github.com/rtfd/sphinx_rtd_theme/issues/117#issuecomment-41571653
 def setup(app):
-    app.add_stylesheet('theme_overrides.css')
+    app.add_css_file('theme_overrides.css')
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Replace the Sphinx library call `add_stylesheet` with `add_css_file`, since the former has been deprecated in new version of Sphinx. This fixes the Travis CI [failures](https://travis-ci.org/github/ni/nimi-python/jobs/770505265) we've started seeing.

### List issues fixed by this Pull Request below, if any.

None

### What testing has been done?

PR build
