### PR TITLE
New PAT with with updated format

### DIFF
--- a/tools/system_test_jobs.groovy
+++ b/tools/system_test_jobs.groovy
@@ -8,7 +8,7 @@ DRIVERS = [ "nidcpower", "nidigital", "nidmm", "nifgen", "niscope", "niswitch", 
 PLATFORMS = [ "win32", "win64" ]
 
 ROOT_FOLDER = "nimi-bot"
-credentials_to_use = 'c07926b1-d626-4476-892a-e21bb6d28733'  // nimi-bot username/Personal Access Token
+credentials_to_use = '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'  // nimi-bot username/Personal Access Token
 
 // This function generates a job for the given driver and platform
 // returns generatd job name

--- a/tools/system_test_jobs.groovy
+++ b/tools/system_test_jobs.groovy
@@ -8,7 +8,7 @@ DRIVERS = [ "nidcpower", "nidigital", "nidmm", "nifgen", "niscope", "niswitch", 
 PLATFORMS = [ "win32", "win64" ]
 
 ROOT_FOLDER = "nimi-bot"
-credentials_to_use = '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'  // nimi-bot username/Personal Access Token
+credentials_to_use = '<PASTE PAT HERE>'  // nimi-bot username/Personal Access Token
 
 // This function generates a job for the given driver and platform
 // returns generatd job name


### PR DESCRIPTION
GitHub said:

"""
We noticed your personal access token, nimi-bot system tests,
has an outdated format and was used to access the GitHub API on
May 19th, 2021 at 17:14 (UTC) with a user-agent header of
Java/1.8.0_144.

We recently updated the format of our API authentication tokens,
providing additional security benefits to all our customers.

In order to benefit from this new format, please regenerate your
personal access token, nimi-bot system tests, using the button below.
"""

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Updates PAT used by nimi-bot. GitHub asked us to use a new one.

### List issues fixed by this Pull Request below, if any.

### What testing has been done?

See if nimi-bot runs PR checks.