### PR TITLE
NI-FAKE: Update metadata to 22.5.0d9, fix _mock_helper

### DIFF
--- a/build/templates/_mock_helper.py.mako
+++ b/build/templates/_mock_helper.py.mako
@@ -82,7 +82,7 @@ ivi_dance_size_param = helper.find_size_parameter(ivi_dance_params, params)
 %           if helper.find_custom_type(p, config) is not None:
         for field in self._defaults['${func_name}']['${p["python_name"]}']._fields_:
             field_name = field[0]
-            setattr(cs.contents, field_name, getattr(self._defaults['${func_name}']['${p["python_name"]}'], field_name))
+            setattr(${p["python_name"]}.contents, field_name, getattr(self._defaults['${func_name}']['${p["python_name"]}'], field_name))
 %           elif p['is_string']:
         test_value = self._defaults['${func_name}']['${p['name']}']
         if type(test_value) is str:

--- a/generated/nifake/nifake/__init__.py
+++ b/generated/nifake/nifake/__init__.py
@@ -13,6 +13,14 @@ from nifake.custom_struct import CustomStruct  # noqa: F401
 
 from nifake.custom_struct import struct_CustomStruct  # noqa: F401
 
+from nifake.custom_struct_nested_typedef import CustomStructNestedTypedef  # noqa: F401
+
+from nifake.custom_struct_nested_typedef import struct_CustomStructNestedTypedef  # noqa: F401
+
+from nifake.custom_struct_typedef import CustomStructTypedef  # noqa: F401
+
+from nifake.custom_struct_typedef import struct_CustomStructTypedef  # noqa: F401
+
 
 def get_diagnostic_information():
     '''Get diagnostic information about the system state that is suitable for printing or logging

--- a/generated/nifake/nifake/_library.py
+++ b/generated/nifake/nifake/_library.py
@@ -9,6 +9,10 @@ from nifake._visatype import *  # noqa: F403,H303
 
 import nifake.custom_struct as custom_struct  # noqa: F401
 
+import nifake.custom_struct_nested_typedef as custom_struct_nested_typedef  # noqa: F401
+
+import nifake.custom_struct_typedef as custom_struct_typedef  # noqa: F401
+
 
 class Library(object):
     '''Library
@@ -29,6 +33,7 @@ class Library(object):
         self.niFake_EnumInputFunctionWithDefaults_cfunc = None
         self.niFake_ExportAttributeConfigurationBuffer_cfunc = None
         self.niFake_FetchWaveform_cfunc = None
+        self.niFake_FunctionWithRepeatedCapabilityType_cfunc = None
         self.niFake_GetABoolean_cfunc = None
         self.niFake_GetANumber_cfunc = None
         self.niFake_GetAStringOfFixedMaximumSize_cfunc = None
@@ -48,6 +53,7 @@ class Library(object):
         self.niFake_GetCalInterval_cfunc = None
         self.niFake_GetCustomType_cfunc = None
         self.niFake_GetCustomTypeArray_cfunc = None
+        self.niFake_GetCustomTypeTypedef_cfunc = None
         self.niFake_GetEnumValue_cfunc = None
         self.niFake_GetError_cfunc = None
         self.niFake_ImportAttributeConfigurationBuffer_cfunc = None
@@ -151,6 +157,14 @@ class Library(object):
                 self.niFake_FetchWaveform_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViReal64), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFake_FetchWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_FetchWaveform_cfunc(vi, number_of_samples, waveform_data, actual_number_of_samples)
+
+    def niFake_FunctionWithRepeatedCapabilityType(self, vi, site_list):  # noqa: N802
+        with self._func_lock:
+            if self.niFake_FunctionWithRepeatedCapabilityType_cfunc is None:
+                self.niFake_FunctionWithRepeatedCapabilityType_cfunc = self._get_library_function('niFake_FunctionWithRepeatedCapabilityType')
+                self.niFake_FunctionWithRepeatedCapabilityType_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
+                self.niFake_FunctionWithRepeatedCapabilityType_cfunc.restype = ViStatus  # noqa: F405
+        return self.niFake_FunctionWithRepeatedCapabilityType_cfunc(vi, site_list)
 
     def niFake_GetABoolean(self, vi, a_boolean):  # noqa: N802
         with self._func_lock:
@@ -303,6 +317,14 @@ class Library(object):
                 self.niFake_GetCustomTypeArray_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(custom_struct.struct_CustomStruct)]  # noqa: F405
                 self.niFake_GetCustomTypeArray_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetCustomTypeArray_cfunc(vi, number_of_elements, cs)
