### PR TITLE
nifgen repeated capability documentation and test updates 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,16 @@ All notable changes to this project will be documented in this file.
     * #### Changed
     * #### Removed
 * ### `nifgen` (NI-FGEN)
-    * #### Added
+    * #### Added 
+        * `data_markers` repeated capability support - [#1668](https://github.com/ni/nimi-python/issues/1668)
     * #### Changed
+        * Addressed [#1627](https://github.com/ni/nimi-python/issues/1627) for attributes supporting the following repeated capabilities
+           * `channels`
+           * `markers`
+           * `data_markers`
+           * `script_triggers`
+        * Corrected multiple mistakes in repeated capability info of attribute metadata
+            * alters API behavior (repeated capability access of attributes) and documentation
     * #### Removed
 * ### `nimodinst` (NI-ModInst)
     * #### Added

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI Modular Instruments Python API'
-copyright = '2017-2021, National Instruments'
+copyright = '2017-2022, National Instruments'
 author = 'National Instruments'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/nifgen/class.rst
+++ b/docs/nifgen/class.rst
@@ -560,15 +560,12 @@ configure_arb_waveform
                 -  :py:meth:`nifgen.Session.create_waveform`
                 -  :py:meth:`nifgen.Session.create_waveform_from_file_i16`
                 -  :py:meth:`nifgen.Session.create_waveform_from_file_f64`
-                -  :py:meth:`nifgen.Session.CreateWaveformFromFileHWS`
 
                 These methods return a handle that you use to identify the waveform.
 
                 **Default Value**: None
 
                 
-
-                .. note:: One or more of the referenced methods are not in the Python API for this driver.
 
 
             :type waveform_handle: int
@@ -920,7 +917,6 @@ create_advanced_arb_sequence
                 -  :py:meth:`nifgen.Session.create_waveform`
                 -  :py:meth:`nifgen.Session.create_waveform_from_file_i16`
                 -  :py:meth:`nifgen.Session.create_waveform_from_file_f64`
-                -  :py:meth:`nifgen.Session.CreateWaveformFromFileHWS`
 
                 **Default Value**: None
 
@@ -1062,7 +1058,6 @@ create_arb_sequence
                 -  :py:meth:`nifgen.Session.create_waveform`
                 -  :py:meth:`nifgen.Session.create_waveform_from_file_i16`
                 -  :py:meth:`nifgen.Session.create_waveform_from_file_f64`
-                -  :py:meth:`nifgen.Session.CreateWaveformFromFileHWS`
 
                 **Default Value**: None
 
@@ -2775,6 +2770,18 @@ arb_gain
         For example, when you set this property to 2.0, the output signal ranges from -2.0 V to +2.0 V.
         Use this property when :py:attr:`nifgen.Session.output_mode` is set to :py:data:`~nifgen.OutputMode.ARB` or :py:data:`~nifgen.OutputMode.SEQ`.
 
+
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].arb_gain`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+            Example: :py:attr:`my_session.arb_gain`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------+
@@ -2784,7 +2791,7 @@ arb_gain
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | None       |
+            | Repeated Capabilities | channels   |
             +-----------------------+------------+
 
         .. tip::
@@ -2833,6 +2840,18 @@ arb_offset
         Use this property when :py:attr:`nifgen.Session.output_mode` is set to :py:data:`~nifgen.OutputMode.ARB` or :py:data:`~nifgen.OutputMode.SEQ`.
         Units: Volts
 
+
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].arb_offset`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+            Example: :py:attr:`my_session.arb_offset`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------+
@@ -2842,7 +2861,7 @@ arb_offset
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | None       |
+            | Repeated Capabilities | channels   |
             +-----------------------+------------+
 
         .. tip::
@@ -2911,6 +2930,18 @@ arb_sequence_handle
         This channel-based property identifies which sequence the signal generator produces. You can create multiple sequences using :py:meth:`nifgen.Session.create_arb_sequence`. :py:meth:`nifgen.Session.create_arb_sequence` returns a handle that you can use to identify the particular sequence. To configure the signal generator to produce a particular sequence, set this property to the sequence handle.
         Use this property only when :py:attr:`nifgen.Session.output_mode` is set to :py:data:`~nifgen.OutputMode.SEQ`.
 
+
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].arb_sequence_handle`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+            Example: :py:attr:`my_session.arb_sequence_handle`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------+
@@ -2920,7 +2951,7 @@ arb_sequence_handle
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | None       |
+            | Repeated Capabilities | channels   |
             +-----------------------+------------+
 
         .. tip::
@@ -2939,13 +2970,20 @@ arb_waveform_handle
         :py:meth:`nifgen.Session.create_waveform`
         :py:meth:`nifgen.Session.create_waveform_from_file_i16`
         :py:meth:`nifgen.Session.create_waveform_from_file_f64`
-        :py:meth:`nifgen.Session.CreateWaveformFromFileHWS`
         These methods return a handle that you can use to identify the particular waveform. To configure the signal generator to produce a particular waveform, set this property to the waveform handle.
         Use this property only when :py:attr:`nifgen.Session.output_mode` is set to :py:data:`~nifgen.OutputMode.ARB`.
 
 
 
-        .. note:: One or more of the referenced methods are not in the Python API for this driver.
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].arb_waveform_handle`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+            Example: :py:attr:`my_session.arb_waveform_handle`
 
         The following table lists the characteristics of this property.
 
@@ -2956,7 +2994,7 @@ arb_waveform_handle
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | None       |
+            | Repeated Capabilities | channels   |
             +-----------------------+------------+
 
         .. tip::
@@ -3022,6 +3060,18 @@ channel_delay
 
         Specifies, in seconds, the delay to apply to the analog output of the channel specified by the channel string. You can use the channel delay to configure the timing relationship between channels on a multichannel device. Values for this property can be zero or positive. A value of zero indicates that the channels are aligned. A positive value delays the analog output by the specified number of seconds.
 
+
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].channel_delay`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+            Example: :py:attr:`my_session.channel_delay`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------+
@@ -3031,7 +3081,7 @@ channel_delay
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | None       |
+            | Repeated Capabilities | channels   |
             +-----------------------+------------+
 
         .. tip::
@@ -3073,6 +3123,18 @@ common_mode_offset
 
         Specifies, in volts, the value the signal generator adds to or subtracts from the arbitrary waveform data. This property applies only when you set the :py:attr:`nifgen.Session.terminal_configuration` property to :py:data:`~nifgen.TerminalConfiguration.DIFFERENTIAL`. Common mode offset is applied to the signals generated at each differential output terminal.
 
+
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].common_mode_offset`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+            Example: :py:attr:`my_session.common_mode_offset`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------+
@@ -3082,7 +3144,7 @@ common_mode_offset
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | None       |
+            | Repeated Capabilities | channels   |
             +-----------------------+------------+
 
         .. tip::
@@ -3123,17 +3185,29 @@ data_marker_event_data_bit_number
 
         Specifies the bit number to assign to the Data Marker Event.
 
+
+
+
+        .. tip:: This property can be set/get on specific data_markers within your :py:class:`nifgen.Session` instance.
+            Use Python index notation on the repeated capabilities container data_markers to specify a subset.
+
+            Example: :py:attr:`my_session.data_markers[ ... ].data_marker_event_data_bit_number`
+
+            To set/get on all data_markers, you can call the property directly on the :py:class:`nifgen.Session`.
+
+            Example: :py:attr:`my_session.data_marker_event_data_bit_number`
+
         The following table lists the characteristics of this property.
 
-            +-----------------------+------------+
-            | Characteristic        | Value      |
-            +=======================+============+
-            | Datatype              | int        |
-            +-----------------------+------------+
-            | Permissions           | read-write |
-            +-----------------------+------------+
-            | Repeated Capabilities | None       |
-            +-----------------------+------------+
+            +-----------------------+--------------+
+            | Characteristic        | Value        |
+            +=======================+==============+
+            | Datatype              | int          |
+            +-----------------------+--------------+
+            | Permissions           | read-write   |
+            +-----------------------+--------------+
+            | Repeated Capabilities | data_markers |
+            +-----------------------+--------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -3148,6 +3222,18 @@ data_marker_event_level_polarity
 
         Specifies the output polarity of the Data marker event.
 
