### PR TITLE
Refactor nidcpower system tests

### DIFF
--- a/build/templates/tox-system_tests.ini.mako
+++ b/build/templates/tox-system_tests.ini.mako
@@ -98,4 +98,13 @@ passenv =
 
 [pytest]
 junit_family = xunit1
-
+% if module_name == 'nidcpower':
+markers = # Defines custom markers used by nidcpower system tests. Prevents PytestUnknownMarkWarning.
+    include_legacy_session: Include a legacy session in nidcpower system tests.
+    legacy_session_only: Exclude an independent channels session in nidcpower system tests.
+    resource_name: Overrides the default resource_name argument in the nidcpower session fixture.
+    channels: Overrides the default channels argument in the nidcpower session fixture.
+    reset: Overrides the default reset argument in the nidcpower session fixture.
+    options: Overrides the default options argument in the nidcpower session fixture.
+    independent_channels: Overrides the default independent_channels argument in the nidcpower session fixture.
+% endif

--- a/generated/nidcpower/tox-system_tests.ini
+++ b/generated/nidcpower/tox-system_tests.ini
@@ -58,4 +58,11 @@ passenv =
 
 [pytest]
 junit_family = xunit1
-
+markers = # Defines custom markers used by nidcpower system tests. Prevents PytestUnknownMarkWarning.
+    include_legacy_session: Include a legacy session in nidcpower system tests.
+    legacy_session_only: Exclude an independent channels session in nidcpower system tests.
+    resource_name: Overrides the default resource_name argument in the nidcpower session fixture.
+    channels: Overrides the default channels argument in the nidcpower session fixture.
+    reset: Overrides the default reset argument in the nidcpower session fixture.
+    options: Overrides the default options argument in the nidcpower session fixture.
+    independent_channels: Overrides the default independent_channels argument in the nidcpower session fixture.

--- a/generated/nidigital/tox-system_tests.ini
+++ b/generated/nidigital/tox-system_tests.ini
@@ -66,4 +66,3 @@ passenv =
 
 [pytest]
 junit_family = xunit1
-

--- a/generated/nidmm/tox-system_tests.ini
+++ b/generated/nidmm/tox-system_tests.ini
@@ -58,4 +58,3 @@ passenv =
 
 [pytest]
 junit_family = xunit1
-

--- a/generated/nifake/tox-system_tests.ini
+++ b/generated/nifake/tox-system_tests.ini
@@ -66,4 +66,3 @@ passenv =
 
 [pytest]
 junit_family = xunit1
-

--- a/generated/nifgen/tox-system_tests.ini
+++ b/generated/nifgen/tox-system_tests.ini
@@ -66,4 +66,3 @@ passenv =
 
 [pytest]
 junit_family = xunit1
-

--- a/generated/nimodinst/tox-system_tests.ini
+++ b/generated/nimodinst/tox-system_tests.ini
@@ -58,4 +58,3 @@ passenv =
 
 [pytest]
 junit_family = xunit1
-

--- a/generated/niscope/tox-system_tests.ini
+++ b/generated/niscope/tox-system_tests.ini
@@ -66,4 +66,3 @@ passenv =
 
 [pytest]
 junit_family = xunit1
-

--- a/generated/nise/tox-system_tests.ini
+++ b/generated/nise/tox-system_tests.ini
@@ -58,4 +58,3 @@ passenv =
 
 [pytest]
 junit_family = xunit1
-

--- a/generated/niswitch/tox-system_tests.ini
+++ b/generated/niswitch/tox-system_tests.ini
@@ -58,4 +58,3 @@ passenv =
 
 [pytest]
 junit_family = xunit1
-

--- a/generated/nitclk/tox-system_tests.ini
+++ b/generated/nitclk/tox-system_tests.ini
@@ -66,4 +66,3 @@ passenv =
 
 [pytest]
 junit_family = xunit1
-

