### PR TITLE
Update return type of NI-FGEN datetime-related functions

### DIFF
--- a/generated/nifgen/nifgen/_library.py
+++ b/generated/nifgen/nifgen/_library.py
@@ -387,21 +387,21 @@ class Library(object):
                 self.niFgen_GetHardwareState_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetHardwareState_cfunc(vi, state)
 
-    def niFgen_GetLastExtCalLastDateAndTime(self, vi, month):  # noqa: N802
+    def niFgen_GetLastExtCalLastDateAndTime(self, vi, last_cal_datetime):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetLastExtCalLastDateAndTime_cfunc is None:
                 self.niFgen_GetLastExtCalLastDateAndTime_cfunc = self._get_library_function('niFgen_GetLastExtCalLastDateAndTime')
                 self.niFgen_GetLastExtCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(hightime.datetime)]  # noqa: F405
                 self.niFgen_GetLastExtCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFgen_GetLastExtCalLastDateAndTime_cfunc(vi, month)
+        return self.niFgen_GetLastExtCalLastDateAndTime_cfunc(vi, last_cal_datetime)
 
-    def niFgen_GetLastSelfCalLastDateAndTime(self, vi, month):  # noqa: N802
+    def niFgen_GetLastSelfCalLastDateAndTime(self, vi, last_cal_datetime):  # noqa: N802
         with self._func_lock:
             if self.niFgen_GetLastSelfCalLastDateAndTime_cfunc is None:
                 self.niFgen_GetLastSelfCalLastDateAndTime_cfunc = self._get_library_function('niFgen_GetLastSelfCalLastDateAndTime')
                 self.niFgen_GetLastSelfCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(hightime.datetime)]  # noqa: F405
                 self.niFgen_GetLastSelfCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFgen_GetLastSelfCalLastDateAndTime_cfunc(vi, month)
+        return self.niFgen_GetLastSelfCalLastDateAndTime_cfunc(vi, last_cal_datetime)
 
     def niFgen_GetSelfCalLastDateAndTime(self, vi, year, month, day, hour, minute):  # noqa: N802
         with self._func_lock:

--- a/generated/nifgen/nifgen/_library.py
+++ b/generated/nifgen/nifgen/_library.py
@@ -55,8 +55,6 @@ class Library(object):
         self.niFgen_GetExtCalLastTemp_cfunc = None
         self.niFgen_GetExtCalRecommendedInterval_cfunc = None
         self.niFgen_GetHardwareState_cfunc = None
-        self.niFgen_GetLastExtCalLastDateAndTime_cfunc = None
-        self.niFgen_GetLastSelfCalLastDateAndTime_cfunc = None
         self.niFgen_GetSelfCalLastDateAndTime_cfunc = None
         self.niFgen_GetSelfCalLastTemp_cfunc = None
         self.niFgen_GetSelfCalSupported_cfunc = None
@@ -386,22 +384,6 @@ class Library(object):
                 self.niFgen_GetHardwareState_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFgen_GetHardwareState_cfunc.restype = ViStatus  # noqa: F405
         return self.niFgen_GetHardwareState_cfunc(vi, state)
-
-    def niFgen_GetLastExtCalLastDateAndTime(self, vi, last_cal_datetime):  # noqa: N802
-        with self._func_lock:
-            if self.niFgen_GetLastExtCalLastDateAndTime_cfunc is None:
-                self.niFgen_GetLastExtCalLastDateAndTime_cfunc = self._get_library_function('niFgen_GetLastExtCalLastDateAndTime')
-                self.niFgen_GetLastExtCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(hightime.datetime)]  # noqa: F405
-                self.niFgen_GetLastExtCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFgen_GetLastExtCalLastDateAndTime_cfunc(vi, last_cal_datetime)
-
-    def niFgen_GetLastSelfCalLastDateAndTime(self, vi, last_cal_datetime):  # noqa: N802
-        with self._func_lock:
-            if self.niFgen_GetLastSelfCalLastDateAndTime_cfunc is None:
-                self.niFgen_GetLastSelfCalLastDateAndTime_cfunc = self._get_library_function('niFgen_GetLastSelfCalLastDateAndTime')
-                self.niFgen_GetLastSelfCalLastDateAndTime_cfunc.argtypes = [ViSession, ctypes.POINTER(hightime.datetime)]  # noqa: F405
-                self.niFgen_GetLastSelfCalLastDateAndTime_cfunc.restype = ViStatus  # noqa: F405
-        return self.niFgen_GetLastSelfCalLastDateAndTime_cfunc(vi, last_cal_datetime)
 
     def niFgen_GetSelfCalLastDateAndTime(self, vi, year, month, day, hour, minute):  # noqa: N802
         with self._func_lock:

--- a/generated/nifgen/nifgen/session.py
+++ b/generated/nifgen/nifgen/session.py
@@ -4144,7 +4144,7 @@ class Session(_SessionBase):
         Returns the date and time of the last successful external calibration. The time returned is 24-hour (military) local time; for example, if the device was calibrated at 2:30 PM, this method returns 14 for the **hour** parameter and 30 for the **minute** parameter.
 
         Returns:
-            month (hightime.datetime): Indicates date and time of the last calibration.
+            last_cal_datetime (hightime.datetime): Indicates date and time of the last calibration.
 
         '''
         year, month, day, hour, minute = self._get_ext_cal_last_date_and_time()
@@ -4157,7 +4157,7 @@ class Session(_SessionBase):
         Returns the date and time of the last successful self-calibration.
 
         Returns:
-            month (hightime.datetime): Returns the date and time the device was last calibrated.
+            last_cal_datetime (hightime.datetime): Returns the date and time the device was last calibrated.
 
         '''
         year, month, day, hour, minute = self._get_self_cal_last_date_and_time()

--- a/generated/nifgen/nifgen/unit_tests/_mock_helper.py
+++ b/generated/nifgen/nifgen/unit_tests/_mock_helper.py
@@ -115,10 +115,10 @@ class SideEffectsHelper(object):
         self._defaults['GetHardwareState']['state'] = None
         self._defaults['GetLastExtCalLastDateAndTime'] = {}
         self._defaults['GetLastExtCalLastDateAndTime']['return'] = 0
-        self._defaults['GetLastExtCalLastDateAndTime']['month'] = None
+        self._defaults['GetLastExtCalLastDateAndTime']['lastCalDatetime'] = None
         self._defaults['GetLastSelfCalLastDateAndTime'] = {}
         self._defaults['GetLastSelfCalLastDateAndTime']['return'] = 0
-        self._defaults['GetLastSelfCalLastDateAndTime']['month'] = None
+        self._defaults['GetLastSelfCalLastDateAndTime']['lastCalDatetime'] = None
         self._defaults['GetSelfCalLastDateAndTime'] = {}
         self._defaults['GetSelfCalLastDateAndTime']['return'] = 0
         self._defaults['GetSelfCalLastDateAndTime']['year'] = None
@@ -539,24 +539,24 @@ class SideEffectsHelper(object):
             state.contents.value = self._defaults['GetHardwareState']['state']
         return self._defaults['GetHardwareState']['return']
 
-    def niFgen_GetLastExtCalLastDateAndTime(self, vi, month):  # noqa: N802
+    def niFgen_GetLastExtCalLastDateAndTime(self, vi, last_cal_datetime):  # noqa: N802
         if self._defaults['GetLastExtCalLastDateAndTime']['return'] != 0:
             return self._defaults['GetLastExtCalLastDateAndTime']['return']
-        # month
-        if self._defaults['GetLastExtCalLastDateAndTime']['month'] is None:
-            raise MockFunctionCallError("niFgen_GetLastExtCalLastDateAndTime", param='month')
-        if month is not None:
-            month.contents.value = self._defaults['GetLastExtCalLastDateAndTime']['month']
+        # last_cal_datetime
+        if self._defaults['GetLastExtCalLastDateAndTime']['lastCalDatetime'] is None:
+            raise MockFunctionCallError("niFgen_GetLastExtCalLastDateAndTime", param='lastCalDatetime')
+        if last_cal_datetime is not None:
+            last_cal_datetime.contents.value = self._defaults['GetLastExtCalLastDateAndTime']['lastCalDatetime']
         return self._defaults['GetLastExtCalLastDateAndTime']['return']
 
