### PR TITLE
NI-DCPower: Enable simple LCR metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
     * #### Removed
 * ### `nidcpower` (NI-DCPower)
     * #### Added
-        * API parity with NI-DCPower 21.8.0.
+        * Partial API parity with NI-DCPower 21.8.0.
             * Properties added:
                 * `instrument_mode`
                 * `lcr_current_amplitude`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@ All notable changes to this project will be documented in this file.
     * #### Removed
 * ### `nidcpower` (NI-DCPower)
     * #### Added
+        * API parity with NI-DCPower 21.8.0.
+            * Properties added:
+                * `instrument_mode`
+                * `lcr_current_amplitude`
+                * `lcr_frequency`
+                * `lcr_stimulus_function`
+                * `lcr_voltage_amplitude`
+            * Enums added:
+                * `InstrumentMode`
+                * `LCRStimulusFunction`
     * #### Changed
         * Updated supported devices information in documentation for methods and properties
     * #### Removed

--- a/docs/nidcpower/class.rst
+++ b/docs/nidcpower/class.rst
@@ -3970,6 +3970,45 @@ instrument_manufacturer
                 - LabVIEW Property: **Inherent IVI Attributes:Instrument Identification:Manufacturer**
                 - C Attribute: **NIDCPOWER_ATTR_INSTRUMENT_MANUFACTURER**
 
+instrument_mode
+---------------
+
+    .. py:attribute:: instrument_mode
+
+        Specifies the mode of operation for an instrument channel for instruments that support multiple modes.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].instrument_mode`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.instrument_mode`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+----------------------+
+            | Characteristic        | Value                |
+            +=======================+======================+
+            | Datatype              | enums.InstrumentMode |
+            +-----------------------+----------------------+
+            | Permissions           | read-write           |
+            +-----------------------+----------------------+
+            | Repeated Capabilities | channels             |
+            +-----------------------+----------------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **LCR:Instrument Mode**
+                - C Attribute: **NIDCPOWER_ATTR_INSTRUMENT_MODE**
+
 instrument_model
 ----------------
 
@@ -4074,6 +4113,164 @@ io_resource_descriptor
 
                 - LabVIEW Property: **Inherent IVI Attributes:Advanced Session Information:Resource Descriptor**
                 - C Attribute: **NIDCPOWER_ATTR_IO_RESOURCE_DESCRIPTOR**
+
+lcr_current_amplitude
+---------------------
+
+    .. py:attribute:: lcr_current_amplitude
+
+        Specifies the amplitude, in amps RMS, of the AC current test signal applied to the DUT for LCR measurements.
+        This property applies when the :py:attr:`nidcpower.Session.lcr_stimulus_function` property is set to :py:data:`~nidcpower.LCRStimulusFunction.CURRENT`.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].lcr_current_amplitude`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.lcr_current_amplitude`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **LCR:AC Stimulus:Current Amplitude**
+                - C Attribute: **NIDCPOWER_ATTR_LCR_CURRENT_AMPLITUDE**
+
+lcr_frequency
+-------------
+
+    .. py:attribute:: lcr_frequency
+
+        Specifies the frequency of the AC test signal applied to the DUT for LCR measurements.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].lcr_frequency`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.lcr_frequency`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **LCR:AC Stimulus:Frequency**
+                - C Attribute: **NIDCPOWER_ATTR_LCR_FREQUENCY**
+
+lcr_stimulus_function
+---------------------
+
+    .. py:attribute:: lcr_stimulus_function
+
+        Specifies the type of test signal to apply to the DUT for LCR measurements.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].lcr_stimulus_function`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.lcr_stimulus_function`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+---------------------------+
+            | Characteristic        | Value                     |
+            +=======================+===========================+
+            | Datatype              | enums.LCRStimulusFunction |
+            +-----------------------+---------------------------+
+            | Permissions           | read-write                |
+            +-----------------------+---------------------------+
+            | Repeated Capabilities | channels                  |
+            +-----------------------+---------------------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **LCR:AC Stimulus:Function**
+                - C Attribute: **NIDCPOWER_ATTR_LCR_STIMULUS_FUNCTION**
+
+lcr_voltage_amplitude
+---------------------
+
+    .. py:attribute:: lcr_voltage_amplitude
+
+        Specifies the amplitude, in V RMS, of the AC voltage test signal applied to the DUT for LCR measurements.
+        This property applies when the :py:attr:`nidcpower.Session.lcr_stimulus_function` property is set to :py:data:`~nidcpower.LCRStimulusFunction.VOLTAGE`.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].lcr_voltage_amplitude`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.lcr_voltage_amplitude`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **LCR:AC Stimulus:Voltage Amplitude**
+                - C Attribute: **NIDCPOWER_ATTR_LCR_VOLTAGE_AMPLITUDE**
 
 logical_name
 ------------

