### PR TITLE
NI-DCPower: Enable LCR time and delay metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,15 +39,20 @@ All notable changes to this project will be documented in this file.
             * Properties added:
                 * `instrument_mode`
                 * `lcr_current_amplitude`
+                * `lcr_custom_measurement_time`
                 * `lcr_dc_bias_current_level`
                 * `lcr_dc_bias_source`
                 * `lcr_dc_bias_voltage_level`
                 * `lcr_frequency`
+                * `lcr_measurement_time`
+                * `lcr_source_delay_mode`
                 * `lcr_stimulus_function`
                 * `lcr_voltage_amplitude`
             * Enums added:
                 * `InstrumentMode`
                 * `LCRDCBiasSource`
+                * `LCRMeasurementTime`
+                * `LCRSourceDelayMode`
                 * `LCRStimulusFunction`
     * #### Changed
         * Updated supported devices information in documentation for methods and properties

--- a/docs/nidcpower/class.rst
+++ b/docs/nidcpower/class.rst
@@ -4154,6 +4154,46 @@ lcr_current_amplitude
                 - LabVIEW Property: **LCR:AC Stimulus:Current Amplitude**
                 - C Attribute: **NIDCPOWER_ATTR_LCR_CURRENT_AMPLITUDE**
 
+lcr_custom_measurement_time
+---------------------------
+
+    .. py:attribute:: lcr_custom_measurement_time
+
+        Specifies the LCR measurement aperture time for a channel, in seconds,
+        when the :py:attr:`nidcpower.Session.lcr_measurement_time` property is set to :py:data:`~nidcpower.LCRMeasurementTime.CUSTOM`.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].lcr_custom_measurement_time`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.lcr_custom_measurement_time`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+-------------------------------------------------------------+
+            | Characteristic        | Value                                                       |
+            +=======================+=============================================================+
+            | Datatype              | hightime.timedelta, datetime.timedelta, or float in seconds |
+            +-----------------------+-------------------------------------------------------------+
+            | Permissions           | read-write                                                  |
+            +-----------------------+-------------------------------------------------------------+
+            | Repeated Capabilities | channels                                                    |
+            +-----------------------+-------------------------------------------------------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **LCR:Custom Measurement Time**
+                - C Attribute: **NIDCPOWER_ATTR_LCR_CUSTOM_MEASUREMENT_TIME**
+
 lcr_dc_bias_current_level
 -------------------------
 
@@ -4309,6 +4349,90 @@ lcr_frequency
 
                 - LabVIEW Property: **LCR:AC Stimulus:Frequency**
                 - C Attribute: **NIDCPOWER_ATTR_LCR_FREQUENCY**
+
+lcr_measurement_time
+--------------------
+
+    .. py:attribute:: lcr_measurement_time
+
+        Selects a general aperture time profile for LCR measurements. The actual duration of each profile depends on the frequency of the LCR test signal.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].lcr_measurement_time`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.lcr_measurement_time`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+--------------------------+
+            | Characteristic        | Value                    |
+            +=======================+==========================+
+            | Datatype              | enums.LCRMeasurementTime |
+            +-----------------------+--------------------------+
+            | Permissions           | read-write               |
+            +-----------------------+--------------------------+
+            | Repeated Capabilities | channels                 |
+            +-----------------------+--------------------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **LCR:Measurement Time**
+                - C Attribute: **NIDCPOWER_ATTR_LCR_MEASUREMENT_TIME**
+
+lcr_source_delay_mode
+---------------------
+
+    .. py:attribute:: lcr_source_delay_mode
+
+        For instruments in LCR mode, determines whether NI-DCPower automatically calculates and applies the source delay or applies a source delay you set manually.
+
+        You can return the source delay duration for either option by reading :py:attr:`nidcpower.Session.source_delay`.
+
+        When you use this property to manually set the source delay, it is possible to set source delays short enough to unbalance the bridge and affect measurement accuracy. LCR measurement methods report whether the bridge is unbalanced.
+
+        Default Value: :py:data:`~nidcpower.LCRSourceDelayMode.AUTOMATIC`
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].lcr_source_delay_mode`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.lcr_source_delay_mode`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+--------------------------+
+            | Characteristic        | Value                    |
+            +=======================+==========================+
+            | Datatype              | enums.LCRSourceDelayMode |
+            +-----------------------+--------------------------+
+            | Permissions           | read-write               |
+            +-----------------------+--------------------------+
+            | Repeated Capabilities | channels                 |
+            +-----------------------+--------------------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **LCR:Source Delay Mode**
+                - C Attribute: **NIDCPOWER_ATTR_LCR_SOURCE_DELAY_MODE**
 
 lcr_stimulus_function
 ---------------------

