### PR TITLE
Fix github workflow issues for AWS

### DIFF
--- a/.github/workflows/github_actions_aws_rhel_python64.yml
+++ b/.github/workflows/github_actions_aws_rhel_python64.yml
@@ -13,7 +13,7 @@ on:
       - VERSION
     types: [ opened, synchronize, reopened ]
 
-  # Allows you to run this workflow manually from the Actions tab
+  # Allows you to run this workflow manually from the Actions tab.
   workflow_dispatch:
 jobs:
   do-the-job1:

--- a/.github/workflows/github_actions_aws_rhel_python64.yml
+++ b/.github/workflows/github_actions_aws_rhel_python64.yml
@@ -13,7 +13,7 @@ on:
       - VERSION
     types: [ opened, synchronize, reopened ]
 
-  # Allows you to run this workflow manually from the Actions tab.
+  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 jobs:
   do-the-job1:

--- a/.github/workflows/github_actions_aws_rhel_python64.yml
+++ b/.github/workflows/github_actions_aws_rhel_python64.yml
@@ -11,7 +11,7 @@ on:
       - .gitattributes
       - LICENSE
       - VERSION
-    types: [review_requested, ready_for_review, synchronize]
+    types: [ opened, synchronize, reopened ]
 
   # Allows you to run this workflow manually from the Actions tab.
   workflow_dispatch:

--- a/.github/workflows/github_actions_aws_windows_python32.yml
+++ b/.github/workflows/github_actions_aws_windows_python32.yml
@@ -11,7 +11,7 @@ on:
       - .gitattributes
       - LICENSE
       - VERSION
-    types: [review_requested, ready_for_review, synchronize]
+    types: [ opened, synchronize, reopened ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/github_actions_aws_windows_python64.yml
+++ b/.github/workflows/github_actions_aws_windows_python64.yml
@@ -11,7 +11,7 @@ on:
       - .gitattributes
       - LICENSE
       - VERSION
-    types: [review_requested, ready_for_review, synchronize]
+    types: [ opened, synchronize, reopened ]
 
   # Allows you to run this workflow manually from the Actions tab.
   workflow_dispatch:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [ ] ~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

- [ ]~I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Issue: Totally 6 workflows are run instead of 3 when PR is created.  
Root Cause: If you specify multiple activity types, only one of those event activity types needs to occur to trigger your workflow. If multiple triggering event activity types for your workflow occur at the same time, multiple workflow runs will be triggered. Refer this [link](https://docs.github.com/en/enterprise-server@3.3/actions/using-workflows/workflow-syntax-for-github-actions#using-activity-types) for more details

Solution: Changed the types so that multiple types does not trigger at a same time.

### List issues fixed by this Pull Request below, if any.

### What testing has been done?
Tested for the below use cases.
1. PR is created -> All 3 workflows ran a single instance.
2. PR is updated -> All 3 workflows ran a single instance.
3. PR is reopened -> All 3 workflows ran a single instance.
4. Draft PR -> All 3 workflows ran a single instance.
5. Convert Draft PR to Normal PR -> None of the workflow trigged as expected.