+
+
+
+        .. tip:: This property can be set/get on specific data_markers within your :py:class:`nifgen.Session` instance.
+            Use Python index notation on the repeated capabilities container data_markers to specify a subset.
+
+            Example: :py:attr:`my_session.data_markers[ ... ].data_marker_event_level_polarity`
+
+            To set/get on all data_markers, you can call the property directly on the :py:class:`nifgen.Session`.
+
+            Example: :py:attr:`my_session.data_marker_event_level_polarity`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------------------------------+
@@ -3157,7 +3243,7 @@ data_marker_event_level_polarity
             +-----------------------+------------------------------------+
             | Permissions           | read-write                         |
             +-----------------------+------------------------------------+
-            | Repeated Capabilities | None                               |
+            | Repeated Capabilities | data_markers                       |
             +-----------------------+------------------------------------+
 
         .. tip::
@@ -3173,17 +3259,29 @@ data_marker_event_output_terminal
 
         Specifies the destination terminal for the Data Marker Event.
 
+
+
+
+        .. tip:: This property can be set/get on specific data_markers within your :py:class:`nifgen.Session` instance.
+            Use Python index notation on the repeated capabilities container data_markers to specify a subset.
+
+            Example: :py:attr:`my_session.data_markers[ ... ].data_marker_event_output_terminal`
+
+            To set/get on all data_markers, you can call the property directly on the :py:class:`nifgen.Session`.
+
+            Example: :py:attr:`my_session.data_marker_event_output_terminal`
+
         The following table lists the characteristics of this property.
 
-            +-----------------------+------------+
-            | Characteristic        | Value      |
-            +=======================+============+
-            | Datatype              | str        |
-            +-----------------------+------------+
-            | Permissions           | read-write |
-            +-----------------------+------------+
-            | Repeated Capabilities | None       |
-            +-----------------------+------------+
+            +-----------------------+--------------+
+            | Characteristic        | Value        |
+            +=======================+==============+
+            | Datatype              | str          |
+            +-----------------------+--------------+
+            | Permissions           | read-write   |
+            +-----------------------+--------------+
+            | Repeated Capabilities | data_markers |
+            +-----------------------+--------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -3332,6 +3430,18 @@ digital_edge_script_trigger_edge
 
         Specifies the active edge for the Script trigger. This property is used when :py:attr:`nifgen.Session.script_trigger_type` is set to Digital Edge.
 
+
+
+
+        .. tip:: This property can be set/get on specific script_triggers within your :py:class:`nifgen.Session` instance.
+            Use Python index notation on the repeated capabilities container script_triggers to specify a subset.
+
+            Example: :py:attr:`my_session.script_triggers[ ... ].digital_edge_script_trigger_edge`
+
+            To set/get on all script_triggers, you can call the property directly on the :py:class:`nifgen.Session`.
+
+            Example: :py:attr:`my_session.digital_edge_script_trigger_edge`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------------------------------+
@@ -3341,7 +3451,7 @@ digital_edge_script_trigger_edge
             +-----------------------+------------------------------------+
             | Permissions           | read-write                         |
             +-----------------------+------------------------------------+
-            | Repeated Capabilities | None                               |
+            | Repeated Capabilities | script_triggers                    |
             +-----------------------+------------------------------------+
 
         .. tip::
@@ -3357,17 +3467,29 @@ digital_edge_script_trigger_source
 
         Specifies the source terminal for the Script trigger. This property is used when :py:attr:`nifgen.Session.script_trigger_type` is set to Digital Edge.
 
+
+
+
+        .. tip:: This property can be set/get on specific script_triggers within your :py:class:`nifgen.Session` instance.
+            Use Python index notation on the repeated capabilities container script_triggers to specify a subset.
+
+            Example: :py:attr:`my_session.script_triggers[ ... ].digital_edge_script_trigger_source`
+
+            To set/get on all script_triggers, you can call the property directly on the :py:class:`nifgen.Session`.
+
+            Example: :py:attr:`my_session.digital_edge_script_trigger_source`
+
         The following table lists the characteristics of this property.
 
-            +-----------------------+------------+
-            | Characteristic        | Value      |
-            +=======================+============+
-            | Datatype              | str        |
-            +-----------------------+------------+
-            | Permissions           | read-write |
-            +-----------------------+------------+
-            | Repeated Capabilities | None       |
-            +-----------------------+------------+
+            +-----------------------+-----------------+
+            | Characteristic        | Value           |
+            +=======================+=================+
+            | Datatype              | str             |
+            +-----------------------+-----------------+
+            | Permissions           | read-write      |
+            +-----------------------+-----------------+
+            | Repeated Capabilities | script_triggers |
+            +-----------------------+-----------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -3775,17 +3897,29 @@ exported_script_trigger_output_terminal
         Specifies the output terminal for the exported Script trigger.
         Setting this property to an empty string means that when you commit the session, the signal is removed from that terminal and, if possible, the terminal is tristated.
 
+
+
+
+        .. tip:: This property can be set/get on specific script_triggers within your :py:class:`nifgen.Session` instance.
+            Use Python index notation on the repeated capabilities container script_triggers to specify a subset.
+
+            Example: :py:attr:`my_session.script_triggers[ ... ].exported_script_trigger_output_terminal`
+
+            To set/get on all script_triggers, you can call the property directly on the :py:class:`nifgen.Session`.
+
+            Example: :py:attr:`my_session.exported_script_trigger_output_terminal`
+
         The following table lists the characteristics of this property.
 
-            +-----------------------+------------+
-            | Characteristic        | Value      |
-            +=======================+============+
-            | Datatype              | str        |
-            +-----------------------+------------+
-            | Permissions           | read-write |
-            +-----------------------+------------+
-            | Repeated Capabilities | None       |
-            +-----------------------+------------+
+            +-----------------------+-----------------+
+            | Characteristic        | Value           |
+            +=======================+=================+
+            | Datatype              | str             |
+            +-----------------------+-----------------+
+            | Permissions           | read-write      |
+            +-----------------------+-----------------+
+            | Repeated Capabilities | script_triggers |
+            +-----------------------+-----------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -4033,6 +4167,16 @@ func_amplitude
 
         .. note:: This parameter does not affect signal generator behavior when you
 
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].func_amplitude`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+            Example: :py:attr:`my_session.func_amplitude`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------+
@@ -4042,7 +4186,7 @@ func_amplitude
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | None       |
+            | Repeated Capabilities | channels   |
             +-----------------------+------------+
 
         .. tip::
@@ -4090,6 +4234,18 @@ func_dc_offset
         For example, to configure a waveform with an amplitude of 10.00 V to  range from 0.00 V to +10.00 V, set DC Offset to 5.00 V.
         Units: volts
 
+
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].func_dc_offset`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+            Example: :py:attr:`my_session.func_dc_offset`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------+
@@ -4099,7 +4255,7 @@ func_dc_offset
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | None       |
+            | Repeated Capabilities | channels   |
             +-----------------------+------------+
 
         .. tip::
@@ -4121,6 +4277,16 @@ func_duty_cycle_high
 
         .. note:: This parameter only affects signal generator behavior when you
 
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].func_duty_cycle_high`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+            Example: :py:attr:`my_session.func_duty_cycle_high`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------+
@@ -4130,7 +4296,7 @@ func_duty_cycle_high
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | None       |
+            | Repeated Capabilities | channels   |
             +-----------------------+------------+
 
         .. tip::
@@ -4153,6 +4319,16 @@ func_frequency
 
         .. note:: :
 
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].func_frequency`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+            Example: :py:attr:`my_session.func_frequency`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------+
@@ -4162,7 +4338,7 @@ func_frequency
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | None       |
+            | Repeated Capabilities | channels   |
             +-----------------------+------------+
 
         .. tip::
@@ -4215,6 +4391,16 @@ func_start_phase
 
         .. note:: This parameter does not affect signal generator behavior when you
 
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].func_start_phase`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+            Example: :py:attr:`my_session.func_start_phase`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------+
@@ -4224,7 +4410,7 @@ func_start_phase
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | None       |
+            | Repeated Capabilities | channels   |
             +-----------------------+------------+
 
         .. tip::
@@ -4250,6 +4436,18 @@ func_waveform
         :py:data:`~nifgen.Waveform.USER`      - User-defined waveform as defined with
         :py:meth:`nifgen.Session.define_user_standard_waveform`
 
+
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].func_waveform`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+            Example: :py:attr:`my_session.func_waveform`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+----------------+
@@ -4259,7 +4457,7 @@ func_waveform
             +-----------------------+----------------+
             | Permissions           | read-write     |
             +-----------------------+----------------+
-            | Repeated Capabilities | None           |
+            | Repeated Capabilities | channels       |
             +-----------------------+----------------+
 
         .. tip::
@@ -4511,6 +4709,18 @@ marker_event_output_terminal
 
         Specifies the destination terminal for the Marker Event.
 
