### PR TITLE
Do not pin the OS used in travis-ci to a specific version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,25 +4,9 @@ matrix:
     include:
       # We run Python 3.9 based tests towards the start. This is where additional tests are run so we give it more time
       - python: 3.9
-        dist: xenial
-        sudo: true
-      # End Python 3.9 based tests
       - python: 3.6
-      # Python 3.7+ needs OpenSSL 1.0.2+ which isn't supported on trusty - use xenial and sudo: true based on workarounds
-      # in Travis issues (this is from multiple issues)
       - python: 3.7
-        dist: xenial
-        sudo: true
       - python: 3.8
-        dist: xenial
-        sudo: true
-      # - python: nightly
-      #   dist: xenial
-      #   sudo: true
-    # No prerelease tests at this point
-    # allow_failures:
-      # Allow tests using under development builds of Python to fail without failing the PR/change
-      # - python: nightly
 
 install:
   - travis_retry sudo apt-get -y install python3-pip


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Stop specifying a particular version of the OS to be used in travis-ci. It was previously required because the default version (trusty) didn't include OpenSSL 1.0.2 which was required in Python 3.7+. Currently the default version is xenial and I don't see a reason for pinning to a particular version.

### List issues fixed by this Pull Request below, if any.

None

### What testing has been done?

travis-ci