+
+    def niFake_GetCustomTypeTypedef(self, vi, cst, csnt):  # noqa: N802
+        with self._func_lock:
+            if self.niFake_GetCustomTypeTypedef_cfunc is None:
+                self.niFake_GetCustomTypeTypedef_cfunc = self._get_library_function('niFake_GetCustomTypeTypedef')
+                self.niFake_GetCustomTypeTypedef_cfunc.argtypes = [ViSession, ctypes.POINTER(custom_struct_typedef.struct_CustomStructTypedef), ctypes.POINTER(custom_struct_nested_typedef.struct_CustomStructNestedTypedef)]  # noqa: F405
+                self.niFake_GetCustomTypeTypedef_cfunc.restype = ViStatus  # noqa: F405
+        return self.niFake_GetCustomTypeTypedef_cfunc(vi, cst, csnt)
 
     def niFake_GetEnumValue(self, vi, a_quantity, a_turtle):  # noqa: N802
         with self._func_lock:

--- a/generated/nifake/nifake/custom_struct_nested_typedef.py
+++ b/generated/nifake/nifake/custom_struct_nested_typedef.py
@@ -1,11 +1,50 @@
 import ctypes
 
+import nifake.custom_struct as custom_struct
+import nifake.custom_struct_typedef as custom_struct_typedef
+
 
 # These custom type classes are created as placeholders
 class struct_CustomStructNestedTypedef(ctypes.Structure):  # noqa N801
-    _fields_ = []
+    _fields_ = [
+        ('struct_custom_struct', custom_struct.struct_CustomStruct),
+        ('struct_custom_struct_typedef', custom_struct_typedef.struct_CustomStructTypedef),
+    ]
+
+    def __init__(self, data=None):
+        super(ctypes.Structure, self).__init__()
+        if data is not None:
+            self.struct_custom_struct = custom_struct.struct_CustomStruct(data.struct_custom_struct)
+            self.struct_custom_struct_typedef = custom_struct_typedef.struct_CustomStructTypedef(
+                data.struct_custom_struct_typedef
+            )
+        else:
+            self.struct_custom_struct = custom_struct.struct_CustomStruct()
+            self.struct_custom_struct_typedef = custom_struct_typedef.struct_CustomStructTypedef()
 
 
 class CustomStructNestedTypedef(object):
-    pass
+    def __init__(
+        self,
+        data=None,
+        struct_custom_struct=custom_struct.CustomStruct(),
+        struct_custom_struct_typedef=custom_struct_typedef.CustomStructTypedef()
+    ):
+        if data is not None:
+            self.struct_custom_struct = custom_struct.CustomStruct(data.struct_custom_struct)
+            self.struct_custom_struct_typedef = custom_struct_typedef.CustomStructTypedef(
+                data.struct_custom_struct_typedef
+            )
+        else:
+            self.struct_custom_struct = struct_custom_struct
+            self.struct_custom_struct_typedef = struct_custom_struct_typedef
 
+    def __repr__(self):
+        return '{0}(data=None, struct_custom_struct={1}, struct_custom_struct_typedef={2})'.format(
+            self.__class__.__name__,
+            repr(self.struct_custom_struct),
+            repr(self.struct_custom_struct_typedef)
+        )
+
+    def __str__(self):
+        return self.__repr__()

--- a/generated/nifake/nifake/custom_struct_nested_typedef.py
+++ b/generated/nifake/nifake/custom_struct_nested_typedef.py
@@ -4,7 +4,6 @@ import nifake.custom_struct as custom_struct
 import nifake.custom_struct_typedef as custom_struct_typedef
 
 
