### PR TITLE
Allow no-codegen method to have method_name_for_doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 * ### ALL
     * #### Added
     * #### Changed
+        * Allow functions with `codegen_method` set to "no" to have `method_name_for_documentation` defined
     * #### Removed
 * ### `nidcpower` (NI-DCPower)
     * #### Added
@@ -46,7 +47,7 @@ All notable changes to this project will be documented in this file.
     * #### Changed
     * #### Removed
 * ### `nifgen` (NI-FGEN)
-    * #### Added 
+    * #### Added
         * `data_markers` repeated capability support - [#1668](https://github.com/ni/nimi-python/issues/1668)
     * #### Changed
         * Addressed [#1627](https://github.com/ni/nimi-python/issues/1627) for attributes supporting the following repeated capabilities

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ All notable changes to this project will be documented in this file.
 * ### ALL
     * #### Added
     * #### Changed
-        * Allow functions with `codegen_method` set to "no" to have `method_name_for_documentation` defined
     * #### Removed
 * ### `nidcpower` (NI-DCPower)
     * #### Added
@@ -47,7 +46,7 @@ All notable changes to this project will be documented in this file.
     * #### Changed
     * #### Removed
 * ### `nifgen` (NI-FGEN)
-    * #### Added
+    * #### Added 
         * `data_markers` repeated capability support - [#1668](https://github.com/ni/nimi-python/issues/1668)
     * #### Changed
         * Addressed [#1627](https://github.com/ni/nimi-python/issues/1627) for attributes supporting the following repeated capabilities

--- a/build/helper/metadata_add_all.py
+++ b/build/helper/metadata_add_all.py
@@ -54,8 +54,7 @@ def _add_python_method_name(function, name):
             function['python_name'] = '_' + camelcase_to_snakecase(name)
         else:
             function['python_name'] = camelcase_to_snakecase(name)
-            if function['codegen_method'] != 'no':
-                assert 'method_name_for_documentation' not in function, "'method_name_for_documentation' not allowed to be set: function['method_name_for_documentation'] = '{0}', function['python_name'] = '{1}'".format(function['method_name_for_documentation'], function['python_name'])
+            assert function['codegen_method'] == 'no' or 'method_name_for_documentation' not in function, "'method_name_for_documentation' not allowed to be set: function['method_name_for_documentation'] = '{0}', function['python_name'] = '{1}'".format(function['method_name_for_documentation'], function['python_name'])
     return function
 
 

--- a/build/helper/metadata_add_all.py
+++ b/build/helper/metadata_add_all.py
@@ -54,7 +54,8 @@ def _add_python_method_name(function, name):
             function['python_name'] = '_' + camelcase_to_snakecase(name)
         else:
             function['python_name'] = camelcase_to_snakecase(name)
-            assert 'method_name_for_documentation' not in function, "'method_name_for_documentation' not allowed to be set: function['method_name_for_documentation'] = '{0}', function['python_name'] = '{1}'".format(function['method_name_for_documentation'], function['python_name'])
+            if function['codegen_method'] != 'no':
+                assert 'method_name_for_documentation' not in function, "'method_name_for_documentation' not allowed to be set: function['method_name_for_documentation'] = '{0}', function['python_name'] = '{1}'".format(function['method_name_for_documentation'], function['python_name'])
     return function
 
 
@@ -777,6 +778,22 @@ functions_input = {
             'description': 'Perform actions as method defined',
         },
     },
+    'MakeANoCodegenMethod': {
+        'codegen_method': 'no',
+        'documentation': {
+            'description': 'This is a method with codegen_method set to no',
+        },
+        'method_name_for_documentation': 'MakeAPublicMethod',
+        'method_templates': [
+            {
+                'session_filename': '/cool_template',
+                'documentation_filename': '/cool_template',
+                'method_python_name_suffix': '',
+            },
+        ],
+        'parameters': [],
+        'returns': 'ViStatus',
+    },
 }
 
 
@@ -1100,6 +1117,28 @@ functions_expected = {
         'is_error_handling': False,
         'render_in_session_base': False,
         'has_repeated_capability': False
+    },
+    'MakeANoCodegenMethod': {
+        'name': 'MakeANoCodegenMethod',
+        'codegen_method': 'no',
+        'method_name_for_documentation': 'MakeAPublicMethod',
+        'use_session_lock': True,
+        'documentation': {
+            'description': 'This is a method with codegen_method set to no'
+        },
+        'has_repeated_capability': False,
+        'is_error_handling': False,
+        'render_in_session_base': False,
+        'method_templates': [
+            {
+                'session_filename': '/cool_template',
+                'documentation_filename': '/cool_template',
+                'method_python_name_suffix': ''
+            }
+        ],
+        'parameters': [],
+        'python_name': 'make_a_no_codegen_method',
+        'returns': 'ViStatus',
     }
 }
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

- Update `_add_python_method_name` to skip the assertion for `method_name_for_documentation` if the `codegen_method` of the function is "no"
- Add unit test for this change

### List issues fixed by this Pull Request below, if any.

### What testing has been done?

All the build tests (including the updated ones) passed