### PR TITLE
NI-Digital 21.0 API updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,17 @@ All notable changes to this project will be documented in this file.
     * #### Removed
 * ### `nidigital` (NI-Digital Pattern Driver)
     * #### Added
+        * API parity with NI-Digital Pattern Driver 21.0.0.
+            * Properties added:
+                * `digital_edge_rio_trigger_edge`
+                * `digital_edge_rio_trigger_source`
+                * `exported_rio_event_output_terminal`
+                * `rio_event_terminal_name`
+                * `rio_trigger_terminal_name`
+                * `rio_trigger_type`
+            * Repeated Capabilities added:
+                * `rio_events`
+                * `rio_triggers`
     * #### Changed
     * #### Removed
 * ### `nidmm` (NI-DMM)

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -3258,6 +3258,88 @@ digital_edge_conditional_jump_trigger_source
 
                 - C Attribute: **NIDIGITAL_ATTR_DIGITAL_EDGE_CONDITIONAL_JUMP_TRIGGER_SOURCE**
 
+digital_edge_rio_trigger_edge
+-----------------------------
+
+    .. py:attribute:: digital_edge_rio_trigger_edge
+
+        Configures the active edge of the incoming trigger signal for the RIO trigger instance. The default value is :py:data:`~nidigital.DigitalEdge.RISING`.
+
+        +-------------------------------------------+---------------------------------------------------------------+
+        | Valid Values:                             |                                                               |
+        +===========================================+===============================================================+
+        | :py:data:`~nidigital.DigitalEdge.RISING`  | Specifies the signal transition from low level to high level. |
+        +-------------------------------------------+---------------------------------------------------------------+
+        | :py:data:`~nidigital.DigitalEdge.FALLING` | Specifies the signal transition from high level to low level. |
+        +-------------------------------------------+---------------------------------------------------------------+
+
+
+        .. tip:: This property can be set/get on specific rio_triggers within your :py:class:`nidigital.Session` instance.
+            Use Python index notation on the repeated capabilities container rio_triggers to specify a subset.
+
+            Example: :py:attr:`my_session.rio_triggers[ ... ].digital_edge_rio_trigger_edge`
+
+            To set/get on all rio_triggers, you can call the property directly on the :py:class:`nidigital.Session`.
+
+            Example: :py:attr:`my_session.digital_edge_rio_trigger_edge`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+-------------------+
+            | Characteristic        | Value             |
+            +=======================+===================+
+            | Datatype              | enums.DigitalEdge |
+            +-----------------------+-------------------+
+            | Permissions           | read-write        |
+            +-----------------------+-------------------+
+            | Repeated Capabilities | rio_triggers      |
+            +-----------------------+-------------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - C Attribute: **NIDIGITAL_ATTR_DIGITAL_EDGE_RIO_TRIGGER_EDGE**
+
+digital_edge_rio_trigger_source
+-------------------------------
+
+    .. py:attribute:: digital_edge_rio_trigger_source
+
+        Configures the digital trigger source terminal for a RIO trigger instance. The PXIe-6570/6571 supports triggering through the PXI trigger bus. You can specify source terminals in one of two ways. If the digital pattern instrument is named Dev1 and your terminal is PXI_Trig0, you can specify the terminal with the fully qualified terminal name, /Dev1/PXI_Trig0, or with the shortened terminal name, PXI_Trig0. The source terminal can also be a terminal from another device, in which case the NI-Digital Pattern Driver automatically finds a route (if one is available) from that terminal to the input terminal (going through a physical PXI backplane trigger line). For example, you can set the source terminal on Dev1 to be /Dev2/RIOTrigger0. The default value is VI_NULL.
+
+        +----------------------------------------------+
+        | Valid Values:                                |
+        +==============================================+
+        | String identifier to any valid terminal name |
+        +----------------------------------------------+
+
+
+        .. tip:: This property can be set/get on specific rio_triggers within your :py:class:`nidigital.Session` instance.
+            Use Python index notation on the repeated capabilities container rio_triggers to specify a subset.
+
+            Example: :py:attr:`my_session.rio_triggers[ ... ].digital_edge_rio_trigger_source`
+
+            To set/get on all rio_triggers, you can call the property directly on the :py:class:`nidigital.Session`.
+
+            Example: :py:attr:`my_session.digital_edge_rio_trigger_source`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+--------------+
+            | Characteristic        | Value        |
+            +=======================+==============+
+            | Datatype              | str          |
+            +-----------------------+--------------+
+            | Permissions           | read-write   |
+            +-----------------------+--------------+
+            | Repeated Capabilities | rio_triggers |
+            +-----------------------+--------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - C Attribute: **NIDIGITAL_ATTR_DIGITAL_EDGE_RIO_TRIGGER_SOURCE**
+
 digital_edge_start_trigger_edge
 -------------------------------
 
@@ -3467,6 +3549,60 @@ exported_pattern_opcode_event_output_terminal
             This property corresponds to the following LabVIEW Property or C Attribute:
 
                 - C Attribute: **NIDIGITAL_ATTR_EXPORTED_PATTERN_OPCODE_EVENT_OUTPUT_TERMINAL**