-# These custom type classes are created as placeholders
 class struct_CustomStructNestedTypedef(ctypes.Structure):  # noqa N801
     _fields_ = [
         ('struct_custom_struct', custom_struct.struct_CustomStruct),

--- a/generated/nifake/nifake/custom_struct_nested_typedef.py
+++ b/generated/nifake/nifake/custom_struct_nested_typedef.py
@@ -1,0 +1,11 @@
+import ctypes
+
+
+# These custom type classes are created as placeholders
+class struct_CustomStructNestedTypedef(ctypes.Structure):  # noqa N801
+    _fields_ = []
+
+
+class CustomStructNestedTypedef(object):
+    pass
+

--- a/generated/nifake/nifake/custom_struct_typedef.py
+++ b/generated/nifake/nifake/custom_struct_typedef.py
@@ -1,11 +1,39 @@
 import ctypes
 
+import nifake._visatype
 
-# These custom type classes are created as placeholders
+
 class struct_CustomStructTypedef(ctypes.Structure):  # noqa N801
-    _fields_ = []
+    _fields_ = [
+        ('struct_int', nifake._visatype.ViInt32),
+        ('struct_double', nifake._visatype.ViReal64),
+    ]
+
+    def __init__(self, data=None):
+        super(ctypes.Structure, self).__init__()
+        if data is not None:
+            self.struct_int = data.struct_int
+            self.struct_double = data.struct_double
+        else:
+            self.struct_int = 0
+            self.struct_double = 0.0
 
 
 class CustomStructTypedef(object):
-    pass
+    def __init__(self, data=None, struct_int=0, struct_double=0.0):
+        if data is not None:
+            self.struct_int = data.struct_int
+            self.struct_double = data.struct_double
+        else:
+            self.struct_int = struct_int
+            self.struct_double = struct_double
 
+    def __repr__(self):
+        return '{0}(data=None, struct_int={1}, struct_double={2})'.format(
+            self.__class__.__name__,
+            self.struct_int,
+            self.struct_double
+        )
+
+    def __str__(self):
+        return self.__repr__()

--- a/generated/nifake/nifake/custom_struct_typedef.py
+++ b/generated/nifake/nifake/custom_struct_typedef.py
@@ -1,0 +1,11 @@
+import ctypes
+
+
+# These custom type classes are created as placeholders
+class struct_CustomStructTypedef(ctypes.Structure):  # noqa N801
+    _fields_ = []
+
+
+class CustomStructTypedef(object):
+    pass
+

--- a/generated/nifake/nifake/session.py
+++ b/generated/nifake/nifake/session.py
@@ -14,6 +14,10 @@ import nifake.errors as errors
 
 import nifake.custom_struct as custom_struct  # noqa: F401
 
+import nifake.custom_struct_nested_typedef as custom_struct_nested_typedef  # noqa: F401
+
+import nifake.custom_struct_typedef as custom_struct_typedef  # noqa: F401
+
 import hightime
 import nitclk
 
@@ -259,6 +263,29 @@ class _SessionBase(object):
             return "Failed to retrieve error description."
 
     ''' These are code-generated '''
+
+    @ivi_synchronized
+    def function_with_repeated_capability_type(self):
+        r'''function_with_repeated_capability_type
+
+        A method with a parameter that specifies repeated_capability_type.
+
+        Tip:
+        This method can be called on specific sites within your :py:class:`nifake.Session` instance.
+        Use Python index notation on the repeated capabilities container sites to specify a subset,
+        and then call this method on the result.
+
+        Example: :py:meth:`my_session.sites[ ... ].function_with_repeated_capability_type`
+
+        To call the method on all sites, you can call it directly on the :py:class:`nifake.Session`.
+
+        Example: :py:meth:`my_session.function_with_repeated_capability_type`
+        '''
+        vi_ctype = _visatype.ViSession(self._vi)  # case S110
+        site_list_ctype = ctypes.create_string_buffer(self._repeated_capability.encode(self._encoding))  # case C010
+        error_code = self._library.niFake_FunctionWithRepeatedCapabilityType(vi_ctype, site_list_ctype)
+        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
+        return
 
     @ivi_synchronized
     def _get_attribute_vi_boolean(self, attribute_id):
@@ -1316,6 +1343,25 @@ class Session(_SessionBase):
         return [custom_struct.CustomStruct(cs_ctype[i]) for i in range(number_of_elements_ctype.value)]
 
     @ivi_synchronized
+    def get_custom_type_typedef(self):
+        r'''get_custom_type_typedef
+
+        This method returns a custom type with typedef and a custom type with nested typedef.
+
+        Returns:
+            cst (CustomStructTypedef): An object of a custom type with typedef
+
+            csnt (CustomStructNestedTypedef): An object of a custom type with nested typedef
+
+        '''
+        vi_ctype = _visatype.ViSession(self._vi)  # case S110
+        cst_ctype = custom_struct_typedef.struct_CustomStructTypedef()  # case S220
+        csnt_ctype = custom_struct_nested_typedef.struct_CustomStructNestedTypedef()  # case S220
+        error_code = self._library.niFake_GetCustomTypeTypedef(vi_ctype, None if cst_ctype is None else (ctypes.pointer(cst_ctype)), None if csnt_ctype is None else (ctypes.pointer(csnt_ctype)))
+        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
+        return custom_struct_typedef.CustomStructTypedef(cst_ctype), custom_struct_nested_typedef.CustomStructNestedTypedef(csnt_ctype)
+
+    @ivi_synchronized
     def get_enum_value(self):
         r'''get_enum_value
 
@@ -1359,7 +1405,7 @@ class Session(_SessionBase):
 
 
         Returns:
-            month (hightime.datetime): Indicates date and time of the last calibration.
+            last_cal_datetime (hightime.datetime): Indicates date and time of the last calibration.
 
         '''
         month, day, year, hour, minute = self._get_cal_date_and_time(cal_type)

--- a/generated/nifake/nifake/unit_tests/_mock_helper.py
+++ b/generated/nifake/nifake/unit_tests/_mock_helper.py
@@ -37,6 +37,8 @@ class SideEffectsHelper(object):
         self._defaults['FetchWaveform']['return'] = 0
         self._defaults['FetchWaveform']['waveformData'] = None
         self._defaults['FetchWaveform']['actualNumberOfSamples'] = None
+        self._defaults['FunctionWithRepeatedCapabilityType'] = {}
+        self._defaults['FunctionWithRepeatedCapabilityType']['return'] = 0
         self._defaults['GetABoolean'] = {}
         self._defaults['GetABoolean']['return'] = 0
         self._defaults['GetABoolean']['aBoolean'] = None
@@ -99,6 +101,10 @@ class SideEffectsHelper(object):
         self._defaults['GetCustomTypeArray'] = {}
         self._defaults['GetCustomTypeArray']['return'] = 0
         self._defaults['GetCustomTypeArray']['cs'] = None
+        self._defaults['GetCustomTypeTypedef'] = {}
+        self._defaults['GetCustomTypeTypedef']['return'] = 0
+        self._defaults['GetCustomTypeTypedef']['cst'] = None
+        self._defaults['GetCustomTypeTypedef']['csnt'] = None
         self._defaults['GetEnumValue'] = {}
         self._defaults['GetEnumValue']['return'] = 0
         self._defaults['GetEnumValue']['aQuantity'] = None
@@ -284,6 +290,11 @@ class SideEffectsHelper(object):
         if actual_number_of_samples is not None:
             actual_number_of_samples.contents.value = self._defaults['FetchWaveform']['actualNumberOfSamples']
         return self._defaults['FetchWaveform']['return']
+
+    def niFake_FunctionWithRepeatedCapabilityType(self, vi, site_list):  # noqa: N802
+        if self._defaults['FunctionWithRepeatedCapabilityType']['return'] != 0:
+            return self._defaults['FunctionWithRepeatedCapabilityType']['return']
+        return self._defaults['FunctionWithRepeatedCapabilityType']['return']
 
     def niFake_GetABoolean(self, vi, a_boolean):  # noqa: N802
         if self._defaults['GetABoolean']['return'] != 0:
@@ -531,6 +542,23 @@ class SideEffectsHelper(object):
         for i in range(len(test_value)):
             cs_ref[i] = test_value[i]
         return self._defaults['GetCustomTypeArray']['return']
+
+    def niFake_GetCustomTypeTypedef(self, vi, cst, csnt):  # noqa: N802
+        if self._defaults['GetCustomTypeTypedef']['return'] != 0:
+            return self._defaults['GetCustomTypeTypedef']['return']
+        # cst
+        if self._defaults['GetCustomTypeTypedef']['cst'] is None:
+            raise MockFunctionCallError("niFake_GetCustomTypeTypedef", param='cst')
+        for field in self._defaults['GetCustomTypeTypedef']['cst']._fields_:
+            field_name = field[0]
+            setattr(cst.contents, field_name, getattr(self._defaults['GetCustomTypeTypedef']['cst'], field_name))
+        # csnt
+        if self._defaults['GetCustomTypeTypedef']['csnt'] is None:
+            raise MockFunctionCallError("niFake_GetCustomTypeTypedef", param='csnt')
+        for field in self._defaults['GetCustomTypeTypedef']['csnt']._fields_:
+            field_name = field[0]
+            setattr(csnt.contents, field_name, getattr(self._defaults['GetCustomTypeTypedef']['csnt'], field_name))
+        return self._defaults['GetCustomTypeTypedef']['return']
 
     def niFake_GetEnumValue(self, vi, a_quantity, a_turtle):  # noqa: N802
         if self._defaults['GetEnumValue']['return'] != 0:
@@ -881,6 +909,8 @@ class SideEffectsHelper(object):
         mock_library.niFake_ExportAttributeConfigurationBuffer.return_value = 0
         mock_library.niFake_FetchWaveform.side_effect = MockFunctionCallError("niFake_FetchWaveform")
         mock_library.niFake_FetchWaveform.return_value = 0
+        mock_library.niFake_FunctionWithRepeatedCapabilityType.side_effect = MockFunctionCallError("niFake_FunctionWithRepeatedCapabilityType")
+        mock_library.niFake_FunctionWithRepeatedCapabilityType.return_value = 0
         mock_library.niFake_GetABoolean.side_effect = MockFunctionCallError("niFake_GetABoolean")
         mock_library.niFake_GetABoolean.return_value = 0
         mock_library.niFake_GetANumber.side_effect = MockFunctionCallError("niFake_GetANumber")
@@ -919,6 +949,8 @@ class SideEffectsHelper(object):
         mock_library.niFake_GetCustomType.return_value = 0
         mock_library.niFake_GetCustomTypeArray.side_effect = MockFunctionCallError("niFake_GetCustomTypeArray")
         mock_library.niFake_GetCustomTypeArray.return_value = 0
+        mock_library.niFake_GetCustomTypeTypedef.side_effect = MockFunctionCallError("niFake_GetCustomTypeTypedef")
+        mock_library.niFake_GetCustomTypeTypedef.return_value = 0
         mock_library.niFake_GetEnumValue.side_effect = MockFunctionCallError("niFake_GetEnumValue")
         mock_library.niFake_GetEnumValue.return_value = 0
         mock_library.niFake_GetError.side_effect = MockFunctionCallError("niFake_GetError")

--- a/generated/nifake/nifake/unit_tests/test_session.py
+++ b/generated/nifake/nifake/unit_tests/test_session.py
@@ -873,6 +873,15 @@ class TestSession(object):
         self.patched_library.niFake_ReadFromChannel.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher('site0/2,site0/3,site1/2,site1/3'), _matchers.ViInt32Matcher(test_maximum_time_ms), _matchers.ViReal64PointerMatcher())
         assert value == test_reading
 
