### PR TITLE
 Use unittest.mock instead of third-party mock library

### DIFF
--- a/generated/nidigital/nidigital/unit_tests/test_nidigital.py
+++ b/generated/nidigital/nidigital/unit_tests/test_nidigital.py
@@ -2,8 +2,8 @@ import _mock_helper
 
 import nidigital
 
-from mock import patch
 import pytest
+from unittest.mock import patch
 
 session_id_for_test = 42
 

--- a/generated/nifake/nifake/unit_tests/test_session.py
+++ b/generated/nifake/nifake/unit_tests/test_session.py
@@ -9,12 +9,12 @@ import numpy
 import platform
 import warnings
 
-from mock import patch
+from unittest.mock import patch
 
 import _matchers
 import _mock_helper
 
-# from mock import ANY
+# from unittest.mock import ANY
 # Tests
 
 
@@ -348,7 +348,7 @@ class TestSession(object):
         with nifake.Session('dev1') as session:
             session.enum_input_function_with_defaults()
             session.enum_input_function_with_defaults(test_turtle)
-            from mock import call
+            from unittest.mock import call
             calls = [call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViInt16Matcher(0)), call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViInt16Matcher(1))]  # 0 is the value of the default of nifake.Turtle.LEONARDO, 1 is the value of nifake.Turtle.DONATELLO
             self.patched_library.niFake_EnumInputFunctionWithDefaults.assert_has_calls(calls)
 
@@ -358,7 +358,7 @@ class TestSession(object):
         with nifake.Session('dev1') as session:
             session.string_valued_enum_input_function_with_defaults()
             session.string_valued_enum_input_function_with_defaults(test_mobile_os_name)
-            from mock import call
+            from unittest.mock import call
             calls = [call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher('Android')), call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher('iOS'))]  # 'ANDROID' is the value of the default of nifake.MobileOSNames.Android, 'iOS' is the value of nifake.MobileOSNames.IOS
             self.patched_library.niFake_StringValuedEnumInputFunctionWithDefaults.assert_has_calls(calls)
 
@@ -777,7 +777,7 @@ class TestSession(object):
         with nifake.Session('dev1') as session:
             result_string = session.get_an_ivi_dance_string()
             assert result_string == string_val
-            from mock import call
+            from unittest.mock import call
             calls = [call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViInt32Matcher(0), None), call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViInt32Matcher(len(string_val)), _matchers.ViCharBufferMatcher(len(string_val)))]
             self.patched_library.niFake_GetAnIviDanceString.assert_has_calls(calls)
             assert self.patched_library.niFake_GetAnIviDanceString.call_count == 2
@@ -807,7 +807,7 @@ class TestSession(object):
         with nifake.Session('dev1') as session:
             result_string = session.get_an_ivi_dance_with_a_twist_string()
             assert result_string == string_val
-            from mock import call
+            from unittest.mock import call
             calls = [
                 call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViInt32Matcher(0), None, _matchers.ViInt32PointerMatcher()),
                 call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViInt32Matcher(len(string_val)), _matchers.ViCharBufferMatcher(len(string_val)), _matchers.ViInt32PointerMatcher())
@@ -953,7 +953,7 @@ class TestSession(object):
         with nifake.Session('dev1') as session:
             attr_string = session.read_write_string
             assert attr_string == string
-            from mock import call
+            from unittest.mock import call
             calls = [call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(1000002), _matchers.ViInt32Matcher(0), None), call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(1000002), _matchers.ViInt32Matcher(15), _matchers.ViCharBufferMatcher(len(string)))]
             self.patched_library.niFake_GetAttributeViString.assert_has_calls(calls)
             assert self.patched_library.niFake_GetAttributeViString.call_count == 2
@@ -973,7 +973,7 @@ class TestSession(object):
         with nifake.Session('dev1') as session:
             attr_string = session.read_write_string_repeated_capability
             assert attr_string == string
