### PR TITLE
NI-DCPower: Enable LCR DC bias metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,11 +39,15 @@ All notable changes to this project will be documented in this file.
             * Properties added:
                 * `instrument_mode`
                 * `lcr_current_amplitude`
+                * `lcr_dc_bias_current_level`
+                * `lcr_dc_bias_source`
+                * `lcr_dc_bias_voltage_level`
                 * `lcr_frequency`
                 * `lcr_stimulus_function`
                 * `lcr_voltage_amplitude`
             * Enums added:
                 * `InstrumentMode`
+                * `LCRDCBiasSource`
                 * `LCRStimulusFunction`
     * #### Changed
         * Updated supported devices information in documentation for methods and properties

--- a/docs/nidcpower/class.rst
+++ b/docs/nidcpower/class.rst
@@ -4154,6 +4154,123 @@ lcr_current_amplitude
                 - LabVIEW Property: **LCR:AC Stimulus:Current Amplitude**
                 - C Attribute: **NIDCPOWER_ATTR_LCR_CURRENT_AMPLITUDE**
 
+lcr_dc_bias_current_level
+-------------------------
+
+    .. py:attribute:: lcr_dc_bias_current_level
+
+        Specifies the DC bias current level, in amps, when the :py:attr:`nidcpower.Session.lcr_dc_bias_source` property is set to :py:data:`~nidcpower.LCRDCBiasSource.CURRENT`.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].lcr_dc_bias_current_level`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.lcr_dc_bias_current_level`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **LCR:DC Bias:Current Level**
+                - C Attribute: **NIDCPOWER_ATTR_LCR_DC_BIAS_CURRENT_LEVEL**
+
+lcr_dc_bias_source
+------------------
+
+    .. py:attribute:: lcr_dc_bias_source
+
+        Specifies how to apply DC bias for LCR measurements.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].lcr_dc_bias_source`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.lcr_dc_bias_source`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+-----------------------+
+            | Characteristic        | Value                 |
+            +=======================+=======================+
+            | Datatype              | enums.LCRDCBiasSource |
+            +-----------------------+-----------------------+
+            | Permissions           | read-write            |
+            +-----------------------+-----------------------+
+            | Repeated Capabilities | channels              |
+            +-----------------------+-----------------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **LCR:DC Bias:Source**
+                - C Attribute: **NIDCPOWER_ATTR_LCR_DC_BIAS_SOURCE**
+
+lcr_dc_bias_voltage_level
+-------------------------
+
+    .. py:attribute:: lcr_dc_bias_voltage_level
+
+        Specifies the DC bias voltage level, in volts, when the :py:attr:`nidcpower.Session.lcr_dc_bias_source` property is set to :py:data:`~nidcpower.LCRDCBiasSource.VOLTAGE`.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].lcr_dc_bias_voltage_level`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.lcr_dc_bias_voltage_level`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **LCR:DC Bias:Voltage Level**
+                - C Attribute: **NIDCPOWER_ATTR_LCR_DC_BIAS_VOLTAGE_LEVEL**
+
 lcr_frequency
 -------------
 

--- a/docs/nidcpower/enums.rst
+++ b/docs/nidcpower/enums.rst
@@ -316,6 +316,7 @@ LCRDCBiasSource
 
         Applies a constant current bias, as defined by the :py:attr:`nidcpower.Session.lcr_dc_bias_current_level` property.
 
+        
 
 
 

--- a/docs/nidcpower/enums.rst
+++ b/docs/nidcpower/enums.rst
@@ -285,6 +285,40 @@ InstrumentMode
 
 
 
+LCRDCBiasSource
+---------------
+
+.. py:class:: LCRDCBiasSource
+
+    .. py:attribute:: LCRDCBiasSource.OFF
+
+
+
+        Disables DC bias in LCR mode.
+
+        
+
+
+
+    .. py:attribute:: LCRDCBiasSource.VOLTAGE
+
+
+
+        Applies a constant voltage bias, as defined by the :py:attr:`nidcpower.Session.lcr_dc_bias_voltage_level` property.
+
+        
+
+
+
+    .. py:attribute:: LCRDCBiasSource.CURRENT
+
+
+
+        Applies a constant current bias, as defined by the :py:attr:`nidcpower.Session.lcr_dc_bias_current_level` property.
+
+
+
+
 LCRStimulusFunction
 -------------------
 