+    def test_function_with_repeated_capability_type(self):
+        self.patched_library.niFake_FunctionWithRepeatedCapabilityType.side_effect = self.side_effects_helper.niFake_FunctionWithRepeatedCapabilityType
+        with nifake.Session('dev1') as session:
+            session.channels['0-3'].function_with_repeated_capability_type()
+            self.patched_library.niFake_FunctionWithRepeatedCapabilityType.assert_called_once_with(
+                _matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST),
+                _matchers.ViStringMatcher('0,1,2,3')
+            )
+
     # Attributes
 
     def test_get_attribute_int32(self):

--- a/generated/nifake/nifake/unit_tests/test_session.py
+++ b/generated/nifake/nifake/unit_tests/test_session.py
@@ -1225,6 +1225,26 @@ class TestSession(object):
                 assert actual.struct_int == expected.struct_int
                 assert actual.struct_double == expected.struct_double
 
+    def test_get_custom_type_typedef(self):
+        self.patched_library.niFake_GetCustomTypeTypedef.side_effect = self.side_effects_helper.niFake_GetCustomTypeTypedef
+        cst = nifake.CustomStructTypedef(struct_int=42, struct_double=4.2)
+        cst_ctype = nifake.struct_CustomStructTypedef(cst)
+        csnt = nifake.CustomStructNestedTypedef(
+            struct_custom_struct=nifake.CustomStruct(struct_int=43, struct_double=4.3),
+            struct_custom_struct_typedef=nifake.CustomStructTypedef(struct_int=44, struct_double=4.4)
+        )
+        csnt_ctype = nifake.struct_CustomStructNestedTypedef(csnt)
+        self.side_effects_helper['GetCustomTypeTypedef']['cst'] = cst_ctype
+        self.side_effects_helper['GetCustomTypeTypedef']['csnt'] = csnt_ctype
+        with nifake.Session('dev1') as session:
+            cst_test, csnt_test = session.get_custom_type_typedef()
+            assert cst_test.struct_int == cst.struct_int
+            assert cst_test.struct_double == cst.struct_double
+            assert csnt_test.struct_custom_struct.struct_int == csnt.struct_custom_struct.struct_int
+            assert csnt_test.struct_custom_struct.struct_double == csnt.struct_custom_struct.struct_double
+            assert csnt_test.struct_custom_struct_typedef.struct_int == csnt.struct_custom_struct_typedef.struct_int
+            assert csnt_test.struct_custom_struct_typedef.struct_double == csnt.struct_custom_struct_typedef.struct_double
+
     # python-code size mechanism
 
     def test_get_array_using_python_code_double(self):

