### PR TITLE
Remove --universal wheel option to prevent "py2" compatibility tag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ System tests exercise the Python bindings. After you have successfully built
 **[nimi-python](https://github.com/ni/nimi-python)**, install the locally built PyPI
 packages using PyPI. For example:
 
-    python3 -m pip install -U generated/nidmm/dist/nidmm-0.1.0.dev4-py2.py3-none-any.whl
+    python3 -m pip install -U generated/nidmm/dist/nidmm-0.1.0.dev4-py3-none-any.whl
 
 You can install all locally built packages in one fell swoop using the following command.
 This will work on Unix-based systems including Windows Subsystem for Linux.

--- a/build/rules.mak
+++ b/build/rules.mak
@@ -112,7 +112,7 @@ wheel: $(WHEEL_BUILD_DONE)
 
 $(WHEEL_BUILD_DONE): # codegen should have already run or just use what is is git
 	$(call trace_to_console, "Creating wheel",$(OUTPUT_DIR)/dist)
-	$(_hide_cmds)$(call log_command_no_tracking,cd $(OUTPUT_DIR) && $(PYTHON_CMD) setup.py bdist_wheel --universal $(LOG_OUTPUT) $(LOG_DIR)/wheel.log)
+	$(_hide_cmds)$(call log_command_no_tracking,cd $(OUTPUT_DIR) && $(PYTHON_CMD) setup.py bdist_wheel $(LOG_OUTPUT) $(LOG_DIR)/wheel.log)
 	$(_hide_cmds)$(call log_command_no_tracking,touch $@)
 
 # If we are building nifake, we just need a placeholder file for inclusion into the wheel that will never be used. We can't build the actual readme since not all the files are created


### PR DESCRIPTION
### What does this Pull Request accomplish?
Removes python2 compatibility from wheel names as python 2 is no longer supported.
Done via removing --universal option when creating the .whl files
Also removed the reference to "py2" in the CONTRIBUTING.md 

### List issues fixed by this Pull Request below, if any.
Fixes Issue: #1641

### What testing has been done?
Built locally and checked that the codegen output wheel file excludes the py2 compatibility tag.
