### PR TITLE
NI-DCPower: Update metadata to 22.0.0d216

### DIFF
--- a/docs/nidcpower/class.rst
+++ b/docs/nidcpower/class.rst
@@ -4122,6 +4122,10 @@ lcr_current_amplitude
         Specifies the amplitude, in amps RMS, of the AC current test signal applied to the DUT for LCR measurements.
         This property applies when the :py:attr:`nidcpower.Session.lcr_stimulus_function` property is set to :py:data:`~nidcpower.LCRStimulusFunction.CURRENT`.
 
+        Valid Values: 7.08e-9 A RMS to 0.707 A RMS
+
+        Instrument specifications affect the valid values you can program. Refer to the specifications for your instrument for more information.
+
 
 
         .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
@@ -4480,6 +4484,10 @@ lcr_voltage_amplitude
 
         Specifies the amplitude, in V RMS, of the AC voltage test signal applied to the DUT for LCR measurements.
         This property applies when the :py:attr:`nidcpower.Session.lcr_stimulus_function` property is set to :py:data:`~nidcpower.LCRStimulusFunction.VOLTAGE`.
+
+        Valid Values: 7.08e-4 V RMS to 7.07 V RMS
+
+        Instrument specifications affect the valid values you can program. Refer to the specifications for your instrument for more information.
 
 
 

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -1042,6 +1042,10 @@ class _SessionBase(object):
     Specifies the amplitude, in amps RMS, of the AC current test signal applied to the DUT for LCR measurements.
     This property applies when the lcr_stimulus_function property is set to LCRStimulusFunction.CURRENT.
 
+    Valid Values: 7.08e-9 A RMS to 0.707 A RMS
+
+    Instrument specifications affect the valid values you can program. Refer to the specifications for your instrument for more information.
+
     Note:
     This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
 
@@ -1211,6 +1215,10 @@ class _SessionBase(object):
 
     Specifies the amplitude, in V RMS, of the AC voltage test signal applied to the DUT for LCR measurements.
     This property applies when the lcr_stimulus_function property is set to LCRStimulusFunction.VOLTAGE.
+
+    Valid Values: 7.08e-4 V RMS to 7.07 V RMS
+
+    Instrument specifications affect the valid values you can program. Refer to the specifications for your instrument for more information.
 
     Note:
     This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.