+
+exported_rio_event_output_terminal
+----------------------------------
+
+    .. py:attribute:: exported_rio_event_output_terminal
+
+        Specifies the destination terminal for exporting the RIO Event. Terminals can be specified in one of two ways. If the digital pattern instrument is named Dev1 and your terminal is PXI_Trig0, you can specify the terminal with the fully qualified terminal name, /Dev1/PXI_Trig0, or with the shortened terminal name, PXI_Trig0.
+
+        +-----------------+--------------------+
+        | Defined Values: |                    |
+        +=================+====================+
+        | PXI_Trig0       | PXI trigger line 0 |
+        +-----------------+--------------------+
+        | PXI_Trig1       | PXI trigger line 1 |
+        +-----------------+--------------------+
+        | PXI_Trig2       | PXI trigger line 2 |
+        +-----------------+--------------------+
+        | PXI_Trig3       | PXI trigger line 3 |
+        +-----------------+--------------------+
+        | PXI_Trig4       | PXI trigger line 4 |
+        +-----------------+--------------------+
+        | PXI_Trig5       | PXI trigger line 5 |
+        +-----------------+--------------------+
+        | PXI_Trig6       | PXI trigger line 6 |
+        +-----------------+--------------------+
+        | PXI_Trig7       | PXI trigger line 7 |
+        +-----------------+--------------------+
+
+
+        .. tip:: This property can be set/get on specific rio_events within your :py:class:`nidigital.Session` instance.
+            Use Python index notation on the repeated capabilities container rio_events to specify a subset.
+
+            Example: :py:attr:`my_session.rio_events[ ... ].exported_rio_event_output_terminal`
+
+            To set/get on all rio_events, you can call the property directly on the :py:class:`nidigital.Session`.
+
+            Example: :py:attr:`my_session.exported_rio_event_output_terminal`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | str        |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | rio_events |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - C Attribute: **NIDIGITAL_ATTR_EXPORTED_RIO_EVENT_OUTPUT_TERMINAL**
 
 exported_start_trigger_output_terminal
 --------------------------------------
@@ -4709,6 +4845,120 @@ record_coercions
             This property corresponds to the following LabVIEW Property or C Attribute:
 
                 - C Attribute: **NIDIGITAL_ATTR_RECORD_COERCIONS**
+
+rio_event_terminal_name
+-----------------------
+
+    .. py:attribute:: rio_event_terminal_name
+
+        Specifies the terminal name for the output signal of the specified instance of a RIO Event. You can use this terminal name as an input signal source for another trigger.
+
+
+
+
+        .. tip:: This property can be set/get on specific rio_events within your :py:class:`nidigital.Session` instance.
+            Use Python index notation on the repeated capabilities container rio_events to specify a subset.
+
+            Example: :py:attr:`my_session.rio_events[ ... ].rio_event_terminal_name`
+
+            To set/get on all rio_events, you can call the property directly on the :py:class:`nidigital.Session`.
+
+            Example: :py:attr:`my_session.rio_event_terminal_name`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | str        |
+            +-----------------------+------------+
+            | Permissions           | read only  |
+            +-----------------------+------------+
+            | Repeated Capabilities | rio_events |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - C Attribute: **NIDIGITAL_ATTR_RIO_EVENT_TERMINAL_NAME**
+
+rio_trigger_terminal_name
+-------------------------
+
+    .. py:attribute:: rio_trigger_terminal_name
+
+        Specifies the terminal name from which the exported RIO trigger signal may be routed to other instruments through the PXI trigger bus. You can use this signal to trigger other instruments when the RIO trigger instance asserts on the digital pattern instrument.
+
+
+
+
+        .. tip:: This property can be set/get on specific rio_triggers within your :py:class:`nidigital.Session` instance.
+            Use Python index notation on the repeated capabilities container rio_triggers to specify a subset.
+
+            Example: :py:attr:`my_session.rio_triggers[ ... ].rio_trigger_terminal_name`
+
+            To set/get on all rio_triggers, you can call the property directly on the :py:class:`nidigital.Session`.
+
+            Example: :py:attr:`my_session.rio_trigger_terminal_name`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+--------------+
+            | Characteristic        | Value        |
+            +=======================+==============+
+            | Datatype              | str          |
+            +-----------------------+--------------+
+            | Permissions           | read only    |
+            +-----------------------+--------------+
+            | Repeated Capabilities | rio_triggers |
+            +-----------------------+--------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - C Attribute: **NIDIGITAL_ATTR_RIO_TRIGGER_TERMINAL_NAME**
+
+rio_trigger_type
+----------------
+
+    .. py:attribute:: rio_trigger_type
+
+        Disables the rio trigger or configures it for hardware triggering.  The default value is :py:data:`~nidigital.TriggerType.NONE`.
+
+        +------------------------------------------------+------------------------------------------------------------------+
+        | Valid Values:                                  |                                                                  |
+        +================================================+==================================================================+
+        | :py:data:`~nidigital.TriggerType.NONE`         | Disables the conditional jump trigger.                           |
+        +------------------------------------------------+------------------------------------------------------------------+
+        | :py:data:`~nidigital.TriggerType.DIGITAL_EDGE` | Configures the conditional jump trigger for hardware triggering. |
+        +------------------------------------------------+------------------------------------------------------------------+
+
+
+        .. tip:: This property can be set/get on specific rio_triggers within your :py:class:`nidigital.Session` instance.
+            Use Python index notation on the repeated capabilities container rio_triggers to specify a subset.
+
+            Example: :py:attr:`my_session.rio_triggers[ ... ].rio_trigger_type`
+
+            To set/get on all rio_triggers, you can call the property directly on the :py:class:`nidigital.Session`.
+
+            Example: :py:attr:`my_session.rio_trigger_type`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+-------------------+
+            | Characteristic        | Value             |
+            +=======================+===================+
+            | Datatype              | enums.TriggerType |
+            +-----------------------+-------------------+
+            | Permissions           | read-write        |
+            +-----------------------+-------------------+
+            | Repeated Capabilities | rio_triggers      |
+            +-----------------------+-------------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - C Attribute: **NIDIGITAL_ATTR_RIO_TRIGGER_TYPE**
 
 selected_function
 -----------------