--- a/docs/nidcpower/enums.rst
+++ b/docs/nidcpower/enums.rst
@@ -320,6 +320,76 @@ LCRDCBiasSource
 
 
 
+LCRMeasurementTime
+------------------
+
+.. py:class:: LCRMeasurementTime
+
+    .. py:attribute:: LCRMeasurementTime.SHORT
+
+
+
+        Uses a short aperture time for LCR measurements.
+
+        
+
+
+
+    .. py:attribute:: LCRMeasurementTime.MEDIUM
+
+
+
+        Uses a medium aperture time for LCR measurements.
+
+        
+
+
+
+    .. py:attribute:: LCRMeasurementTime.LONG
+
+
+
+        Uses a long aperture time for LCR measurements.
+
+        
+
+
+
+    .. py:attribute:: LCRMeasurementTime.CUSTOM
+
+
+
+        Uses a custom aperture time for LCR measurements as specified by the :py:attr:`nidcpower.Session.lcr_custom_measurement_time` property.
+
+        
+
+
+
+LCRSourceDelayMode
+------------------
+
+.. py:class:: LCRSourceDelayMode
+
+    .. py:attribute:: LCRSourceDelayMode.AUTOMATIC
+
+
+
+        NI-DCPower automatically applies source delay of sufficient duration to account for settling time.
+
+        
+
+
+
+    .. py:attribute:: LCRSourceDelayMode.MANUAL
+
+
+
+        NI-DCPower applies the source delay that you set manually with :py:attr:`nidcpower.Session.source_delay`. You can use this option to set a shorter delay to reduce measurement time at the possible expense of measurement accuracy.
+
+        
+
+
+
 LCRStimulusFunction
 -------------------
 

