### PR TITLE
Enable system tests for new modules on RHEL

### DIFF
--- a/.github/workflows/github_actions_aws_rhel_python64.yml
+++ b/.github/workflows/github_actions_aws_rhel_python64.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 40
     strategy:
       matrix:
-        module_name: ["nidmm", "niswitch"]
+        module_name: ["nidcpower", "nidmm", "nifgen", "niscope", "niswitch"]
     steps:
       - name: checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Add `nidcpower`, `nifgen`, and `niscope` to the list of modules, for which system tests are run on RHEL.

### List issues fixed by this Pull Request below, if any.

* Fix #1701
* Fixes #1669 partially

### What testing has been done?

System tests that run as part of the PR build