--- a/docs/nidigital/enums.rst
+++ b/docs/nidigital/enums.rst
@@ -430,6 +430,16 @@ SelectedFunction
 
 
 
+    .. py:attribute:: SelectedFunction.RIO
+
+
+
+        Yields control of the specified pin(s) to LabVIEW FPGA.
+
+        
+
+
+
 SequencerFlag
 -------------
 

--- a/docs/nidigital/rep_caps.rst
+++ b/docs/nidigital/rep_caps.rst
@@ -137,4 +137,56 @@ sites
         passes a string of :python:`'site0, site1, site2'` to the set attribute function.
 
 
+rio_events
+----------
+
+    .. py:attribute:: nidigital.Session.rio_events[]
+
+        If no prefix is added to the items in the parameter, the correct prefix will be added when
+        the driver function call is made.
+
+        .. code:: python
+
+            session.rio_events['0-2'].channel_enabled = True
+
+        passes a string of :python:`'RIOEvent0, RIOEvent1, RIOEvent2'` to the set attribute function.
+
+        If an invalid repeated capability is passed to the driver, the driver will return an error.
+
+        You can also explicitly use the prefix as part of the parameter, but it must be the correct prefix
+        for the specific repeated capability.
+
+        .. code:: python
+
+            session.rio_events['RIOEvent0-RIOEvent2'].channel_enabled = True
+
+        passes a string of :python:`'RIOEvent0, RIOEvent1, RIOEvent2'` to the set attribute function.
+
+
+rio_triggers
+------------
+
+    .. py:attribute:: nidigital.Session.rio_triggers[]
+
+        If no prefix is added to the items in the parameter, the correct prefix will be added when
+        the driver function call is made.
+
+        .. code:: python
+
+            session.rio_triggers['0-2'].channel_enabled = True
+
+        passes a string of :python:`'RIOTrigger0, RIOTrigger1, RIOTrigger2'` to the set attribute function.
+
+        If an invalid repeated capability is passed to the driver, the driver will return an error.
+
+        You can also explicitly use the prefix as part of the parameter, but it must be the correct prefix
+        for the specific repeated capability.
+
+        .. code:: python
+
+            session.rio_triggers['RIOTrigger0-RIOTrigger2'].channel_enabled = True
+
+        passes a string of :python:`'RIOTrigger0, RIOTrigger1, RIOTrigger2'` to the set attribute function.
+
+
 

--- a/generated/nidigital/nidigital/enums.py
+++ b/generated/nidigital/nidigital/enums.py
@@ -194,6 +194,10 @@ class SelectedFunction(Enum):
     r'''
     The I/O switch connecting the instrument channel is open to the I/O connector. If the PPMU is sourcing, it is stopped prior to opening the I/O switch.
     '''
+    RIO = 1104
+    r'''
+    Yields control of the specified pin(s) to LabVIEW FPGA.
+    '''
 
 
 class SequencerFlag(Enum):

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -301,6 +301,50 @@ class _SessionBase(object):
 
     Example: :py:attr:`my_session.digital_edge_conditional_jump_trigger_source`
     '''
+    digital_edge_rio_trigger_edge = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.DigitalEdge, 1150088)
+    '''Type: enums.DigitalEdge
+
+    Configures the active edge of the incoming trigger signal for the RIO trigger instance. The default value is DigitalEdge.RISING.
+
+    +---------------------+---------------------------------------------------------------+
+    | Valid Values:       |                                                               |
+    +=====================+===============================================================+
+    | DigitalEdge.RISING  | Specifies the signal transition from low level to high level. |
+    +---------------------+---------------------------------------------------------------+
+    | DigitalEdge.FALLING | Specifies the signal transition from high level to low level. |
+    +---------------------+---------------------------------------------------------------+
+
+    Tip:
+    This property can be set/get on specific rio_triggers within your :py:class:`nidigital.Session` instance.
+    Use Python index notation on the repeated capabilities container rio_triggers to specify a subset.
+
+    Example: :py:attr:`my_session.rio_triggers[ ... ].digital_edge_rio_trigger_edge`
+
+    To set/get on all rio_triggers, you can call the property directly on the :py:class:`nidigital.Session`.
+
+    Example: :py:attr:`my_session.digital_edge_rio_trigger_edge`
+    '''
+    digital_edge_rio_trigger_source = _attributes.AttributeViString(1150087)
+    '''Type: str
+
+    Configures the digital trigger source terminal for a RIO trigger instance. The PXIe-6570/6571 supports triggering through the PXI trigger bus. You can specify source terminals in one of two ways. If the digital pattern instrument is named Dev1 and your terminal is PXI_Trig0, you can specify the terminal with the fully qualified terminal name, /Dev1/PXI_Trig0, or with the shortened terminal name, PXI_Trig0. The source terminal can also be a terminal from another device, in which case the NI-Digital Pattern Driver automatically finds a route (if one is available) from that terminal to the input terminal (going through a physical PXI backplane trigger line). For example, you can set the source terminal on Dev1 to be /Dev2/RIOTrigger0. The default value is VI_NULL.
+
+    +----------------------------------------------+
+    | Valid Values:                                |
+    +==============================================+
+    | String identifier to any valid terminal name |
+    +----------------------------------------------+
+
+    Tip:
+    This property can be set/get on specific rio_triggers within your :py:class:`nidigital.Session` instance.
+    Use Python index notation on the repeated capabilities container rio_triggers to specify a subset.
+
+    Example: :py:attr:`my_session.rio_triggers[ ... ].digital_edge_rio_trigger_source`
+
+    To set/get on all rio_triggers, you can call the property directly on the :py:class:`nidigital.Session`.
+
+    Example: :py:attr:`my_session.digital_edge_rio_trigger_source`
+    '''
     digital_edge_start_trigger_edge = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.DigitalEdge, 1150031)
     '''Type: enums.DigitalEdge
 
