### PR TITLE
Fix python binary name used in tox-system_tests.ini

### DIFF
--- a/build/templates/tox-system_tests.ini.mako
+++ b/build/templates/tox-system_tests.ini.mako
@@ -46,7 +46,7 @@ changedir =
 
 commands =
 % if uses_other_wheel:
-    ${wheel_env_no_py}: python.exe setup.py bdist_wheel --universal
+    ${wheel_env_no_py}: python setup.py bdist_wheel --universal
 
 % endif
     # --disable-pip-version-check prevents pip from telling us we need to upgrade pip, since we are doing that now

--- a/generated/nidigital/tox-system_tests.ini
+++ b/generated/nidigital/tox-system_tests.ini
@@ -21,7 +21,7 @@ changedir =
     nidigital-coverage: .
 
 commands =
-    nidigital-wheel_dep: python.exe setup.py bdist_wheel --universal
+    nidigital-wheel_dep: python setup.py bdist_wheel --universal
 
     # --disable-pip-version-check prevents pip from telling us we need to upgrade pip, since we are doing that now
     nidigital-system_tests: python -m pip install --disable-pip-version-check --upgrade pip

--- a/generated/nifake/tox-system_tests.ini
+++ b/generated/nifake/tox-system_tests.ini
@@ -21,7 +21,7 @@ changedir =
     nifake-coverage: .
 
 commands =
-    nifake-wheel_dep: python.exe setup.py bdist_wheel --universal
+    nifake-wheel_dep: python setup.py bdist_wheel --universal
 
     # --disable-pip-version-check prevents pip from telling us we need to upgrade pip, since we are doing that now
     nifake-system_tests: python -m pip install --disable-pip-version-check --upgrade pip

--- a/generated/nifgen/tox-system_tests.ini
+++ b/generated/nifgen/tox-system_tests.ini
@@ -21,7 +21,7 @@ changedir =
     nifgen-coverage: .
 
 commands =
-    nifgen-wheel_dep: python.exe setup.py bdist_wheel --universal
+    nifgen-wheel_dep: python setup.py bdist_wheel --universal
 
     # --disable-pip-version-check prevents pip from telling us we need to upgrade pip, since we are doing that now
     nifgen-system_tests: python -m pip install --disable-pip-version-check --upgrade pip

--- a/generated/niscope/tox-system_tests.ini
+++ b/generated/niscope/tox-system_tests.ini
@@ -21,7 +21,7 @@ changedir =
     niscope-coverage: .
 
 commands =
-    niscope-wheel_dep: python.exe setup.py bdist_wheel --universal
+    niscope-wheel_dep: python setup.py bdist_wheel --universal
 
     # --disable-pip-version-check prevents pip from telling us we need to upgrade pip, since we are doing that now
     niscope-system_tests: python -m pip install --disable-pip-version-check --upgrade pip

--- a/generated/nitclk/tox-system_tests.ini
+++ b/generated/nitclk/tox-system_tests.ini
@@ -21,7 +21,7 @@ changedir =
     nitclk-coverage: .
 
 commands =
-    nitclk-wheel_dep: python.exe setup.py bdist_wheel --universal
+    nitclk-wheel_dep: python setup.py bdist_wheel --universal
 
     # --disable-pip-version-check prevents pip from telling us we need to upgrade pip, since we are doing that now
     nitclk-system_tests: python -m pip install --disable-pip-version-check --upgrade pip


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Fix python binary name used in tox-system_tests.ini, so that system tests can be run on both Windows and Linux platforms via tox.

This will fix the failure we're seeing with the internal pipeline that creates the VMs for running system tests.

### List issues fixed by this Pull Request below, if any.

N/a

### What testing has been done?
PR build