### PR TITLE
Disable niswitch system tests that use session-simulated DAQmx devices

### DIFF
--- a/src/niswitch/system_tests/test_system_niswitch.py
+++ b/src/niswitch/system_tests/test_system_niswitch.py
@@ -61,6 +61,7 @@ def test_channel_connection(session):
     assert session.can_connect(channel1, channel2) == niswitch.PathCapability.PATH_AVAILABLE
 
 
+@pytest.mark.skip(reason="TODO(sbethur): Intermittent failures, GitHub issue #1622.")
 def test_continuous_software_scanning(session_2532):
     scan_list = 'r0->c0; r1->c1'
     session_2532.scan_list = scan_list
@@ -107,6 +108,7 @@ def test_vi_real64_attribute(session):
     assert session.settling_time.total_seconds() == 0.1
 
 
+@pytest.mark.skip(reason="TODO(sbethur): Intermittent failures, GitHub issue #1622.")
 def test_enum_attribute(session_2532):
     assert session_2532.scan_mode == niswitch.ScanMode.BREAK_BEFORE_MAKE
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Disable niswitch system tests that use session-simulated DAQmx devices since they fail intermittently on nimi-bot. Created #1622 to fix the failures.

### List issues fixed by this Pull Request below, if any.

None

### What testing has been done?

Will verify the test is skipped on nimi-bot