@@ -415,6 +459,41 @@ class _SessionBase(object):
     To set/get on all pattern_opcode_events, you can call the property directly on the :py:class:`nidigital.Session`.
 
     Example: :py:attr:`my_session.exported_pattern_opcode_event_output_terminal`
+    '''
+    exported_rio_event_output_terminal = _attributes.AttributeViString(1150090)
+    '''Type: str
+
+    Specifies the destination terminal for exporting the RIO Event. Terminals can be specified in one of two ways. If the digital pattern instrument is named Dev1 and your terminal is PXI_Trig0, you can specify the terminal with the fully qualified terminal name, /Dev1/PXI_Trig0, or with the shortened terminal name, PXI_Trig0.
+
+    +-----------------+--------------------+
+    | Defined Values: |                    |
+    +=================+====================+
+    | PXI_Trig0       | PXI trigger line 0 |
+    +-----------------+--------------------+
+    | PXI_Trig1       | PXI trigger line 1 |
+    +-----------------+--------------------+
+    | PXI_Trig2       | PXI trigger line 2 |
+    +-----------------+--------------------+
+    | PXI_Trig3       | PXI trigger line 3 |
+    +-----------------+--------------------+
+    | PXI_Trig4       | PXI trigger line 4 |
+    +-----------------+--------------------+
+    | PXI_Trig5       | PXI trigger line 5 |
+    +-----------------+--------------------+
+    | PXI_Trig6       | PXI trigger line 6 |
+    +-----------------+--------------------+
+    | PXI_Trig7       | PXI trigger line 7 |
+    +-----------------+--------------------+
+
+    Tip:
+    This property can be set/get on specific rio_events within your :py:class:`nidigital.Session` instance.
+    Use Python index notation on the repeated capabilities container rio_events to specify a subset.
+
+    Example: :py:attr:`my_session.rio_events[ ... ].exported_rio_event_output_terminal`
+
+    To set/get on all rio_events, you can call the property directly on the :py:class:`nidigital.Session`.
+
+    Example: :py:attr:`my_session.exported_rio_event_output_terminal`
     '''
     exported_start_trigger_output_terminal = _attributes.AttributeViString(1150032)
     '''Type: str
@@ -871,6 +950,59 @@ class _SessionBase(object):
 
     Specifies whether the IVI engine keeps a list of the value coercions it makes for integer and real type properties. Enabling record value coercions is not supported.
     '''
+    rio_event_terminal_name = _attributes.AttributeViString(1150091)
+    '''Type: str
+
+    Specifies the terminal name for the output signal of the specified instance of a RIO Event. You can use this terminal name as an input signal source for another trigger.
+
+    Tip:
+    This property can be set/get on specific rio_events within your :py:class:`nidigital.Session` instance.
+    Use Python index notation on the repeated capabilities container rio_events to specify a subset.
+
+    Example: :py:attr:`my_session.rio_events[ ... ].rio_event_terminal_name`
+
+    To set/get on all rio_events, you can call the property directly on the :py:class:`nidigital.Session`.
+
+    Example: :py:attr:`my_session.rio_event_terminal_name`
+    '''
+    rio_trigger_terminal_name = _attributes.AttributeViString(1150089)
+    '''Type: str
+
+    Specifies the terminal name from which the exported RIO trigger signal may be routed to other instruments through the PXI trigger bus. You can use this signal to trigger other instruments when the RIO trigger instance asserts on the digital pattern instrument.
+
+    Tip:
+    This property can be set/get on specific rio_triggers within your :py:class:`nidigital.Session` instance.
+    Use Python index notation on the repeated capabilities container rio_triggers to specify a subset.
+
+    Example: :py:attr:`my_session.rio_triggers[ ... ].rio_trigger_terminal_name`
+
+    To set/get on all rio_triggers, you can call the property directly on the :py:class:`nidigital.Session`.
+
+    Example: :py:attr:`my_session.rio_trigger_terminal_name`
+    '''
+    rio_trigger_type = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.TriggerType, 1150086)
+    '''Type: enums.TriggerType
+
+    Disables the rio trigger or configures it for hardware triggering.  The default value is TriggerType.NONE.
+
+    +--------------------------+------------------------------------------------------------------+
+    | Valid Values:            |                                                                  |
+    +==========================+==================================================================+
+    | TriggerType.NONE         | Disables the conditional jump trigger.                           |
+    +--------------------------+------------------------------------------------------------------+
+    | TriggerType.DIGITAL_EDGE | Configures the conditional jump trigger for hardware triggering. |
+    +--------------------------+------------------------------------------------------------------+
+
+    Tip:
+    This property can be set/get on specific rio_triggers within your :py:class:`nidigital.Session` instance.
+    Use Python index notation on the repeated capabilities container rio_triggers to specify a subset.
+
+    Example: :py:attr:`my_session.rio_triggers[ ... ].rio_trigger_type`
+
+    To set/get on all rio_triggers, you can call the property directly on the :py:class:`nidigital.Session`.
+
+    Example: :py:attr:`my_session.rio_trigger_type`
+    '''
     selected_function = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.SelectedFunction, 1150004)
     '''Type: enums.SelectedFunction
 
