### PR TITLE
Update release process to use correct version in examples documentation

### DIFF
--- a/build/templates/examples.rst.mako
+++ b/build/templates/examples.rst.mako
@@ -1,8 +1,9 @@
 <%
     import build.helper as helper
 
-    config        = template_parameters['metadata'].config
-    module_name = config['module_name']
+    config         = template_parameters['metadata'].config
+    module_name    = config['module_name']
+    module_version = config['module_version']
 
     import glob
     import os
@@ -15,7 +16,7 @@
     #   1) URL to zip file containing all examples and in cases like nidigital, support files
     #   2) Code snippet and URL to example file in src folder, for each example
     #
-    #  - If there is dev or pre ('a', 'b', 'rc') in the VERSION file then:
+    #  - If there is dev or pre ('a', 'b', 'rc') in module_version then:
     #       - it means code generator is being run during development
     #       - (1) will link to the zip file created during last release and the text will include "..for latest version.."
     #       - (2) will include current code snippet and URL will point to master branch
@@ -30,16 +31,12 @@
 
     example_url_base = 'https://github.com/ni/nimi-python/blob/'
 
-    # We need to use the global version and not the module version since the release version will match the global version
-    # and may not match the module version
-    with open('./VERSION') as vf:
-        global_version = vf.read().strip()
     from packaging.version import Version
-    v = Version(global_version)
+    v = Version(module_version)
 
     if v.dev is None and v.pre is None:
         examples_zip_url_text = '`You can download all {0} examples here <{1}>`_'.format(module_name, released_zip_url)
-        example_url_base += str(v)
+        example_url_base += latest_release_version
     else:
         examples_zip_url_text = '`You can download all {0} examples for latest version here <{1}>`_'.format(module_name, released_zip_url)
         example_url_base += 'master'

--- a/tools/build_release.py
+++ b/tools/build_release.py
@@ -38,9 +38,9 @@ Steps
         * Change the "Unreleased" header to the version of the release
         * Change [Unreleased] in TOC to the version of the release
         * Commit to branch
+    * Update contents of LATEST_RELEASE with the version of the release being created.
     * `python3 tools/build_release.py --update --release`
         * This will update all the versions to remove any '.devN'
-        * Update contents of LATEST_RELEASE with the version of the release being created.
         * Commit to branch
     * `python3 tools/build_release.py --build`
         * Clean and build to update generated files with new version


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

The wording and version used in examples documentation differs based on [master ](https://nimi-python.readthedocs.io/en/master/nidcpower/examples.html) version of the docs vs. [release](https://nimi-python.readthedocs.io/en/1.4.0/nidcpower/examples.html) version of the docs.

There was a bug in code generator that encodes this difference - The version in [VERSION file](https://github.com/ni/nimi-python/blob/master/VERSION) was used in the conditional, but that file is updated later in the build process than when `examples.rst` gets generated. So when the release build step is performed it does not have the correct content yet.
The issue was workaround by calling the build step twice in a local batch file I use when making releases, which I had forgotten to address. While updating the batch file for Python 3.9, I noticed the issue.

Fix is to use `LATEST_VERSION` which manually updated as part of the release process before the build step.

### List issues fixed by this Pull Request below, if any.

None

### What testing has been done?

- I ran `tox` to ensure `examples.rst` doesn't change during local development.
- I ran the build script to ensure correct version gets generated in `examples.rst` during release.