### PR TITLE
Remove --universal wheel option to prevent "py2" compatibility tag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ System tests exercise the Python bindings. After you have successfully built
 **[nimi-python](https://github.com/ni/nimi-python)**, install the locally built PyPI
 packages using PyPI. For example:
 
-    python3 -m pip install -U generated/nidmm/dist/nidmm-0.1.0.dev4-py2.py3-none-any.whl
+    python3 -m pip install -U generated/nidmm/dist/nidmm-0.1.0.dev4-py3-none-any.whl
 
 You can install all locally built packages in one fell swoop using the following command.
 This will work on Unix-based systems including Windows Subsystem for Linux.

--- a/build/rules.mak
+++ b/build/rules.mak
@@ -112,7 +112,7 @@ wheel: $(WHEEL_BUILD_DONE)
 
 $(WHEEL_BUILD_DONE): # codegen should have already run or just use what is is git
 	$(call trace_to_console, "Creating wheel",$(OUTPUT_DIR)/dist)
-	$(_hide_cmds)$(call log_command_no_tracking,cd $(OUTPUT_DIR) && $(PYTHON_CMD) setup.py bdist_wheel --universal $(LOG_OUTPUT) $(LOG_DIR)/wheel.log)
+	$(_hide_cmds)$(call log_command_no_tracking,cd $(OUTPUT_DIR) && $(PYTHON_CMD) setup.py bdist_wheel $(LOG_OUTPUT) $(LOG_DIR)/wheel.log)
 	$(_hide_cmds)$(call log_command_no_tracking,touch $@)
 
 # If we are building nifake, we just need a placeholder file for inclusion into the wheel that will never be used. We can't build the actual readme since not all the files are created

--- a/build/templates/tox-system_tests.ini.mako
+++ b/build/templates/tox-system_tests.ini.mako
@@ -46,7 +46,7 @@ changedir =
 
 commands =
 % if uses_other_wheel:
-    ${wheel_env_no_py}: python setup.py bdist_wheel --universal
+    ${wheel_env_no_py}: python setup.py bdist_wheel
 
 % endif
     # --disable-pip-version-check prevents pip from telling us we need to upgrade pip, since we are doing that now

--- a/generated/nidigital/tox-system_tests.ini
+++ b/generated/nidigital/tox-system_tests.ini
@@ -21,7 +21,7 @@ changedir =
     nidigital-coverage: .
 
 commands =
-    nidigital-wheel_dep: python setup.py bdist_wheel --universal
+    nidigital-wheel_dep: python setup.py bdist_wheel
 
     # --disable-pip-version-check prevents pip from telling us we need to upgrade pip, since we are doing that now
     nidigital-system_tests: python -m pip install --disable-pip-version-check --upgrade pip

--- a/generated/nifake/tox-system_tests.ini
+++ b/generated/nifake/tox-system_tests.ini
@@ -21,7 +21,7 @@ changedir =
     nifake-coverage: .
 
 commands =
-    nifake-wheel_dep: python setup.py bdist_wheel --universal
+    nifake-wheel_dep: python setup.py bdist_wheel
 
     # --disable-pip-version-check prevents pip from telling us we need to upgrade pip, since we are doing that now
     nifake-system_tests: python -m pip install --disable-pip-version-check --upgrade pip

--- a/generated/nifgen/tox-system_tests.ini
+++ b/generated/nifgen/tox-system_tests.ini
@@ -21,7 +21,7 @@ changedir =
     nifgen-coverage: .
 
 commands =
-    nifgen-wheel_dep: python setup.py bdist_wheel --universal
+    nifgen-wheel_dep: python setup.py bdist_wheel
 
     # --disable-pip-version-check prevents pip from telling us we need to upgrade pip, since we are doing that now
     nifgen-system_tests: python -m pip install --disable-pip-version-check --upgrade pip

--- a/generated/niscope/tox-system_tests.ini
+++ b/generated/niscope/tox-system_tests.ini
@@ -21,7 +21,7 @@ changedir =
     niscope-coverage: .
 
 commands =
-    niscope-wheel_dep: python setup.py bdist_wheel --universal
+    niscope-wheel_dep: python setup.py bdist_wheel
 
     # --disable-pip-version-check prevents pip from telling us we need to upgrade pip, since we are doing that now
     niscope-system_tests: python -m pip install --disable-pip-version-check --upgrade pip

--- a/generated/nitclk/tox-system_tests.ini
+++ b/generated/nitclk/tox-system_tests.ini
@@ -21,7 +21,7 @@ changedir =
     nitclk-coverage: .
 
 commands =
-    nitclk-wheel_dep: python setup.py bdist_wheel --universal
+    nitclk-wheel_dep: python setup.py bdist_wheel
 
     # --disable-pip-version-check prevents pip from telling us we need to upgrade pip, since we are doing that now
     nitclk-system_tests: python -m pip install --disable-pip-version-check --upgrade pip


### PR DESCRIPTION
### What does this Pull Request accomplish?
Removes python2 compatibility from wheel names as python 2 is no longer supported.
Done via removing `--universal` option when creating the `.whl` files
Also removed the reference to `py2` in the `CONTRIBUTING.md`

### List issues fixed by this Pull Request below, if any.
Fixes Issue: https://github.com/ni/nimi-python/issues/1641

### What testing has been done?
Built locally and checked that the codegen output wheel file excludes the py2 compatibility tag.

### Note to reviewers
Pull Request takes over and obsoletes Pull Request #1718 by cherry-picking commit from @mmorin-ni fork.