--- a/src/nidcpower/metadata/attributes.py
+++ b/src/nidcpower/metadata/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 22.0.0d200
+# This file is generated from NI-DCPower API metadata version 22.0.0d216
 attributes = {
     1050003: {
         'access': 'read-write',
@@ -1681,7 +1681,7 @@ attributes = {
     1150211: {
         'access': 'read-write',
         'documentation': {
-            'description': '\nSpecifies the amplitude, in V RMS, of the AC voltage test signal applied to the DUT for LCR measurements.\nThis property applies when the NIDCPOWER_ATTR_LCR_STIMULUS_FUNCTION property is set to NIDCPOWER_VAL_AC_VOLTAGE.\n',
+            'description': '\nSpecifies the amplitude, in V RMS, of the AC voltage test signal applied to the DUT for LCR measurements.\nThis property applies when the NIDCPOWER_ATTR_LCR_STIMULUS_FUNCTION property is set to NIDCPOWER_VAL_AC_VOLTAGE.\n\nValid Values: 7.08e-4 V RMS to 7.07 V RMS\n\nInstrument specifications affect the valid values you can program. Refer to the specifications for your instrument for more information.',
             'note': '\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device.\n'
         },
         'lv_property': 'LCR:AC Stimulus:Voltage Amplitude',
@@ -1694,7 +1694,7 @@ attributes = {
     1150212: {
         'access': 'read-write',
         'documentation': {
-            'description': '\nSpecifies the amplitude, in amps RMS, of the AC current test signal applied to the DUT for LCR measurements.\nThis property applies when the NIDCPOWER_ATTR_LCR_STIMULUS_FUNCTION property is set to NIDCPOWER_VAL_AC_CURRENT.\n',
+            'description': '\nSpecifies the amplitude, in amps RMS, of the AC current test signal applied to the DUT for LCR measurements.\nThis property applies when the NIDCPOWER_ATTR_LCR_STIMULUS_FUNCTION property is set to NIDCPOWER_VAL_AC_CURRENT.\n\nValid Values: 7.08e-9 A RMS to 0.707 A RMS\n\nInstrument specifications affect the valid values you can program. Refer to the specifications for your instrument for more information.',
             'note': '\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device.\n'
         },
         'lv_property': 'LCR:AC Stimulus:Current Amplitude',
@@ -1800,8 +1800,8 @@ attributes = {
     1150222: {
         'access': 'read-write',
         'documentation': {
-            'description': '\nSpecifies whether to apply load LCR compensation data to LCR measurements.\nBoth the NIDCPOWER_ATTR_LCR_OPEN_COMPENSATION_ENABLED and NIDCPOWER_ATTR_LCR_SHORT_COMPENSATION_ENABLED properties must be set to VI_TRUE in order to set this property to VI_TRUE.\n\nUse the NIDCPOWER_ATTR_LCR_OPEN_SHORT_LOAD_COMPENSATION_DATA_SOURCE property to define where the load compensation data that is applied to LCR measurements comes from.\n\nLoad compensation data are applied only for those specific frequencies you define with niDCPower_PerformLCRLoadCompensation;\nload compensation is not interpolated from the specific frequencies you define and applied to other frequencies.\n',
-            'note': '\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device.\n'
+            'description': '\nSpecifies whether to apply load LCR compensation data to LCR measurements.\nBoth the NIDCPOWER_ATTR_LCR_OPEN_COMPENSATION_ENABLED and NIDCPOWER_ATTR_LCR_SHORT_COMPENSATION_ENABLED properties must be set to VI_TRUE in order to set this property to VI_TRUE.\n\nUse the NIDCPOWER_ATTR_LCR_OPEN_SHORT_LOAD_COMPENSATION_DATA_SOURCE property to define where the load compensation data that is applied to LCR measurements comes from.\n',
+            'note': '\nLoad compensation data are applied only for those specific frequencies you define with niDCPower_PerformLCRLoadCompensation;\nload compensation is not interpolated from the specific frequencies you define and applied to other frequencies.\n\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device.\n'
         },
         'lv_property': 'LCR:Compensation:Load:Enabled',
         'name': 'LCR_LOAD_COMPENSATION_ENABLED',
@@ -2269,7 +2269,17 @@ attributes = {
         'access': 'read-write',
         'documentation': {
             'description': '\nDefines how to apply short custom cable compensation in LCR mode when NIDCPOWER_ATTR_CABLE_LENGTH property is set to NIDCPOWER_VAL_CUSTOM_ONBOARD_STORAGE or NIDCPOWER_VAL_CUSTOM_AS_CONFIGURED.\n\nLCR custom cable compensation uses compensation data for both an open and short configuration.\nFor open custom cable compensation, you must supply your own data from a call to niDCPower_PerformLCROpenCustomCableCompensation.\nFor short custom cable compensation, you can supply your own data from a call to niDCPower_PerformLCRShortCustomCableCompensation or NI-DCPower can apply a default set of short compensation data.\n',
-            'note': '\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device.\n'
+            'note': '\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device.\n',
+            'table_body': [
+                [
+                    'VI_FALSE',
+                    'Uses default short compensation data.'
+                ],
+                [
+                    'VI_TRUE',
+                    'Uses short custom cable compensation data generated by niDCPower_PerformLCRShortCustomCableCompensation.'
+                ]
+            ]
         },
         'lv_property': 'LCR:Compensation:LCR Short Custom Cable Compensation Enabled',
         'name': 'LCR_SHORT_CUSTOM_CABLE_COMPENSATION_ENABLED',

--- a/src/nidcpower/metadata/attributes.py
+++ b/src/nidcpower/metadata/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 22.0.0d131
+# This file is generated from NI-DCPower API metadata version 22.0.0d200
 attributes = {
     1050003: {
         'access': 'read-write',
@@ -2295,20 +2295,25 @@ attributes = {
     },
     1150302: {
         'access': 'read-write',
+        'attribute_class': 'AttributeIsolationState',
         'documentation': {
             'description': '\nDefines whether the channel is isolated.\n',
             'note': '\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device.\n'
         },
-        'enum': 'IsolationState',
         'lv_property': 'Advanced:Isolation State',
         'name': 'ISOLATION_STATE',
         'supported_rep_caps': [
             'channels'
         ],
-        'type': 'ViInt32'
+        'type': 'ViInt32',
+        'type_in_documentation': 'bool'
     },
     1150314: {
         'access': 'read-write',
+        'documentation': {
+            'description': '\nAutomatically optimizes the measurement aperture time according to the actual current range when measurement autorange is enabled.\nOptimization accounts for power line frequency when the NIDCPOWER_ATTR_APERTURE_TIME_UNITS attribute is set to NIDCPOWER_VAL_POWER_LINE_CYCLES.\n\nThis attribute is applicable only if the NIDCPOWER_ATTR_OUTPUT_FUNCTION attribute is set to NIDCPOWER_VAL_DC_VOLTAGE and the NIDCPOWER_ATTR_AUTORANGE attribute is enabled.',
+            'note': '\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device.\n'
+        },
         'enum': 'ApertureTimeAutoMode',
         'lv_property': 'Measurement:Aperture Time Auto Mode',
         'name': 'APERTURE_TIME_AUTO_MODE',

--- a/src/nidcpower/metadata/config.py
+++ b/src/nidcpower/metadata/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 22.0.0d131
+# This file is generated from NI-DCPower API metadata version 22.0.0d200
 config = {
-    'api_version': '22.0.0d131',
+    'api_version': '22.0.0d200',
     'c_function_prefix': 'niDCPower_',
     'close_function': 'close',
     'context_manager_name': {
@@ -11,19 +11,14 @@ config = {
     },
     'custom_types': [
         {
-            'ctypes_type': 'struct_NIComplexNumber',
-            'file_name': 'ni_complex_number',
-            'python_name': 'NIComplexNumber'
-        },
-        {
             'ctypes_type': 'struct_NILCRLoadCompensationSpot',
-            'file_name': 'ni_lcr_load_compensation_spot',
-            'python_name': 'NILCRLoadCompensationSpot'
+            'file_name': 'lcr_load_compensation_spot',
+            'python_name': 'LCRLoadCompensationSpot'
         },
         {
             'ctypes_type': 'struct_NILCRMeasurement',
-            'file_name': 'ni_lcr_measurement',
-            'python_name': 'NILCRMeasurement'
+            'file_name': 'lcr_measurement',
+            'python_name': 'LCRMeasurement'
         }
     ],
     'driver_name': 'NI-DCPower',

--- a/src/nidcpower/metadata/config.py
+++ b/src/nidcpower/metadata/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 22.0.0d200
+# This file is generated from NI-DCPower API metadata version 22.0.0d216
 config = {
-    'api_version': '22.0.0d200',
+    'api_version': '22.0.0d216',
     'c_function_prefix': 'niDCPower_',
     'close_function': 'close',
     'context_manager_name': {

--- a/src/nidcpower/metadata/enums.py
+++ b/src/nidcpower/metadata/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 22.0.0d200
+# This file is generated from NI-DCPower API metadata version 22.0.0d216
 enums = {
     'ApertureTimeAutoMode': {
         'values': [
@@ -435,35 +435,35 @@ enums = {
         'values': [
             {
                 'documentation': {
-                    'description': 'Returns the date and time that open LCR compensation data was most recently generated.'
+                    'description': 'Open LCR compensation.'
                 },
                 'name': 'NIDCPOWER_VAL_OPEN_COMPENSATION',
                 'value': 1130
             },
             {
                 'documentation': {
-                    'description': 'Returns the date and time that short LCR compensation data was most recently generated.'
+                    'description': 'Short LCR compensation.'
                 },
                 'name': 'NIDCPOWER_VAL_SHORT_COMPENSATION',
                 'value': 1131
             },
             {
                 'documentation': {
-                    'description': 'Returns the date and time that load LCR compensation data was most recently generated.'
+                    'description': 'Load LCR compensation.'
                 },
                 'name': 'NIDCPOWER_VAL_LOAD_COMPENSATION',
                 'value': 1132
             },
             {
                 'documentation': {
-                    'description': 'Returns the date and time that open custom cable compensation data was most recently generated.'
+                    'description': 'Open custom cable compensation.'
                 },
                 'name': 'NIDCPOWER_VAL_OPEN_CUSTOM_CABLE_COMPENSATION',
                 'value': 1133
             },
             {
                 'documentation': {
-                    'description': 'Returns the date and time that short custom cable compensation data was most recently generated.'
+                    'description': 'Short custom cable compensation.'
                 },
                 'name': 'NIDCPOWER_VAL_SHORT_CUSTOM_CABLE_COMPENSATION',
                 'value': 1134

--- a/src/nidcpower/metadata/enums.py
+++ b/src/nidcpower/metadata/enums.py
@@ -1,21 +1,33 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 22.0.0d131
+# This file is generated from NI-DCPower API metadata version 22.0.0d200
 enums = {
     'ApertureTimeAutoMode': {
         'values': [
             {
+                'documentation': {
+                    'description': 'Disables automatic aperture time scaling. The NIDCPOWER_ATTR_APERTURE_TIME attribute specifies the aperture time for all ranges.'
+                },
                 'name': 'NIDCPOWER_VAL_APERTURE_TIME_AUTO_MODE_OFF',
                 'value': 1135
             },
             {
+                'documentation': {
+                    'description': 'Prioritizes measurement speed over measurement accuracy by quickly scaling down aperture time in larger current ranges. The NIDCPOWER_ATTR_APERTURE_TIME attribute specifies the aperture time for the minimum range.'
+                },
                 'name': 'NIDCPOWER_VAL_APERTURE_TIME_AUTO_MODE_SHORT',
                 'value': 1136
             },
             {
+                'documentation': {
+                    'description': 'Balances measurement accuracy and speed by scaling down aperture time in larger current ranges. The NIDCPOWER_ATTR_APERTURE_TIME attribute specifies the aperture time for the minimum range.'
+                },
                 'name': 'NIDCPOWER_VAL_APERTURE_TIME_AUTO_MODE_NORMAL',
                 'value': 1137
             },
             {
+                'documentation': {
+                    'description': 'Prioritizes accuracy while still decreasing measurement time by slowly scaling down aperture time in larger current ranges. The NIDCPOWER_ATTR_APERTURE_TIME attribute specifies the aperture time for the minimum range.'
+                },
                 'name': 'NIDCPOWER_VAL_APERTURE_TIME_AUTO_MODE_LONG',
                 'value': 1138
             }
@@ -416,24 +428,6 @@ enums = {
                 },
                 'name': 'NIDCPOWER_VAL_LCR',
                 'value': 1062
-            }
-        ]
-    },
-    'IsolationState': {
-        'values': [
-            {
-                'documentation': {
-                    'description': 'The channel is disconnected from chassis ground.'
-                },
-                'name': 'NIDCPOWER_VAL_ISOLATED',
-                'value': 1128
-            },
-            {
-                'documentation': {
-                    'description': 'The channel is connected to chassis ground.'
-                },
-                'name': 'NIDCPOWER_VAL_NON_ISOLATED',
-                'value': 1129
             }
         ]
     },

--- a/src/nidcpower/metadata/enums_addon.py
+++ b/src/nidcpower/metadata/enums_addon.py
@@ -6,7 +6,6 @@ enums_override_metadata = {
     #  subsequent smaller PRs
     "ApertureTimeAutoMode": {"codegen_method": "no"},
     "CableLength": {"codegen_method": "no"},
-    "IsolationState": {"codegen_method": "no"},
     "LCRCompensationType": {"codegen_method": "no"},
     "LCRImpedanceRangeSource": {"codegen_method": "no"},
     "LCROpenShortLoadCompensationDataSource": {"codegen_method": "no"},

--- a/src/nidcpower/metadata/functions.py
+++ b/src/nidcpower/metadata/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 22.0.0d200
+# This file is generated from NI-DCPower API metadata version 22.0.0d216
 functions = {
     'AbortWithChannels': {
         'documentation': {
@@ -197,7 +197,7 @@ functions = {
     },
     'ConfigureLCRCustomCableCompensation': {
         'documentation': {
-            'description': '\nApplies previously generated open and short custom cable compensation data to LCR measurements.\n\nThis function applies custom cable compensation data when you have set NIDCPOWER_ATTR_CABLE_LENGTH property to NIDCPOWER_VAL_CUSTOM_AS_CONFIGURED.\n\nCall this function after you have obtained custom cable compensation data.\n\nIf NIDCPOWER_ATTR_LCR_SHORT_CUSTOM_CABLE_COMPENSATION_ENABLED property is set to **TRUE**, you must generate data with both niDCPower_PerformLCROpenCustomCableCompensation and niDCPower_PerformLCRShortCustomCableCompensation;\nif **FALSE**, you must only use niDCPower_PerformLCROpenCustomCableCompensation, and NI-DCPower uses default short data.\n\nCall niDCPower_GetLCRCustomCableCompensationData and pass the **custom cable compensation data** to this function.\n',
+            'description': '\nApplies previously generated open and short custom cable compensation data to LCR measurements.\n\nThis function applies custom cable compensation data when you have set NIDCPOWER_ATTR_CABLE_LENGTH property to NIDCPOWER_VAL_CUSTOM_AS_CONFIGURED.\n\nCall this function after you have obtained custom cable compensation data.\n\nIf NIDCPOWER_ATTR_LCR_SHORT_CUSTOM_CABLE_COMPENSATION_ENABLED property is set to VI_TRUE, you must generate data with both niDCPower_PerformLCROpenCustomCableCompensation and niDCPower_PerformLCRShortCustomCableCompensation;\nif VI_FALSE, you must only use niDCPower_PerformLCROpenCustomCableCompensation, and NI-DCPower uses default short data.\n\nCall niDCPower_GetLCRCustomCableCompensationData and pass the **custom cable compensation data** to this function.\n',
             'note': '\nThis function is not supported on all devices. For more information about supported devices, search ni.com for Supported Functions by Device.\n'
         },
         'parameters': [
@@ -2775,7 +2775,7 @@ functions = {
     },
     'PerformLCRLoadCompensation': {
         'documentation': {
-            'description': '\nGenerates load compensation data for LCR measurements for the test spots you specify.\n\nYou must physically configure your LCR circuit with an appropriate reference load to use this function to generate valid load compensation data.\n\nWhen you call this function:\n\n-  The load compensation data is written to the onboard storage of the instrument. Onboard storage can contain only the most recent set of data.\n-  Most NI-DCPower attributes in the session are reset to their default values. Rewrite the values of any attributes you want to maintain.\n\nTo apply the load compensation data you generate with this function to your LCR measurements, set the NIDCPOWER_ATTR_LCR_LOAD_COMPENSATION_ENABLED property to **TRUE**.\n\nLoad compensation data are generated only for those specific frequencies you define with this function; load compensation is not interpolated from the specific frequencies you define and applied to other frequencies.\n',
+            'description': '\nGenerates load compensation data for LCR measurements for the test spots you specify.\n\nYou must physically configure your LCR circuit with an appropriate reference load to use this function to generate valid load compensation data.\n\nWhen you call this function:\n\n-  The load compensation data is written to the onboard storage of the instrument. Onboard storage can contain only the most recent set of data.\n-  Most NI-DCPower attributes in the session are reset to their default values. Rewrite the values of any attributes you want to maintain.\n\nTo apply the load compensation data you generate with this function to your LCR measurements, set the NIDCPOWER_ATTR_LCR_LOAD_COMPENSATION_ENABLED property to VI_TRUE.\n\nLoad compensation data are generated only for those specific frequencies you define with this function; load compensation is not interpolated from the specific frequencies you define and applied to other frequencies.\n',
             'note': '\nThis function is not supported on all devices. For more information about supported devices, search ni.com for Supported Functions by Device.\n'
         },
         'parameters': [
@@ -2838,8 +2838,11 @@ functions = {
     },
     'PerformLCROpenCompensation': {
         'documentation': {
-            'description': '\nGenerates open compensation data for LCR measurements based on a default set of test frequencies and, optionally, additional frequencies you can specify.\n\nYou must physically configure an open LCR circuit to use this function to generate valid open compensation data.\n\nWhen you call this function:\n\n-  The open compensation data is written to the onboard storage of the instrument. Onboard storage can contain only the most recent set of data.\n-  Most NI-DCPower attributes in the session are reset to their default values. Rewrite the values of any attributes you want to maintain.\n\nTo apply the open compensation data you generate with this method to your LCR measurements, set the NIDCPOWER_ATTR_LCR_OPEN_COMPENSATION_ENABLED property to **TRUE**.\n\nCorrections for frequencies other than the default frequencies or any additional frequencies you specify are interpolated.\n',
-            'note': '\nThis function is not supported on all devices. For more information about supported devices, search ni.com for Supported Functions by Device.\n'
+            'description': '\nGenerates open compensation data for LCR measurements based on a default set of test frequencies and, optionally, additional frequencies you can specify.\n\nYou must physically configure an open LCR circuit to use this function to generate valid open compensation data.\n\nWhen you call this function:\n\n-  The open compensation data is written to the onboard storage of the instrument. Onboard storage can contain only the most recent set of data.\n-  Most NI-DCPower attributes in the session are reset to their default values. Rewrite the values of any attributes you want to maintain.\n\nTo apply the open compensation data you generate with this method to your LCR measurements, set the NIDCPOWER_ATTR_LCR_OPEN_COMPENSATION_ENABLED property to VI_TRUE.\n\nCorrections for frequencies other than the default frequencies or any additional frequencies you specify are interpolated.\n',
+            'note': [
+                '\nThis function is not supported on all devices. For more information about supported devices, search ni.com for Supported Functions by Device.\n',
+                '\nDefault Open Compensation Frequencies:\nBy default, NI-DCPower uses the following frequencies for LCR open compensation:\n\n-  10 logarithmic steps at 1 kHz frequency decade\n-  10 logarithmic steps at 10 kHz frequency decade\n-  100 logarithmic steps at 100 kHz frequency decade\n-  100 logarithmic steps at 1 MHz frequency decade\n\nThe actual frequencies used depend on the bandwidth of your instrument.\n'
+            ]
         },
         'parameters': [
             {
@@ -2877,8 +2880,7 @@ functions = {
                     'mechanism': 'len',
                     'value': 'numFrequencies'
                 },
-                'type': 'ViReal64[]',
-                'use_array': True
+                'type': 'ViReal64[]'
             }
         ],
         'returns': 'ViStatus'
@@ -2910,8 +2912,11 @@ functions = {
     },
     'PerformLCRShortCompensation': {
         'documentation': {
-            'description': '\nGenerates short compensation data for LCR measurements based on a default set of test frequencies and, optionally, additional frequencies you can specify.\n\nYou must physically configure your LCR circuit with a short to use this function to generate valid short compensation data.\n\nWhen you call this function:\n\n-  The short compensation data is written to the onboard storage of the instrument. Onboard storage can contain only the most recent set of data.\n- Most NI-DCPower attributes in the session are reset to their default values. Rewrite the values of any attributes you want to maintain.\n\nTo apply the short compensation data you generate with this method to your LCR measurements, set the NIDCPOWER_ATTR_LCR_SHORT_COMPENSATION_ENABLED property to **TRUE**.\n\nCorrections for frequencies other than the default frequencies or any additional frequencies you specify are interpolated.\n',
-            'note': '\nThis function is not supported on all devices. For more information about supported devices, search ni.com for Supported Functions by Device.\n'
+            'description': '\nGenerates short compensation data for LCR measurements based on a default set of test frequencies and, optionally, additional frequencies you can specify.\n\nYou must physically configure your LCR circuit with a short to use this function to generate valid short compensation data.\n\nWhen you call this function:\n\n-  The short compensation data is written to the onboard storage of the instrument. Onboard storage can contain only the most recent set of data.\n- Most NI-DCPower attributes in the session are reset to their default values. Rewrite the values of any attributes you want to maintain.\n\nTo apply the short compensation data you generate with this method to your LCR measurements, set the NIDCPOWER_ATTR_LCR_SHORT_COMPENSATION_ENABLED property to VI_TRUE.\n\nCorrections for frequencies other than the default frequencies or any additional frequencies you specify are interpolated.\n',
+            'note': [
+                '\nThis function is not supported on all devices. For more information about supported devices, search ni.com for Supported Functions by Device.\n',
+                '\nDefault Short Compensation Frequencies:\nBy default, NI-DCPower uses the following frequencies for LCR short compensation:\n\n-  10 logarithmic steps at 1 kHz frequency decade\n-  10 logarithmic steps at 10 kHz frequency decade\n-  100 logarithmic steps at 100 kHz frequency decade\n-  100 logarithmic steps at 1 MHz frequency decade\n\nThe actual frequencies used depend on the bandwidth of your instrument.'
+            ]
         },
         'parameters': [
             {
@@ -2949,15 +2954,14 @@ functions = {
                     'mechanism': 'len',
                     'value': 'numFrequencies'
                 },
-                'type': 'ViReal64[]',
-                'use_array': True
+                'type': 'ViReal64[]'
             }
         ],
         'returns': 'ViStatus'
     },
     'PerformLCRShortCustomCableCompensation': {
         'documentation': {
-            'description': '\nGenerates short custom cable compensation data for LCR measurements.\n\nTo use this function:\n\n-  You must physically configure your LCR circuit with a short to generate valid short custom cable compensation data.\n-  Set NIDCPOWER_ATTR_LCR_SHORT_CUSTOM_CABLE_COMPENSATION_ENABLED property to **TRUE** \n\nWhen you call this function:\n\n-  The short compensation data is written to the onboard storage of the instrument. Onboard storage can contain only the most recent set of data.\n-  Most NI-DCPower properties in the session are reset to their default values. Rewrite the values of any properties you want to maintain.\n',
+            'description': '\nGenerates short custom cable compensation data for LCR measurements.\n\nTo use this function:\n\n-  You must physically configure your LCR circuit with a short to generate valid short custom cable compensation data.\n-  Set NIDCPOWER_ATTR_LCR_SHORT_CUSTOM_CABLE_COMPENSATION_ENABLED property to VI_TRUE \n\nWhen you call this function:\n\n-  The short compensation data is written to the onboard storage of the instrument. Onboard storage can contain only the most recent set of data.\n-  Most NI-DCPower properties in the session are reset to their default values. Rewrite the values of any properties you want to maintain.\n',
             'note': '\nThis function is not supported on all devices. For more information about supported devices, search ni.com for Supported Functions by Device.\n'
         },
         'parameters': [

--- a/src/nidcpower/metadata/functions.py
+++ b/src/nidcpower/metadata/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 22.0.0d131
+# This file is generated from NI-DCPower API metadata version 22.0.0d200
 functions = {
     'AbortWithChannels': {
         'documentation': {


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Metadata 22.0.0d200
- Add documentation for 'aperture time auto mode' attribute and enum
- Remove 'ni_complex_number' custom type (to be replaced with built-in Python `complex` class)
- Remove 'ni_' prefix for 'lcr_load_compensation_spot' and 'lcr_measurement' custom types
- Remove 'IsolationState' enum to be replaced with 'AttributeIsolationState' attribute class
- Remove the codegen_method override for 'IsolationState' enum now that it has been removed

Metadata 22.0.0d216
- Add valid values for "lcr current amplitude" and "lcr voltage amplitude"
- Move some description for "lcr load compensation enabled" to its "note"
- Create table that explains about the valid values for 'lcr short custom cable compensation enabled'
- Make documentations for LCRCompensationType enum values more generic
- Use VI_TRUE in place of TRUE and VI_FALSE in place of FALSE for boolean properties
- Add docs for default open/short compensation frequencies
- Remove "'use_array': True" for the 'additional frequencies' parameter of 'perform lcr open compensation' and 'perform lcr short compensation' so that it can be used with Python list for duck typing purpose

### Additional Info

This PR is split from #1738, which includes the AttributeIsolationState class changes, to unblock subsequent PRs.