--- a/src/nidcpower/system_tests/conftest.py
+++ b/src/nidcpower/system_tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+def pytest_collection_modifyitems(items):
+    '''Ignores initializer deprecation warnings for all nidcpower system tests.'''
+    for item in items:
+        item.add_marker(pytest.mark.filterwarnings('ignore:Attempting to initialize an independent channels session with a channels argument.:DeprecationWarning'))
+        item.add_marker(pytest.mark.filterwarnings('ignore:Initializing session without independent channels enabled.:DeprecationWarning'))

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -482,9 +482,15 @@ def test_init_issues_deprecation_warnings(resource_name, channels, independent_c
     argument is supplied.
     """
     options = {'Simulate': True, 'DriverSetup': {'Model': '4162', 'BoardType': 'PXIe'}}
-    with pytest.deprecated_call():
+    with pytest.deprecated_call() as dc:
         with nidcpower.Session(resource_name, channels, options=options, independent_channels=independent_channels):
             pass
+    assert len(dc.list) == 1  # assert only 1 deprecation warning was thrown
+    message = dc.list[0].message.args[0]
+    if not independent_channels:
+        assert message.find('Initializing session without independent channels enabled.') != -1
+    if channels and independent_channels:
+        assert message.find('Attempting to initialize an independent channels session with a channels argument.') != -1
 
 
 @pytest.mark.parametrize(

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -681,7 +681,6 @@ def test_instruments_repeated_capability(session, device_name):
     assert session.instruments[device_name].instrument_model == 'NI PXIe-4162'
 
 
-@pytest.mark.skip('Requires PR 1626 to be merged before this test will pass.')
 @pytest.mark.resource_name('Dev1/0:3, Dev2/0:3')
 @pytest.mark.parametrize(
     'channels',

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -596,3 +596,18 @@ def test_error_channel_name_not_allowed(session):
 @pytest.mark.include_legacy_session
 def test_repeated_capabilities_with_initiate(session):
     session.channels['0-11'].initiate()
+
+
+@pytest.mark.resource_name('Dev1,Dev2')
+def test_repeated_capabilities_with_initiate_multi_instrument_session(session):
+    session.channels['Dev1/0-11,Dev2/0-11'].initiate()
+
+
+@pytest.mark.resource_name('Dev1/0')
+def test_repeated_capabilities_with_initiate_fully_qualified_channel_name(session):
+    session.channels['Dev1/0'].initiate()
+
+
+@pytest.mark.resource_name('Dev1/0-3,Dev2/0,Dev3/0:3')
+def test_repeated_capabilities_with_initiate_and_get_channel_names(session):
+    session.channels[session.get_channel_names('0:8')].initiate()

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -486,7 +486,7 @@ def test_init_issues_deprecation_warnings(resource_name, channels, independent_c
         with nidcpower.Session(resource_name, channels, options=options, independent_channels=independent_channels):
             pass
     assert len(dc.list) == 1  # assert only 1 deprecation warning was thrown
-    message = dc.list[0].message.args[0]
+    message = dc.list[0].message.args[0]  # grabs the deprecation warning message
     if not independent_channels:
         assert message.find('Initializing session without independent channels enabled.') != -1
     if channels and independent_channels:
@@ -525,7 +525,9 @@ def test_init_backwards_compatibility_with_initialize_with_channels(resource_nam
         ('Dev1/0,Dev2/1', None),
         ('Dev1/0,Dev2/1', ''),
         (['Dev1/0', 'Dev1/1'], ''),  # construct with list
-        (('Dev1/0', 'Dev1/1'), '')  # construct with tuple
+        (('Dev1/0', 'Dev1/1'), ''),  # construct with tuple
+        ('Dev1/0-3', None),
+        ('Dev1/0:3', None)
     ]
 )
 def test_init_with_independent_channels(resource_name, channels):

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -586,9 +586,12 @@ def test_init_raises_driver_errors_for_invalid_arguments(resource_name, channels
     ]
 )
 def test_init_raises_driver_errors_for_invalid_arguments_legacy_session(resource_name, channels):
-    """Multi-instrument resource names are valid for simulated initialize with channels sessions.
-    So, we attempt to initialize a true session and assert an unsupported device exception is raised.
+    """Tests invalid initializer arguments for legacy initialize with channels sessions.
+
+    Multi-instrument resource names are valid for simulated initialize with channels sessions. So,
+    we attempt to initialize a true session and assert an unsupported device exception is raised.
     """
+
     with pytest.raises(nidcpower.errors.DriverError) as e:
         with nidcpower.Session(resource_name, channels, independent_channels=False):
             pass

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -8,11 +8,10 @@ import tempfile
 def pytest_generate_tests(metafunc):
     '''Parametrizes the "session" fixture by examining the the markers set for a test.
 
-    By default, the session fixture is parametrized so each test runs twice. Once with a legacy
-    Synchronized Channels session and once with an Independent Channels session. To limit the
-    session used for a test to only a legacy session, decorate the test with
-    @pytest.mark.legacy_session_only. To limit the session used for a test to only an Independent
-    Channels session, decorate the test with @pytest.mark.independent_channels_session_only.
+    By default, the session fixture is parametrized so each test runs once with an Independent
+    Channels session. To also run a test with a legacy Synchronized Channels session, decorate the
+    test with the custom marker @pytest.mark.include_legacy_session. To run a test with only a
+    legacy session, decorate the test with @pytest.mark.legacy_session_only.
     '''
 
     if 'session' in metafunc.fixturenames:
@@ -20,14 +19,14 @@ def pytest_generate_tests(metafunc):
         # markers from being set on the same test
 
         legacy_session_only = metafunc.definition.get_closest_marker('legacy_session_only')
-        independent_channels_session_only = metafunc.definition.get_closest_marker('independent_channels_session_only')
+        include_legacy_session = metafunc.definition.get_closest_marker('include_legacy_session')
 
         if legacy_session_only:
             metafunc.parametrize('session', [False], indirect=True)
-        if independent_channels_session_only:
+        if include_legacy_session:
+            metafunc.parametrize('session', [True, False], indirect=True)
+        if not legacy_session_only and not include_legacy_session:
             metafunc.parametrize('session', [True], indirect=True)
-        if not legacy_session_only and not independent_channels_session_only:
-            metafunc.parametrize('session', [False, True], indirect=True)
 
 
 @pytest.fixture(scope='function')
@@ -44,9 +43,9 @@ def session(request):
         @pytest.mark.options
         @pytest.mark.independent_channels
 
-    By default, all dependent tests will run twice. First with a legacy Synchronized Channels
-    session. Second with an Independent Channels session. Dependent tests can override this behavior
-    by using markers. Refer to the documentation in pytest_generate_tests for more information.
+    By default, all dependent tests will run once with an Independent Channels session. Dependent
+    tests can override this behavior by using custom markers. Refer to the documentation in
+    pytest_generate_tests for more information.
     '''
 
     # set default values
@@ -68,15 +67,16 @@ def session(request):
         yield simulated_session
 
 
+@pytest.mark.include_legacy_session
 def test_self_test(session):
     session.self_test()
 
 
+@pytest.mark.include_legacy_session
 def test_self_cal(session):
     session.self_cal()
 
 
-@pytest.mark.independent_channels_session_only
 def test_get_channel_name_independent_channels(session):
     name = session.get_channel_name(1)
     assert name == '4162/0'
@@ -88,7 +88,6 @@ def test_get_channel_name_synchronized_channels(session):
     assert name == '0'
 
 
-@pytest.mark.independent_channels_session_only
 def test_get_channel_names_independent_channels(session):
     expected_string = ['4162/{0}'.format(x) for x in range(12)]
     channel_indices = ['0-1, 2, 3:4', 5, (6, 7), range(8, 10), slice(10, 12)]
@@ -102,11 +101,13 @@ def test_get_channel_names_synchronized_channels(session):
     assert session.get_channel_names(channel_indices) == expected_string
 
 
+@pytest.mark.include_legacy_session
 def test_get_attribute_string(session):
     model = session.instrument_model
     assert model == 'NI PXIe-4162'
 
 
+@pytest.mark.include_legacy_session
 def test_error_message():
     try:
         # We pass in an invalid model name to force going to error_message
@@ -117,6 +118,7 @@ def test_error_message():
         assert e.description.find('The option string parameter contains an entry with an unknown option value.') != -1
 
 
+@pytest.mark.include_legacy_session
 def test_get_error(session):
     try:
         session.instrument_model = ''
@@ -126,6 +128,7 @@ def test_get_error(session):
         assert e.description.find('Attribute is read-only.') != -1
 
 
+@pytest.mark.include_legacy_session
 def test_get_self_cal_last_date_and_time(session):
     last_cal = session.get_self_cal_last_date_and_time()
     assert last_cal.year == 1940
@@ -135,16 +138,19 @@ def test_get_self_cal_last_date_and_time(session):
     assert last_cal.minute == 0
 
 
+@pytest.mark.include_legacy_session
 def test_get_self_cal_last_temp(session):
     temperature = session.get_self_cal_last_temp()
     assert temperature == 25.0
 
 
+@pytest.mark.include_legacy_session
 def test_read_current_temperature(session):
     temperature = session.read_current_temperature()
     assert temperature == 25.0
 
 
+@pytest.mark.include_legacy_session
 def test_reset_device(session):
     channel = session.channels['0']
     default_output_function = channel.output_function
@@ -155,6 +161,7 @@ def test_reset_device(session):
     assert function_after_reset == default_output_function
 
 
+@pytest.mark.include_legacy_session
 def test_reset_with_default(session):
     channel = session.channels['0']
     assert channel.aperture_time_units == nidcpower.ApertureTimeUnits.SECONDS
@@ -163,6 +170,7 @@ def test_reset_with_default(session):
     assert channel.aperture_time_units == nidcpower.ApertureTimeUnits.SECONDS
 
 
+@pytest.mark.include_legacy_session
 def test_reset(session):
     channel = session.channels['0']
     assert channel.output_enabled is True
@@ -171,6 +179,7 @@ def test_reset(session):
     assert channel.output_enabled is True
 
 
+@pytest.mark.include_legacy_session
 def test_disable(session):
     channel = session.channels['0']
     assert channel.output_enabled is True
@@ -179,6 +188,7 @@ def test_disable(session):
 
 
 @pytest.mark.channels('0')
+@pytest.mark.include_legacy_session
 def test_measure(session):
     session.source_mode = nidcpower.SourceMode.SINGLE_POINT
     session.output_function = nidcpower.OutputFunction.DC_VOLTAGE
@@ -191,6 +201,7 @@ def test_measure(session):
 
 
 @pytest.mark.channels('0')
+@pytest.mark.include_legacy_session
 def test_query_output_state(session):
     with session.initiate():
         assert session.query_output_state(nidcpower.OutputStates.VOLTAGE) is True   # since default function is DCVolt when initiated output state for DC Volt\DC current should be True and False respectively
@@ -198,6 +209,7 @@ def test_query_output_state(session):
 
 
 @pytest.mark.channels('0')
+@pytest.mark.include_legacy_session
 def test_config_aperture_time(session):
     expected_default_aperture_time = 0.01666
     default_aperture_time = session.aperture_time
@@ -213,6 +225,7 @@ def test_config_aperture_time(session):
 
 
 @pytest.mark.channels('0')
+@pytest.mark.include_legacy_session
 def test_fetch_multiple(session):
     session.source_mode = nidcpower.SourceMode.SINGLE_POINT
     session.configure_aperture_time(0, nidcpower.ApertureTimeUnits.SECONDS)
@@ -229,6 +242,7 @@ def test_fetch_multiple(session):
         assert measurements[1].current == 0.00001
 
 
+@pytest.mark.include_legacy_session
 def test_measure_multiple(session):
     with session.initiate():
         # session is open to all 12 channels on the device
@@ -246,6 +260,7 @@ def test_measure_multiple(session):
 
 
 @pytest.mark.channels('0')
+@pytest.mark.include_legacy_session
 def test_query_max_current_limit(session):
     max_current_limit = session.query_max_current_limit(6)
     expected_max_current_limit = 0.1  # for a simulated 4162 max current limit should be 0.1 for 6V Voltage level
@@ -254,6 +269,7 @@ def test_query_max_current_limit(session):
 
 
 @pytest.mark.channels('0')
+@pytest.mark.include_legacy_session
 def test_query_max_voltage_level(session):
     max_voltage_level = session.query_max_voltage_level(0.03)
     expected_max_voltage_level = 24  # for a simulated 4162 max voltage level should be 24V for 30mA current limit
@@ -262,6 +278,7 @@ def test_query_max_voltage_level(session):
 
 
 @pytest.mark.channels('0')
+@pytest.mark.include_legacy_session
 def test_query_min_current_limit(session):
     min_current_limit = session.query_min_current_limit(0.03)
     expected_min_current_limit = 0.0000001  # for a simulated 4162 min_current_limit should be 1uA for 6V voltage level
@@ -270,11 +287,13 @@ def test_query_min_current_limit(session):
 
 
 @pytest.mark.channels('0')
+@pytest.mark.include_legacy_session
 def test_set_sequence_with_source_delays(session):
     session.set_sequence([0.1, 0.2, 0.3], [0.001, 0.002, 0.003])
 
 
 @pytest.mark.channels('0')
+@pytest.mark.include_legacy_session
 def test_set_sequence_with_too_many_source_delays(session):
     try:
         session.set_sequence([0.1, 0.2, 0.3], [0.001, 0.002, 0.003, 0.004])
@@ -284,6 +303,7 @@ def test_set_sequence_with_too_many_source_delays(session):
 
 
 @pytest.mark.channels('0')
+@pytest.mark.include_legacy_session
 def test_set_sequence_with_too_few_source_delays(session):
     try:
         session.set_sequence([0.1, 0.2, 0.3, 0.4], [0.001, 0.002])
@@ -293,18 +313,21 @@ def test_set_sequence_with_too_few_source_delays(session):
 
 
 @pytest.mark.channels('0')
+@pytest.mark.include_legacy_session
 def test_wait_for_event_default_timeout(session):
     with session.initiate():
         session.wait_for_event(nidcpower.Event.SOURCE_COMPLETE)
 
 
 @pytest.mark.channels('0')
+@pytest.mark.include_legacy_session
 def test_wait_for_event_with_timeout(session):
     with session.initiate():
         session.wait_for_event(nidcpower.Event.SOURCE_COMPLETE, hightime.timedelta(seconds=0.5))
 
 
 @pytest.mark.channels('0')
+@pytest.mark.include_legacy_session
 def test_commit(session):
     non_default_current_limit = 0.00021
     session.current_limit = non_default_current_limit
@@ -312,6 +335,7 @@ def test_commit(session):
 
 
 @pytest.mark.channels('0')
+@pytest.mark.include_legacy_session
 def test_import_export_buffer(session):
     test_value_1 = 1
     test_value_2 = 2
@@ -325,6 +349,7 @@ def test_import_export_buffer(session):
 
 
 @pytest.mark.channels('0')
+@pytest.mark.include_legacy_session
 def test_import_export_file(session):
     test_value_1 = 1
     test_value_2 = 2
@@ -343,6 +368,7 @@ def test_import_export_file(session):
 
 
 @pytest.mark.channels('0')
+@pytest.mark.include_legacy_session
 def test_create_and_delete_advanced_sequence(session):
     properties_used = ['output_function', 'voltage_level']
     sequence_name = 'my_sequence'
@@ -361,6 +387,7 @@ def test_create_and_delete_advanced_sequence(session):
 
 
 @pytest.mark.channels('0')
+@pytest.mark.include_legacy_session
 def test_create_and_delete_advanced_sequence_bad_name(session):
     properties_used = ['output_function_bad', 'voltage_level']
     sequence_name = 'my_sequence'
@@ -373,6 +400,7 @@ def test_create_and_delete_advanced_sequence_bad_name(session):
 
 
 @pytest.mark.channels('0')
+@pytest.mark.include_legacy_session
 def test_create_and_delete_advanced_sequence_bad_type(session):
     properties_used = ['unlock', 'voltage_level']
     sequence_name = 'my_sequence'
@@ -394,6 +422,7 @@ def test_send_software_edge_trigger_error(session):
         assert e.description.find('The requested function is not available when multiple channels are present in the same session.') != -1
 
 
+@pytest.mark.include_legacy_session
 def test_get_ext_cal_last_date_and_time(session):
     print(type(session))
     last_cal = session.get_ext_cal_last_date_and_time()
@@ -404,22 +433,26 @@ def test_get_ext_cal_last_date_and_time(session):
     assert last_cal.minute == 0
 
 
+@pytest.mark.include_legacy_session
 def test_get_ext_cal_last_temp(session):
     temperature = session.get_ext_cal_last_temp()
     assert temperature == 25.0
 
 
+@pytest.mark.include_legacy_session
 def test_get_ext_cal_recommended_interval(session):
     interval = session.get_ext_cal_recommended_interval()
     assert interval.days == 365
 
 
+@pytest.mark.include_legacy_session
 def test_set_get_vi_int_64_attribute(session):
     session.channels['0'].active_advanced_sequence_step = 1
     read_advanced_sequence_step = session.channels['0'].active_advanced_sequence_step
     assert read_advanced_sequence_step == 1
 
 
+@pytest.mark.include_legacy_session
 def test_channel_format_types():
     with nidcpower.Session('4162', [0, 1], False, 'Simulate=1, DriverSetup=Model:4162; BoardType:PXIe') as simulated_session:
         assert simulated_session.channel_count == 2
@@ -527,6 +560,7 @@ def test_init_raises_driver_errors_for_invalid_arguments(resource_name, channels
     assert e.value.code == expected_error_code
 
 
+@pytest.mark.include_legacy_session
 def test_repeated_capabilities_on_method_when_all_channels_are_specified(session):
     '''Sessions should not error when specifying all channels by number.'''
     assert session.channels['0'].output_enabled is True
@@ -551,5 +585,6 @@ def test_error_channel_name_not_allowed(session):
     assert e.value.description.find('The channel or repeated capability name is not allowed.') != -1
 
 
+@pytest.mark.include_legacy_session
 def test_repeated_capabilities_with_initiate(session):
     session.channels['0-11'].initiate()

--- a/tox.ini
+++ b/tox.ini
@@ -174,11 +174,3 @@ norecursedirs = system_tests examples .* build dist CVS _darcs {arch} *.egg venv
 junit_suite_name = nimi-python
 python_files = *.py
 junit_family = xunit1
-markers = # Defines custom markers used by nidcpower system tests. Prevents PytestUnknownMarkWarning.
-    include_legacy_session: Include a legacy session in nidcpower system tests.
-    legacy_session_only: Exclude an independent channels session in nidcpower system tests.
-    resource_name: Overrides the default resource_name argument in the nidcpower session fixture.
-    channels: Overrides the default channels argument in the nidcpower session fixture.
-    reset: Overrides the default reset argument in the nidcpower session fixture.
-    options: Overrides the default options argument in the nidcpower session fixture.
-    independent_channels: Overrides the default independent_channels argument in the nidcpower session fixture.

--- a/tox.ini
+++ b/tox.ini
@@ -174,4 +174,11 @@ norecursedirs = system_tests examples .* build dist CVS _darcs {arch} *.egg venv
 junit_suite_name = nimi-python
 python_files = *.py
 junit_family = xunit1
-
+markers = # Defines custom markers used by nidcpower system tests. Prevents PytestUnknownMarkWarning.
+    include_legacy_session: Include a legacy session in nidcpower system tests.
+    legacy_session_only: Exclude an independent channels session in nidcpower system tests.
+    resource_name: Overrides the default resource_name argument in the nidcpower session fixture.
+    channels: Overrides the default channels argument in the nidcpower session fixture.
+    reset: Overrides the default reset argument in the nidcpower session fixture.
+    options: Overrides the default options argument in the nidcpower session fixture.
+    independent_channels: Overrides the default independent_channels argument in the nidcpower session fixture.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

Refactors the nidcpower system test to accomplish the following goals:
1. Reduce the number of fixtures, thus making it easier to decide which fixtures future devs should use.
2. Enable a developer to mark at test to run on a legacy session, independent channels session, or both

This PR also adds additional tests focused on channel based repeated capabilities for both session types.

### List issues fixed by this Pull Request below, if any.

- Resolves #1614 

### What testing has been done?

Tests are passing on local machine.