--- a/generated/nidcpower/nidcpower/enums.py
+++ b/generated/nidcpower/nidcpower/enums.py
@@ -136,6 +136,36 @@ class LCRDCBiasSource(Enum):
     '''
 
 
+class LCRMeasurementTime(Enum):
+    SHORT = 1071
+    r'''
+    Uses a short aperture time for LCR measurements.
+    '''
+    MEDIUM = 1072
+    r'''
+    Uses a medium aperture time for LCR measurements.
+    '''
+    LONG = 1073
+    r'''
+    Uses a long aperture time for LCR measurements.
+    '''
+    CUSTOM = 1117
+    r'''
+    Uses a custom aperture time for LCR measurements as specified by the lcr_custom_measurement_time property.
+    '''
+
+
+class LCRSourceDelayMode(Enum):
+    AUTOMATIC = 1144
+    r'''
+    NI-DCPower automatically applies source delay of sufficient duration to account for settling time.
+    '''
+    MANUAL = 1145
+    r'''
+    NI-DCPower applies the source delay that you set manually with source_delay. You can use this option to set a shorter delay to reduce measurement time at the possible expense of measurement accuracy.
+    '''
+
+
 class LCRStimulusFunction(Enum):
     VOLTAGE = 1063
     r'''

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -1055,6 +1055,25 @@ class _SessionBase(object):
 
     Example: :py:attr:`my_session.lcr_current_amplitude`
     '''
+    lcr_custom_measurement_time = _attributes.AttributeViReal64TimeDeltaSeconds(1150258)
+    '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
+
+    Specifies the LCR measurement aperture time for a channel, in seconds,
+    when the lcr_measurement_time property is set to LCRMeasurementTime.CUSTOM.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].lcr_custom_measurement_time`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.lcr_custom_measurement_time`
+    '''
     lcr_dc_bias_current_level = _attributes.AttributeViReal64(1150215)
     '''Type: float
 
@@ -1126,6 +1145,48 @@ class _SessionBase(object):
     To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
 
     Example: :py:attr:`my_session.lcr_frequency`
+    '''
+    lcr_measurement_time = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.LCRMeasurementTime, 1150218)
+    '''Type: enums.LCRMeasurementTime
+
+    Selects a general aperture time profile for LCR measurements. The actual duration of each profile depends on the frequency of the LCR test signal.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].lcr_measurement_time`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.lcr_measurement_time`
+    '''
+    lcr_source_delay_mode = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.LCRSourceDelayMode, 1150315)
+    '''Type: enums.LCRSourceDelayMode
+
+    For instruments in LCR mode, determines whether NI-DCPower automatically calculates and applies the source delay or applies a source delay you set manually.
+
+    You can return the source delay duration for either option by reading source_delay.
+
+    When you use this property to manually set the source delay, it is possible to set source delays short enough to unbalance the bridge and affect measurement accuracy. LCR measurement methods report whether the bridge is unbalanced.
+
+    Default Value: LCRSourceDelayMode.AUTOMATIC
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].lcr_source_delay_mode`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.lcr_source_delay_mode`
     '''
     lcr_stimulus_function = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.LCRStimulusFunction, 1150209)
     '''Type: enums.LCRStimulusFunction

--- a/src/nidcpower/metadata/attributes_addon.py
+++ b/src/nidcpower/metadata/attributes_addon.py
@@ -5,12 +5,10 @@ attributes_override_metadata = {
     # TODO(olsl21): Temporarily disable the new attributes (#1715), they will be re-enabled in
     #  subsequent smaller PRs
     1150217: {"codegen_method": "no"},
-    1150218: {"codegen_method": "no"},
     1150220: {"codegen_method": "no"},
     1150221: {"codegen_method": "no"},
     1150222: {"codegen_method": "no"},
     1150223: {"codegen_method": "no"},
-    1150258: {"codegen_method": "no"},
     1150261: {"codegen_method": "no"},
     1150262: {"codegen_method": "no"},
     1150263: {"codegen_method": "no"},
@@ -25,7 +23,6 @@ attributes_override_metadata = {
     1150299: {"codegen_method": "no"},
     1150302: {"codegen_method": "no"},
     1150314: {"codegen_method": "no"},
-    1150315: {"codegen_method": "no"},
     1150318: {"codegen_method": "no"},
     1150319: {"codegen_method": "no"},
     1150320: {"codegen_method": "no"},

--- a/src/nidcpower/metadata/enums_addon.py
+++ b/src/nidcpower/metadata/enums_addon.py
@@ -9,9 +9,7 @@ enums_override_metadata = {
     "IsolationState": {"codegen_method": "no"},
     "LCRCompensationType": {"codegen_method": "no"},
     "LCRImpedanceRangeSource": {"codegen_method": "no"},
-    "LCRMeasurementTime": {"codegen_method": "no"},
     "LCROpenShortLoadCompensationDataSource": {"codegen_method": "no"},
-    "LCRReferenceValueType": {"codegen_method": "no"},
-    "LCRSourceDelayMode": {"codegen_method": "no"}
+    "LCRReferenceValueType": {"codegen_method": "no"}
 }
 

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -724,15 +724,3 @@ def test_wait_for_event_repeated_capabilities(session, channels):
     channels_session = session.channels[channels]
     with channels_session.initiate():
         channels_session.wait_for_event(nidcpower.Event.SOURCE_COMPLETE)
-
-
-@pytest.mark.resource_name("4190/0")
-@pytest.mark.options("Simulate=1, DriverSetup=Model:4190; BoardType:PXIe")
-def test_lcr_attributes(session):
-    session.lcr_measurement_time = nidcpower.LCRMeasurementTime.CUSTOM
-    session.lcr_custom_measurement_time = 0.003
-    assert session.lcr_measurement_time == nidcpower.LCRMeasurementTime.CUSTOM
-    assert session.lcr_custom_measurement_time == hightime.timedelta(seconds=0.003)
-
-    session.lcr_source_delay_mode = nidcpower.LCRSourceDelayMode.MANUAL
-    assert session.lcr_source_delay_mode == nidcpower.LCRSourceDelayMode.MANUAL

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -724,3 +724,15 @@ def test_wait_for_event_repeated_capabilities(session, channels):
     channels_session = session.channels[channels]
     with channels_session.initiate():
         channels_session.wait_for_event(nidcpower.Event.SOURCE_COMPLETE)
+
+
+@pytest.mark.resource_name("4190/0")
+@pytest.mark.options("Simulate=1, DriverSetup=Model:4190; BoardType:PXIe")
+def test_lcr_attributes(session):
+    session.lcr_measurement_time = nidcpower.LCRMeasurementTime.CUSTOM
+    session.lcr_custom_measurement_time = 0.003
+    assert session.lcr_measurement_time == nidcpower.LCRMeasurementTime.CUSTOM
+    assert session.lcr_custom_measurement_time == hightime.timedelta(seconds=0.003)
+
+    session.lcr_source_delay_mode = nidcpower.LCRSourceDelayMode.MANUAL
+    assert session.lcr_source_delay_mode == nidcpower.LCRSourceDelayMode.MANUAL


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

- Enable LCR measurement time and source delay related attributes and associated enums
- Update CHANGELOG.md

### What testing has been done?

Locally added system tests passed.
```
test_lcr_attributes[True] PASSED
148 passed, 5 skipped in 15.23s
```

### Additional Info

This PR is part of a series of PRs to enable all the new LCR metadata.