@@ -1153,6 +1285,8 @@ class _SessionBase(object):
         self.pattern_opcode_events = _RepeatedCapabilities(self, 'patternOpcodeEvent', repeated_capability_list)
         self.conditional_jump_triggers = _RepeatedCapabilities(self, 'conditionalJumpTrigger', repeated_capability_list)
         self.sites = _RepeatedCapabilities(self, 'site', repeated_capability_list)
+        self.rio_events = _RepeatedCapabilities(self, 'RIOEvent', repeated_capability_list)
+        self.rio_triggers = _RepeatedCapabilities(self, 'RIOTrigger', repeated_capability_list)
 
         self._is_frozen = freeze_it
 

--- a/src/nidigital/metadata/attributes.py
+++ b/src/nidigital/metadata/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-Digital Pattern Driver API metadata version 21.0.0d3
+# This file is generated from NI-Digital Pattern Driver API metadata version 21.3.0d40
 attributes = {
     1050002: {
         'access': 'read-write',
@@ -1168,5 +1168,144 @@ attributes = {
         },
         'name': 'FREQUENCY_COUNTER_HYSTERESIS_ENABLED',
         'type': 'ViBoolean'
+    },
+    1150086: {
+        'access': 'read-write',
+        'documentation': {
+            'description': 'Disables the rio trigger or configures it for hardware triggering.  The default value is NIDIGITAL_VAL_NONE.\n',
+            'table_body': [
+                [
+                    'NIDIGITAL_VAL_NONE',
+                    'Disables the conditional jump trigger.'
+                ],
+                [
+                    'NIDIGITAL_VAL_DIGITAL_EDGE',
+                    'Configures the conditional jump trigger for hardware triggering.'
+                ]
+            ],
+            'table_header': [
+                'Valid Values:'
+            ]
+        },
+        'enum': 'TriggerType',
+        'name': 'RIO_TRIGGER_TYPE',
+        'supported_rep_caps': [
+            'rio_triggers'
+        ],
+        'type': 'ViInt32'
+    },
+    1150087: {
+        'access': 'read-write',
+        'documentation': {
+            'description': 'Configures the digital trigger source terminal for a RIO trigger instance. The PXIe-6570/6571 supports triggering through the PXI trigger bus. You can specify source terminals in one of two ways. If the digital pattern instrument is named Dev1 and your terminal is PXI_Trig0, you can specify the terminal with the fully qualified terminal name, /Dev1/PXI_Trig0, or with the shortened terminal name, PXI_Trig0. The source terminal can also be a terminal from another device, in which case the NI-Digital Pattern Driver automatically finds a route (if one is available) from that terminal to the input terminal (going through a physical PXI backplane trigger line). For example, you can set the source terminal on Dev1 to be /Dev2/RIOTrigger0. The default value is VI_NULL.\n',
+            'table_body': [
+                [
+                    'String identifier to any valid terminal name'
+                ]
+            ],
+            'table_header': [
+                'Valid Values:'
+            ]
+        },
+        'name': 'DIGITAL_EDGE_RIO_TRIGGER_SOURCE',
+        'supported_rep_caps': [
+            'rio_triggers'
+        ],
+        'type': 'ViString'
+    },
+    1150088: {
+        'access': 'read-write',
+        'documentation': {
+            'description': 'Configures the active edge of the incoming trigger signal for the RIO trigger instance. The default value is NIDIGITAL_VAL_RISING_EDGE.\n',
+            'table_body': [
+                [
+                    'NIDIGITAL_VAL_RISING_EDGE',
+                    'Specifies the signal transition from low level to high level.'
+                ],
+                [
+                    'NIDIGITAL_VAL_FALLING_EDGE',
+                    'Specifies the signal transition from high level to low level.'
+                ]
+            ],
+            'table_header': [
+                'Valid Values:'
+            ]
+        },
+        'enum': 'DigitalEdge',
+        'name': 'DIGITAL_EDGE_RIO_TRIGGER_EDGE',
+        'supported_rep_caps': [
+            'rio_triggers'
+        ],
+        'type': 'ViInt32'
+    },
+    1150089: {
+        'access': 'read only',
+        'documentation': {
+            'description': 'Specifies the terminal name from which the exported RIO trigger signal may be routed to other instruments through the PXI trigger bus. You can use this signal to trigger other instruments when the RIO trigger instance asserts on the digital pattern instrument.\n'
+        },
+        'name': 'RIO_TRIGGER_TERMINAL_NAME',
+        'supported_rep_caps': [
+            'rio_triggers'
+        ],
+        'type': 'ViString'
+    },
+    1150090: {
+        'access': 'read-write',
+        'documentation': {
+            'description': 'Specifies the destination terminal for exporting the RIO Event. Terminals can be specified in one of two ways. If the digital pattern instrument is named Dev1 and your terminal is PXI_Trig0, you can specify the terminal with the fully qualified terminal name, /Dev1/PXI_Trig0, or with the shortened terminal name, PXI_Trig0.\n',
+            'table_body': [
+                [
+                    'PXI_Trig0',
+                    'PXI trigger line 0'
+                ],
+                [
+                    'PXI_Trig1',
+                    'PXI trigger line 1'
+                ],
+                [
+                    'PXI_Trig2',
+                    'PXI trigger line 2'
+                ],
+                [
+                    'PXI_Trig3',
+                    'PXI trigger line 3'
+                ],
+                [
+                    'PXI_Trig4',
+                    'PXI trigger line 4'
+                ],
+                [
+                    'PXI_Trig5',
+                    'PXI trigger line 5'
+                ],
+                [
+                    'PXI_Trig6',
+                    'PXI trigger line 6'
+                ],
+                [
+                    'PXI_Trig7',
+                    'PXI trigger line 7'
+                ]
+            ],
+            'table_header': [
+                'Defined Values:'
+            ]
+        },
+        'name': 'EXPORTED_RIO_EVENT_OUTPUT_TERMINAL',
+        'supported_rep_caps': [
+            'rio_events'
+        ],
+        'type': 'ViString'
+    },
+    1150091: {
+        'access': 'read only',
+        'documentation': {
+            'description': 'Specifies the terminal name for the output signal of the specified instance of a RIO Event. You can use this terminal name as an input signal source for another trigger.\n'
+        },
+        'name': 'RIO_EVENT_TERMINAL_NAME',
+        'supported_rep_caps': [
+            'rio_events'
+        ],
+        'type': 'ViString'
     }
 }