-    def niFgen_GetLastSelfCalLastDateAndTime(self, vi, month):  # noqa: N802
+    def niFgen_GetLastSelfCalLastDateAndTime(self, vi, last_cal_datetime):  # noqa: N802
         if self._defaults['GetLastSelfCalLastDateAndTime']['return'] != 0:
             return self._defaults['GetLastSelfCalLastDateAndTime']['return']
-        # month
-        if self._defaults['GetLastSelfCalLastDateAndTime']['month'] is None:
-            raise MockFunctionCallError("niFgen_GetLastSelfCalLastDateAndTime", param='month')
-        if month is not None:
-            month.contents.value = self._defaults['GetLastSelfCalLastDateAndTime']['month']
+        # last_cal_datetime
+        if self._defaults['GetLastSelfCalLastDateAndTime']['lastCalDatetime'] is None:
+            raise MockFunctionCallError("niFgen_GetLastSelfCalLastDateAndTime", param='lastCalDatetime')
+        if last_cal_datetime is not None:
+            last_cal_datetime.contents.value = self._defaults['GetLastSelfCalLastDateAndTime']['lastCalDatetime']
         return self._defaults['GetLastSelfCalLastDateAndTime']['return']
 
     def niFgen_GetSelfCalLastDateAndTime(self, vi, year, month, day, hour, minute):  # noqa: N802

--- a/generated/nifgen/nifgen/unit_tests/_mock_helper.py
+++ b/generated/nifgen/nifgen/unit_tests/_mock_helper.py
@@ -113,12 +113,6 @@ class SideEffectsHelper(object):
         self._defaults['GetHardwareState'] = {}
         self._defaults['GetHardwareState']['return'] = 0
         self._defaults['GetHardwareState']['state'] = None
-        self._defaults['GetLastExtCalLastDateAndTime'] = {}
-        self._defaults['GetLastExtCalLastDateAndTime']['return'] = 0
-        self._defaults['GetLastExtCalLastDateAndTime']['lastCalDatetime'] = None
-        self._defaults['GetLastSelfCalLastDateAndTime'] = {}
-        self._defaults['GetLastSelfCalLastDateAndTime']['return'] = 0
-        self._defaults['GetLastSelfCalLastDateAndTime']['lastCalDatetime'] = None
         self._defaults['GetSelfCalLastDateAndTime'] = {}
         self._defaults['GetSelfCalLastDateAndTime']['return'] = 0
         self._defaults['GetSelfCalLastDateAndTime']['year'] = None
@@ -539,26 +533,6 @@ class SideEffectsHelper(object):
             state.contents.value = self._defaults['GetHardwareState']['state']
         return self._defaults['GetHardwareState']['return']
 
-    def niFgen_GetLastExtCalLastDateAndTime(self, vi, last_cal_datetime):  # noqa: N802
-        if self._defaults['GetLastExtCalLastDateAndTime']['return'] != 0:
-            return self._defaults['GetLastExtCalLastDateAndTime']['return']
-        # last_cal_datetime
-        if self._defaults['GetLastExtCalLastDateAndTime']['lastCalDatetime'] is None:
-            raise MockFunctionCallError("niFgen_GetLastExtCalLastDateAndTime", param='lastCalDatetime')
-        if last_cal_datetime is not None:
-            last_cal_datetime.contents.value = self._defaults['GetLastExtCalLastDateAndTime']['lastCalDatetime']
-        return self._defaults['GetLastExtCalLastDateAndTime']['return']
-
-    def niFgen_GetLastSelfCalLastDateAndTime(self, vi, last_cal_datetime):  # noqa: N802
-        if self._defaults['GetLastSelfCalLastDateAndTime']['return'] != 0:
-            return self._defaults['GetLastSelfCalLastDateAndTime']['return']
-        # last_cal_datetime
-        if self._defaults['GetLastSelfCalLastDateAndTime']['lastCalDatetime'] is None:
-            raise MockFunctionCallError("niFgen_GetLastSelfCalLastDateAndTime", param='lastCalDatetime')
-        if last_cal_datetime is not None:
-            last_cal_datetime.contents.value = self._defaults['GetLastSelfCalLastDateAndTime']['lastCalDatetime']
-        return self._defaults['GetLastSelfCalLastDateAndTime']['return']
-
     def niFgen_GetSelfCalLastDateAndTime(self, vi, year, month, day, hour, minute):  # noqa: N802
         if self._defaults['GetSelfCalLastDateAndTime']['return'] != 0:
             return self._defaults['GetSelfCalLastDateAndTime']['return']