--- a/docs/nidcpower/enums.rst
+++ b/docs/nidcpower/enums.rst
@@ -260,6 +260,56 @@ Event
 
 
 
+InstrumentMode
+--------------
+
+.. py:class:: InstrumentMode
+
+    .. py:attribute:: InstrumentMode.SMU_PS
+
+
+
+        The channel operates as an SMU/power supply.
+
+        
+
+
+
+    .. py:attribute:: InstrumentMode.LCR
+
+
+
+        The channel operates as an LCR meter.
+
+        
+
+
+
+LCRStimulusFunction
+-------------------
+
+.. py:class:: LCRStimulusFunction
+
+    .. py:attribute:: LCRStimulusFunction.VOLTAGE
+
+
+
+        Applies an AC voltage for LCR stimulus.
+
+        
+
+
+
+    .. py:attribute:: LCRStimulusFunction.CURRENT
+
+
+
+        Applies an AC current for LCR stimulus.
+
+        
+
+
+
 MeasureWhen
 -----------
 

--- a/generated/nidcpower/nidcpower/enums.py
+++ b/generated/nidcpower/nidcpower/enums.py
@@ -110,6 +110,28 @@ class Event(Enum):
     READY_FOR_PULSE_TRIGGER = 1052
 
 
+class InstrumentMode(Enum):
+    SMU_PS = 1061
+    r'''
+    The channel operates as an SMU/power supply.
+    '''
+    LCR = 1062
+    r'''
+    The channel operates as an LCR meter.
+    '''
+
+
+class LCRStimulusFunction(Enum):
+    VOLTAGE = 1063
+    r'''
+    Applies an AC voltage for LCR stimulus.
+    '''
+    CURRENT = 1064
+    r'''
+    Applies an AC current for LCR stimulus.
+    '''
+
+
 class MeasureWhen(Enum):
     AUTOMATICALLY_AFTER_SOURCE_COMPLETE = 1025
     r'''

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -976,6 +976,24 @@ class _SessionBase(object):
 
     Example: :py:attr:`my_session.instrument_manufacturer`
     '''