--- a/src/nidigital/metadata/config.py
+++ b/src/nidigital/metadata/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-Digital Pattern Driver API metadata version 19.5.0d7
+# This file is generated from NI-Digital Pattern Driver API metadata version 21.3.0d40
 config = {
-    'api_version': '19.5.0d7',
+    'api_version': '21.3.0d40',
     'c_function_prefix': 'niDigital_',
     'close_function': 'close',
     'context_manager_name': {
@@ -64,8 +64,16 @@ config = {
             'prefix': 'site',
             'python_name': 'sites'
         },
+        {
+            'prefix': 'RIOEvent',
+            'python_name': 'rio_events'
+        },
+        {
+            'prefix': 'RIOTrigger',
+            'python_name': 'rio_triggers'
+        }
     ],
     'session_class_description': 'An NI-Digital Pattern Driver session',
     'session_handle_parameter_name': 'vi',
-    'uses_nitclk': True,
+    'uses_nitclk': True
 }

--- a/src/nidigital/metadata/enums.py
+++ b/src/nidigital/metadata/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-Digital Pattern Driver API metadata version 19.5.0d7
+# This file is generated from NI-Digital Pattern Driver API metadata version 21.3.0d40
 enums = {
     'BitOrder': {
         'values': [
@@ -119,6 +119,13 @@ enums = {
             {
                 'name': 'NIDIGITAL_VAL_REF_CLOCK',
                 'value': 2003
+            },
+            {
+                'documentation': {
+                    'description': 'Specifies to route a RIO event signal.'
+                },
+                'name': 'NIDIGITAL_VAL_RIO_EVENT',
+                'value': 2004
             }
         ]
     },
@@ -268,8 +275,8 @@ enums = {
                     'description': 'A digital state of 0.'
                 },
                 'name': 'NIDIGITAL_VAL_0',
-                'python_name': 'ZERO',
                 'pretty_name': '0',
+                'python_name': 'ZERO',
                 'value': 0
             },
             {
@@ -277,8 +284,8 @@ enums = {
                     'description': 'A digital state of 1.'
                 },
                 'name': 'NIDIGITAL_VAL_1',
-                'python_name': 'ONE',
                 'pretty_name': '1',
+                'python_name': 'ONE',
                 'value': 1
             },
             {
@@ -348,6 +355,86 @@ enums = {
             }
         ]
     },