--- a/generated/nidcpower/nidcpower/enums.py
+++ b/generated/nidcpower/nidcpower/enums.py
@@ -121,6 +121,21 @@ class InstrumentMode(Enum):
     '''
 
 
+class LCRDCBiasSource(Enum):
+    OFF = 1065
+    r'''
+    Disables DC bias in LCR mode.
+    '''
+    VOLTAGE = 1066
+    r'''
+    Applies a constant voltage bias, as defined by the lcr_dc_bias_voltage_level property.
+    '''
+    CURRENT = 1067
+    r'''
+    Applies a constant current bias, as defined by the lcr_dc_bias_current_level property.
+    '''
+
+
 class LCRStimulusFunction(Enum):
     VOLTAGE = 1063
     r'''

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -1055,6 +1055,60 @@ class _SessionBase(object):
 
     Example: :py:attr:`my_session.lcr_current_amplitude`
     '''
+    lcr_dc_bias_current_level = _attributes.AttributeViReal64(1150215)
+    '''Type: float
+
+    Specifies the DC bias current level, in amps, when the lcr_dc_bias_source property is set to LCRDCBiasSource.CURRENT.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].lcr_dc_bias_current_level`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.lcr_dc_bias_current_level`
+    '''
+    lcr_dc_bias_source = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.LCRDCBiasSource, 1150213)
+    '''Type: enums.LCRDCBiasSource
+
+    Specifies how to apply DC bias for LCR measurements.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].lcr_dc_bias_source`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.lcr_dc_bias_source`
+    '''
+    lcr_dc_bias_voltage_level = _attributes.AttributeViReal64(1150214)
+    '''Type: float
+
+    Specifies the DC bias voltage level, in volts, when the lcr_dc_bias_source property is set to LCRDCBiasSource.VOLTAGE.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].lcr_dc_bias_voltage_level`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.lcr_dc_bias_voltage_level`
+    '''
     lcr_frequency = _attributes.AttributeViReal64(1150210)
     '''Type: float
 

--- a/src/nidcpower/metadata/attributes_addon.py
+++ b/src/nidcpower/metadata/attributes_addon.py
@@ -4,9 +4,6 @@
 attributes_override_metadata = {
     # TODO(olsl21): Temporarily disable the new attributes (#1715), they will be re-enabled in
     #  subsequent smaller PRs
-    1150213: {"codegen_method": "no"},
-    1150214: {"codegen_method": "no"},
-    1150215: {"codegen_method": "no"},
     1150217: {"codegen_method": "no"},
     1150218: {"codegen_method": "no"},
     1150220: {"codegen_method": "no"},

--- a/src/nidcpower/metadata/enums_addon.py
+++ b/src/nidcpower/metadata/enums_addon.py
@@ -8,7 +8,6 @@ enums_override_metadata = {
     "CableLength": {"codegen_method": "no"},
     "IsolationState": {"codegen_method": "no"},
     "LCRCompensationType": {"codegen_method": "no"},
-    "LCRDCBiasSource": {"codegen_method": "no"},
     "LCRImpedanceRangeSource": {"codegen_method": "no"},
     "LCRMeasurementTime": {"codegen_method": "no"},
     "LCROpenShortLoadCompensationDataSource": {"codegen_method": "no"},

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -724,3 +724,18 @@ def test_wait_for_event_repeated_capabilities(session, channels):
     channels_session = session.channels[channels]
     with channels_session.initiate():
         channels_session.wait_for_event(nidcpower.Event.SOURCE_COMPLETE)
+
+
+@pytest.mark.resource_name("4190/0")
+@pytest.mark.options("Simulate=1, DriverSetup=Model:4190; BoardType:PXIe")
+def test_lcr_attributes(session):
+    session.lcr_dc_bias_source = nidcpower.LCRDCBiasSource.OFF
+    assert session.lcr_dc_bias_source == nidcpower.LCRDCBiasSource.OFF
+
+    session.lcr_dc_bias_source = nidcpower.LCRDCBiasSource.VOLTAGE
+    session.lcr_dc_bias_voltage_level = 0.5
+    assert session.lcr_dc_bias_voltage_level == 0.5
+
+    session.lcr_dc_bias_source = nidcpower.LCRDCBiasSource.CURRENT
+    session.lcr_dc_bias_current_level = 0.005
+    assert session.lcr_dc_bias_current_level == 0.005

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -724,18 +724,3 @@ def test_wait_for_event_repeated_capabilities(session, channels):
     channels_session = session.channels[channels]
     with channels_session.initiate():
         channels_session.wait_for_event(nidcpower.Event.SOURCE_COMPLETE)
-
-
-@pytest.mark.resource_name("4190/0")
-@pytest.mark.options("Simulate=1, DriverSetup=Model:4190; BoardType:PXIe")
-def test_lcr_attributes(session):
-    session.lcr_dc_bias_source = nidcpower.LCRDCBiasSource.OFF
-    assert session.lcr_dc_bias_source == nidcpower.LCRDCBiasSource.OFF
-
-    session.lcr_dc_bias_source = nidcpower.LCRDCBiasSource.VOLTAGE
-    session.lcr_dc_bias_voltage_level = 0.5
-    assert session.lcr_dc_bias_voltage_level == 0.5
-
-    session.lcr_dc_bias_source = nidcpower.LCRDCBiasSource.CURRENT
-    session.lcr_dc_bias_current_level = 0.005
-    assert session.lcr_dc_bias_current_level == 0.005


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

- Enable LCR DC bias related attributes and associated enums
- Add simple system test to set/get the newly added attributes
- Update CHANGELOG.md

### What testing has been done?

The newly added system tests passed.
```
test_lcr_attributes[True] PASSED
148 passed, 5 skipped in 15.17s
```

### Additional Info

This PR is part of a series of PRs to enable all the new LCR metadata.