@@ -956,10 +930,6 @@ class SideEffectsHelper(object):
         mock_library.niFgen_GetExtCalRecommendedInterval.return_value = 0
         mock_library.niFgen_GetHardwareState.side_effect = MockFunctionCallError("niFgen_GetHardwareState")
         mock_library.niFgen_GetHardwareState.return_value = 0
-        mock_library.niFgen_GetLastExtCalLastDateAndTime.side_effect = MockFunctionCallError("niFgen_GetLastExtCalLastDateAndTime")
-        mock_library.niFgen_GetLastExtCalLastDateAndTime.return_value = 0
-        mock_library.niFgen_GetLastSelfCalLastDateAndTime.side_effect = MockFunctionCallError("niFgen_GetLastSelfCalLastDateAndTime")
-        mock_library.niFgen_GetLastSelfCalLastDateAndTime.return_value = 0
         mock_library.niFgen_GetSelfCalLastDateAndTime.side_effect = MockFunctionCallError("niFgen_GetSelfCalLastDateAndTime")
         mock_library.niFgen_GetSelfCalLastDateAndTime.return_value = 0
         mock_library.niFgen_GetSelfCalLastTemp.side_effect = MockFunctionCallError("niFgen_GetSelfCalLastTemp")

--- a/src/nifgen/metadata/functions.py
+++ b/src/nifgen/metadata/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FGEN API metadata version 21.5.0d106
+# This file is generated from NI-FGEN API metadata version 22.0.0d9999
 functions = {
     'AbortGeneration': {
         'documentation': {
@@ -1734,7 +1734,7 @@ functions = {
                 'documentation': {
                     'description': 'Indicates date and time of the last calibration.'
                 },
-                'name': 'month',
+                'name': 'lastCalDatetime',
                 'type': 'hightime.datetime'
             }
         ],
@@ -1768,7 +1768,7 @@ functions = {
                 'documentation': {
                     'description': 'Returns the date and time the device was last calibrated.'
                 },
-                'name': 'month',
+                'name': 'lastCalDatetime',
                 'type': 'hightime.datetime'
             }
         ],

--- a/src/nifgen/metadata/functions.py
+++ b/src/nifgen/metadata/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FGEN API metadata version 22.0.0d9999
+# This file is generated from NI-FGEN API metadata version 22.0.0d76
 functions = {
     'AbortGeneration': {
         'documentation': {
@@ -1709,7 +1709,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'GetLastExtCalLastDateAndTime': {
-        'codegen_method': 'public',
+        'codegen_method': 'python-only',
         'documentation': {
             'description': 'Returns the date and time of the last successful external calibration. The time returned is 24-hour (military) local time; for example, if the device was calibrated at 2:30 PM, this function returns 14 for the **hour** parameter and 30 for the **minute** parameter.'
         },
@@ -1743,7 +1743,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'GetLastSelfCalLastDateAndTime': {
-        'codegen_method': 'public',
+        'codegen_method': 'python-only',
         'documentation': {
             'description': 'Returns the date and time of the last successful self-calibration.'
         },


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

~~- [ ] I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

This pull request fixes a documentation issue where some functions in NI-FGEN that returned calibration dates returned `month` instead of `last_cal_datetime`. This has been updated to be consistent with SCOPE and DC-Power. 

### List issues fixed by this Pull Request below, if any.

Part of fix for issue "The return value of get_date_and_time() related function(s) across drivers should be consistently named"

### What testing has been done?

Confirmed that generated files show `last_cal_datetime` as the return value instead of `month`.
