### PR TITLE
NI-FAKE: Add enum with converter and related attr

### DIFF
--- a/generated/nifake/nifake/enums.py
+++ b/generated/nifake/nifake/enums.py
@@ -23,6 +23,13 @@ class Color(Enum):
     '''
 
 
+class EnumWithConverter(Enum):
+    RED = 1
+    BLUE = 2
+    YELLOW = 5
+    BLACK = 42
+
+
 class FloatEnum(Enum):
     THREE_POINT_FIVE = 3.5
     r'''

--- a/generated/nifake/nifake/session.py
+++ b/generated/nifake/nifake/session.py
@@ -169,6 +169,7 @@ class _SessionBase(object):
 
     Example: :py:attr:`my_session.read_write_double_with_repeated_capability`
     '''
+    read_write_enum_with_converter = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.EnumWithConverter, 1000011)
     read_write_int64 = _attributes.AttributeViInt64(1000006)
     '''Type: int
 

--- a/src/nifake/metadata/attributes.py
+++ b/src/nifake/metadata/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 22.5.0d9
+# This file is generated from NI-FAKE API metadata version 22.5.0d21
 attributes = {
     1000000: {
         'access': 'read-write',
@@ -109,5 +109,11 @@ attributes = {
         ],
         'type': 'ViString',
         'type_in_documentation': "Any repeated capability type, as defined in nimi-python:\n        - str\n        - str - Comma delimited list\n        - str - Range (using '-' or ':')\n        - int\n        - Basic sequence types (list, tuple, range, slice) of other supported types"
+    },
+    1000011: {
+        'access': 'read-write',
+        'enum': 'EnumWithConverter',
+        'name': 'READ_WRITE_ENUM_WITH_CONVERTER',
+        'type': 'ViInt32'
     }
 }

--- a/src/nifake/metadata/config.py
+++ b/src/nifake/metadata/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 22.5.0d9
+# This file is generated from NI-FAKE API metadata version 22.5.0d21
 config = {
-    'api_version': '22.5.0d9',
+    'api_version': '22.5.0d21',
     'c_function_prefix': 'niFake_',
     'close_function': 'close',
     'context_manager_name': {

--- a/src/nifake/metadata/enums.py
+++ b/src/nifake/metadata/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 22.5.0d9
+# This file is generated from NI-FAKE API metadata version 22.5.0d21
 enums = {
     'AltColor': {
         'values': [
@@ -108,6 +108,32 @@ enums = {
                 'value': 5
             },
             {
+                'name': 'NIFAKE_VAL_BLACK',
+                'value': 42
+            }
+        ]
+    },
+    'EnumWithConverter': {
+        'converted_value_to_enum_function_name': 'convert_to_enum_with_converter_enum',
+        'enum_to_converted_value_function_name': 'convert_from_enum_with_converter_enum',
+        'values': [
+            {
+                'converts_to_value': True,
+                'name': 'NIFAKE_VAL_RED',
+                'value': 1
+            },
+            {
+                'converts_to_value': False,
+                'name': 'NIFAKE_VAL_BLUE',
+                'value': 2
+            },
+            {
+                'converts_to_value': 'yellow',
+                'name': 'NIFAKE_VAL_YELLOW',
+                'value': 5
+            },
+            {
+                'converts_to_value': 42,
                 'name': 'NIFAKE_VAL_BLACK',
                 'value': 42
             }

--- a/src/nifake/metadata/functions.py
+++ b/src/nifake/metadata/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 22.5.0d9
+# This file is generated from NI-FAKE API metadata version 22.5.0d21
 functions = {
     'Abort': {
         'codegen_method': 'public',


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

- Update NI-FAKE metadata to 22.5.0d21
  - Add `EnumWithConverter` enum
  - Add `read_write_enum_with_converter` attribute that uses the new enum

Note: This PR is only adding the attribute and enum without the new EnumWithConverter infrastructure, which is implemented in #1738.

### What testing has been done?

Local build succeeded.