+
+
+
+        .. tip:: This property can be set/get on specific markers within your :py:class:`nifgen.Session` instance.
+            Use Python index notation on the repeated capabilities container markers to specify a subset.
+
+            Example: :py:attr:`my_session.markers[ ... ].marker_event_output_terminal`
+
+            To set/get on all markers, you can call the property directly on the :py:class:`nifgen.Session`.
+
+            Example: :py:attr:`my_session.marker_event_output_terminal`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------+
@@ -4520,7 +4730,7 @@ marker_event_output_terminal
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | None       |
+            | Repeated Capabilities | markers    |
             +-----------------------+------------+
 
         .. tip::
@@ -4912,6 +5122,18 @@ output_enabled
 
         This channel-based property specifies whether the signal that the signal generator produces appears at the output connector.
 
+
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].output_enabled`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+            Example: :py:attr:`my_session.output_enabled`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------+
@@ -4921,7 +5143,7 @@ output_enabled
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | None       |
+            | Repeated Capabilities | channels   |
             +-----------------------+------------+
 
         .. tip::
@@ -4937,6 +5159,18 @@ output_impedance
 
         This channel-based property specifies the signal generator output impedance at the output connector. NI signal sources modules have an output impedance of 50 ohms and an optional 75 ohms on select modules. If the load impedance matches the output impedance, then the voltage at the signal output connector is at the needed level. The voltage at the signal output connector varies with load output impedance, up to doubling the voltage for a high-impedance load.
 
+
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].output_impedance`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+            Example: :py:attr:`my_session.output_impedance`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------+
@@ -4946,7 +5180,7 @@ output_impedance
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | None       |
+            | Repeated Capabilities | channels   |
             +-----------------------+------------+
 
         .. tip::
@@ -5216,6 +5450,18 @@ script_trigger_type
 
         Specifies the Script trigger type. Depending upon the value of this property, additional properties may need to be configured to fully configure the trigger.
 
+
+
+
+        .. tip:: This property can be set/get on specific script_triggers within your :py:class:`nifgen.Session` instance.
+            Use Python index notation on the repeated capabilities container script_triggers to specify a subset.
+
+            Example: :py:attr:`my_session.script_triggers[ ... ].script_trigger_type`
+
+            To set/get on all script_triggers, you can call the property directly on the :py:class:`nifgen.Session`.
+
+            Example: :py:attr:`my_session.script_trigger_type`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+-------------------------+
@@ -5225,7 +5471,7 @@ script_trigger_type
             +-----------------------+-------------------------+
             | Permissions           | read-write              |
             +-----------------------+-------------------------+
-            | Repeated Capabilities | None                    |
+            | Repeated Capabilities | script_triggers         |
             +-----------------------+-------------------------+
 
         .. tip::
@@ -5601,6 +5847,18 @@ terminal_configuration
 
         Specifies whether gain and offset values will be analyzed based on single-ended or differential operation.
 
+
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].terminal_configuration`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+            Example: :py:attr:`my_session.terminal_configuration`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+-----------------------------+
@@ -5610,7 +5868,7 @@ terminal_configuration
             +-----------------------+-----------------------------+
             | Permissions           | read-write                  |
             +-----------------------+-----------------------------+
-            | Repeated Capabilities | None                        |
+            | Repeated Capabilities | channels                    |
             +-----------------------+-----------------------------+
 
         .. tip::
@@ -5626,6 +5884,18 @@ trigger_mode
 
         Controls the trigger mode.
 
+
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].trigger_mode`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+            Example: :py:attr:`my_session.trigger_mode`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+-------------------+
@@ -5635,7 +5905,7 @@ trigger_mode
             +-----------------------+-------------------+
             | Permissions           | read-write        |
             +-----------------------+-------------------+
-            | Repeated Capabilities | None              |
+            | Repeated Capabilities | channels          |
             +-----------------------+-------------------+
 
         .. tip::

--- a/docs/nifgen/rep_caps.rst
+++ b/docs/nifgen/rep_caps.rst
@@ -87,4 +87,30 @@ markers
         passes a string of :python:`'Marker0, Marker1, Marker2'` to the set attribute function.
 
 
+data_markers
+------------
+
+    .. py:attribute:: nifgen.Session.data_markers[]
+
+        If no prefix is added to the items in the parameter, the correct prefix will be added when
+        the driver function call is made.
+
+        .. code:: python
+
+            session.data_markers['0-2'].channel_enabled = True
+
+        passes a string of :python:`'DataMarker0, DataMarker1, DataMarker2'` to the set attribute function.
+
+        If an invalid repeated capability is passed to the driver, the driver will return an error.
+
+        You can also explicitly use the prefix as part of the parameter, but it must be the correct prefix
+        for the specific repeated capability.
+
+        .. code:: python
+
+            session.data_markers['DataMarker0-DataMarker2'].channel_enabled = True
+
+        passes a string of :python:`'DataMarker0, DataMarker1, DataMarker2'` to the set attribute function.
+
+
 

--- a/generated/nifgen/nifgen/session.py
+++ b/generated/nifgen/nifgen/session.py
@@ -181,6 +181,16 @@ class _SessionBase(object):
     Specifies the factor by which the signal generator scales the arbitrary waveform data. When you create arbitrary waveforms, you must first normalize the data points to the range -1.0 to +1.0. Use this property to scale the arbitrary waveform to other ranges.
     For example, when you set this property to 2.0, the output signal ranges from -2.0 V to +2.0 V.
     Use this property when output_mode is set to OutputMode.ARB or OutputMode.SEQ.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].arb_gain`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+    Example: :py:attr:`my_session.arb_gain`
     '''
     arb_marker_position = _attributes.AttributeViInt32(1150327)
     '''Type: int
@@ -198,6 +208,16 @@ class _SessionBase(object):
     For example, when you set this property to 1.0, the output signal ranges from 2.0 V to 0.0 V.
     Use this property when output_mode is set to OutputMode.ARB or OutputMode.SEQ.
     Units: Volts
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].arb_offset`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+    Example: :py:attr:`my_session.arb_offset`
     '''
     arb_repeat_count = _attributes.AttributeViInt32(1150328)
     '''Type: int
@@ -216,6 +236,16 @@ class _SessionBase(object):
 
     This channel-based property identifies which sequence the signal generator produces. You can create multiple sequences using create_arb_sequence. create_arb_sequence returns a handle that you can use to identify the particular sequence. To configure the signal generator to produce a particular sequence, set this property to the sequence handle.
     Use this property only when output_mode is set to OutputMode.SEQ.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].arb_sequence_handle`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+    Example: :py:attr:`my_session.arb_sequence_handle`
     '''
     arb_waveform_handle = _attributes.AttributeViInt32(1250201)
     '''Type: int
@@ -225,12 +255,18 @@ class _SessionBase(object):
     create_waveform
     create_waveform_from_file_i16
     create_waveform_from_file_f64
-    CreateWaveformFromFileHWS
     These methods return a handle that you can use to identify the particular waveform. To configure the signal generator to produce a particular waveform, set this property to the waveform handle.
     Use this property only when output_mode is set to OutputMode.ARB.
 
-    Note:
-    One or more of the referenced methods are not in the Python API for this driver.
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].arb_waveform_handle`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+    Example: :py:attr:`my_session.arb_waveform_handle`
     '''
     aux_power_enabled = _attributes.AttributeViBoolean(1150411)
     '''Type: bool