-            from mock import call
+            from unittest.mock import call
             calls = [call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(1000010), _matchers.ViInt32Matcher(0), None), call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(1000010), _matchers.ViInt32Matcher(20), _matchers.ViCharBufferMatcher(len(string)))]
             self.patched_library.niFake_GetAttributeViString.assert_has_calls(calls)
             assert self.patched_library.niFake_GetAttributeViString.call_count == 2

--- a/generated/nimodinst/nimodinst/unit_tests/test_modinst.py
+++ b/generated/nimodinst/nimodinst/unit_tests/test_modinst.py
@@ -4,7 +4,7 @@ import _mock_helper
 import nimodinst
 import warnings
 
-from mock import patch
+from unittest.mock import patch
 
 SESSION_NUM_FOR_TEST = 42
 

--- a/generated/nitclk/nitclk/unit_tests/test_nitclk.py
+++ b/generated/nitclk/nitclk/unit_tests/test_nitclk.py
@@ -4,7 +4,7 @@ import _mock_helper
 import hightime
 import nitclk
 
-from mock import patch
+from unittest.mock import patch
 
 SESSION_NUM_FOR_TEST = 42
 single_session = [SESSION_NUM_FOR_TEST]
@@ -227,7 +227,7 @@ class TestNitclkApi(object):
         attr_string = session.sync_pulse_sender_sync_pulse_source
         assert(attr_string == test_string)
 
-        from mock import call
+        from unittest.mock import call
         calls = [call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt32Matcher(0), None), call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt32Matcher(len(test_string)), _matchers.ViCharBufferMatcher(len(test_string)))]
         self.patched_library.niTClk_GetAttributeViString.assert_has_calls(calls)
         assert self.patched_library.niTClk_GetAttributeViString.call_count == 2

--- a/src/nidigital/unit_tests/test_nidigital.py
+++ b/src/nidigital/unit_tests/test_nidigital.py
@@ -2,8 +2,8 @@ import _mock_helper
 
 import nidigital
 
-from mock import patch
 import pytest
+from unittest.mock import patch
 
 session_id_for_test = 42
 

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -9,12 +9,12 @@ import numpy
 import platform
 import warnings
 
-from mock import patch
+from unittest.mock import patch
 
 import _matchers
 import _mock_helper
 
-# from mock import ANY
+# from unittest.mock import ANY
 # Tests
 
 
@@ -348,7 +348,7 @@ class TestSession(object):
         with nifake.Session('dev1') as session:
             session.enum_input_function_with_defaults()
             session.enum_input_function_with_defaults(test_turtle)
-            from mock import call
+            from unittest.mock import call
             calls = [call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViInt16Matcher(0)), call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViInt16Matcher(1))]  # 0 is the value of the default of nifake.Turtle.LEONARDO, 1 is the value of nifake.Turtle.DONATELLO
             self.patched_library.niFake_EnumInputFunctionWithDefaults.assert_has_calls(calls)
 
@@ -358,7 +358,7 @@ class TestSession(object):
         with nifake.Session('dev1') as session:
             session.string_valued_enum_input_function_with_defaults()
             session.string_valued_enum_input_function_with_defaults(test_mobile_os_name)
-            from mock import call
+            from unittest.mock import call
             calls = [call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher('Android')), call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher('iOS'))]  # 'ANDROID' is the value of the default of nifake.MobileOSNames.Android, 'iOS' is the value of nifake.MobileOSNames.IOS
             self.patched_library.niFake_StringValuedEnumInputFunctionWithDefaults.assert_has_calls(calls)
 
@@ -777,7 +777,7 @@ class TestSession(object):
         with nifake.Session('dev1') as session:
             result_string = session.get_an_ivi_dance_string()
             assert result_string == string_val
-            from mock import call
+            from unittest.mock import call
             calls = [call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViInt32Matcher(0), None), call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViInt32Matcher(len(string_val)), _matchers.ViCharBufferMatcher(len(string_val)))]
             self.patched_library.niFake_GetAnIviDanceString.assert_has_calls(calls)
             assert self.patched_library.niFake_GetAnIviDanceString.call_count == 2
