### PR TITLE
NI-DCPower: Enable new non-LCR attributes, enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ All notable changes to this project will be documented in this file.
     * #### Added
         * Partial API parity with NI-DCPower 21.8.0.
             * Properties added:
+                * `aperture_time_auto_mode`
+                * `autorange_maximum_delay_after_range_change`
                 * `instrument_mode`
                 * `lcr_actual_load_reactance`
                 * `lcr_actual_load_resistance`
@@ -61,6 +63,7 @@ All notable changes to this project will be documented in this file.
                 * `lcr_stimulus_function`
                 * `lcr_voltage_amplitude`
             * Enums added:
+                * `ApertureTimeAutoMode`
                 * `InstrumentMode`
                 * `LCRDCBiasSource`
                 * `LCRMeasurementTime`

--- a/docs/nidcpower/class.rst
+++ b/docs/nidcpower/class.rst
@@ -2440,6 +2440,48 @@ aperture_time
                 - LabVIEW Property: **Measurement:Aperture Time**
                 - C Attribute: **NIDCPOWER_ATTR_APERTURE_TIME**
 
+aperture_time_auto_mode
+-----------------------
+
+    .. py:attribute:: aperture_time_auto_mode
+
+        Automatically optimizes the measurement aperture time according to the actual current range when measurement autorange is enabled.
+        Optimization accounts for power line frequency when the :py:attr:`nidcpower.Session.aperture_time_units` property is set to :py:data:`~nidcpower.ApertureTimeUnits.POWER_LINE_CYCLES`.
+
+        This property is applicable only if the :py:attr:`nidcpower.Session.output_function` property is set to :py:data:`~nidcpower.OutputFunction.DC_VOLTAGE` and the :py:attr:`nidcpower.Session.autorange` property is enabled.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].aperture_time_auto_mode`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.aperture_time_auto_mode`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+----------------------------+
+            | Characteristic        | Value                      |
+            +=======================+============================+
+            | Datatype              | enums.ApertureTimeAutoMode |
+            +-----------------------+----------------------------+
+            | Permissions           | read-write                 |
+            +-----------------------+----------------------------+
+            | Repeated Capabilities | channels                   |
+            +-----------------------+----------------------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Measurement:Aperture Time Auto Mode**
+                - C Attribute: **NIDCPOWER_ATTR_APERTURE_TIME_AUTO_MODE**
+
 aperture_time_units
 -------------------
 
@@ -2597,6 +2639,45 @@ autorange_behavior
 
                 - LabVIEW Property: **Measurement:Advanced:Autorange Behavior**
                 - C Attribute: **NIDCPOWER_ATTR_AUTORANGE_BEHAVIOR**
+
+autorange_maximum_delay_after_range_change
+------------------------------------------
+
+    .. py:attribute:: autorange_maximum_delay_after_range_change
+
+        Balances between settling time and maximum measurement time by specifying the maximum time delay between when a range change occurs and when measurements resume.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].autorange_maximum_delay_after_range_change`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.autorange_maximum_delay_after_range_change`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+-------------------------------------------------------------+
+            | Characteristic        | Value                                                       |
+            +=======================+=============================================================+
+            | Datatype              | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +-----------------------+-------------------------------------------------------------+
+            | Permissions           | read-write                                                  |
+            +-----------------------+-------------------------------------------------------------+
+            | Repeated Capabilities | channels                                                    |
+            +-----------------------+-------------------------------------------------------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Measurement:Advanced:Autorange Maximum Delay After Range Change**
+                - C Attribute: **NIDCPOWER_ATTR_AUTORANGE_MAXIMUM_DELAY_AFTER_RANGE_CHANGE**
 
 autorange_minimum_aperture_time
 -------------------------------

--- a/docs/nidcpower/enums.rst
+++ b/docs/nidcpower/enums.rst
@@ -6,6 +6,51 @@ Enums used in NI-DCPower
 .. py:currentmodule:: nidcpower
 
 
+ApertureTimeAutoMode
+--------------------
+
+.. py:class:: ApertureTimeAutoMode
+
+    .. py:attribute:: ApertureTimeAutoMode.OFF
+
+
+
+        Disables automatic aperture time scaling. The :py:attr:`nidcpower.Session.aperture_time` property specifies the aperture time for all ranges.
+
+        
+
+
+
+    .. py:attribute:: ApertureTimeAutoMode.SHORT
+
+
+
+        Prioritizes measurement speed over measurement accuracy by quickly scaling down aperture time in larger current ranges. The :py:attr:`nidcpower.Session.aperture_time` property specifies the aperture time for the minimum range.
+
+        
+
+
+
+    .. py:attribute:: ApertureTimeAutoMode.NORMAL
+
+
+
+        Balances measurement accuracy and speed by scaling down aperture time in larger current ranges. The :py:attr:`nidcpower.Session.aperture_time` property specifies the aperture time for the minimum range.
+
+        
+
+
+
+    .. py:attribute:: ApertureTimeAutoMode.LONG
+
+
+
+        Prioritizes accuracy while still decreasing measurement time by slowly scaling down aperture time in larger current ranges. The :py:attr:`nidcpower.Session.aperture_time` property specifies the aperture time for the minimum range.
+
+        
+
+
+
 ApertureTimeUnits
 -----------------
 