--- a/src/nifake/custom_types/custom_struct_nested_typedef.py
+++ b/src/nifake/custom_types/custom_struct_nested_typedef.py
@@ -1,11 +1,50 @@
 import ctypes
 
+import nifake.custom_struct as custom_struct
+import nifake.custom_struct_typedef as custom_struct_typedef
+
 
 # These custom type classes are created as placeholders
 class struct_CustomStructNestedTypedef(ctypes.Structure):  # noqa N801
-    _fields_ = []
+    _fields_ = [
+        ('struct_custom_struct', custom_struct.struct_CustomStruct),
+        ('struct_custom_struct_typedef', custom_struct_typedef.struct_CustomStructTypedef),
+    ]
+
+    def __init__(self, data=None):
+        super(ctypes.Structure, self).__init__()
+        if data is not None:
+            self.struct_custom_struct = custom_struct.struct_CustomStruct(data.struct_custom_struct)
+            self.struct_custom_struct_typedef = custom_struct_typedef.struct_CustomStructTypedef(
+                data.struct_custom_struct_typedef
+            )
+        else:
+            self.struct_custom_struct = custom_struct.struct_CustomStruct()
+            self.struct_custom_struct_typedef = custom_struct_typedef.struct_CustomStructTypedef()
 
 
 class CustomStructNestedTypedef(object):
