### PR TITLE
Repeated Capabilites documentation improvements

### DIFF
--- a/build/templates/rep_caps.rst.mako
+++ b/build/templates/rep_caps.rst.mako
@@ -25,10 +25,15 @@ ${helper.get_rst_header_snippet('Repeated Capabilities', '=')}
 
     Repeated capabilities attributes use the indexing operator :python:`[]` to indicate the repeated capabilities.
     The parameter can be a string, list, tuple, or slice (range). Each element of those can be a string or
-    an integer. If it is a string, you can indicate a range using the same format as the driver: :python:`'0-2'` or
-    :python:`'0:2'`
+    an integer.
 
-    Some repeated capabilities use a prefix before the number and this is optional
+    ..
+        If it is a string, you can indicate a range using the same format as the driver: :python:`'0-2'` or
+        :python:`'0:2'`
+
+        Some repeated capabilities use a prefix before the number and this is optional.
+
+    The recommended way of accessing repeated capabilities is with an integer :python:`[0]` or range :python:`[0:2]`.
 
 % for rep_cap in config['repeated_capabilities']:
 <%
@@ -40,27 +45,43 @@ ${helper.get_rst_header_snippet(name, '-')}
     .. py:attribute:: ${module_name}.Session.${name}[]
 
 % if len(prefix) > 0:
-        If no prefix is added to the items in the parameter, the correct prefix will be added when
-        the driver function call is made.
+        ..
+            If no prefix is added to the items in the parameter, the correct prefix will be added when
+            the driver function call is made.
 
-        .. code:: python
+            .. code:: python
 
-            session.${name}['0-2'].channel_enabled = True
+                session.${name}['0-2'].channel_enabled = True
 
-        passes a string of :python:`'${prefix}0, ${prefix}1, ${prefix}2'` to the set attribute function.
+            passes a string of :python:`'${prefix}0, ${prefix}1, ${prefix}2'` to the set attribute function.
 
-        If an invalid repeated capability is passed to the driver, the driver will return an error.
+            If an invalid repeated capability is passed to the driver, the driver will return an error.
 
-        You can also explicitly use the prefix as part of the parameter, but it must be the correct prefix
-        for the specific repeated capability.
+            You can also explicitly use the prefix as part of the parameter, but it must be the correct prefix
+            for the specific repeated capability.
+
+            .. code:: python
+
+                session.${name}['${prefix}0-${prefix}2'].channel_enabled = True
+
+            passes a string of :python:`'${prefix}0, ${prefix}1, ${prefix}2'` to the set attribute function.
 
 % endif
         .. code:: python
 
-            session.${name}['${prefix}0-${prefix}2'].channel_enabled = True
+            session.${name}[0].channel_enabled = True
 
-        passes a string of :python:`'${prefix}0, ${prefix}1, ${prefix}2'` to the set attribute function.
+        sets :py:attr:`channel_enabled` to :python:`True` for ${name} 0.
 
+        .. code:: python
+
+            session.${name}[0:2].channel_enabled = True
+        
+        sets :py:attr:`channel_enabled` to :python:`True` for ${name} 0, 1, 2.
+
+        Note that :py:attr:`channel_enabled` is only used as an example and is not necessarily a property which
+        supports this repeated capability. See documentation for individual properties and methods to
+        learn what repeated capabilites they support, if any.
 
 % endfor
 


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [ ] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [ ] ~~I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

There are several issues open against the way we document usage of repeated capabilities in our rep_caps.rst pages.

Summary of Issues
* We present implementation details that the user doesn't care about
  - These may be useful to contributors, but to everyone else they're just distracting.
* We list all of the possible types that can be passed to the indexing operator but don't make it clear what the recommended or "pythonic" types are.
  - This information is worth keeping, but we need to provide better guidance.
* We use channel_enabled in all of our examples, though it may not actually support the repeated capability in the example code.

This PR addresses these by doing the following:
* Turn documentation related to implementation details into comments only viewable in the raw source
* Explicitly recommend what types to pass to the indexing operator.
* Present examples which demonstrate accessing the repeated capability with our recommended types.
  - Do not present examples using other types.
* Add a note that channel_enabled may not actually support the repeated capability and to check individual property and method documentation.

### List issues fixed by this Pull Request below, if any.

TODO: List of issues.

* Fix #1388
* Fix #1334
* Fix #1126

### What testing has been done?

Local code generation with documentation inspection.
