### PR TITLE
Remove a direct dependency on flake8

### DIFF
--- a/tox-travis.ini
+++ b/tox-travis.ini
@@ -123,7 +123,6 @@ deps =
     build_test: pytest
     build_test: coverage
     build_test: mako
-    build_test: flake8
     build_test: hacking
     build_test: pep8-naming
     codegen: mako
@@ -131,7 +130,6 @@ deps =
     installers: wheel
     installers: setuptools
     installers: packaging
-    flake8: flake8
     flake8: hacking
     flake8: pep8-naming
     docs: sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -123,7 +123,6 @@ deps =
     build_test: pytest
     build_test: coverage
     build_test: mako
-    build_test: flake8
     build_test: hacking
     build_test: pep8-naming
     codegen: mako
@@ -131,7 +130,6 @@ deps =
     installers: wheel
     installers: setuptools
     installers: packaging
-    flake8: flake8
     flake8: hacking
     flake8: pep8-naming
     docs: sphinx


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

`hacking` pulls in `flake8`. Listing both results in an old version of `hacking` (0.5.4) to be pulled in which is incompatible with the version of `flake8` (4.0.1)

### List issues fixed by this Pull Request below, if any.

None

### What testing has been done?

PR build