### PR TITLE
Update nidigital metadata from internal metadata export

### DIFF
--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -2978,7 +2978,10 @@ class _SessionBase(object):
             site_numbers (list of int): The returned site numbers that correspond to data read from the digital pattern instrument using the specified repeated capabilities. If you do not want to use this parameter, pass VI_NULL.
 
             channel_indexes (list of int): The returned index of channels corresponding to data read from the digital pattern instrument using the specified repeated capabilities. If you do not want to use this parameter, pass VI_NULL.
-                Call get_channel_name to get the name of the channel associated with an index. Channel indexes are one-based.
+                Call GetChannelName to get the name of the channel associated with an index. Channel indexes are one-based.
+
+                Note:
+                One or more of the referenced methods are not in the Python API for this driver.
 
         '''
         vi_ctype = _visatype.ViSession(self._vi)  # case S110

--- a/generated/nidigital/nidigital/unit_tests/_mock_helper.py
+++ b/generated/nidigital/nidigital/unit_tests/_mock_helper.py
@@ -111,7 +111,7 @@ class SideEffectsHelper(object):
         self._defaults['GetAttributeViString']['value'] = None
         self._defaults['GetChannelNameFromString'] = {}
         self._defaults['GetChannelNameFromString']['return'] = 0
-        self._defaults['GetChannelNameFromString']['names'] = None
+        self._defaults['GetChannelNameFromString']['name'] = None
         self._defaults['GetError'] = {}
         self._defaults['GetError']['return'] = 0
         self._defaults['GetError']['errorCode'] = None
@@ -558,11 +558,11 @@ class SideEffectsHelper(object):
     def niDigital_GetChannelNameFromString(self, vi, indices, name_buffer_size, names):  # noqa: N802
         if self._defaults['GetChannelNameFromString']['return'] != 0:
             return self._defaults['GetChannelNameFromString']['return']
-        if self._defaults['GetChannelNameFromString']['names'] is None:
-            raise MockFunctionCallError("niDigital_GetChannelNameFromString", param='names')
+        if self._defaults['GetChannelNameFromString']['name'] is None:
+            raise MockFunctionCallError("niDigital_GetChannelNameFromString", param='name')
         if name_buffer_size.value == 0:
-            return len(self._defaults['GetChannelNameFromString']['names'])
-        names.value = self._defaults['GetChannelNameFromString']['names'].encode('ascii')
+            return len(self._defaults['GetChannelNameFromString']['name'])
+        names.value = self._defaults['GetChannelNameFromString']['name'].encode('ascii')
         return self._defaults['GetChannelNameFromString']['return']
 
     def niDigital_GetError(self, vi, error_code, error_description_buffer_size, error_description):  # noqa: N802

--- a/src/nidigital/metadata/attributes.py
+++ b/src/nidigital/metadata/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-Digital Pattern Driver API metadata version 21.3.0d40
+# This file is generated from NI-Digital Pattern Driver API metadata version 22.0.0d53
 attributes = {
     1050002: {
         'access': 'read-write',
@@ -832,7 +832,6 @@ attributes = {
     },
     1150043: {
         'access': 'read-write',
-        'enum': 'HistoryRAMTriggerType',
         'documentation': {
             'description': 'Specifies the type of trigger condition on which History RAM starts acquiring pattern information.\n',
             'table_body': [
@@ -853,6 +852,7 @@ attributes = {
                 'Defined Values:'
             ]
         },
+        'enum': 'HistoryRAMTriggerType',
         'name': 'HISTORY_RAM_TRIGGER_TYPE',
         'type': 'ViInt32'
     },
@@ -882,7 +882,6 @@ attributes = {
     },
     1150047: {
         'access': 'read-write',
-        'enum': 'HistoryRAMCyclesToAcquire',
         'documentation': {
             'description': 'Configures which cycles History RAM acquires after the trigger conditions are met. If you configure History RAM to only acquire failed cycles, you must set the pretrigger samples for History RAM to 0.\n',
             'table_body': [
@@ -899,6 +898,7 @@ attributes = {
                 'Defined Values:'
             ]
         },
+        'enum': 'HistoryRAMCyclesToAcquire',
         'name': 'HISTORY_RAM_CYCLES_TO_ACQUIRE',
         'type': 'ViInt32'
     },

--- a/src/nidigital/metadata/config.py
+++ b/src/nidigital/metadata/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-Digital Pattern Driver API metadata version 21.3.0d40
+# This file is generated from NI-Digital Pattern Driver API metadata version 22.0.0d53
 config = {
-    'api_version': '21.3.0d40',
+    'api_version': '22.0.0d53',
     'c_function_prefix': 'niDigital_',
     'close_function': 'close',
     'context_manager_name': {

--- a/src/nidigital/metadata/enums.py
+++ b/src/nidigital/metadata/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-Digital Pattern Driver API metadata version 21.3.0d40
+# This file is generated from NI-Digital Pattern Driver API metadata version 22.0.0d53
 enums = {
     'BitOrder': {
         'values': [
@@ -129,6 +129,24 @@ enums = {
             }
         ]
     },
+    'FrequencyMeasurementMode': {
+        'values': [
+            {
+                'documentation': {
+                    'description': 'Frequency measurements are made serially for groups of channels associated with a single frequency counter for each group.\n\nMaximum frequency measured: 200 MHz.'
+                },
+                'name': 'NIDIGITAL_VAL_BANKED',
+                'value': 3700
+            },
+            {
+                'documentation': {
+                    'description': 'Frequency measurements are made by multiple frequency counters in parallel.\n\nMaximum frequency measured: 100 MHz.'
+                },
+                'name': 'NIDIGITAL_VAL_PARALLEL',
+                'value': 3701
+            }
+        ]
+    },
     'HistoryRAMCyclesToAcquire': {
         'values': [
             {
@@ -169,24 +187,6 @@ enums = {
                 },
                 'name': 'NIDIGITAL_VAL_PATTERN_LABEL',
                 'value': 2202
-            }
-        ]
-    },
-    'FrequencyMeasurementMode': {
-        'values': [
-            {
-                'documentation': {
-                    'description': 'Frequency measurements are made serially for groups of channels associated with a single frequency counter for each group.\n\nMaximum frequency measured: 200 MHz.'
-                },
-                'name': 'NIDIGITAL_VAL_BANKED',
-                'value': 3700
-            },
-            {
-                'documentation': {
-                    'description': 'Frequency measurements are made by multiple frequency counters in parallel.\n\nMaximum frequency measured: 100 MHz.'
-                },
-                'name': 'NIDIGITAL_VAL_PARALLEL',
-                'value': 3701
             }
         ]
     },

--- a/src/nidigital/metadata/functions.py
+++ b/src/nidigital/metadata/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-Digital Pattern Driver API metadata version 21.3.0d40
+# This file is generated from NI-Digital Pattern Driver API metadata version 22.0.0d53
 functions = {
     'Abort': {
         'documentation': {
@@ -37,6 +37,7 @@ functions = {
         'documentation': {
             'description': 'Applies digital levels and timing values defined in previously loaded levels and timing sheets. When applying a levels sheet, only the levels specified in the sheet are affected. Any levels not specified in the sheet remain unchanged. When applying a timing sheet, all existing time sets are deleted before the new time sets are loaded.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -48,12 +49,12 @@ functions = {
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'sites',
                 'documentation': {
                     'description': 'Comma-delimited list of strings in the form of ``siteN`` , where ``N`` is the site number. If you enter an empty string, this function applies the levels and initial states to all sites.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'siteList',
+                'repeated_capability_type': 'sites',
                 'type': 'ViConstString'
             },
             {
@@ -81,7 +82,7 @@ functions = {
                 'name': 'initialStateHighPins',
                 'python_api_converter_name': 'convert_repeated_capabilities_without_prefix',
                 'type': 'ViConstString',
-                'type_in_documentation': 'basic sequence types or str',
+                'type_in_documentation': 'basic sequence types or str'
             },
             {
                 'default_value': 'None',
@@ -92,7 +93,7 @@ functions = {
                 'name': 'initialStateLowPins',
                 'python_api_converter_name': 'convert_repeated_capabilities_without_prefix',
                 'type': 'ViConstString',
-                'type_in_documentation': 'basic sequence types or str',
+                'type_in_documentation': 'basic sequence types or str'
             },
             {
                 'default_value': 'None',
@@ -103,9 +104,10 @@ functions = {
                 'name': 'initialStateTristatePins',
                 'python_api_converter_name': 'convert_repeated_capabilities_without_prefix',
                 'type': 'ViConstString',
-                'type_in_documentation': 'basic sequence types or str',
+                'type_in_documentation': 'basic sequence types or str'
             }
         ],
+        'repeated_capability_type': 'sites',
         'returns': 'ViStatus'
     },
     'ApplyTDROffsets': {
@@ -159,6 +161,7 @@ functions = {
         'documentation': {
             'description': 'Uses the **startLabel** you specify to burst the pattern on the sites you specify and provides the option to wait for the burst to complete. Digital pins retain their state at the end of a pattern burst until the first vector of a subsequent pattern burst, a call to niDigital_WriteStatic, or a call to niDigital_ApplyLevelsAndTiming.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -170,12 +173,12 @@ functions = {
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'sites',
                 'documentation': {
                     'description': 'The sites on which to burst the pattern as a comma-delimited list of strings in the form site\\ ``N``, where ``N`` is the site number. If you specify an empty string, the pattern is burst on all sites.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'siteList',
+                'repeated_capability_type': 'sites',
                 'type': 'ViConstString'
             },
             {
@@ -216,23 +219,7 @@ functions = {
                 'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
-        'returns': 'ViStatus'
-    },
-    'ClearError': {
-        'codegen_method': 'no',
-        'documentation': {
-            'description': 'Clears the error information for the current execution thread and the IVI session you specify. If you pass VI_NULL for the **vi** parameter, this function clears the error information only for the current execution thread.\n'
-        },
-        'parameters': [
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'The specified instrument session the niDigital_init or niDigital_InitWithOptions function returns.\n'
-                },
-                'name': 'vi',
-                'type': 'ViSession'
-            }
-        ],
+        'repeated_capability_type': 'sites',
         'returns': 'ViStatus'
     },
     'ClockGenerator_Abort': {
@@ -300,32 +287,6 @@ functions = {
             }
         ],
         'python_name': 'clock_generator_generate_clock',
-        'returns': 'ViStatus'
-    },
-    'ClockGenerator_Initiate': {
-        'codegen_method': 'no',
-        'documentation': {
-            'description': 'Initiates clock generation on the specified channel(s) or pin(s) and pin group(s).\n'
-        },
-        'parameters': [
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'The specified instrument session the niDigital_init or niDigital_InitWithOptions function returns.\n'
-                },
-                'name': 'vi',
-                'type': 'ViSession'
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'List of channel names or list of pins. Do not pass a mix of channel names and pin names. An empty string denotes all digital pattern instrument channels.\n\nPin names and pin groups apply to all enabled sites, unless the pin name explicitly specifies the site. You can specify a pin in a specific site using the form site\\ ``N``/pinName\\ ````, where ``N`` is the site number. This function ignores pins that are not mapped to the digital pattern instrument.\n\nSpecify channel names using the form ``PXI1Slot3``/``0``,\\ ``2-3`` or ``PXI1Slot3``/``0``,\\ ``PXI1Slot3``/``2-3``, where ``PXI1Slot3`` is the instrument resource name and ``0``, ``2``, ``3`` are channel names. To specify channels from multiple instruments, use the form ``PXI1Slot3``/``0``,\\ ``PXI1Slot3``/``2-3``,\\ ``PXI1Slot4``/``2-3``. The instruments must be in the same chassis.\n'
-                },
-                'name': 'channelList',
-                'type': 'ViConstString'
-            }
-        ],
-        'python_name': 'clock_generator_initiate',
         'returns': 'ViStatus'
     },
     'Commit': {
@@ -396,6 +357,7 @@ functions = {
         'documentation': {
             'description': 'Configures which sites burst the pattern on the next call to the initiate function. The pattern burst sites can also be modified through the repeated capabilities for the niDigital_FancyBurstPattern function. If a site has been disabled through the niDigital_DisableSites function, the site does not burst a pattern even if included in the pattern burst sites.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -407,21 +369,23 @@ functions = {
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'sites',
                 'documentation': {
                     'description': 'A comma-delimited list of strings in the form of site\\ ``N``, where ``N`` is the site number. If you specify an empty string, the function returns pass or fail results for all sites. If the string is empty, all sites are configured for pattern bursting.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'siteList',
+                'repeated_capability_type': 'sites',
                 'type': 'ViConstString'
             }
         ],
+        'repeated_capability_type': 'sites',
         'returns': 'ViStatus'
     },
     'ConfigureTimeSetCompareEdgesStrobe': {
         'documentation': {
             'description': 'Configures the strobe edge time for the specified pins. Use this function to modify time set values after applying a timing sheet with the niDigital_ApplyLevelsAndTiming function, or to create time sets programmatically without the use of timing sheets. This function does not modify the timing sheet file or the timing sheet contents that will be used in future calls to niDigital_ApplyLevelsAndTiming; it only affects the values of the current timing context.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -433,20 +397,21 @@ functions = {
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'pins',
                 'documentation': {
                     'description': 'List of pin and pin group names for which to configure the time set edges.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'pinList',
+                'repeated_capability_type': 'pins',
                 'type': 'ViConstString'
             },
             {
                 'direction': 'in',
-                'name': 'timeSetName',
                 'documentation': {
                     'description': 'The specified time set name.\n'
                 },
+                'name': 'timeSet',
+                'python_name': 'time_set_name',
                 'type': 'ViConstString'
             },
             {
@@ -460,12 +425,14 @@ functions = {
                 'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
+        'repeated_capability_type': 'pins',
         'returns': 'ViStatus'
     },
     'ConfigureTimeSetCompareEdgesStrobe2x': {
         'documentation': {
             'description': 'Configures the compare strobes for the specified pins in the time set, including the 2x strobe. Use this function to modify time set values after applying a timing sheet with the niDigital_ApplyLevelsAndTiming function, or to create time sets programmatically without the use of timing sheets. This function does not modify the timing sheet file or the timing sheet contents that will be used in future calls to niDigital_ApplyLevelsAndTiming; it only affects the values of the current timing context.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -477,20 +444,21 @@ functions = {
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'pins',
                 'documentation': {
                     'description': 'List of pin and pin group names for which to configure the time set edges.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'pinList',
+                'repeated_capability_type': 'pins',
                 'type': 'ViConstString'
             },
             {
                 'direction': 'in',
-                'name': 'timeSetName',
                 'documentation': {
                     'description': 'The specified time set name.\n'
                 },
+                'name': 'timeSet',
+                'python_name': 'time_set_name',
                 'type': 'ViConstString'
             },
             {
@@ -514,12 +482,14 @@ functions = {
                 'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
+        'repeated_capability_type': 'pins',
         'returns': 'ViStatus'
     },
     'ConfigureTimeSetDriveEdges': {
         'documentation': {
             'description': 'Configures the drive format and drive edge placement for the specified pins. Use this function to modify time set values after applying a timing sheet with the niDigital_ApplyLevelsAndTiming function, or to create time sets programmatically without the use of timing sheets. This function does not modify the timing sheet file or the timing sheet contents that will be used in future calls to niDigital_ApplyLevelsAndTiming; it only affects the values of the current timing context.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -531,20 +501,21 @@ functions = {
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'pins',
                 'documentation': {
                     'description': 'List of pin and pin group names for which to configure the time set edges.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'pinList',
+                'repeated_capability_type': 'pins',
                 'type': 'ViConstString'
             },
             {
                 'direction': 'in',
-                'name': 'timeSetName',
                 'documentation': {
                     'description': 'The specified time set name.\n'
                 },
+                'name': 'timeSet',
+                'python_name': 'time_set_name',
                 'type': 'ViConstString'
             },
             {
@@ -597,12 +568,14 @@ functions = {
                 'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
+        'repeated_capability_type': 'pins',
         'returns': 'ViStatus'
     },
     'ConfigureTimeSetDriveEdges2x': {
         'documentation': {
             'description': 'Configures the drive edges of the pins in the time set, including 2x edges. Use this function to modify time set values after applying a timing sheet with the niDigital_ApplyLevelsAndTiming function, or to create time sets programmatically without the use of timing sheets. This function does not modify the timing sheet file or the timing sheet contents that will be used in future calls to niDigital_ApplyLevelsAndTiming; it only affects the values of the current timing context.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -614,20 +587,21 @@ functions = {
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'pins',
                 'documentation': {
                     'description': 'List of pin and pin group names for which to configure the time set edges.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'pinList',
+                'repeated_capability_type': 'pins',
                 'type': 'ViConstString'
             },
             {
                 'direction': 'in',
-                'name': 'timeSetName',
                 'documentation': {
                     'description': 'The specified time set name.\n'
                 },
+                'name': 'timeSet',
+                'python_name': 'time_set_name',
                 'type': 'ViConstString'
             },
             {
@@ -700,12 +674,14 @@ functions = {
                 'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
+        'repeated_capability_type': 'pins',
         'returns': 'ViStatus'
     },
     'ConfigureTimeSetDriveFormat': {
         'documentation': {
             'description': 'Configures the drive format for the pins specified in the **pinList**. Use this function to modify time set values after applying a timing sheet with the niDigital_ApplyLevelsAndTiming function, or to create time sets programmatically without the use of timing sheets. This function does not modify the timing sheet file or the timing sheet contents that will be used in future calls to niDigital_ApplyLevelsAndTiming; it only affects the values of the current timing context.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -717,20 +693,21 @@ functions = {
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'pins',
                 'documentation': {
                     'description': 'List of pin and pin group names for which to configure the time set edges.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'pinList',
+                'repeated_capability_type': 'pins',
                 'type': 'ViConstString'
             },
             {
                 'direction': 'in',
-                'name': 'timeSetName',
                 'documentation': {
                     'description': 'The specified time set name.\n'
                 },
+                'name': 'timeSet',
+                'python_name': 'time_set_name',
                 'type': 'ViConstString'
             },
             {
@@ -743,12 +720,14 @@ functions = {
                 'type': 'ViInt32'
             }
         ],
+        'repeated_capability_type': 'pins',
         'returns': 'ViStatus'
     },
     'ConfigureTimeSetEdge': {
         'documentation': {
             'description': 'Configures the edge placement for the pins specified in the pin list. Use this function to modify time set values after applying a timing sheet with the niDigital_ApplyLevelsAndTiming function, or to create time sets programmatically without the use of timing sheets. This function does not modify the timing sheet file or the timing sheet contents that will be used in future calls to niDigital_ApplyLevelsAndTiming; it only affects the values of the current timing context.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -760,20 +739,21 @@ functions = {
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'pins',
                 'documentation': {
                     'description': 'List of pin and pin group names for which to configure the time set edges.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'pinList',
+                'repeated_capability_type': 'pins',
                 'type': 'ViConstString'
             },
             {
                 'direction': 'in',
-                'name': 'timeSetName',
                 'documentation': {
                     'description': 'The specified time set name.\n'
                 },
+                'name': 'timeSet',
+                'python_name': 'time_set_name',
                 'type': 'ViConstString'
             },
             {
@@ -796,12 +776,14 @@ functions = {
                 'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
             }
         ],
+        'repeated_capability_type': 'pins',
         'returns': 'ViStatus'
     },
     'ConfigureTimeSetEdgeMultiplier': {
         'documentation': {
             'description': 'Configures the edge multiplier of the pins in the time set. Use this function to modify time set values after applying a timing sheet with the niDigital_ApplyLevelsAndTiming function, or to create time sets programmatically without the use of timing sheets. This function does not modify the timing sheet file or the timing sheet contents that will be used in future calls to niDigital_ApplyLevelsAndTiming; it only affects the values of the current timing context.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -813,20 +795,21 @@ functions = {
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'pins',
                 'documentation': {
                     'description': 'List of pin and pin group names for which to configure the time set edges.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'pinList',
+                'repeated_capability_type': 'pins',
                 'type': 'ViConstString'
             },
             {
                 'direction': 'in',
-                'name': 'timeSetName',
                 'documentation': {
                     'description': 'The specified time set name.\n'
                 },
+                'name': 'timeSet',
+                'python_name': 'time_set_name',
                 'type': 'ViConstString'
             },
             {
@@ -838,6 +821,7 @@ functions = {
                 'type': 'ViInt32'
             }
         ],
+        'repeated_capability_type': 'pins',
         'returns': 'ViStatus'
     },
     'ConfigureTimeSetPeriod': {
@@ -855,10 +839,11 @@ functions = {
             },
             {
                 'direction': 'in',
-                'name': 'timeSetName',
                 'documentation': {
                     'description': 'The specified time set name.\n'
                 },
+                'name': 'timeSet',
+                'python_name': 'time_set_name',
                 'type': 'ViConstString'
             },
             {
@@ -974,6 +959,7 @@ functions = {
         'documentation': {
             'description': 'Sets the capture waveform settings for parallel acquisition. Settings apply across all sites if multiple sites are configured in the pin map. You cannot reconfigure settings after waveforms are created.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -985,12 +971,12 @@ functions = {
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'pins',
                 'documentation': {
                     'description': 'List of capture pins from the waveform. The **pinList** must match the capture pins in the pattern that references the waveform. The pin order in the **pinList** determines the bit positions of the data captured by the niDigital_FetchCaptureWaveform function.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'pinList',
+                'repeated_capability_type': 'pins',
                 'type': 'ViConstString'
             },
             {
@@ -1002,12 +988,14 @@ functions = {
                 'type': 'ViConstString'
             }
         ],
+        'repeated_capability_type': 'pins',
         'returns': 'ViStatus'
     },
     'CreateCaptureWaveformSerial': {
         'documentation': {
             'description': 'Sets the capture waveform settings for serial acquisition. Settings apply across all sites if multiple sites are configured in the pin map. You cannot reconfigure settings after waveforms are created.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -1019,12 +1007,12 @@ functions = {
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'pins',
                 'documentation': {
                     'description': 'List of capture pins from the waveform. The **pinList** must match the capture pins in the pattern that references the waveform. The pin order in the **pinList** determines the bit positions of the data captured by the niDigital_FetchCaptureWaveform function.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'pinList',
+                'repeated_capability_type': 'pins',
                 'type': 'ViConstString'
             },
             {
@@ -1053,6 +1041,7 @@ functions = {
                 'type': 'ViInt32'
             }
         ],
+        'repeated_capability_type': 'pins',
         'returns': 'ViStatus'
     },
     'CreateSourceWaveformFromFileTDMS': {
@@ -1100,6 +1089,7 @@ functions = {
         'documentation': {
             'description': 'Sets the source waveform settings required for parallel sourcing. Settings apply across all sites if multiple sites are configured in the pin map. You cannot reconfigure settings after waveforms are created.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -1111,12 +1101,12 @@ functions = {
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'pins',
                 'documentation': {
                     'description': 'Source pins for the waveform. The **pinList** must match the source pins in the pattern that references the waveform. The pin order in the **pinList** determines the bit positions of the data written by the niDigital_WriteSourceWaveform function.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'pinList',
+                'repeated_capability_type': 'pins',
                 'type': 'ViConstString'
             },
             {
@@ -1137,12 +1127,14 @@ functions = {
                 'type': 'ViInt32'
             }
         ],
+        'repeated_capability_type': 'pins',
         'returns': 'ViStatus'
     },
     'CreateSourceWaveformSerial': {
         'documentation': {
             'description': 'Sets the source waveform settings required for serial sourcing. Settings apply across all sites if multiple sites are configured in the pin map. You cannot reconfigure settings after waveforms are created.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -1154,12 +1146,12 @@ functions = {
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'pins',
                 'documentation': {
                     'description': 'Source pins for the waveform. The **pinList** must match the source pins in the pattern that references the waveform. The pin order in the **pinList** determines the bit positions of the data written by the niDigital_WriteSourceWaveform function.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'pinList',
+                'repeated_capability_type': 'pins',
                 'type': 'ViConstString'
             },
             {
@@ -1197,6 +1189,7 @@ functions = {
                 'type': 'ViInt32'
             }
         ],
+        'repeated_capability_type': 'pins',
         'returns': 'ViStatus'
     },
     'CreateTimeSet': {
@@ -1243,6 +1236,7 @@ functions = {
         'documentation': {
             'description': 'Disables specified sites. Disabled sites are not included in pattern bursts initiated by the initiate function or the niDigital_FancyBurstPattern function, even if the site is specified in the list of pattern burst sites in niDigital_ConfigurePatternBurstSites function or in the repeated capabilities for the niDigital_FancyBurstPattern function. Additionally, if you specify a list of pin or pin group names in repeated capabilities in any NI-Digital function, digital pattern instrument channels mapped to disabled sites are not affected by the function. The functions that return per-pin data, such as the niDigital_PPMU_Measure function, do not return data for channels mapped to disabled sites. The digital pattern instrument channels mapped to the sites specified are left in their current state. NI TestStand Semiconductor Module requires all sites to always be enabled, and manages the set of active sites without disabling the sites in the digital instrument session. Do not use this function with the Semiconductor Module.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -1254,21 +1248,23 @@ functions = {
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'sites',
                 'documentation': {
                     'description': 'Comma-delimited list of strings in the form of site\\ ``N``, where ``N`` is the site number. If you enter an empty string, the function disables all sites.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'siteList',
+                'repeated_capability_type': 'sites',
                 'type': 'ViConstString'
             }
         ],
+        'repeated_capability_type': 'sites',
         'returns': 'ViStatus'
     },
     'EnableSites': {
         'documentation': {
             'description': 'Enables the sites you specify. All sites are enabled by default.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -1280,15 +1276,16 @@ functions = {
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'sites',
                 'documentation': {
                     'description': 'Comma-delimited list of strings in the form of site\\ ``N``, where ``N`` is the site number. If you enter an empty string, the function enables all sites.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'siteList',
+                'repeated_capability_type': 'sites',
                 'type': 'ViConstString'
             }
         ],
+        'repeated_capability_type': 'sites',
         'returns': 'ViStatus'
     },
     'FancySelfTest': {
@@ -1335,6 +1332,7 @@ functions = {
         'documentation': {
             'description': 'Fetches a defined number of samples for a specific list of sites. This function only returns data from sites that are enabled when fetch is called.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -1346,12 +1344,12 @@ functions = {
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'sites',
                 'documentation': {
                     'description': 'Site numbers listed as a comma-delimited list of strings of form site\\ ``N``, where ``N`` is the site number. If you enter an empty string, the function fetches data from all sites.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'siteList',
+                'repeated_capability_type': 'sites',
                 'type': 'ViConstString'
             },
             {
@@ -1416,6 +1414,7 @@ functions = {
                 'type': 'ViInt32'
             }
         ],
+        'repeated_capability_type': 'sites',
         'returns': 'ViStatus'
     },
     'FetchHistoryRAMCycleInformation': {
@@ -1423,6 +1422,7 @@ functions = {
         'documentation': {
             'description': 'Gets the per-cycle pattern information acquired for the specified cycle.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -1434,12 +1434,12 @@ functions = {
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'sites',
                 'documentation': {
                     'description': 'Site specified as a string in the form of ``siteN``, where ``N`` is the site number. The function returns an error if more than one site is specified.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'site',
+                'repeated_capability_type': 'sites',
                 'type': 'ViConstString'
             },
             {
@@ -1491,6 +1491,7 @@ functions = {
                 'type': 'ViInt32'
             }
         ],
+        'repeated_capability_type': 'sites',
         'returns': 'ViStatus'
     },
     'FetchHistoryRAMCyclePinData': {
@@ -1498,6 +1499,7 @@ functions = {
         'documentation': {
             'description': 'Gets the per-pin pattern data acquired for the specified cycle.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -1509,12 +1511,12 @@ functions = {
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'sites',
                 'documentation': {
                     'description': 'Site specified as a string in the form of ``siteN``, where ``N`` is the site number. The function returns an error if more than one site is specified.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'site',
+                'repeated_capability_type': 'sites',
                 'type': 'ViConstString'
             },
             {
@@ -1599,6 +1601,7 @@ functions = {
                 'type': 'ViInt32'
             }
         ],
+        'repeated_capability_type': 'sites',
         'returns': 'ViStatus'
     },
     'FetchHistoryRAMScanCycleNumber': {
@@ -1606,6 +1609,7 @@ functions = {
         'documentation': {
             'description': 'Fetches the History RAM Scan Cycle Number for the sample index. If the sample is not from a scan vector, the scan cycle number will be returned as -1.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -1617,12 +1621,12 @@ functions = {
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'sites',
                 'documentation': {
                     'description': 'Site specified as a string in the form of ``siteN``, where ``N`` is the site number. The function returns an error if more than one site is specified.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'site',
+                'repeated_capability_type': 'sites',
                 'type': 'ViConstString'
             },
             {
@@ -1642,6 +1646,7 @@ functions = {
                 'type': 'ViInt64'
             }
         ],
+        'repeated_capability_type': 'sites',
         'returns': 'ViStatus'
     },
     'FrequencyCounter_MeasureFrequency': {
@@ -1714,10 +1719,10 @@ functions = {
             },
             {
                 'direction': 'in',
-                'name': 'channelName',
                 'documentation': {
                     'description': 'List of channel names or list of pins. Do not pass a mix of channel names and pin names. An empty string denotes all digital pattern instrument channels.\n\nPin names and pin groups apply to all enabled sites, unless the pin name explicitly specifies the site. You can specify a pin in a specific site using the form site\\ ``N``/pinName\\ ````, where ``N`` is the site number. This function ignores pins that are not mapped to the digital pattern instrument.\n\nSpecify channel names using the form ``PXI1Slot3``/``0``,\\ ``2-3`` or ``PXI1Slot3``/``0``,\\ ``PXI1Slot3``/``2-3``, where ``PXI1Slot3`` is the instrument resource name and ``0``, ``2``, ``3`` are channel names. To specify channels from multiple instruments, use the form ``PXI1Slot3``/``0``,\\ ``PXI1Slot3``/``2-3``,\\ ``PXI1Slot4``/``2-3``. The instruments must be in the same chassis.\n'
                 },
+                'name': 'channelName',
                 'type': 'ViConstString'
             },
             {
@@ -1755,10 +1760,10 @@ functions = {
             },
             {
                 'direction': 'in',
-                'name': 'channelName',
                 'documentation': {
                     'description': 'List of channel names or list of pins. Do not pass a mix of channel names and pin names. An empty string denotes all digital pattern instrument channels.\n\nPin names and pin groups apply to all enabled sites, unless the pin name explicitly specifies the site. You can specify a pin in a specific site using the form site\\ ``N``/pinName\\ ````, where ``N`` is the site number. This function ignores pins that are not mapped to the digital pattern instrument.\n\nSpecify channel names using the form ``PXI1Slot3``/``0``,\\ ``2-3`` or ``PXI1Slot3``/``0``,\\ ``PXI1Slot3``/``2-3``, where ``PXI1Slot3`` is the instrument resource name and ``0``, ``2``, ``3`` are channel names. To specify channels from multiple instruments, use the form ``PXI1Slot3``/``0``,\\ ``PXI1Slot3``/``2-3``,\\ ``PXI1Slot4``/``2-3``. The instruments must be in the same chassis.\n'
                 },
+                'name': 'channelName',
                 'type': 'ViConstString'
             },
             {
@@ -1796,10 +1801,10 @@ functions = {
             },
             {
                 'direction': 'in',
-                'name': 'channelName',
                 'documentation': {
                     'description': 'List of channel names or list of pins. Do not pass a mix of channel names and pin names. An empty string denotes all digital pattern instrument channels.\n\nPin names and pin groups apply to all enabled sites, unless the pin name explicitly specifies the site. You can specify a pin in a specific site using the form site\\ ``N``/pinName\\ ````, where ``N`` is the site number. This function ignores pins that are not mapped to the digital pattern instrument.\n\nSpecify channel names using the form ``PXI1Slot3``/``0``,\\ ``2-3`` or ``PXI1Slot3``/``0``,\\ ``PXI1Slot3``/``2-3``, where ``PXI1Slot3`` is the instrument resource name and ``0``, ``2``, ``3`` are channel names. To specify channels from multiple instruments, use the form ``PXI1Slot3``/``0``,\\ ``PXI1Slot3``/``2-3``,\\ ``PXI1Slot4``/``2-3``. The instruments must be in the same chassis.\n'
                 },
+                'name': 'channelName',
                 'type': 'ViConstString'
             },
             {
@@ -1837,10 +1842,10 @@ functions = {
             },
             {
                 'direction': 'in',
-                'name': 'channelName',
                 'documentation': {
                     'description': 'List of channel names or list of pins. Do not pass a mix of channel names and pin names. An empty string denotes all digital pattern instrument channels.\n\nPin names and pin groups apply to all enabled sites, unless the pin name explicitly specifies the site. You can specify a pin in a specific site using the form site\\ ``N``/pinName\\ ````, where ``N`` is the site number. This function ignores pins that are not mapped to the digital pattern instrument.\n\nSpecify channel names using the form ``PXI1Slot3``/``0``,\\ ``2-3`` or ``PXI1Slot3``/``0``,\\ ``PXI1Slot3``/``2-3``, where ``PXI1Slot3`` is the instrument resource name and ``0``, ``2``, ``3`` are channel names. To specify channels from multiple instruments, use the form ``PXI1Slot3``/``0``,\\ ``PXI1Slot3``/``2-3``,\\ ``PXI1Slot4``/``2-3``. The instruments must be in the same chassis.\n'
                 },
+                'name': 'channelName',
                 'type': 'ViConstString'
             },
             {
@@ -1878,10 +1883,10 @@ functions = {
             },
             {
                 'direction': 'in',
-                'name': 'channelName',
                 'documentation': {
                     'description': 'List of channel names or list of pins. Do not pass a mix of channel names and pin names. An empty string denotes all digital pattern instrument channels.\n\nPin names and pin groups apply to all enabled sites, unless the pin name explicitly specifies the site. You can specify a pin in a specific site using the form site\\ ``N``/pinName\\ ````, where ``N`` is the site number. This function ignores pins that are not mapped to the digital pattern instrument.\n\nSpecify channel names using the form ``PXI1Slot3``/``0``,\\ ``2-3`` or ``PXI1Slot3``/``0``,\\ ``PXI1Slot3``/``2-3``, where ``PXI1Slot3`` is the instrument resource name and ``0``, ``2``, ``3`` are channel names. To specify channels from multiple instruments, use the form ``PXI1Slot3``/``0``,\\ ``PXI1Slot3``/``2-3``,\\ ``PXI1Slot4``/``2-3``. The instruments must be in the same chassis.\n'
                 },
+                'name': 'channelName',
                 'type': 'ViConstString'
             },
             {
@@ -1915,51 +1920,6 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
-    'GetChannelName': {
-        'codegen_method': 'no',
-        'documentation': {
-            'description': 'Returns the channel name that corresponds to the index you specify. Channel indexes are one-based. You must provide a ViChar array to serve as a buffer for the value. You pass the number of bytes in the buffer as the **nameBufferSize**. If the current value of the attribute, including the terminating NULL byte, is larger than the size you indicate in the buffer size, the function copies (buffer size - 1) bytes into the buffer, places an ASCII NULL byte at the end of the buffer, and returns the buffer size you must pass to get the entire value. For example, if the value is "123456" and the buffer size is 4, the function places "123" into the buffer and returns 7. If you want to call this function just to get the required buffer size, you can pass 0 for **nameBufferSize** and VI_NULL for the name.\n'
-        },
-        'parameters': [
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'The specified instrument session the niDigital_init or niDigital_InitWithOptions function returns.\n'
-                },
-                'name': 'vi',
-                'type': 'ViSession'
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Specifies a one-based index for the desired channel in the session. Valid values are from one to the total number of channels in the session.\n'
-                },
-                'name': 'index',
-                'type': 'ViInt32'
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'The number of elements in the ViChar array you specify for name.\n'
-                },
-                'name': 'nameBufferSize',
-                'type': 'ViInt32'
-            },
-            {
-                'direction': 'out',
-                'documentation': {
-                    'description': 'The returned channel name(s) at the specified index.\n'
-                },
-                'name': 'name',
-                'size': {
-                    'mechanism': 'ivi-dance',
-                    'value': 'nameBufferSize'
-                },
-                'type': 'ViChar[]'
-            }
-        ],
-        'returns': 'ViStatus'
-    },
     'GetChannelNameFromString': {
         'documentation': {
             'description': 'Returns a list of channel names for given channel indices.\n'
@@ -1978,10 +1938,11 @@ functions = {
                 'documentation': {
                     'description': 'Index list for the channels in the session. Valid values are from zero to the total number of channels in the session minus one. The index string can be one of the following formats:\n\n-   A comma-separated list—for example, "0,2,3,1"\n-   A range using a hyphen—for example, "0-3"\n-   A range using a colon—for example, "0:3 "\n\nYou can combine comma-separated lists and ranges that use a hyphen or colon. Both out-of-order and repeated indices are supported ("2,3,0," "1,2,2,3"). White space characters, including spaces, tabs, feeds, and carriage returns, are allowed between characters. Ranges can be incrementing or decrementing.\n'
                 },
-                'name': 'indices',
+                'name': 'index',
                 'python_api_converter_name': 'convert_repeated_capabilities_without_prefix',
+                'python_name': 'indices',
                 'type': 'ViConstString',
-                'type_in_documentation': 'basic sequence types or str or int',
+                'type_in_documentation': 'basic sequence types or str or int'
             },
             {
                 'direction': 'in',
@@ -1996,18 +1957,19 @@ functions = {
                 'documentation': {
                     'description': 'The channel name(s) at the specified indices.\n'
                 },
-                'name': 'names',
+                'name': 'name',
                 'python_api_converter_name': 'convert_comma_separated_string_to_list',
+                'python_name': 'names',
                 'size': {
                     'mechanism': 'ivi-dance',
                     'value': 'nameBufferSize'
                 },
                 'type': 'ViChar[]',
-                'type_in_documentation': 'list of str',
+                'type_in_documentation': 'list of str'
             }
         ],
         'python_name': 'get_channel_names',
-        'render_in_session_base': True,  # Used in FancyGetPinResultsPinInformation()
+        'render_in_session_base': True,
         'returns': 'ViStatus'
     },
     'GetError': {
@@ -2113,31 +2075,9 @@ functions = {
     'GetHistoryRAMSampleCount': {
         'documentation': {
             'description': 'Returns the number of samples History RAM acquired on the last pattern burst.\n',
-            'note': """\nBefore bursting a pattern, you must configure the History RAM trigger and specify which cycles to acquire.
-
-NIDIGITAL_ATTR_HISTORY_RAM_TRIGGER_TYPE should be used to specify the trigger condition on which History RAM
-starts acquiring pattern information.
-
-If History RAM trigger is configured as NIDIGITAL_VAL_CYCLE_NUMBER,
-NIDIGITAL_ATTR_CYCLE_NUMBER_HISTORY_RAM_TRIGGER_CYCLE_NUMBER should be used to specify the cycle number on which
-History RAM starts acquiring pattern information.
-
-If History RAM trigger is configured as NIDIGITAL_VAL_PATTERN_LABEL,
-NIDIGITAL_ATTR_PATTERN_LABEL_HISTORY_RAM_TRIGGER_LABEL should be used to specify the pattern label from which to
-start acquiring pattern information.
-NIDIGITAL_ATTR_PATTERN_LABEL_HISTORY_RAM_TRIGGER_VECTOR_OFFSET should be used to specify the number of vectors
-following the specified pattern label from which to start acquiring pattern information.
-NIDIGITAL_ATTR_PATTERN_LABEL_HISTORY_RAM_TRIGGER_CYCLE_OFFSET should be used to specify the number of cycles
-following the specified pattern label and vector offset from which to start acquiring pattern information.
-
-For all History RAM trigger conditions, NIDIGITAL_ATTR_HISTORY_RAM_PRETRIGGER_SAMPLES should be used to specify
-the number of samples to acquire before the trigger conditions are met. If you configure History RAM to only
-acquire failed cycles, you must set NIDIGITAL_ATTR_HISTORY_RAM_PRETRIGGER_SAMPLES to 0.
-
-NIDIGITAL_ATTR_HISTORY_RAM_CYCLES_TO_ACQUIRE should be used to specify which cycles History RAM acquires after
-the trigger conditions are met.
-""",
+            'note': '\nBefore bursting a pattern, you must configure the History RAM trigger and specify which cycles to acquire.\n\nNIDIGITAL_ATTR_HISTORY_RAM_TRIGGER_TYPE should be used to specify the trigger condition on which History RAM\nstarts acquiring pattern information.\n\nIf History RAM trigger is configured as NIDIGITAL_VAL_CYCLE_NUMBER,\nNIDIGITAL_ATTR_CYCLE_NUMBER_HISTORY_RAM_TRIGGER_CYCLE_NUMBER should be used to specify the cycle number on which\nHistory RAM starts acquiring pattern information.\n\nIf History RAM trigger is configured as NIDIGITAL_VAL_PATTERN_LABEL,\nNIDIGITAL_ATTR_PATTERN_LABEL_HISTORY_RAM_TRIGGER_LABEL should be used to specify the pattern label from which to\nstart acquiring pattern information.\nNIDIGITAL_ATTR_PATTERN_LABEL_HISTORY_RAM_TRIGGER_VECTOR_OFFSET should be used to specify the number of vectors\nfollowing the specified pattern label from which to start acquiring pattern information.\nNIDIGITAL_ATTR_PATTERN_LABEL_HISTORY_RAM_TRIGGER_CYCLE_OFFSET should be used to specify the number of cycles\nfollowing the specified pattern label and vector offset from which to start acquiring pattern information.\n\nFor all History RAM trigger conditions, NIDIGITAL_ATTR_HISTORY_RAM_PRETRIGGER_SAMPLES should be used to specify\nthe number of samples to acquire before the trigger conditions are met. If you configure History RAM to only\nacquire failed cycles, you must set NIDIGITAL_ATTR_HISTORY_RAM_PRETRIGGER_SAMPLES to 0.\n\nNIDIGITAL_ATTR_HISTORY_RAM_CYCLES_TO_ACQUIRE should be used to specify which cycles History RAM acquires after\nthe trigger conditions are met.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -2149,12 +2089,12 @@ the trigger conditions are met.
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'sites',
                 'documentation': {
                     'description': 'Site specified as a string in the form of ``siteN``, where ``N`` is the site number. The function returns an error if more than one site is specified.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'site',
+                'repeated_capability_type': 'sites',
                 'type': 'ViConstString'
             },
             {
@@ -2166,6 +2106,7 @@ the trigger conditions are met.
                 'type': 'ViInt64'
             }
         ],
+        'repeated_capability_type': 'sites',
         'returns': 'ViStatus'
     },
     'GetPatternName': {
@@ -2199,7 +2140,7 @@ the trigger conditions are met.
                 'type': 'ViChar[]'
             }
         ],
-        'render_in_session_base': True,  # Called from FancyFetchHistoryRAMCycleInformation() which uses rep cap
+        'render_in_session_base': True,
         'returns': 'ViStatus'
     },
     'GetPatternPinList': {
@@ -2243,7 +2184,7 @@ the trigger conditions are met.
                     'value': 'pinListBufferSize'
                 },
                 'type': 'ViChar[]',
-                'type_in_documentation': 'list of str',
+                'type_in_documentation': 'list of str'
             }
         ],
         'python_name': 'get_pattern_pin_names',
@@ -2380,6 +2321,7 @@ the trigger conditions are met.
         'documentation': {
             'description': 'Returns the pass or fail results for each site.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -2391,12 +2333,12 @@ the trigger conditions are met.
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'sites',
                 'documentation': {
                     'description': 'A comma-delimited list of strings in the form of site\\ ``N``, where ``N`` is the site number. If you specify an empty string, the function returns pass or fail results for all sites.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'siteList',
+                'repeated_capability_type': 'sites',
                 'type': 'ViConstString'
             },
             {
@@ -2429,6 +2371,7 @@ the trigger conditions are met.
                 'type': 'ViInt32'
             }
         ],
+        'repeated_capability_type': 'sites',
         'returns': 'ViStatus'
     },
     'GetSiteResultsSiteNumbers': {
@@ -2436,6 +2379,7 @@ the trigger conditions are met.
         'documentation': {
             'description': 'Returns the site numbers that correspond to per-site data read from the digital pattern instrument. The function returns site numbers in the same order as values read using the niDigital_GetSitePassFail and niDigital_FetchCaptureWaveformU32 functions. Use this function to match values the previously listed functions return with site numbers.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -2447,12 +2391,12 @@ the trigger conditions are met.
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'sites',
                 'documentation': {
                     'description': 'Site numbers listed as a comma-delimited list of strings of form site\\ ``N``, where ``N`` is the site number.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'siteList',
+                'repeated_capability_type': 'sites',
                 'type': 'ViConstString'
             },
             {
@@ -2494,12 +2438,14 @@ the trigger conditions are met.
                 'type': 'ViInt32'
             }
         ],
+        'repeated_capability_type': 'sites',
         'returns': 'ViStatus'
     },
     'GetTimeSetDriveFormat': {
         'documentation': {
             'description': 'Returns the drive format of a pin in the specified time set.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -2511,20 +2457,21 @@ the trigger conditions are met.
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'pins',
                 'documentation': {
                     'description': 'Name of the specified pin.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'pin',
+                'repeated_capability_type': 'pins',
                 'type': 'ViConstString'
             },
             {
                 'direction': 'in',
-                'name': 'timeSetName',
                 'documentation': {
                     'description': 'The specified time set name.\n'
                 },
+                'name': 'timeSet',
+                'python_name': 'time_set_name',
                 'type': 'ViConstString'
             },
             {
@@ -2537,12 +2484,14 @@ the trigger conditions are met.
                 'type': 'ViInt32'
             }
         ],
+        'repeated_capability_type': 'pins',
         'returns': 'ViStatus'
     },
     'GetTimeSetEdge': {
         'documentation': {
             'description': 'Returns the edge time of a pin in the specified time set.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -2554,20 +2503,21 @@ the trigger conditions are met.
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'pins',
                 'documentation': {
                     'description': 'Name of the specified pin.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'pin',
+                'repeated_capability_type': 'pins',
                 'type': 'ViConstString'
             },
             {
                 'direction': 'in',
-                'name': 'timeSetName',
                 'documentation': {
                     'description': 'The specified time set name.\n'
                 },
+                'name': 'timeSet',
+                'python_name': 'time_set_name',
                 'type': 'ViConstString'
             },
             {
@@ -2590,12 +2540,14 @@ the trigger conditions are met.
                 'type_in_documentation': 'hightime.timedelta'
             }
         ],
+        'repeated_capability_type': 'pins',
         'returns': 'ViStatus'
     },
     'GetTimeSetEdgeMultiplier': {
         'documentation': {
             'description': 'Returns the edge multiplier of the specified time set.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -2607,20 +2559,21 @@ the trigger conditions are met.
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'pins',
                 'documentation': {
                     'description': 'Name of the specified pin.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'pin',
+                'repeated_capability_type': 'pins',
                 'type': 'ViConstString'
             },
             {
                 'direction': 'in',
-                'name': 'timeSetName',
                 'documentation': {
                     'description': 'The specified time set name.\n'
                 },
+                'name': 'timeSet',
+                'python_name': 'time_set_name',
                 'type': 'ViConstString'
             },
             {
@@ -2632,6 +2585,7 @@ the trigger conditions are met.
                 'type': 'ViInt32'
             }
         ],
+        'repeated_capability_type': 'pins',
         'returns': 'ViStatus'
     },
     'GetTimeSetName': {
@@ -2665,7 +2619,7 @@ the trigger conditions are met.
                 'type': 'ViChar[]'
             }
         ],
-        'render_in_session_base': True,  # Called from FancyFetchHistoryRAMCycleInformation() which uses rep cap
+        'render_in_session_base': True,
         'returns': 'ViStatus'
     },
     'GetTimeSetPeriod': {
@@ -2683,10 +2637,11 @@ the trigger conditions are met.
             },
             {
                 'direction': 'in',
-                'name': 'timeSetName',
                 'documentation': {
                     'description': 'The specified time set name.\n'
                 },
+                'name': 'timeSet',
+                'python_name': 'time_set_name',
                 'type': 'ViConstString'
             },
             {
@@ -2806,6 +2761,7 @@ the trigger conditions are met.
             'description': 'Checks if a specified site is enabled.\n',
             'note': 'The function returns an error if more than one site is specified.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -2817,12 +2773,12 @@ the trigger conditions are met.
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'sites',
                 'documentation': {
                     'description': 'Site specified as a string in the form of ``siteN``, where ``N`` is the site number. The function returns an error if more than one site is specified.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'site',
+                'repeated_capability_type': 'sites',
                 'type': 'ViConstString'
             },
             {
@@ -2834,6 +2790,7 @@ the trigger conditions are met.
                 'type': 'ViBoolean'
             }
         ],
+        'repeated_capability_type': 'sites',
         'returns': 'ViStatus'
     },
     'LoadLevels': {
@@ -2852,10 +2809,11 @@ the trigger conditions are met.
             },
             {
                 'direction': 'in',
-                'name': 'filePath',
                 'documentation': {
                     'description': 'Absolute file path to the specified levels sheet file.\n'
                 },
+                'name': 'levelsFilePath',
+                'python_name': 'file_path',
                 'type': 'ViConstString'
             }
         ],
@@ -2892,18 +2850,19 @@ the trigger conditions are met.
         'parameters': [
             {
                 'direction': 'in',
-                'name': 'vi',
-                'type': 'ViSession',
                 'documentation': {
                     'description': 'The specified instrument session the niDigital_init or niDigital_InitWithOptions function returns.\n'
                 },
+                'name': 'vi',
+                'type': 'ViSession'
             },
             {
                 'direction': 'in',
-                'name': 'filePath',
                 'documentation': {
                     'description': 'Absolute file path to a pin map file created with the Digital Pattern Editor or the NI TestStand Semiconductor Module.\n'
                 },
+                'name': 'pinMapFilePath',
+                'python_name': 'file_path',
                 'type': 'ViConstString'
             }
         ],
@@ -2925,10 +2884,11 @@ the trigger conditions are met.
             },
             {
                 'direction': 'in',
-                'name': 'filePath',
                 'documentation': {
                     'description': 'Absolute file path to a specifications file.\n'
                 },
+                'name': 'specificationsFilePath',
+                'python_name': 'file_path',
                 'type': 'ViConstString'
             }
         ],
@@ -2950,10 +2910,11 @@ the trigger conditions are met.
             },
             {
                 'direction': 'in',
-                'name': 'filePath',
                 'documentation': {
                     'description': 'Absolute file path to the specified timing sheet file.\n'
                 },
+                'name': 'timingFilePath',
+                'python_name': 'file_path',
                 'type': 'ViConstString'
             }
         ],
@@ -3201,39 +3162,6 @@ the trigger conditions are met.
         ],
         'returns': 'ViStatus'
     },
-    'ResetAttribute': {
-        'codegen_method': 'no',
-        'documentation': {
-            'description': 'Resets the attribute to its default value.\n'
-        },
-        'parameters': [
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'The specified instrument session the niDigital_init or niDigital_InitWithOptions function returns.\n'
-                },
-                'name': 'vi',
-                'type': 'ViSession'
-            },
-            {
-                'direction': 'in',
-                'name': 'channelName',
-                'documentation': {
-                    'description': 'List of channel names or list of pins. Do not pass a mix of channel names and pin names. An empty string denotes all digital pattern instrument channels.\n\nPin names and pin groups apply to all enabled sites, unless the pin name explicitly specifies the site. You can specify a pin in a specific site using the form site\\ ``N``/pinName\\ ````, where ``N`` is the site number. This function ignores pins that are not mapped to the digital pattern instrument.\n\nSpecify channel names using the form ``PXI1Slot3``/``0``,\\ ``2-3`` or ``PXI1Slot3``/``0``,\\ ``PXI1Slot3``/``2-3``, where ``PXI1Slot3`` is the instrument resource name and ``0``, ``2``, ``3`` are channel names. To specify channels from multiple instruments, use the form ``PXI1Slot3``/``0``,\\ ``PXI1Slot3``/``2-3``,\\ ``PXI1Slot4``/``2-3``. The instruments must be in the same chassis.\n'
-                },
-                'type': 'ViConstString'
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Pass the ID of an attribute.\n'
-                },
-                'name': 'attributeId',
-                'type': 'ViAttr'
-            }
-        ],
-        'returns': 'ViStatus'
-    },
     'ResetDevice': {
         'documentation': {
             'description': 'Returns a digital pattern instrument to a known state. This function performs the following actions:\n\n- Aborts pattern execution.\n- Clears pin maps, time sets, source and capture waveforms, and patterns.\n- Resets all properties to default values, including the NIDIGITAL_ATTR_SELECTED_FUNCTION property that is set to NIDIGITAL_VAL_DISCONNECT, causing the I/O switches to open.\n- Stops export of all external signals and events.\n- Clears over-temperature and over-power conditions.\n'
@@ -3272,10 +3200,10 @@ the trigger conditions are met.
         },
         'parameters': [
             {
+                'direction': 'in',
                 'documentation': {
                     'description': 'The specified instrument session the niDigital_init or niDigital_InitWithOptions function returns.\n'
                 },
-                'direction': 'in',
                 'name': 'vi',
                 'type': 'ViSession'
             },
@@ -3291,25 +3219,21 @@ the trigger conditions are met.
                         [
                             'NIDIGITAL_VAL_CONDITIONAL_JUMP_TRIGGER',
                             'Specifies to route a conditional jump trigger. You must specify a conditional jump trigger in the trigger_identifier parameter.'
-                        ],
+                        ]
                     ],
                     'table_header': [
-                        'Defined Values',
-                    ],
+                        'Defined Values'
+                    ]
                 },
                 'enum': 'SoftwareTrigger',
                 'name': 'trigger',
                 'type': 'ViInt32'
             },
             {
-                'documentation': {
-                    'description': """Trigger Identifier specifies the instance of the trigger you want to override.
-If trigger is specified as NIDIGITAL_VAL_START_TRIGGER, this parameter must be an empty string. If trigger is
-specified as NIDIGITAL_VAL_CONDITIONAL_JUMP_TRIGGER, allowed values are conditionalJumpTrigger0,
-conditionalJumpTrigger1, conditionalJumpTrigger2, and conditionalJumpTrigger3.
-"""
-                },
                 'direction': 'in',
+                'documentation': {
+                    'description': 'Trigger Identifier specifies the instance of the trigger you want to override.\nIf trigger is specified as NIDIGITAL_VAL_START_TRIGGER, this parameter must be an empty string. If trigger is\nspecified as NIDIGITAL_VAL_CONDITIONAL_JUMP_TRIGGER, allowed values are conditionalJumpTrigger0,\nconditionalJumpTrigger1, conditionalJumpTrigger2, and conditionalJumpTrigger3.\n'
+                },
                 'name': 'triggerIdentifier',
                 'type': 'ViConstString'
             }
@@ -3332,10 +3256,10 @@ conditionalJumpTrigger1, conditionalJumpTrigger2, and conditionalJumpTrigger3.
             },
             {
                 'direction': 'in',
-                'name': 'channelName',
                 'documentation': {
                     'description': 'List of channel names or list of pins. Do not pass a mix of channel names and pin names. An empty string denotes all digital pattern instrument channels.\n\nPin names and pin groups apply to all enabled sites, unless the pin name explicitly specifies the site. You can specify a pin in a specific site using the form site\\ ``N``/pinName\\ ````, where ``N`` is the site number. This function ignores pins that are not mapped to the digital pattern instrument.\n\nSpecify channel names using the form ``PXI1Slot3``/``0``,\\ ``2-3`` or ``PXI1Slot3``/``0``,\\ ``PXI1Slot3``/``2-3``, where ``PXI1Slot3`` is the instrument resource name and ``0``, ``2``, ``3`` are channel names. To specify channels from multiple instruments, use the form ``PXI1Slot3``/``0``,\\ ``PXI1Slot3``/``2-3``,\\ ``PXI1Slot4``/``2-3``. The instruments must be in the same chassis.\n'
                 },
+                'name': 'channelName',
                 'type': 'ViConstString'
             },
             {
@@ -3373,10 +3297,10 @@ conditionalJumpTrigger1, conditionalJumpTrigger2, and conditionalJumpTrigger3.
             },
             {
                 'direction': 'in',
-                'name': 'channelName',
                 'documentation': {
                     'description': 'List of channel names or list of pins. Do not pass a mix of channel names and pin names. An empty string denotes all digital pattern instrument channels.\n\nPin names and pin groups apply to all enabled sites, unless the pin name explicitly specifies the site. You can specify a pin in a specific site using the form site\\ ``N``/pinName\\ ````, where ``N`` is the site number. This function ignores pins that are not mapped to the digital pattern instrument.\n\nSpecify channel names using the form ``PXI1Slot3``/``0``,\\ ``2-3`` or ``PXI1Slot3``/``0``,\\ ``PXI1Slot3``/``2-3``, where ``PXI1Slot3`` is the instrument resource name and ``0``, ``2``, ``3`` are channel names. To specify channels from multiple instruments, use the form ``PXI1Slot3``/``0``,\\ ``PXI1Slot3``/``2-3``,\\ ``PXI1Slot4``/``2-3``. The instruments must be in the same chassis.\n'
                 },
+                'name': 'channelName',
                 'type': 'ViConstString'
             },
             {
@@ -3414,10 +3338,10 @@ conditionalJumpTrigger1, conditionalJumpTrigger2, and conditionalJumpTrigger3.
             },
             {
                 'direction': 'in',
-                'name': 'channelName',
                 'documentation': {
                     'description': 'List of channel names or list of pins. Do not pass a mix of channel names and pin names. An empty string denotes all digital pattern instrument channels.\n\nPin names and pin groups apply to all enabled sites, unless the pin name explicitly specifies the site. You can specify a pin in a specific site using the form site\\ ``N``/pinName\\ ````, where ``N`` is the site number. This function ignores pins that are not mapped to the digital pattern instrument.\n\nSpecify channel names using the form ``PXI1Slot3``/``0``,\\ ``2-3`` or ``PXI1Slot3``/``0``,\\ ``PXI1Slot3``/``2-3``, where ``PXI1Slot3`` is the instrument resource name and ``0``, ``2``, ``3`` are channel names. To specify channels from multiple instruments, use the form ``PXI1Slot3``/``0``,\\ ``PXI1Slot3``/``2-3``,\\ ``PXI1Slot4``/``2-3``. The instruments must be in the same chassis.\n'
                 },
+                'name': 'channelName',
                 'type': 'ViConstString'
             },
             {
@@ -3455,10 +3379,10 @@ conditionalJumpTrigger1, conditionalJumpTrigger2, and conditionalJumpTrigger3.
             },
             {
                 'direction': 'in',
-                'name': 'channelName',
                 'documentation': {
                     'description': 'List of channel names or list of pins. Do not pass a mix of channel names and pin names. An empty string denotes all digital pattern instrument channels.\n\nPin names and pin groups apply to all enabled sites, unless the pin name explicitly specifies the site. You can specify a pin in a specific site using the form site\\ ``N``/pinName\\ ````, where ``N`` is the site number. This function ignores pins that are not mapped to the digital pattern instrument.\n\nSpecify channel names using the form ``PXI1Slot3``/``0``,\\ ``2-3`` or ``PXI1Slot3``/``0``,\\ ``PXI1Slot3``/``2-3``, where ``PXI1Slot3`` is the instrument resource name and ``0``, ``2``, ``3`` are channel names. To specify channels from multiple instruments, use the form ``PXI1Slot3``/``0``,\\ ``PXI1Slot3``/``2-3``,\\ ``PXI1Slot4``/``2-3``. The instruments must be in the same chassis.\n'
                 },
+                'name': 'channelName',
                 'type': 'ViConstString'
             },
             {
@@ -3496,10 +3420,10 @@ conditionalJumpTrigger1, conditionalJumpTrigger2, and conditionalJumpTrigger3.
             },
             {
                 'direction': 'in',
-                'name': 'channelName',
                 'documentation': {
                     'description': 'List of channel names or list of pins. Do not pass a mix of channel names and pin names. An empty string denotes all digital pattern instrument channels.\n\nPin names and pin groups apply to all enabled sites, unless the pin name explicitly specifies the site. You can specify a pin in a specific site using the form site\\ ``N``/pinName\\ ````, where ``N`` is the site number. This function ignores pins that are not mapped to the digital pattern instrument.\n\nSpecify channel names using the form ``PXI1Slot3``/``0``,\\ ``2-3`` or ``PXI1Slot3``/``0``,\\ ``PXI1Slot3``/``2-3``, where ``PXI1Slot3`` is the instrument resource name and ``0``, ``2``, ``3`` are channel names. To specify channels from multiple instruments, use the form ``PXI1Slot3``/``0``,\\ ``PXI1Slot3``/``2-3``,\\ ``PXI1Slot4``/``2-3``. The instruments must be in the same chassis.\n'
                 },
+                'name': 'channelName',
                 'type': 'ViConstString'
             },
             {
@@ -3626,10 +3550,11 @@ conditionalJumpTrigger1, conditionalJumpTrigger2, and conditionalJumpTrigger3.
             },
             {
                 'direction': 'in',
-                'name': 'filePath',
                 'documentation': {
                     'description': 'Absolute file path to a loaded specifications file.\n'
                 },
+                'name': 'specificationsFilePath',
+                'python_name': 'file_path',
                 'type': 'ViConstString'
             }
         ],
@@ -3844,6 +3769,7 @@ conditionalJumpTrigger1, conditionalJumpTrigger2, and conditionalJumpTrigger3.
         'documentation': {
             'description': 'Writes one waveform per site. Use this write function if you set the parameter of the create source waveform function to Site Unique.\n'
         },
+        'has_repeated_capability': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -3855,12 +3781,12 @@ conditionalJumpTrigger1, conditionalJumpTrigger2, and conditionalJumpTrigger3.
             },
             {
                 'direction': 'in',
-                'is_repeated_capability': True,
-                'repeated_capability_type': 'sites',
                 'documentation': {
                     'description': 'Site numbers listed as a comma-delimited list of strings of form site\\ ``N``, where ``N`` is the site number.\n'
                 },
+                'is_repeated_capability': True,
                 'name': 'siteList',
+                'repeated_capability_type': 'sites',
                 'type': 'ViConstString'
             },
             {
@@ -3901,6 +3827,7 @@ conditionalJumpTrigger1, conditionalJumpTrigger2, and conditionalJumpTrigger3.
                 'use_array': True
             }
         ],
+        'repeated_capability_type': 'sites',
         'returns': 'ViStatus'
     },
     'WriteStatic': {


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

The comment at the top of our metadata about it being generated is a lie. It's been modified since it was last generated. This makes it true again. So basically, this change just makes us feel a little better about ourselves.

Comments on changes produced by `tox -e codegen`:
- session.py
  - GetChannelName is no longer part of the uploaded metadata because we set codegen_method to 'no' (which is what it was set to in this repo). As a result, session.py references the name that it has in metadata, rather than the name it would have in the Python API (which it already wasn't a part of).
  - Note also that the method referencing it is not part of the public API
- _mock_helper.py: 
  - It's just changing the parameter name for the mock C Function Call and it changed it everywhere
    - The new name is the one actually used by the C API
    - We'll still be able to set the return value; we'll need just need to use the new parameter name: 'name'
  - We're not using this Function Mock, right now
  - All unit tests pass.
 
### List issues fixed by this Pull Request below, if any.
None

### What testing has been done?

TODO: Detail what testing has been done to ensure this submission meets requirements.