@@ -246,6 +282,16 @@ class _SessionBase(object):
     '''Type: float
 
     Specifies, in seconds, the delay to apply to the analog output of the channel specified by the channel string. You can use the channel delay to configure the timing relationship between channels on a multichannel device. Values for this property can be zero or positive. A value of zero indicates that the channels are aligned. A positive value delays the analog output by the specified number of seconds.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].channel_delay`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+    Example: :py:attr:`my_session.channel_delay`
     '''
     clock_mode = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.ClockMode, 1150110)
     '''Type: enums.ClockMode
@@ -257,6 +303,16 @@ class _SessionBase(object):
     '''Type: float
 
     Specifies, in volts, the value the signal generator adds to or subtracts from the arbitrary waveform data. This property applies only when you set the terminal_configuration property to TerminalConfiguration.DIFFERENTIAL. Common mode offset is applied to the signals generated at each differential output terminal.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].common_mode_offset`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+    Example: :py:attr:`my_session.common_mode_offset`
     '''
     data_marker_events_count = _attributes.AttributeViInt32(1150273)
     '''Type: int
@@ -267,16 +323,46 @@ class _SessionBase(object):
     '''Type: int
 
     Specifies the bit number to assign to the Data Marker Event.
+
+    Tip:
+    This property can be set/get on specific data_markers within your :py:class:`nifgen.Session` instance.
+    Use Python index notation on the repeated capabilities container data_markers to specify a subset.
+
+    Example: :py:attr:`my_session.data_markers[ ... ].data_marker_event_data_bit_number`
+
+    To set/get on all data_markers, you can call the property directly on the :py:class:`nifgen.Session`.
+
+    Example: :py:attr:`my_session.data_marker_event_data_bit_number`
     '''
     data_marker_event_level_polarity = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.DataMarkerEventLevelPolarity, 1150338)
     '''Type: enums.DataMarkerEventLevelPolarity
 
     Specifies the output polarity of the Data marker event.
+
+    Tip:
+    This property can be set/get on specific data_markers within your :py:class:`nifgen.Session` instance.
+    Use Python index notation on the repeated capabilities container data_markers to specify a subset.
+
+    Example: :py:attr:`my_session.data_markers[ ... ].data_marker_event_level_polarity`
+
+    To set/get on all data_markers, you can call the property directly on the :py:class:`nifgen.Session`.
+
+    Example: :py:attr:`my_session.data_marker_event_level_polarity`
     '''
     data_marker_event_output_terminal = _attributes.AttributeViString(1150339)
     '''Type: str
 
     Specifies the destination terminal for the Data Marker Event.
+
+    Tip:
+    This property can be set/get on specific data_markers within your :py:class:`nifgen.Session` instance.
+    Use Python index notation on the repeated capabilities container data_markers to specify a subset.
+
+    Example: :py:attr:`my_session.data_markers[ ... ].data_marker_event_output_terminal`
+
+    To set/get on all data_markers, you can call the property directly on the :py:class:`nifgen.Session`.
+
+    Example: :py:attr:`my_session.data_marker_event_output_terminal`
     '''
     data_transfer_block_size = _attributes.AttributeViInt32(1150241)
     '''Type: int
@@ -315,11 +401,31 @@ class _SessionBase(object):
     '''Type: enums.ScriptTriggerDigitalEdgeEdge
 
     Specifies the active edge for the Script trigger. This property is used when script_trigger_type is set to Digital Edge.
+
+    Tip:
+    This property can be set/get on specific script_triggers within your :py:class:`nifgen.Session` instance.
+    Use Python index notation on the repeated capabilities container script_triggers to specify a subset.
+
+    Example: :py:attr:`my_session.script_triggers[ ... ].digital_edge_script_trigger_edge`
+
+    To set/get on all script_triggers, you can call the property directly on the :py:class:`nifgen.Session`.
+
+    Example: :py:attr:`my_session.digital_edge_script_trigger_edge`
     '''
     digital_edge_script_trigger_source = _attributes.AttributeViString(1150291)
     '''Type: str
 
     Specifies the source terminal for the Script trigger. This property is used when script_trigger_type is set to Digital Edge.
+
+    Tip:
+    This property can be set/get on specific script_triggers within your :py:class:`nifgen.Session` instance.
+    Use Python index notation on the repeated capabilities container script_triggers to specify a subset.
+
+    Example: :py:attr:`my_session.script_triggers[ ... ].digital_edge_script_trigger_source`
+
+    To set/get on all script_triggers, you can call the property directly on the :py:class:`nifgen.Session`.
+
+    Example: :py:attr:`my_session.digital_edge_script_trigger_source`
     '''
     digital_edge_start_trigger_edge = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.StartTriggerDigitalEdgeEdge, 1150282)
     '''Type: enums.StartTriggerDigitalEdgeEdge
@@ -414,6 +520,16 @@ class _SessionBase(object):
 
     Specifies the output terminal for the exported Script trigger.
     Setting this property to an empty string means that when you commit the session, the signal is removed from that terminal and, if possible, the terminal is tristated.
+
+    Tip:
+    This property can be set/get on specific script_triggers within your :py:class:`nifgen.Session` instance.
+    Use Python index notation on the repeated capabilities container script_triggers to specify a subset.
+
+    Example: :py:attr:`my_session.script_triggers[ ... ].exported_script_trigger_output_terminal`
+
+    To set/get on all script_triggers, you can call the property directly on the :py:class:`nifgen.Session`.
+
+    Example: :py:attr:`my_session.exported_script_trigger_output_terminal`
     '''
     exported_start_trigger_output_terminal = _attributes.AttributeViString(1150283)
     '''Type: str
@@ -470,6 +586,16 @@ class _SessionBase(object):
     Units: Vpk-pk
 
     Note: This parameter does not affect signal generator behavior when you
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].func_amplitude`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+    Example: :py:attr:`my_session.func_amplitude`
     '''
     func_buffer_size = _attributes.AttributeViInt32(1150238)
     '''Type: int
@@ -485,6 +611,16 @@ class _SessionBase(object):
     Controls the DC offset of the standard waveform that the  signal generator produces.  This value is the offset at the output  terminal. The value is the offset from ground to the center of the  waveform that you specify with the Waveform parameter.
     For example, to configure a waveform with an amplitude of 10.00 V to  range from 0.00 V to +10.00 V, set DC Offset to 5.00 V.
     Units: volts
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].func_dc_offset`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+    Example: :py:attr:`my_session.func_dc_offset`
     '''
     func_duty_cycle_high = _attributes.AttributeViReal64(1250106)
     '''Type: float
@@ -494,6 +630,16 @@ class _SessionBase(object):
     Units: Percentage of time the waveform is high
 
     Note: This parameter only affects signal generator behavior when you
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].func_duty_cycle_high`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+    Example: :py:attr:`my_session.func_duty_cycle_high`
     '''
     func_frequency = _attributes.AttributeViReal64(1250104)
     '''Type: float
@@ -505,6 +651,16 @@ class _SessionBase(object):
 
     Note:
     :
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].func_frequency`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+    Example: :py:attr:`my_session.func_frequency`
     '''
     func_max_buffer_size = _attributes.AttributeViInt32(1150239)
     '''Type: int
@@ -523,6 +679,16 @@ class _SessionBase(object):
     Units: Degrees of one cycle
 
     Note: This parameter does not affect signal generator behavior when you
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].func_start_phase`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+    Example: :py:attr:`my_session.func_start_phase`
     '''
     func_waveform = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.Waveform, 1250101)
     '''Type: enums.Waveform
@@ -538,6 +704,16 @@ class _SessionBase(object):
     Waveform.NOISE     - White noise
     Waveform.USER      - User-defined waveform as defined with
     define_user_standard_waveform
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].func_waveform`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+    Example: :py:attr:`my_session.func_waveform`
     '''
     idle_behavior = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.IdleBehavior, 1150377)
     '''Type: enums.IdleBehavior
@@ -597,6 +773,16 @@ class _SessionBase(object):
     '''Type: str
 
     Specifies the destination terminal for the Marker Event.
+
+    Tip:
+    This property can be set/get on specific markers within your :py:class:`nifgen.Session` instance.
+    Use Python index notation on the repeated capabilities container markers to specify a subset.
+
+    Example: :py:attr:`my_session.markers[ ... ].marker_event_output_terminal`
+
+    To set/get on all markers, you can call the property directly on the :py:class:`nifgen.Session`.
+
+    Example: :py:attr:`my_session.marker_event_output_terminal`
     '''
     max_freq_list_duration = _attributes.AttributeViReal64(1150213)
     '''Type: float
@@ -678,11 +864,31 @@ class _SessionBase(object):
     '''Type: bool
 
     This channel-based property specifies whether the signal that the signal generator produces appears at the output connector.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].output_enabled`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+    Example: :py:attr:`my_session.output_enabled`
     '''
     output_impedance = _attributes.AttributeViReal64(1250004)
     '''Type: float
 
     This channel-based property specifies the signal generator output impedance at the output connector. NI signal sources modules have an output impedance of 50 ohms and an optional 75 ohms on select modules. If the load impedance matches the output impedance, then the voltage at the signal output connector is at the needed level. The voltage at the signal output connector varies with load output impedance, up to doubling the voltage for a high-impedance load.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].output_impedance`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+    Example: :py:attr:`my_session.output_impedance`
     '''
     output_mode = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.OutputMode, 1250001)
     '''Type: enums.OutputMode
@@ -750,6 +956,16 @@ class _SessionBase(object):
     '''Type: enums.ScriptTriggerType
 
     Specifies the Script trigger type. Depending upon the value of this property, additional properties may need to be configured to fully configure the trigger.
+
+    Tip:
+    This property can be set/get on specific script_triggers within your :py:class:`nifgen.Session` instance.
+    Use Python index notation on the repeated capabilities container script_triggers to specify a subset.
+
+    Example: :py:attr:`my_session.script_triggers[ ... ].script_trigger_type`
+
+    To set/get on all script_triggers, you can call the property directly on the :py:class:`nifgen.Session`.
+
+    Example: :py:attr:`my_session.script_trigger_type`
     '''
     serial_number = _attributes.AttributeViString(1150243)
     '''Type: str
@@ -834,11 +1050,31 @@ class _SessionBase(object):
     '''Type: enums.TerminalConfiguration
 
     Specifies whether gain and offset values will be analyzed based on single-ended or differential operation.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].terminal_configuration`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+    Example: :py:attr:`my_session.terminal_configuration`
     '''
     trigger_mode = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.TriggerMode, 1150108)
     '''Type: enums.TriggerMode
 
     Controls the trigger mode.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nifgen.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].trigger_mode`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nifgen.Session`.