+    'RIOEvent': {
+        'values': [
+            {
+                'name': 'NIDIGITAL_VAL_RIO_EVENT0',
+                'value': 'RIOEvent0'
+            },
+            {
+                'name': 'NIDIGITAL_VAL_RIO_EVENT1',
+                'value': 'RIOEvent1'
+            },
+            {
+                'name': 'NIDIGITAL_VAL_RIO_EVENT2',
+                'value': 'RIOEvent2'
+            },
+            {
+                'name': 'NIDIGITAL_VAL_RIO_EVENT3',
+                'value': 'RIOEvent3'
+            },
+            {
+                'name': 'NIDIGITAL_VAL_RIO_EVENT4',
+                'value': 'RIOEvent4'
+            },
+            {
+                'name': 'NIDIGITAL_VAL_RIO_EVENT5',
+                'value': 'RIOEvent5'
+            },
+            {
+                'name': 'NIDIGITAL_VAL_RIO_EVENT6',
+                'value': 'RIOEvent6'
+            },
+            {
+                'name': 'NIDIGITAL_VAL_RIO_EVENT7',
+                'value': 'RIOEvent7'
+            }
+        ]
+    },
+    'RIOTriggerId': {
+        'values': [
+            {
+                'name': 'NIDIGITAL_VAL_RIO_TRIGGER0',
+                'python_name': 'RIO_TRIGGER0',
+                'value': 'RIOTrigger0'
+            },
+            {
+                'name': 'NIDIGITAL_VAL_RIO_TRIGGER1',
+                'python_name': 'RIO_TRIGGER1',
+                'value': 'RIOTrigger1'
+            },
+            {
+                'name': 'NIDIGITAL_VAL_RIO_TRIGGER2',
+                'python_name': 'RIO_TRIGGER2',
+                'value': 'RIOTrigger2'
+            },
+            {
+                'name': 'NIDIGITAL_VAL_RIO_TRIGGER3',
+                'python_name': 'RIO_TRIGGER3',
+                'value': 'RIOTrigger3'
+            },
+            {
+                'name': 'NIDIGITAL_VAL_RIO_TRIGGER4',
+                'python_name': 'RIO_TRIGGER4',
+                'value': 'RIOTrigger4'
+            },
+            {
+                'name': 'NIDIGITAL_VAL_RIO_TRIGGER5',
+                'python_name': 'RIO_TRIGGER5',
+                'value': 'RIOTrigger5'
+            },
+            {
+                'name': 'NIDIGITAL_VAL_RIO_TRIGGER6',
+                'python_name': 'RIO_TRIGGER6',
+                'value': 'RIOTrigger6'
+            },
+            {
+                'name': 'NIDIGITAL_VAL_RIO_TRIGGER7',
+                'python_name': 'RIO_TRIGGER7',
+                'value': 'RIOTrigger7'
+            }
+        ]
+    },
     'SelectedFunction': {
         'values': [
             {
@@ -377,6 +464,13 @@ enums = {
                 },
                 'name': 'NIDIGITAL_VAL_DISCONNECT',
                 'value': 1103
+            },
+            {
+                'documentation': {
+                    'description': 'Yields control of the specified pin(s) to LabVIEW FPGA.'
+                },
+                'name': 'NIDIGITAL_VAL_RIO',
+                'value': 1104
             }
         ]
     },
@@ -697,8 +791,8 @@ enums = {
                     'description': 'Specifies to drive low.'
                 },
                 'name': 'NIDIGITAL_VAL_0',
-                'python_name': 'ZERO',
                 'pretty_name': '0',