--- a/generated/nidcpower/nidcpower/enums.py
+++ b/generated/nidcpower/nidcpower/enums.py
@@ -4,6 +4,25 @@
 from enum import Enum
 
 
+class ApertureTimeAutoMode(Enum):
+    OFF = 1135
+    r'''
+    Disables automatic aperture time scaling. The aperture_time property specifies the aperture time for all ranges.
+    '''
+    SHORT = 1136
+    r'''
+    Prioritizes measurement speed over measurement accuracy by quickly scaling down aperture time in larger current ranges. The aperture_time property specifies the aperture time for the minimum range.
+    '''
+    NORMAL = 1137
+    r'''
+    Balances measurement accuracy and speed by scaling down aperture time in larger current ranges. The aperture_time property specifies the aperture time for the minimum range.
+    '''
+    LONG = 1138
+    r'''
+    Prioritizes accuracy while still decreasing measurement time by slowly scaling down aperture time in larger current ranges. The aperture_time property specifies the aperture time for the minimum range.
+    '''
+
+
 class ApertureTimeUnits(Enum):
     SECONDS = 1028
     r'''

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -204,6 +204,27 @@ class _SessionBase(object):
 
     Example: :py:attr:`my_session.aperture_time`
     '''
+    aperture_time_auto_mode = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.ApertureTimeAutoMode, 1150314)
+    '''Type: enums.ApertureTimeAutoMode
+
+    Automatically optimizes the measurement aperture time according to the actual current range when measurement autorange is enabled.
+    Optimization accounts for power line frequency when the aperture_time_units property is set to ApertureTimeUnits.POWER_LINE_CYCLES.
+
+    This property is applicable only if the output_function property is set to OutputFunction.DC_VOLTAGE and the autorange property is enabled.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].aperture_time_auto_mode`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.aperture_time_auto_mode`
+    '''
     aperture_time_units = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.ApertureTimeUnits, 1150059)
     '''Type: enums.ApertureTimeUnits
 
@@ -277,6 +298,24 @@ class _SessionBase(object):
     To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
 
     Example: :py:attr:`my_session.autorange_behavior`
+    '''
+    autorange_maximum_delay_after_range_change = _attributes.AttributeViReal64TimeDeltaSeconds(1150322)
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
+
+    Balances between settling time and maximum measurement time by specifying the maximum time delay between when a range change occurs and when measurements resume.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].autorange_maximum_delay_after_range_change`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.autorange_maximum_delay_after_range_change`
     '''
     autorange_minimum_aperture_time = _attributes.AttributeViReal64(1150247)
     '''Type: float

--- a/src/nidcpower/metadata/attributes_addon.py
+++ b/src/nidcpower/metadata/attributes_addon.py
@@ -10,10 +10,8 @@ attributes_override_metadata = {
     1150291: {"codegen_method": "no"},
     1150299: {"codegen_method": "no"},
     1150302: {"codegen_method": "no"},
-    1150314: {"codegen_method": "no"},
     1150318: {"codegen_method": "no"},
     1150319: {"codegen_method": "no"},
     1150320: {"codegen_method": "no"},
-    1150321: {"codegen_method": "no"},
-    1150322: {"codegen_method": "no"}
+    1150321: {"codegen_method": "no"}
 }

--- a/src/nidcpower/metadata/enums_addon.py
+++ b/src/nidcpower/metadata/enums_addon.py
@@ -4,7 +4,6 @@
 enums_override_metadata = {
     # TODO(olsl21): Temporarily disable the new enums (#1715), they will be re-enabled in
     #  subsequent smaller PRs
-    "ApertureTimeAutoMode": {"codegen_method": "no"},
     "CableLength": {"codegen_method": "no"},
     "LCRCompensationType": {"codegen_method": "no"},
     "LCRImpedanceRangeSource": {"codegen_method": "no"},


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
~~- [ ] I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

- Enable `aperture_time_auto_mode` and `autorange_maximum_delay_after_range_change` attributes
- Enable `aperture_time_auto_mode` enum
- Update CHANGELOG

### What testing has been done?

Tested that the attributes can be retrieved correctly.
```
>>> with nidcpower.Session(resource_name='4137_sim', channels='0', options='Simulate=1, DriverSetup=Model:4137; BoardType:PXIe') as smu:
...     print(smu.aperture_time_auto_mode)
...
ApertureTimeAutoMode.OFF
>>> with nidcpower.Session(resource_name='4162_sim', channels='0', options='Simulate=1, DriverSetup=Model:4162; BoardType:PXIe') as smu:
...     print(smu.autorange_maximum_delay_after_range_change)
...
0:00:00.100000
```