+
+    Example: :py:attr:`my_session.trigger_mode`
     '''
     wait_behavior = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.WaitBehavior, 1150379)
     '''Type: enums.WaitBehavior
@@ -876,6 +1112,7 @@ class _SessionBase(object):
         self.channels = _RepeatedCapabilities(self, '', repeated_capability_list)
         self.script_triggers = _RepeatedCapabilities(self, 'ScriptTrigger', repeated_capability_list)
         self.markers = _RepeatedCapabilities(self, 'Marker', repeated_capability_list)
+        self.data_markers = _RepeatedCapabilities(self, 'DataMarker', repeated_capability_list)
 
         self._is_frozen = freeze_it
 
@@ -1114,14 +1351,10 @@ class _SessionBase(object):
                 -  create_waveform
                 -  create_waveform_from_file_i16
                 -  create_waveform_from_file_f64
-                -  CreateWaveformFromFileHWS
 
                 These methods return a handle that you use to identify the waveform.
 
                 **Default Value**: None
-
-                Note:
-                One or more of the referenced methods are not in the Python API for this driver.
 
             gain (float): Specifies the factor by which the signal generator scales the arbitrary
                 waveforms in the sequence. When you create an arbitrary waveform, you
@@ -2472,7 +2705,6 @@ class _SessionBase(object):
         -  create_waveform
         -  create_waveform_from_file_i16
         -  create_waveform_from_file_f64
-        -  CreateWaveformFromFileHWS
 
         Tip:
         This method can be called on specific channels within your :py:class:`nifgen.Session` instance.
@@ -2580,7 +2812,6 @@ class _SessionBase(object):
         -  create_waveform
         -  create_waveform_from_file_i16
         -  create_waveform_from_file_f64
-        -  CreateWaveformFromFileHWS
 
         Tip:
         This method can be called on specific channels within your :py:class:`nifgen.Session` instance.
@@ -2703,7 +2934,6 @@ class _SessionBase(object):
         -  create_waveform
         -  create_waveform_from_file_i16
         -  create_waveform_from_file_f64
-        -  CreateWaveformFromFileHWS
 
         By default, the subsequent call to the write_waveform
         method continues writing data from the position of the last sample
@@ -2755,7 +2985,6 @@ class _SessionBase(object):
         -  create_waveform
         -  create_waveform_from_file_i16
         -  create_waveform_from_file_f64
-        -  CreateWaveformFromFileHWS
 
         By default, the subsequent call to the write_waveform
         method continues writing data from the position of the last sample
@@ -2896,7 +3125,6 @@ class _SessionBase(object):
         -  create_waveform
         -  create_waveform_from_file_i16
         -  create_waveform_from_file_f64
-        -  CreateWaveformFromFileHWS
 
         By default, the subsequent call to the write_waveform method
         continues writing data from the position of the last sample written. You
@@ -2949,7 +3177,6 @@ class _SessionBase(object):
         -  create_waveform
         -  create_waveform_from_file_i16
         -  create_waveform_from_file_f64
-        -  CreateWaveformFromFileHWS
 
         By default, the subsequent call to the write_waveform method
         continues writing data from the position of the last sample written. You
@@ -3346,7 +3573,6 @@ class Session(_SessionBase):
                 -  create_waveform
                 -  create_waveform_from_file_i16
                 -  create_waveform_from_file_f64
-                -  CreateWaveformFromFileHWS
 
                 **Defined Value**:
 
@@ -3354,9 +3580,6 @@ class Session(_SessionBase):
                 generator.
 
                 **Default Value**: None
-
-                Note:
-                One or more of the referenced methods are not in the Python API for this driver.
 
                 Note:
                 One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
@@ -3473,7 +3696,6 @@ class Session(_SessionBase):
                 -  create_waveform
                 -  create_waveform_from_file_i16
                 -  create_waveform_from_file_f64
-                -  CreateWaveformFromFileHWS
 
                 **Default Value**: None
 
@@ -3587,7 +3809,6 @@ class Session(_SessionBase):
                 -  create_waveform
                 -  create_waveform_from_file_i16
                 -  create_waveform_from_file_f64
-                -  CreateWaveformFromFileHWS
 
                 **Default Value**: None
 