+    instrument_mode = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.InstrumentMode, 1150208)
+    '''Type: enums.InstrumentMode
+
+    Specifies the mode of operation for an instrument channel for instruments that support multiple modes.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].instrument_mode`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.instrument_mode`
+    '''
     instrument_model = _attributes.AttributeViString(1050512)
     '''Type: str
 
@@ -1017,6 +1035,80 @@ class _SessionBase(object):
     Indicates the resource descriptor NI-DCPower uses to identify the physical device.
     If you initialize NI-DCPower with a logical name, this property contains the resource descriptor that corresponds to the entry in the IVI Configuration utility.
     If you initialize NI-DCPower with the resource descriptor, this property contains that value.
+    '''
+    lcr_current_amplitude = _attributes.AttributeViReal64(1150212)
+    '''Type: float
+
+    Specifies the amplitude, in amps RMS, of the AC current test signal applied to the DUT for LCR measurements.
+    This property applies when the lcr_stimulus_function property is set to LCRStimulusFunction.CURRENT.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].lcr_current_amplitude`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.lcr_current_amplitude`
+    '''
+    lcr_frequency = _attributes.AttributeViReal64(1150210)
+    '''Type: float
+
+    Specifies the frequency of the AC test signal applied to the DUT for LCR measurements.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].lcr_frequency`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.lcr_frequency`
+    '''
+    lcr_stimulus_function = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.LCRStimulusFunction, 1150209)
+    '''Type: enums.LCRStimulusFunction
+
+    Specifies the type of test signal to apply to the DUT for LCR measurements.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].lcr_stimulus_function`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.lcr_stimulus_function`
+    '''
+    lcr_voltage_amplitude = _attributes.AttributeViReal64(1150211)
+    '''Type: float
+
+    Specifies the amplitude, in V RMS, of the AC voltage test signal applied to the DUT for LCR measurements.
+    This property applies when the lcr_stimulus_function property is set to LCRStimulusFunction.VOLTAGE.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].lcr_voltage_amplitude`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.lcr_voltage_amplitude`
     '''
     logical_name = _attributes.AttributeViString(1050305)
     '''Type: str

--- a/src/nidcpower/metadata/attributes_addon.py
+++ b/src/nidcpower/metadata/attributes_addon.py
@@ -4,11 +4,6 @@
 attributes_override_metadata = {
     # TODO(olsl21): Temporarily disable the new attributes (#1715), they will be re-enabled in
     #  subsequent smaller PRs
-    1150208: {"codegen_method": "no"},
-    1150209: {"codegen_method": "no"},
-    1150210: {"codegen_method": "no"},
-    1150211: {"codegen_method": "no"},
-    1150212: {"codegen_method": "no"},
     1150213: {"codegen_method": "no"},
     1150214: {"codegen_method": "no"},
     1150215: {"codegen_method": "no"},

--- a/src/nidcpower/metadata/enums_addon.py
+++ b/src/nidcpower/metadata/enums_addon.py
@@ -6,7 +6,6 @@ enums_override_metadata = {
     #  subsequent smaller PRs
     "ApertureTimeAutoMode": {"codegen_method": "no"},
     "CableLength": {"codegen_method": "no"},
-    "InstrumentMode": {"codegen_method": "no"},
     "IsolationState": {"codegen_method": "no"},
     "LCRCompensationType": {"codegen_method": "no"},
     "LCRDCBiasSource": {"codegen_method": "no"},
@@ -14,7 +13,6 @@ enums_override_metadata = {
     "LCRMeasurementTime": {"codegen_method": "no"},
     "LCROpenShortLoadCompensationDataSource": {"codegen_method": "no"},
     "LCRReferenceValueType": {"codegen_method": "no"},
-    "LCRSourceDelayMode": {"codegen_method": "no"},
-    "LCRStimulusFunction": {"codegen_method": "no"}
+    "LCRSourceDelayMode": {"codegen_method": "no"}
 }
 

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -724,22 +724,3 @@ def test_wait_for_event_repeated_capabilities(session, channels):
     channels_session = session.channels[channels]
     with channels_session.initiate():
         channels_session.wait_for_event(nidcpower.Event.SOURCE_COMPLETE)
-
-
-@pytest.mark.resource_name("4190/0")
-@pytest.mark.options("Simulate=1, DriverSetup=Model:4190; BoardType:PXIe")
-def test_lcr_attributes(session):
-    session.instrument_mode = nidcpower.InstrumentMode.LCR
-    session.lcr_frequency = 10_000.0
-    assert session.instrument_mode == nidcpower.InstrumentMode.LCR
-    assert session.lcr_frequency == 10_000.0
-
-    session.lcr_stimulus_function = nidcpower.LCRStimulusFunction.VOLTAGE
-    session.lcr_voltage_amplitude = 0.7
-    assert session.lcr_stimulus_function == nidcpower.LCRStimulusFunction.VOLTAGE
-    assert session.lcr_voltage_amplitude == 0.7
-
-    session.lcr_stimulus_function = nidcpower.LCRStimulusFunction.CURRENT
-    session.lcr_current_amplitude = 700.0e-6
-    assert session.lcr_stimulus_function == nidcpower.LCRStimulusFunction.CURRENT
-    assert session.lcr_current_amplitude == 700.0e-6

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -724,3 +724,22 @@ def test_wait_for_event_repeated_capabilities(session, channels):
     channels_session = session.channels[channels]
     with channels_session.initiate():
         channels_session.wait_for_event(nidcpower.Event.SOURCE_COMPLETE)
+
+
+@pytest.mark.resource_name("4190/0")
+@pytest.mark.options("Simulate=1, DriverSetup=Model:4190; BoardType:PXIe")
+def test_lcr_attributes(session):
+    session.instrument_mode = nidcpower.InstrumentMode.LCR
+    session.lcr_frequency = 10_000.0
+    assert session.instrument_mode == nidcpower.InstrumentMode.LCR
+    assert session.lcr_frequency == 10_000.0
+
+    session.lcr_stimulus_function = nidcpower.LCRStimulusFunction.VOLTAGE
+    session.lcr_voltage_amplitude = 0.7
+    assert session.lcr_stimulus_function == nidcpower.LCRStimulusFunction.VOLTAGE
+    assert session.lcr_voltage_amplitude == 0.7
+
+    session.lcr_stimulus_function = nidcpower.LCRStimulusFunction.CURRENT
+    session.lcr_current_amplitude = 700.0e-6
+    assert session.lcr_stimulus_function == nidcpower.LCRStimulusFunction.CURRENT
+    assert session.lcr_current_amplitude == 700.0e-6


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

- Enable simple LCR attributes and associated enums
  - Properties added:
      - `instrument_mode`
      - `lcr_current_amplitude`
      - `lcr_frequency`
      - `lcr_stimulus_function`
      - `lcr_voltage_amplitude`
  - Enums added:
      - `InstrumentMode`
      - `LCRStimulusFunction`
- Update CHANGELOG.md

### What testing has been done?

Locally added system tests passed.
```
test_lcr_attributes[True] PASSED
148 passed, 5 skipped in 16.42s
```

### Additional Info

This PR is part of a series of PRs to enable all the new LCR metadata.