-    pass
+    def __init__(
+        self,
+        data=None,
+        struct_custom_struct=custom_struct.CustomStruct(),
+        struct_custom_struct_typedef=custom_struct_typedef.CustomStructTypedef()
+    ):
+        if data is not None:
+            self.struct_custom_struct = custom_struct.CustomStruct(data.struct_custom_struct)
+            self.struct_custom_struct_typedef = custom_struct_typedef.CustomStructTypedef(
+                data.struct_custom_struct_typedef
+            )
+        else:
+            self.struct_custom_struct = struct_custom_struct
+            self.struct_custom_struct_typedef = struct_custom_struct_typedef
 
+    def __repr__(self):
+        return '{0}(data=None, struct_custom_struct={1}, struct_custom_struct_typedef={2})'.format(
+            self.__class__.__name__,
+            repr(self.struct_custom_struct),
+            repr(self.struct_custom_struct_typedef)
+        )
+
+    def __str__(self):
+        return self.__repr__()

--- a/src/nifake/custom_types/custom_struct_nested_typedef.py
+++ b/src/nifake/custom_types/custom_struct_nested_typedef.py
@@ -4,7 +4,6 @@ import nifake.custom_struct as custom_struct
 import nifake.custom_struct_typedef as custom_struct_typedef
 
 
