### PR TITLE
NI-DCPower 21.0.0 API parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ All notable changes to this project will be documented in this file.
     * #### Removed
 * ### `nidcpower` (NI-DCPower)
     * #### Added
+        * API parity with NI-DCPower 21.0.0.
+            * Properties added:
+                * `output_cutoff_delay`
     * #### Changed
     * #### Removed
 * ### `nidigital` (NI-Digital Pattern Driver)

--- a/docs/nidcpower/class.rst
+++ b/docs/nidcpower/class.rst
@@ -4915,6 +4915,45 @@ output_cutoff_current_overrange_enabled
                 - LabVIEW Property: **Source:Output Cutoff:Current Overrange Enabled**
                 - C Attribute: **NIDCPOWER_ATTR_OUTPUT_CUTOFF_CURRENT_OVERRANGE_ENABLED**
 
+output_cutoff_delay
+-------------------
+
+    .. py:attribute:: output_cutoff_delay
+
+        Delays disconnecting the output by the time you specify, in seconds, when a limit is exceeded.
+
+
+
+        .. note:: Refer to Supported Properties by Device for information about supported devices.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].output_cutoff_delay`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.output_cutoff_delay`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+-------------------------------------------------------------+
+            | Characteristic        | Value                                                       |
+            +=======================+=============================================================+
+            | Datatype              | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +-----------------------+-------------------------------------------------------------+
+            | Permissions           | read-write                                                  |
+            +-----------------------+-------------------------------------------------------------+
+            | Repeated Capabilities | channels                                                    |
+            +-----------------------+-------------------------------------------------------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Source:Output Cutoff:Delay**
+                - C Attribute: **NIDCPOWER_ATTR_OUTPUT_CUTOFF_DELAY**
+
 output_cutoff_enabled
 ---------------------
 

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -1394,6 +1394,23 @@ class _SessionBase(object):
 
     Example: :py:attr:`my_session.output_cutoff_current_overrange_enabled`
     '''
+    output_cutoff_delay = _attributes.AttributeViReal64TimeDeltaSeconds(1150300)
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
+
+    Delays disconnecting the output by the time you specify, in seconds, when a limit is exceeded.
+
+    Note: Refer to Supported Properties by Device for information about supported devices.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].output_cutoff_delay`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.output_cutoff_delay`
+    '''
     output_cutoff_enabled = _attributes.AttributeViBoolean(1150235)
     '''Type: bool
 

--- a/src/nidcpower/metadata/attributes.py
+++ b/src/nidcpower/metadata/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 21.0.0d347
+# This file is generated from NI-DCPower API metadata version 21.0.0f353
 attributes = {
     1050003: {
         'access': 'read-write',
@@ -1916,6 +1916,21 @@ attributes = {
             'channels'
         ],
         'type': 'ViReal64'
+    },
+    1150300: {
+        'access': 'read-write',
+        'attribute_class': 'AttributeViReal64TimeDeltaSeconds',
+        'documentation': {
+            'description': '\nDelays disconnecting the output by the time you specify, in seconds, when a limit is exceeded.',
+            'note': 'Refer to Supported Attributes by Device for information about supported devices.'
+        },
+        'lv_property': 'Source:Output Cutoff:Delay',
+        'name': 'OUTPUT_CUTOFF_DELAY',
+        'supported_rep_caps': [
+            'channels'
+        ],
+        'type': 'ViReal64',
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
     },
     1250001: {
         'access': 'read-write',

--- a/src/nidcpower/metadata/config.py
+++ b/src/nidcpower/metadata/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 21.0.0d347
+# This file is generated from NI-DCPower API metadata version 21.0.0f353
 config = {
-    'api_version': '21.0.0d347',
+    'api_version': '21.0.0f353',
     'c_function_prefix': 'niDCPower_',
     'close_function': 'close',
     'context_manager_name': {

--- a/src/nidcpower/metadata/enums.py
+++ b/src/nidcpower/metadata/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 21.0.0d347
+# This file is generated from NI-DCPower API metadata version 21.0.0f353
 enums = {
     'ApertureTimeUnits': {
         'values': [

--- a/src/nidcpower/metadata/functions.py
+++ b/src/nidcpower/metadata/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 21.3.0d12
+# This file is generated from NI-DCPower API metadata version 21.0.0f353
 functions = {
     'AbortWithChannels': {
         'documentation': {


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Update nidcpower to be on par with API changes made in NI-DCPower 21.0.0 driver runtime.
 -  Properties added:
      - `output_cutoff_delay`

### List issues fixed by this Pull Request below, if any.

None

### What testing has been done?

Visual inspection of generated files and PR build.