@@ -807,7 +807,7 @@ class TestSession(object):
         with nifake.Session('dev1') as session:
             result_string = session.get_an_ivi_dance_with_a_twist_string()
             assert result_string == string_val
-            from mock import call
+            from unittest.mock import call
             calls = [
                 call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViInt32Matcher(0), None, _matchers.ViInt32PointerMatcher()),
                 call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViInt32Matcher(len(string_val)), _matchers.ViCharBufferMatcher(len(string_val)), _matchers.ViInt32PointerMatcher())
@@ -953,7 +953,7 @@ class TestSession(object):
         with nifake.Session('dev1') as session:
             attr_string = session.read_write_string
             assert attr_string == string
-            from mock import call
+            from unittest.mock import call
             calls = [call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(1000002), _matchers.ViInt32Matcher(0), None), call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(1000002), _matchers.ViInt32Matcher(15), _matchers.ViCharBufferMatcher(len(string)))]
             self.patched_library.niFake_GetAttributeViString.assert_has_calls(calls)
             assert self.patched_library.niFake_GetAttributeViString.call_count == 2
@@ -973,7 +973,7 @@ class TestSession(object):
         with nifake.Session('dev1') as session:
             attr_string = session.read_write_string_repeated_capability
             assert attr_string == string
-            from mock import call
+            from unittest.mock import call
             calls = [call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(1000010), _matchers.ViInt32Matcher(0), None), call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(1000010), _matchers.ViInt32Matcher(20), _matchers.ViCharBufferMatcher(len(string)))]
             self.patched_library.niFake_GetAttributeViString.assert_has_calls(calls)
             assert self.patched_library.niFake_GetAttributeViString.call_count == 2

--- a/src/nimodinst/unit_tests/test_modinst.py
+++ b/src/nimodinst/unit_tests/test_modinst.py
@@ -4,7 +4,7 @@ import _mock_helper
 import nimodinst
 import warnings
 
-from mock import patch
+from unittest.mock import patch
 
 SESSION_NUM_FOR_TEST = 42
 

--- a/src/nitclk/unit_tests/test_nitclk.py
+++ b/src/nitclk/unit_tests/test_nitclk.py
@@ -4,7 +4,7 @@ import _mock_helper
 import hightime
 import nitclk
 
-from mock import patch
+from unittest.mock import patch
 
 SESSION_NUM_FOR_TEST = 42
 single_session = [SESSION_NUM_FOR_TEST]
@@ -227,7 +227,7 @@ class TestNitclkApi(object):
         attr_string = session.sync_pulse_sender_sync_pulse_source
         assert(attr_string == test_string)
 
-        from mock import call
+        from unittest.mock import call
         calls = [call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt32Matcher(0), None), call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt32Matcher(len(test_string)), _matchers.ViCharBufferMatcher(len(test_string)))]
         self.patched_library.niTClk_GetAttributeViString.assert_has_calls(calls)
         assert self.patched_library.niTClk_GetAttributeViString.call_count == 2

--- a/tox-travis.ini
+++ b/tox-travis.ini
@@ -117,7 +117,6 @@ commands =
 deps =
     test: pytest
     test: coverage
-    test: mock
     test: mako
     test: numpy
     test: hightime

--- a/tox.ini
+++ b/tox.ini
@@ -117,7 +117,6 @@ commands =
 deps =
     test: pytest
     test: coverage
-    test: mock
     test: mako
     test: numpy
     test: hightime


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Latest version of the flake8 plugin `hacking` added a check - `H216: The unittest.mock module should be used rather than the third party mock package unless actually needed.`

When I recreated my tox environment locally, I ran into this violation. The PR replaces third-party mock library with the built-in one.

Note: This is a retry of #1608, which was approved for submission but git rebase on it went south.

### List issues fixed by this Pull Request below, if any.

N/a

### What testing has been done?

PR pipeline tests