-# These custom type classes are created as placeholders
 class struct_CustomStructNestedTypedef(ctypes.Structure):  # noqa N801
     _fields_ = [
         ('struct_custom_struct', custom_struct.struct_CustomStruct),

--- a/src/nifake/custom_types/custom_struct_nested_typedef.py
+++ b/src/nifake/custom_types/custom_struct_nested_typedef.py
@@ -1,0 +1,11 @@
+import ctypes
+
+
+# These custom type classes are created as placeholders
+class struct_CustomStructNestedTypedef(ctypes.Structure):  # noqa N801
+    _fields_ = []
+
+
+class CustomStructNestedTypedef(object):
+    pass
+

--- a/src/nifake/custom_types/custom_struct_typedef.py
+++ b/src/nifake/custom_types/custom_struct_typedef.py
@@ -1,11 +1,39 @@
 import ctypes
 
+import nifake._visatype
 
-# These custom type classes are created as placeholders
+
 class struct_CustomStructTypedef(ctypes.Structure):  # noqa N801
-    _fields_ = []
+    _fields_ = [
+        ('struct_int', nifake._visatype.ViInt32),
+        ('struct_double', nifake._visatype.ViReal64),
+    ]
+
+    def __init__(self, data=None):
+        super(ctypes.Structure, self).__init__()
+        if data is not None:
+            self.struct_int = data.struct_int
+            self.struct_double = data.struct_double
+        else:
+            self.struct_int = 0
+            self.struct_double = 0.0
 
 
 class CustomStructTypedef(object):
-    pass
+    def __init__(self, data=None, struct_int=0, struct_double=0.0):
+        if data is not None:
+            self.struct_int = data.struct_int
+            self.struct_double = data.struct_double
+        else:
+            self.struct_int = struct_int
+            self.struct_double = struct_double
 
+    def __repr__(self):
+        return '{0}(data=None, struct_int={1}, struct_double={2})'.format(
+            self.__class__.__name__,
+            self.struct_int,
+            self.struct_double
+        )
+
+    def __str__(self):
+        return self.__repr__()

--- a/src/nifake/custom_types/custom_struct_typedef.py
+++ b/src/nifake/custom_types/custom_struct_typedef.py
@@ -1,0 +1,11 @@
+import ctypes
+
+
+# These custom type classes are created as placeholders
+class struct_CustomStructTypedef(ctypes.Structure):  # noqa N801
+    _fields_ = []
+
+
+class CustomStructTypedef(object):
+    pass
+

--- a/src/nifake/metadata/attributes.py
+++ b/src/nifake/metadata/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 21.0.0d11
+# This file is generated from NI-FAKE API metadata version 22.5.0d9
 attributes = {
     1000000: {
         'access': 'read-write',

--- a/src/nifake/metadata/config.py
+++ b/src/nifake/metadata/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 1.2.0d9
+# This file is generated from NI-FAKE API metadata version 22.5.0d9
 config = {
-    'api_version': '1.2.0d9',
+    'api_version': '22.5.0d9',
     'c_function_prefix': 'niFake_',
     'close_function': 'close',
     'context_manager_name': {
@@ -14,6 +14,16 @@ config = {
             'ctypes_type': 'struct_CustomStruct',
             'file_name': 'custom_struct',
             'python_name': 'CustomStruct'
+        },
+        {
+            'ctypes_type': 'struct_CustomStructNestedTypedef',
+            'file_name': 'custom_struct_nested_typedef',
+            'python_name': 'CustomStructNestedTypedef'
+        },
+        {
+            'ctypes_type': 'struct_CustomStructTypedef',
+            'file_name': 'custom_struct_typedef',
+            'python_name': 'CustomStructTypedef'
         }
     ],
     'driver_name': 'NI-FAKE',

--- a/src/nifake/metadata/enums.py
+++ b/src/nifake/metadata/enums.py
@@ -1,6 +1,26 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 1.2.0d9
+# This file is generated from NI-FAKE API metadata version 22.5.0d9
 enums = {
+    'AltColor': {
+        'values': [
+            {
+                'name': 'NIFAKE_VAL_RED',
+                'value': 1
+            },
+            {
+                'name': 'NIFAKE_VAL_BLUE',
+                'value': 2
+            },
+            {
+                'name': 'NIFAKE_VAL_YELLOW',
+                'value': 5
+            },
+            {
+                'name': 'NIFAKE_VAL_BLACK',
+                'value': 42
+            }
+        ]
+    },
     'BeautifulColor': {
         'values': [
             {

--- a/src/nifake/metadata/functions.py
+++ b/src/nifake/metadata/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 1.2.0d9
+# This file is generated from NI-FAKE API metadata version 22.5.0d9
 functions = {
     'Abort': {
         'codegen_method': 'public',
@@ -302,6 +302,34 @@ functions = {
                 'use_in_python_api': False
             }
         ],
+        'returns': 'ViStatus'
+    },
+    'FunctionWithRepeatedCapabilityType': {
+        'documentation': {
+            'description': 'A function with a parameter that specifies repeated_capability_type.'
+        },
+        'has_repeated_capability': True,
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Identifies a particular instrument session.'
+                },
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'A list of sites.'
+                },
+                'is_repeated_capability': True,
+                'name': 'siteList',
+                'repeated_capability_type': 'sites',
+                'type': 'ViConstString'
+            }
+        ],
+        'repeated_capability_type': 'sites',
         'returns': 'ViStatus'
     },
     'GetABoolean': {
@@ -1009,6 +1037,39 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
+    'GetCustomTypeTypedef': {
+        'codegen_method': 'public',
+        'documentation': {
+            'description': 'This function returns a custom type with typedef and a custom type with nested typedef.'
+        },
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Identifies a particular instrument session.'
+                },
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'out',
+                'documentation': {
+                    'description': 'An object of a custom type with typedef'
+                },
+                'name': 'cst',
+                'type': 'CustomStructTypedef'
+            },
+            {
+                'direction': 'out',
+                'documentation': {
+                    'description': 'An object of a custom type with nested typedef'
+                },
+                'name': 'csnt',
+                'type': 'CustomStructNestedTypedef'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
     'GetEnumValue': {
         'codegen_method': 'public',
         'documentation': {
@@ -1144,7 +1205,7 @@ functions = {
                 'documentation': {
                     'description': 'Indicates date and time of the last calibration.'
                 },
-                'name': 'month',
+                'name': 'lastCalDatetime',
                 'type': 'hightime.datetime'
             }
         ],

--- a/src/nifake/nifake.mak
+++ b/src/nifake/nifake.mak
@@ -11,6 +11,8 @@ MODULE_FILES_TO_COPY := $(DEFAULT_PY_FILES_TO_COPY)
 
 CUSTOM_TYPES_TO_COPY += \
     custom_struct.py \
+    custom_struct_typedef.py \
+    custom_struct_nested_typedef.py \
 
 include $(BUILD_HELPER_DIR)/rules.mak
 

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -873,6 +873,15 @@ class TestSession(object):
         self.patched_library.niFake_ReadFromChannel.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher('site0/2,site0/3,site1/2,site1/3'), _matchers.ViInt32Matcher(test_maximum_time_ms), _matchers.ViReal64PointerMatcher())
         assert value == test_reading
 
+    def test_function_with_repeated_capability_type(self):
+        self.patched_library.niFake_FunctionWithRepeatedCapabilityType.side_effect = self.side_effects_helper.niFake_FunctionWithRepeatedCapabilityType
+        with nifake.Session('dev1') as session:
+            session.channels['0-3'].function_with_repeated_capability_type()
+            self.patched_library.niFake_FunctionWithRepeatedCapabilityType.assert_called_once_with(
+                _matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST),
+                _matchers.ViStringMatcher('0,1,2,3')
+            )
+
     # Attributes
 
     def test_get_attribute_int32(self):

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -1225,6 +1225,26 @@ class TestSession(object):
                 assert actual.struct_int == expected.struct_int
                 assert actual.struct_double == expected.struct_double
 
+    def test_get_custom_type_typedef(self):
+        self.patched_library.niFake_GetCustomTypeTypedef.side_effect = self.side_effects_helper.niFake_GetCustomTypeTypedef
+        cst = nifake.CustomStructTypedef(struct_int=42, struct_double=4.2)
+        cst_ctype = nifake.struct_CustomStructTypedef(cst)
+        csnt = nifake.CustomStructNestedTypedef(
+            struct_custom_struct=nifake.CustomStruct(struct_int=43, struct_double=4.3),
+            struct_custom_struct_typedef=nifake.CustomStructTypedef(struct_int=44, struct_double=4.4)
+        )
+        csnt_ctype = nifake.struct_CustomStructNestedTypedef(csnt)
+        self.side_effects_helper['GetCustomTypeTypedef']['cst'] = cst_ctype
+        self.side_effects_helper['GetCustomTypeTypedef']['csnt'] = csnt_ctype
+        with nifake.Session('dev1') as session:
+            cst_test, csnt_test = session.get_custom_type_typedef()
+            assert cst_test.struct_int == cst.struct_int
+            assert cst_test.struct_double == cst.struct_double
+            assert csnt_test.struct_custom_struct.struct_int == csnt.struct_custom_struct.struct_int
+            assert csnt_test.struct_custom_struct.struct_double == csnt.struct_custom_struct.struct_double
+            assert csnt_test.struct_custom_struct_typedef.struct_int == csnt.struct_custom_struct_typedef.struct_int
+            assert csnt_test.struct_custom_struct_typedef.struct_double == csnt.struct_custom_struct_typedef.struct_double
+
     # python-code size mechanism
 
     def test_get_array_using_python_code_double(self):


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

- Update NI-FAKE metadata to 22.5.0d9
  - New additions:
    - `custom_struct_typedef` and `custom_struct_nested_typedef` custom types
    - `AltColor` enum
    - `FunctionWithRepeatedCapabilityType` and `GetCustomTypeTypedef`
  - Create custom type implementation files for the new `custom_struct_typedef` and `custom_struct_nested_typedef` custom types
  - Update nifake.mak to copy the custom type implementation files so that the build can succeed
  - Create unit test for the new `get_custom_type_typedef()` function that uses the new custom types
- Fix `_mock_helper.py.mako` codegen logic for functions with custom type parameter to use the actual parameter name instead of hardcoded "cs"

### What testing has been done?

Local build succeeded.