--- a/src/nifgen/metadata/attributes.py
+++ b/src/nifgen/metadata/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FGEN API metadata version 20.7.0d242
+# This file is generated from NI-FGEN API metadata version 21.5.0d106
 attributes = {
     1050005: {
         'access': 'read-write',
@@ -183,6 +183,9 @@ attributes = {
         'enum': 'TriggerMode',
         'lv_property': 'Triggers:Trigger Mode',
         'name': 'TRIGGER_MODE',
+        'supported_rep_caps': [
+            'channels'
+        ],
         'type': 'ViInt32'
     },
     1150110: {
@@ -529,7 +532,9 @@ attributes = {
         'enum': 'ScriptTriggerType',
         'lv_property': 'Triggers:Script:Trigger Type',
         'name': 'SCRIPT_TRIGGER_TYPE',
-        'repeated_capability_type': 'script_triggers',
+        'supported_rep_caps': [
+            'script_triggers'
+        ],
         'type': 'ViInt32'
     },
     1150291: {
@@ -539,7 +544,9 @@ attributes = {
         },
         'lv_property': 'Triggers:Script:Digital Edge:Source',
         'name': 'DIGITAL_EDGE_SCRIPT_TRIGGER_SOURCE',
-        'repeated_capability_type': 'script_triggers',
+        'supported_rep_caps': [
+            'script_triggers'
+        ],
         'type': 'ViString'
     },
     1150292: {
@@ -550,7 +557,9 @@ attributes = {
         'enum': 'ScriptTriggerDigitalEdgeEdge',
         'lv_property': 'Triggers:Script:Digital Edge:Edge',
         'name': 'DIGITAL_EDGE_SCRIPT_TRIGGER_EDGE',
-        'repeated_capability_type': 'script_triggers',
+        'supported_rep_caps': [
+            'script_triggers'
+        ],
         'type': 'ViInt32'
     },
     1150295: {
@@ -560,7 +569,9 @@ attributes = {
         },
         'lv_property': 'Triggers:Script:Output Terminal',
         'name': 'EXPORTED_SCRIPT_TRIGGER_OUTPUT_TERMINAL',
-        'repeated_capability_type': 'script_triggers',
+        'supported_rep_caps': [
+            'script_triggers'
+        ],
         'type': 'ViString'
     },
     1150310: {
@@ -579,7 +590,9 @@ attributes = {
         },
         'lv_property': 'Events:Marker:Output Terminal',
         'name': 'MARKER_EVENT_OUTPUT_TERMINAL',
-        'repeated_capability_type': 'markers',
+        'supported_rep_caps': [
+            'markers'
+        ],
         'type': 'ViString'
     },
     1150314: {
@@ -670,7 +683,6 @@ attributes = {
         },
         'lv_property': 'Arbitrary Waveform:Arbitrary Waveform Mode:Marker Position',
         'name': 'ARB_MARKER_POSITION',
-        'repeated_capability_type': 'markers',
         'type': 'ViInt32'
     },
     1150328: {
@@ -699,7 +711,9 @@ attributes = {
         },
         'lv_property': 'Events:Data Marker:Data Bit Number',
         'name': 'DATA_MARKER_EVENT_DATA_BIT_NUMBER',
-        'repeated_capability_type': 'markers',
+        'supported_rep_caps': [
+            'data_markers'
+        ],
         'type': 'ViInt32'
     },
     1150338: {
@@ -710,7 +724,9 @@ attributes = {
         'enum': 'DataMarkerEventLevelPolarity',
         'lv_property': 'Events:Data Marker:Level:Active Level',
         'name': 'DATA_MARKER_EVENT_LEVEL_POLARITY',
-        'repeated_capability_type': 'markers',
+        'supported_rep_caps': [
+            'data_markers'
+        ],
         'type': 'ViInt32'
     },
     1150339: {
@@ -720,7 +736,9 @@ attributes = {
         },
         'lv_property': 'Events:Data Marker:Output Terminal',
         'name': 'DATA_MARKER_EVENT_OUTPUT_TERMINAL',
-        'repeated_capability_type': 'markers',
+        'supported_rep_caps': [
+            'data_markers'
+        ],
         'type': 'ViString'
     },
     1150344: {
@@ -749,6 +767,9 @@ attributes = {
         'enum': 'TerminalConfiguration',
         'lv_property': 'Output:Terminal Configuration',
         'name': 'TERMINAL_CONFIGURATION',
+        'supported_rep_caps': [
+            'channels'
+        ],
         'type': 'ViInt32'
     },
     1150366: {
@@ -758,6 +779,9 @@ attributes = {
         },
         'lv_property': 'Output:Common Mode Offset',
         'name': 'COMMON_MODE_OFFSET',
+        'supported_rep_caps': [
+            'channels'
+        ],
         'type': 'ViReal64'
     },
     1150367: {
@@ -788,6 +812,9 @@ attributes = {
         },
         'lv_property': 'Output:Channel Delay',
         'name': 'CHANNEL_DELAY',
+        'supported_rep_caps': [
+            'channels'
+        ],
         'type': 'ViReal64'
     },
     1150373: {
@@ -931,6 +958,9 @@ attributes = {
         },
         'lv_property': 'Output:Output Enabled',
         'name': 'OUTPUT_ENABLED',
+        'supported_rep_caps': [
+            'channels'
+        ],
         'type': 'ViBoolean'
     },
     1250004: {
@@ -940,6 +970,9 @@ attributes = {
         },
         'lv_property': 'Output:Output Impedance',
         'name': 'OUTPUT_IMPEDANCE',
+        'supported_rep_caps': [
+            'channels'
+        ],
         'type': 'ViReal64'
     },
     1250101: {
@@ -950,6 +983,9 @@ attributes = {
         'enum': 'Waveform',
         'lv_property': 'Standard Function:Waveform',
         'name': 'FUNC_WAVEFORM',
+        'supported_rep_caps': [
+            'channels'
+        ],
         'type': 'ViInt32'
     },
     1250102: {
@@ -960,6 +996,9 @@ attributes = {
         },
         'lv_property': 'Standard Function:Amplitude',
         'name': 'FUNC_AMPLITUDE',
+        'supported_rep_caps': [
+            'channels'
+        ],
         'type': 'ViReal64'
     },
     1250103: {
@@ -969,6 +1008,9 @@ attributes = {
         },
         'lv_property': 'Standard Function:DC Offset',
         'name': 'FUNC_DC_OFFSET',
+        'supported_rep_caps': [
+            'channels'
+        ],
         'type': 'ViReal64'
     },
     1250104: {
@@ -979,6 +1021,9 @@ attributes = {
         },
         'lv_property': 'Standard Function:Standard Function Mode:Frequency',
         'name': 'FUNC_FREQUENCY',
+        'supported_rep_caps': [
+            'channels'
+        ],
         'type': 'ViReal64'
     },
     1250105: {
@@ -989,6 +1034,9 @@ attributes = {
         },
         'lv_property': 'Standard Function:Start Phase',
         'name': 'FUNC_START_PHASE',
+        'supported_rep_caps': [
+            'channels'
+        ],
         'type': 'ViReal64'
     },
     1250106: {
@@ -999,15 +1047,21 @@ attributes = {
         },
         'lv_property': 'Standard Function:Duty Cycle High',
         'name': 'FUNC_DUTY_CYCLE_HIGH',
+        'supported_rep_caps': [
+            'channels'
+        ],
         'type': 'ViReal64'
     },
     1250201: {
         'access': 'read-write',
         'documentation': {
-            'description': '\nSelects which arbitrary waveform the signal generator produces. You can create multiple arbitrary waveforms using one of the following niFgen Create Waveform functions:\nniFgen_CreateWaveformF64\nniFgen_CreateWaveformI16\nniFgen_CreateWaveformFromFileI16\nniFgen_CreateWaveformFromFileF64\nniFgen_CreateWaveformFromFileHWS\nThese functions return a handle that you can use to identify the particular waveform. To configure the signal generator to produce a particular waveform, set this attribute to the waveform handle.\nUse this attribute only when NIFGEN_ATTR_OUTPUT_MODE is set to NIFGEN_VAL_OUTPUT_ARB.\n'
+            'description': '\nSelects which arbitrary waveform the signal generator produces. You can create multiple arbitrary waveforms using one of the following niFgen Create Waveform functions:\nniFgen_CreateWaveformF64\nniFgen_CreateWaveformI16\nniFgen_CreateWaveformFromFileI16\nniFgen_CreateWaveformFromFileF64\nThese functions return a handle that you can use to identify the particular waveform. To configure the signal generator to produce a particular waveform, set this attribute to the waveform handle.\nUse this attribute only when NIFGEN_ATTR_OUTPUT_MODE is set to NIFGEN_VAL_OUTPUT_ARB.\n'
         },
         'lv_property': 'Arbitrary Waveform:Arbitrary Waveform Mode:Arbitrary Waveform Handle',
         'name': 'ARB_WAVEFORM_HANDLE',
+        'supported_rep_caps': [
+            'channels'
+        ],
         'type': 'ViInt32'
     },
     1250202: {
@@ -1017,6 +1071,9 @@ attributes = {
         },
         'lv_property': 'Arbitrary Waveform:Gain',
         'name': 'ARB_GAIN',
+        'supported_rep_caps': [
+            'channels'
+        ],
         'type': 'ViReal64'
     },
     1250203: {
@@ -1026,6 +1083,9 @@ attributes = {
         },
         'lv_property': 'Arbitrary Waveform:Offset',
         'name': 'ARB_OFFSET',
+        'supported_rep_caps': [
+            'channels'
+        ],
         'type': 'ViReal64'
     },
     1250204: {
@@ -1080,6 +1140,9 @@ attributes = {
         },
         'lv_property': 'Arbitrary Waveform:Arbitrary Sequence Mode:Arbitrary Sequence Handle',
         'name': 'ARB_SEQUENCE_HANDLE',
+        'supported_rep_caps': [
+            'channels'
+        ],
         'type': 'ViInt32'
     },
     1250212: {

--- a/src/nifgen/metadata/config.py
+++ b/src/nifgen/metadata/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FGEN API metadata version 20.0.0d5
+# This file is generated from NI-FGEN API metadata version 21.5.0d106
 config = {
-    'api_version': '20.0.0d5',
+    'api_version': '21.5.0d106',
     'c_function_prefix': 'niFgen_',
     'close_function': 'close',
     'context_manager_name': {
@@ -49,6 +49,10 @@ config = {
         {
             'prefix': 'Marker',
             'python_name': 'markers'
+        },
+        {
+            'prefix': 'DataMarker',
+            'python_name': 'data_markers'
         }
     ],
     'session_class_description': 'An NI-FGEN session to a National Instruments Signal Generator.',

--- a/src/nifgen/metadata/enums.py
+++ b/src/nifgen/metadata/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FGEN API metadata version 20.0.0d5
+# This file is generated from NI-FGEN API metadata version 21.5.0d106
 enums = {
     'AnalogPath': {
         'values': [

--- a/src/nifgen/metadata/functions.py
+++ b/src/nifgen/metadata/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FGEN API metadata version 20.0.0d5
+# This file is generated from NI-FGEN API metadata version 21.5.0d106
 functions = {
     'AbortGeneration': {
         'documentation': {
@@ -160,7 +160,7 @@ functions = {
             {
                 'direction': 'in',
                 'documentation': {
-                    'description': '\nSpecifies the handle of the arbitrary waveform that you want the signal\ngenerator to remove.\n\nYou can create multiple arbitrary waveforms using one of the following\nniFgen Create Waveform functions:\n\n-  niFgen_CreateWaveformF64\n-  niFgen_CreateWaveformI16\n-  niFgen_CreateWaveformFromFileI16\n-  niFgen_CreateWaveformFromFileF64\n-  niFgen_CreateWaveformFromFileHWS\n\n**Defined Value**:\n\nNIFGEN_VAL_ALL_WAVEFORMS—Remove all waveforms from the signal\ngenerator.\n\n**Default Value**: None\n'
+                    'description': '\nSpecifies the handle of the arbitrary waveform that you want the signal\ngenerator to remove.\n\nYou can create multiple arbitrary waveforms using one of the following\nniFgen Create Waveform functions:\n\n-  niFgen_CreateWaveformF64\n-  niFgen_CreateWaveformI16\n-  niFgen_CreateWaveformFromFileI16\n-  niFgen_CreateWaveformFromFileF64\n\n**Defined Value**:\n\nNIFGEN_VAL_ALL_WAVEFORMS—Remove all waveforms from the signal\ngenerator.\n\n**Default Value**: None\n'
                 },
                 'name': 'waveformHandle',
                 'type': 'ViInt32'
@@ -309,7 +309,7 @@ functions = {
             {
                 'direction': 'in',
                 'documentation': {
-                    'description': '\nSpecifies the handle of the arbitrary waveform you want the signal\ngenerator to produce. NI-FGEN sets the\nNIFGEN_ATTR_ARB_WAVEFORM_HANDLE attribute to this value. You can\ncreate an arbitrary waveform using one of the following niFgen Create\nWaveform functions:\n\n-  niFgen_CreateWaveformF64\n-  niFgen_CreateWaveformI16\n-  niFgen_CreateWaveformFromFileI16\n-  niFgen_CreateWaveformFromFileF64\n-  niFgen_CreateWaveformFromFileHWS\n\nThese functions return a handle that you use to identify the waveform.\n\n**Default Value**: None\n'
+                    'description': '\nSpecifies the handle of the arbitrary waveform you want the signal\ngenerator to produce. NI-FGEN sets the\nNIFGEN_ATTR_ARB_WAVEFORM_HANDLE attribute to this value. You can\ncreate an arbitrary waveform using one of the following niFgen Create\nWaveform functions:\n\n-  niFgen_CreateWaveformF64\n-  niFgen_CreateWaveformI16\n-  niFgen_CreateWaveformFromFileI16\n-  niFgen_CreateWaveformFromFileF64\n\nThese functions return a handle that you use to identify the waveform.\n\n**Default Value**: None\n'
                 },
                 'name': 'waveformHandle',
                 'type': 'ViInt32'
@@ -526,7 +526,7 @@ functions = {
             {
                 'direction': 'in',
                 'documentation': {
-                    'description': '\nSpecifies the array of waveform handles from which you want to create a\nnew arbitrary sequence. The array must have at least as many elements as\nthe value that you specify in **sequenceLength**. Each\n**waveformHandlesArray** element has a corresponding **loopCountsArray**\nelement that indicates how many times that waveform is repeated. You\nobtain waveform handles when you create arbitrary waveforms with the\nnifgen_AllocateWaveform function or one of the following niFgen\nCreateWaveform functions:\n\n-  nifgen_CreateWaveformF64\n-  nifgen_CreateWaveformI16\n-  nifgen_CreateWaveformFromFileI16\n-  nifgen_CreateWaveformFromFileF64\n-  nifgen_CreateWaveformFromFileHWS\n\n**Default Value**: None\n'
+                    'description': '\nSpecifies the array of waveform handles from which you want to create a\nnew arbitrary sequence. The array must have at least as many elements as\nthe value that you specify in **sequenceLength**. Each\n**waveformHandlesArray** element has a corresponding **loopCountsArray**\nelement that indicates how many times that waveform is repeated. You\nobtain waveform handles when you create arbitrary waveforms with the\nnifgen_AllocateWaveform function or one of the following niFgen\nCreateWaveform functions:\n\n-  nifgen_CreateWaveformF64\n-  nifgen_CreateWaveformI16\n-  nifgen_CreateWaveformFromFileI16\n-  nifgen_CreateWaveformFromFileF64\n\n**Default Value**: None\n'
                 },
                 'name': 'waveformHandlesArray',
                 'size': {
@@ -621,7 +621,7 @@ functions = {
             {
                 'direction': 'in',
                 'documentation': {
-                    'description': '\nSpecifies the array of waveform handles from which you want to create a\nnew arbitrary sequence. The array must have at least as many elements as\nthe value that you specify in **sequenceLength**. Each\n**waveformHandlesArray** element has a corresponding **loopCountsArray**\nelement that indicates how many times that waveform is repeated. You\nobtain waveform handles when you create arbitrary waveforms with the\nnifgen_AllocateWaveform function or one of the following niFgen\nCreateWaveform functions:\n\n-  nifgen_CreateWaveformF64\n-  nifgen_CreateWaveformI16\n-  nifgen_CreateWaveformFromFileI16\n-  nifgen_CreateWaveformFromFileF64\n-  nifgen_CreateWaveformFromFileHWS\n\n**Default Value**: None\n'
+                    'description': '\nSpecifies the array of waveform handles from which you want to create a\nnew arbitrary sequence. The array must have at least as many elements as\nthe value that you specify in **sequenceLength**. Each\n**waveformHandlesArray** element has a corresponding **loopCountsArray**\nelement that indicates how many times that waveform is repeated. You\nobtain waveform handles when you create arbitrary waveforms with the\nnifgen_AllocateWaveform function or one of the following niFgen\nCreateWaveform functions:\n\n-  nifgen_CreateWaveformF64\n-  nifgen_CreateWaveformI16\n-  nifgen_CreateWaveformFromFileI16\n-  nifgen_CreateWaveformFromFileF64\n\n**Default Value**: None\n'
                 },
                 'name': 'waveformHandlesArray',
                 'size': {
@@ -2635,7 +2635,7 @@ functions = {
     'SetNamedWaveformNextWritePosition': {
         'codegen_method': 'private',
         'documentation': {
-            'description': '\nSets the position in the waveform to which data is written at the next\nwrite. This function allows you to write to arbitrary locations within\nthe waveform. These settings apply only to the next write to the\nwaveform specified by the **waveformHandle** parameter. Subsequent\nwrites to that waveform begin where the last write left off, unless this\nfunction is called again. The **waveformHandle** passed in must have\nbeen created with a call to one of the following functions:\n\n-  nifgen_AllocateWaveform\n-  nifgen_CreateWaveformF64\n-  nifgen_CreateWaveformI16\n-  nifgen_CreateWaveformFromFileI16\n-  nifgen_CreateWaveformFromFileF64\n-  nifgen_CreateWaveformFromFileHWS\n'
+            'description': '\nSets the position in the waveform to which data is written at the next\nwrite. This function allows you to write to arbitrary locations within\nthe waveform. These settings apply only to the next write to the\nwaveform specified by the **waveformHandle** parameter. Subsequent\nwrites to that waveform begin where the last write left off, unless this\nfunction is called again. The **waveformHandle** passed in must have\nbeen created with a call to one of the following functions:\n\n-  nifgen_AllocateWaveform\n-  nifgen_CreateWaveformF64\n-  nifgen_CreateWaveformI16\n-  nifgen_CreateWaveformFromFileI16\n-  nifgen_CreateWaveformFromFileF64\n'
         },
         'method_name_for_documentation': 'set_next_write_position',
         'parameters': [
@@ -2765,7 +2765,7 @@ functions = {
     'SetWaveformNextWritePosition': {
         'codegen_method': 'private',
         'documentation': {
-            'description': '\nSets the position in the waveform at which the next waveform data is\nwritten. This function allows you to write to arbitrary locations within\nthe waveform. These settings apply only to the next write to the\nwaveform specified by the waveformHandle parameter. Subsequent writes to\nthat waveform begin where the last write left off, unless this function\nis called again. The waveformHandle passed in must have been created by\na call to the nifgen_AllocateWaveform function or one of the following\nniFgen CreateWaveform functions:\n\n-  nifgen_CreateWaveformF64\n-  nifgen_CreateWaveformI16\n-  nifgen_CreateWaveformFromFileI16\n-  nifgen_CreateWaveformFromFileF64\n-  nifgen_CreateWaveformFromFileHWS\n'
+            'description': '\nSets the position in the waveform at which the next waveform data is\nwritten. This function allows you to write to arbitrary locations within\nthe waveform. These settings apply only to the next write to the\nwaveform specified by the waveformHandle parameter. Subsequent writes to\nthat waveform begin where the last write left off, unless this function\nis called again. The waveformHandle passed in must have been created by\na call to the nifgen_AllocateWaveform function or one of the following\nniFgen CreateWaveform functions:\n\n-  nifgen_CreateWaveformF64\n-  nifgen_CreateWaveformI16\n-  nifgen_CreateWaveformFromFileI16\n-  nifgen_CreateWaveformFromFileF64\n'
         },
         'method_name_for_documentation': 'set_next_write_position',
         'parameters': [
@@ -2949,7 +2949,7 @@ functions = {
     'WriteNamedWaveformF64': {
         'codegen_method': 'private',
         'documentation': {
-            'description': '\nWrites floating-point data to the waveform in onboard memory. The\nwaveform handle passed in must have been created by a call to the\nnifgen_AllocateWaveform function or to one of the following niFgen\nCreate Waveform functions:\n\n-  nifgen_CreateWaveformF64\n-  nifgen_CreateWaveformI16\n-  nifgen_CreateWaveformFromFileI16\n-  nifgen_CreateWaveformFromFileF64\n-  nifgen_CreateWaveformFromFileHWS\n\nBy default, the subsequent call to the niFgen_WriteNamedWaveformF64\nfunction continues writing data from the position of the last sample\nwritten. You can set the write position and offset by calling the\nnifgen_SetNamedWaveformNextWritePosition function. If streaming is\nenabled, you can write more data than the allocated waveform size in\nonboard memory. Refer to the\n`Streaming <REPLACE_DRIVER_SPECIFIC_URL_2(streaming)>`__ topic for more\ninformation about streaming data.\n'
+            'description': '\nWrites floating-point data to the waveform in onboard memory. The\nwaveform handle passed in must have been created by a call to the\nnifgen_AllocateWaveform function or to one of the following niFgen\nCreate Waveform functions:\n\n-  nifgen_CreateWaveformF64\n-  nifgen_CreateWaveformI16\n-  nifgen_CreateWaveformFromFileI16\n-  nifgen_CreateWaveformFromFileF64\n\nBy default, the subsequent call to the niFgen_WriteNamedWaveformF64\nfunction continues writing data from the position of the last sample\nwritten. You can set the write position and offset by calling the\nnifgen_SetNamedWaveformNextWritePosition function. If streaming is\nenabled, you can write more data than the allocated waveform size in\nonboard memory. Refer to the\n`Streaming <REPLACE_DRIVER_SPECIFIC_URL_2(streaming)>`__ topic for more\ninformation about streaming data.\n'
         },
         'method_name_for_documentation': 'write_waveform',
         'method_templates': [
@@ -3109,7 +3109,7 @@ functions = {
     'WriteWaveform': {
         'codegen_method': 'private',
         'documentation': {
-            'description': '\nWrites floating-point data to the waveform in onboard memory. The\nwaveform handle passed in must have been created by a call to the\nnifgen_AllocateWaveform function or one of the following niFgen\nCreateWaveform functions:\n\n-  nifgen_CreateWaveformF64\n-  nifgen_CreateWaveformI16\n-  nifgen_CreateWaveformFromFileI16\n-  nifgen_CreateWaveformFromFileF64\n-  nifgen_CreateWaveformFromFileHWS\n\nBy default, the subsequent call to the niFgen_WriteWaveform function\ncontinues writing data from the position of the last sample written. You\ncan set the write position and offset by calling the\nnifgen_SetWaveformNextWritePosition function. If streaming is enabled,\nyou can write more data than the allocated waveform size in onboard\nmemory. Refer to the\n`Streaming <REPLACE_DRIVER_SPECIFIC_URL_2(streaming)>`__ topic for more\ninformation about streaming data.\n'
+            'description': '\nWrites floating-point data to the waveform in onboard memory. The\nwaveform handle passed in must have been created by a call to the\nnifgen_AllocateWaveform function or one of the following niFgen\nCreateWaveform functions:\n\n-  nifgen_CreateWaveformF64\n-  nifgen_CreateWaveformI16\n-  nifgen_CreateWaveformFromFileI16\n-  nifgen_CreateWaveformFromFileF64\n\nBy default, the subsequent call to the niFgen_WriteWaveform function\ncontinues writing data from the position of the last sample written. You\ncan set the write position and offset by calling the\nnifgen_SetWaveformNextWritePosition function. If streaming is enabled,\nyou can write more data than the allocated waveform size in onboard\nmemory. Refer to the\n`Streaming <REPLACE_DRIVER_SPECIFIC_URL_2(streaming)>`__ topic for more\ninformation about streaming data.\n'
         },
         'method_name_for_documentation': 'write_waveform',
         'method_templates': [

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -88,6 +88,39 @@ def test_self_cal(session):
     session.self_cal()
 
 
+def test_channels_rep_cap(session):
+    session.func_amplitude = 0.5
+    assert session.channels['0-1'].func_amplitude == 0.5
+
+    session.channels[0].func_amplitude = 1
+    assert session.channels['0'].func_amplitude == 1
+    assert session.channels[1].func_amplitude == 0.5
+
+
+def test_markers_rep_cap(session):
+    assert '' == session.markers['Marker0'].marker_event_output_terminal
+
+    requested_terminal_name = '/Dev1/PXI_Trig0'
+    session.markers['Marker0'].marker_event_output_terminal = requested_terminal_name
+    assert requested_terminal_name == session.markers[0].marker_event_output_terminal
+
+
+def test_data_markers_rep_cap(session):
+    assert '' == session.data_markers['DataMarker0'].marker_event_output_terminal
+
+    requested_terminal_name = '/Dev1/PXI_Trig0'
+    session.data_markers['DataMarker0'].data_marker_event_output_terminal = requested_terminal_name
+    assert requested_terminal_name == session.data_markers[0].data_marker_event_output_terminal
+
+
+def test_script_triggers_rep_cap(session):
+    assert '' == session.script_triggers['ScriptTrigger0'].exported_script_trigger_output_terminal
+
+    requested_terminal_name = '/Dev1/PXI_Trig0'
+    session.script_triggers['ScriptTrigger0'].exported_script_trigger_output_terminal = requested_terminal_name
+    assert requested_terminal_name == session.script_triggers[0].exported_script_trigger_output_terminal
+
+
 def test_standard_waveform(session):
     session.output_mode = nifgen.OutputMode.FUNC
     session.configure_standard_waveform(nifgen.Waveform.SINE, 2.0, 2000000, 1.0, 0.0)

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -88,13 +88,14 @@ def test_self_cal(session):
     session.self_cal()
 
 
-def test_channels_rep_cap(session):
-    session.func_amplitude = 0.5
-    assert session.channels['0-1'].func_amplitude == 0.5
+def test_channels_rep_cap():
+    with nifgen.Session('', '', False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe') as session:
+        session.func_amplitude = 0.5
+        assert session.channels['0-1'].func_amplitude == 0.5
 
-    session.channels[0].func_amplitude = 1
-    assert session.channels['0'].func_amplitude == 1
-    assert session.channels[1].func_amplitude == 0.5
+        session.channels[0].func_amplitude = 1
+        assert session.channels['0'].func_amplitude == 1
+        assert session.channels[1].func_amplitude == 0.5
 
 
 def test_markers_rep_cap(session):
@@ -106,11 +107,11 @@ def test_markers_rep_cap(session):
 
 
 def test_data_markers_rep_cap(session):
-    assert '' == session.data_markers['DataMarker0'].marker_event_output_terminal
+    assert nifgen.DataMarkerEventLevelPolarity.HIGH == session.data_markers['DataMarker0'].data_marker_event_level_polarity
 
-    requested_terminal_name = '/Dev1/PXI_Trig0'
-    session.data_markers['DataMarker0'].data_marker_event_output_terminal = requested_terminal_name
-    assert requested_terminal_name == session.data_markers[0].data_marker_event_output_terminal
+    requested_polarity = nifgen.DataMarkerEventLevelPolarity.LOW
+    session.data_markers['DataMarker0'].data_marker_event_level_polarity = requested_polarity
+    assert requested_polarity == session.data_markers[0].data_marker_event_level_polarity
 
 
 def test_script_triggers_rep_cap(session):


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- [X] I've added tests applicable for this pull request

### What does this Pull Request accomplish?
* Updates nifgen metadata to properly document and support accessing of attributes with the following repeated capabilities:
   * channels
   * script_triggers
   * markers
   * data_markers
 * Side effect: removed mention of `CreateWaveformFromFileHWS` from documentation. Support for this entrypoint is removed in NI-FGEN 21.3.
 * Regenerates nifgen docs to display the changes mentioned above
 * Adds nifgen system tests for the repeated capabilities mentioned above

### List issues fixed by this Pull Request below, if any.

* Fix #1668
* Partially addresses #1627

### What testing has been done?
* Ran tox locally.
* Ran the NI-FGEN systems tests on a local system.