+                'python_name': 'ZERO',
                 'value': 0
             },
             {
@@ -706,8 +800,8 @@ enums = {
                     'description': 'Specifies to drive high.'
                 },
                 'name': 'NIDIGITAL_VAL_1',
-                'python_name': 'ONE',
                 'pretty_name': '1',
+                'python_name': 'ONE',
                 'value': 1
             },
             {

--- a/src/nidigital/metadata/functions.py
+++ b/src/nidigital/metadata/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-Digital Pattern Driver API metadata version 19.5.0d7
+# This file is generated from NI-Digital Pattern Driver API metadata version 21.3.0d40
 functions = {
     'Abort': {
         'documentation': {

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -18,6 +18,12 @@ def multi_instrument_session():
         yield simulated_session
 
 
+@pytest.fixture(scope='function')
+def single_instrument_session():
+    with nidigital.Session(resource_name=instruments[0], options='Simulate=1, DriverSetup=Model:6570') as simulated_session:
+        yield simulated_session
+
+
 def test_close():
     session = nidigital.Session(resource_name=','.join(instruments), options='Simulate=1, DriverSetup=Model:6570')
     session.vil = 1
@@ -143,6 +149,22 @@ def test_conditional_jump_triggers_rep_cap(multi_instrument_session):
     requested_trigger_type = nidigital.TriggerType.DIGITAL_EDGE
     multi_instrument_session.conditional_jump_triggers['conditionalJumpTrigger3'].conditional_jump_trigger_type = requested_trigger_type
     assert requested_trigger_type == multi_instrument_session.conditional_jump_triggers['conditionalJumpTrigger3'].conditional_jump_trigger_type
+
+
+def test_rio_events_rep_cap(single_instrument_session):
+    assert '' == single_instrument_session.rio_events['RIOEvent3'].exported_rio_event_output_terminal
+
+    requested_terminal_name = '/Dev1/PXI_Trig0'
+    single_instrument_session.rio_events['RIOEvent3'].exported_rio_event_output_terminal = requested_terminal_name
+    assert requested_terminal_name == single_instrument_session.rio_events['RIOEvent3'].exported_rio_event_output_terminal
+
+
+def test_rio_triggers_rep_cap(single_instrument_session):
+    assert nidigital.TriggerType.NONE == single_instrument_session.rio_triggers['RIOTrigger3'].rio_trigger_type
+
+    requested_trigger_type = nidigital.TriggerType.DIGITAL_EDGE
+    single_instrument_session.rio_triggers['RIOTrigger3'].rio_trigger_type = requested_trigger_type
+    assert requested_trigger_type == single_instrument_session.rio_triggers['RIOTrigger3'].rio_trigger_type
 
 
 def test_property_boolean(multi_instrument_session):

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -136,35 +136,35 @@ def test_instruments_rep_cap(multi_instrument_session):
 
 
 def test_pattern_opcode_events_rep_cap(multi_instrument_session):
-    assert '' == multi_instrument_session.pattern_opcode_events['patternOpcodeEvent3'].exported_pattern_opcode_event_output_terminal
+    assert '' == multi_instrument_session.pattern_opcode_events[3].exported_pattern_opcode_event_output_terminal
 
     requested_terminal_name = '/Dev1/PXI_Trig0'
-    multi_instrument_session.pattern_opcode_events['patternOpcodeEvent3'].exported_pattern_opcode_event_output_terminal = requested_terminal_name
-    assert requested_terminal_name == multi_instrument_session.pattern_opcode_events['patternOpcodeEvent3'].exported_pattern_opcode_event_output_terminal
+    multi_instrument_session.pattern_opcode_events[3].exported_pattern_opcode_event_output_terminal = requested_terminal_name
+    assert requested_terminal_name == multi_instrument_session.pattern_opcode_events[3].exported_pattern_opcode_event_output_terminal
 
 
 def test_conditional_jump_triggers_rep_cap(multi_instrument_session):
-    assert nidigital.TriggerType.NONE == multi_instrument_session.conditional_jump_triggers['conditionalJumpTrigger3'].conditional_jump_trigger_type
+    assert nidigital.TriggerType.NONE == multi_instrument_session.conditional_jump_triggers[3].conditional_jump_trigger_type
 
     requested_trigger_type = nidigital.TriggerType.DIGITAL_EDGE
-    multi_instrument_session.conditional_jump_triggers['conditionalJumpTrigger3'].conditional_jump_trigger_type = requested_trigger_type
-    assert requested_trigger_type == multi_instrument_session.conditional_jump_triggers['conditionalJumpTrigger3'].conditional_jump_trigger_type
+    multi_instrument_session.conditional_jump_triggers[3].conditional_jump_trigger_type = requested_trigger_type
+    assert requested_trigger_type == multi_instrument_session.conditional_jump_triggers[3].conditional_jump_trigger_type
 
 
 def test_rio_events_rep_cap(single_instrument_session):
-    assert '' == single_instrument_session.rio_events['RIOEvent3'].exported_rio_event_output_terminal
+    assert '' == single_instrument_session.rio_events[3].exported_rio_event_output_terminal
 
     requested_terminal_name = '/Dev1/PXI_Trig0'
-    single_instrument_session.rio_events['RIOEvent3'].exported_rio_event_output_terminal = requested_terminal_name
-    assert requested_terminal_name == single_instrument_session.rio_events['RIOEvent3'].exported_rio_event_output_terminal
+    single_instrument_session.rio_events[3].exported_rio_event_output_terminal = requested_terminal_name
+    assert requested_terminal_name == single_instrument_session.rio_events[3].exported_rio_event_output_terminal
 
 
 def test_rio_triggers_rep_cap(single_instrument_session):
-    assert nidigital.TriggerType.NONE == single_instrument_session.rio_triggers['RIOTrigger3'].rio_trigger_type
+    assert nidigital.TriggerType.NONE == single_instrument_session.rio_triggers[3].rio_trigger_type
 
     requested_trigger_type = nidigital.TriggerType.DIGITAL_EDGE
-    single_instrument_session.rio_triggers['RIOTrigger3'].rio_trigger_type = requested_trigger_type
-    assert requested_trigger_type == single_instrument_session.rio_triggers['RIOTrigger3'].rio_trigger_type
+    single_instrument_session.rio_triggers[3].rio_trigger_type = requested_trigger_type
+    assert requested_trigger_type == single_instrument_session.rio_triggers[3].rio_trigger_type
 
 
 def test_property_boolean(multi_instrument_session):


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

API parity with NI-Digital Pattern Driver 21.0.0.
* Properties added:
    * `digital_edge_rio_trigger_edge`
    * `digital_edge_rio_trigger_source`
    * `exported_rio_event_output_terminal`
    * `rio_event_terminal_name`
    * `rio_trigger_terminal_name`
    * `rio_trigger_type`
* Repeated Capabilities added:
    * `rio_events`
    * `rio_triggers`

### List issues fixed by this Pull Request below, if any.

None

### What testing has been done?

 - Manual review of API metadata
 - Added new system tests for the new rep caps
 - Execution of unit and system tests.