### PR TITLE
Store session param_list as dict instead of string

### DIFF
--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -195,12 +195,12 @@ constructor_params = helper.filter_parameters(init_function, helper.ParameterUsa
         self._encoding = encoding
 
         # Store the parameter list for later printing in __repr__
-        param_list = []
-        param_list.append("repeated_capability_list=" + pp.pformat(repeated_capability_list))
-        param_list.append("${config['session_handle_parameter_name']}=" + pp.pformat(${config['session_handle_parameter_name']}))
-        param_list.append("library=" + pp.pformat(library))
-        param_list.append("encoding=" + pp.pformat(encoding))
-        self._param_list = ', '.join(param_list)
+        self._params = {
+            'repeated_capability_list': repeated_capability_list,
+            '${config['session_handle_parameter_name']}': ${config['session_handle_parameter_name']},
+            'library': library,
+            'encoding': encoding,
+        }
 
 % if len(config['repeated_capabilities']) > 0:
         # Instantiate any repeated capability objects
@@ -212,7 +212,10 @@ constructor_params = helper.filter_parameters(init_function, helper.ParameterUsa
         self._is_frozen = freeze_it
 
     def __repr__(self):
-        return '{0}.{1}({2})'.format('${module_name}', self.__class__.__name__, self._param_list)
+        params_string = ', '.join(
+            [param + '=' + pp.pformat(self._params[param]) for param in self._params]
+        )
+        return '{0}.{1}({2})'.format('${module_name}', self.__class__.__name__, params_string)
 
     def __setattr__(self, key, value):
         if self._is_frozen and key not in dir(self):
@@ -287,11 +290,11 @@ class Session(_SessionBase):
 
 % endif
         # Store the parameter list for later printing in __repr__
-        param_list = []
+        self._params = {
 %       for param in constructor_params:
-        param_list.append("${param['python_name']}=" + pp.pformat(${param['python_name']}))
+            '${param['python_name']}': ${param['python_name']},
 %       endfor
-        self._param_list = ', '.join(param_list)
+        }
 
         self._is_frozen = True
 

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -3889,12 +3889,12 @@ class _SessionBase(object):
         self._encoding = encoding
 
         # Store the parameter list for later printing in __repr__
-        param_list = []
-        param_list.append("repeated_capability_list=" + pp.pformat(repeated_capability_list))
-        param_list.append("vi=" + pp.pformat(vi))
-        param_list.append("library=" + pp.pformat(library))
-        param_list.append("encoding=" + pp.pformat(encoding))
-        self._param_list = ', '.join(param_list)
+        self._params = {
+            'repeated_capability_list': repeated_capability_list,
+            'vi': vi,
+            'library': library,
+            'encoding': encoding,
+        }
 
         # Instantiate any repeated capability objects
         self.channels = _RepeatedCapabilities(self, '', repeated_capability_list)
@@ -3903,7 +3903,10 @@ class _SessionBase(object):
         self._is_frozen = freeze_it
 
     def __repr__(self):
-        return '{0}.{1}({2})'.format('nidcpower', self.__class__.__name__, self._param_list)
+        params_string = ', '.join(
+            [param + '=' + pp.pformat(self._params[param]) for param in self._params]
+        )
+        return '{0}.{1}({2})'.format('nidcpower', self.__class__.__name__, params_string)
 
     def __setattr__(self, key, value):
         if self._is_frozen and key not in dir(self):
@@ -6727,13 +6730,13 @@ class Session(_SessionBase):
         self._vi = self._fancy_initialize(resource_name, channels, reset, options, independent_channels)
 
         # Store the parameter list for later printing in __repr__
-        param_list = []
-        param_list.append("resource_name=" + pp.pformat(resource_name))
-        param_list.append("channels=" + pp.pformat(channels))
-        param_list.append("reset=" + pp.pformat(reset))
-        param_list.append("options=" + pp.pformat(options))
-        param_list.append("independent_channels=" + pp.pformat(independent_channels))
-        self._param_list = ', '.join(param_list)
+        self._params = {
+            'resource_name': resource_name,
+            'channels': channels,
+            'reset': reset,
+            'options': options,
+            'independent_channels': independent_channels,
+        }
 
         self._is_frozen = True
 

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -1271,12 +1271,12 @@ class _SessionBase(object):
         self._encoding = encoding
 
         # Store the parameter list for later printing in __repr__
-        param_list = []
-        param_list.append("repeated_capability_list=" + pp.pformat(repeated_capability_list))
-        param_list.append("vi=" + pp.pformat(vi))
-        param_list.append("library=" + pp.pformat(library))
-        param_list.append("encoding=" + pp.pformat(encoding))
-        self._param_list = ', '.join(param_list)
+        self._params = {
+            'repeated_capability_list': repeated_capability_list,
+            'vi': vi,
+            'library': library,
+            'encoding': encoding,
+        }
 
         # Instantiate any repeated capability objects
         self.channels = _RepeatedCapabilities(self, '', repeated_capability_list)
@@ -1291,7 +1291,10 @@ class _SessionBase(object):
         self._is_frozen = freeze_it
 
     def __repr__(self):
-        return '{0}.{1}({2})'.format('nidigital', self.__class__.__name__, self._param_list)
+        params_string = ', '.join(
+            [param + '=' + pp.pformat(self._params[param]) for param in self._params]
+        )
+        return '{0}.{1}({2})'.format('nidigital', self.__class__.__name__, params_string)
 
     def __setattr__(self, key, value):
         if self._is_frozen and key not in dir(self):
@@ -3777,11 +3780,11 @@ class Session(_SessionBase):
         self.tclk = nitclk.SessionReference(self._vi)
 
         # Store the parameter list for later printing in __repr__
-        param_list = []
-        param_list.append("resource_name=" + pp.pformat(resource_name))
-        param_list.append("reset_device=" + pp.pformat(reset_device))
-        param_list.append("options=" + pp.pformat(options))
-        self._param_list = ', '.join(param_list)
+        self._params = {
+            'resource_name': resource_name,
+            'reset_device': reset_device,
+            'options': options,
+        }
 
         self._is_frozen = True
 

--- a/generated/nidmm/nidmm/session.py
+++ b/generated/nidmm/nidmm/session.py
@@ -523,17 +523,20 @@ class _SessionBase(object):
         self._encoding = encoding
 
         # Store the parameter list for later printing in __repr__
-        param_list = []
-        param_list.append("repeated_capability_list=" + pp.pformat(repeated_capability_list))
-        param_list.append("vi=" + pp.pformat(vi))
-        param_list.append("library=" + pp.pformat(library))
-        param_list.append("encoding=" + pp.pformat(encoding))
-        self._param_list = ', '.join(param_list)
+        self._params = {
+            'repeated_capability_list': repeated_capability_list,
+            'vi': vi,
+            'library': library,
+            'encoding': encoding,
+        }
 
         self._is_frozen = freeze_it
 
     def __repr__(self):
-        return '{0}.{1}({2})'.format('nidmm', self.__class__.__name__, self._param_list)
+        params_string = ', '.join(
+            [param + '=' + pp.pformat(self._params[param]) for param in self._params]
+        )
+        return '{0}.{1}({2})'.format('nidmm', self.__class__.__name__, params_string)
 
     def __setattr__(self, key, value):
         if self._is_frozen and key not in dir(self):
@@ -1194,11 +1197,11 @@ class Session(_SessionBase):
         self._vi = self._init_with_options(resource_name, id_query, reset_device, options)
 
         # Store the parameter list for later printing in __repr__
-        param_list = []
-        param_list.append("resource_name=" + pp.pformat(resource_name))
-        param_list.append("reset_device=" + pp.pformat(reset_device))
-        param_list.append("options=" + pp.pformat(options))
-        self._param_list = ', '.join(param_list)
+        self._params = {
+            'resource_name': resource_name,
+            'reset_device': reset_device,
+            'options': options,
+        }
 
         self._is_frozen = True
 

--- a/generated/nifake/nifake/session.py
+++ b/generated/nifake/nifake/session.py
@@ -214,12 +214,12 @@ class _SessionBase(object):
         self._encoding = encoding
 
         # Store the parameter list for later printing in __repr__
-        param_list = []
-        param_list.append("repeated_capability_list=" + pp.pformat(repeated_capability_list))
-        param_list.append("vi=" + pp.pformat(vi))
-        param_list.append("library=" + pp.pformat(library))
-        param_list.append("encoding=" + pp.pformat(encoding))
-        self._param_list = ', '.join(param_list)
+        self._params = {
+            'repeated_capability_list': repeated_capability_list,
+            'vi': vi,
+            'library': library,
+            'encoding': encoding,
+        }
 
         # Instantiate any repeated capability objects
         self.channels = _RepeatedCapabilities(self, '', repeated_capability_list)
@@ -229,7 +229,10 @@ class _SessionBase(object):
         self._is_frozen = freeze_it
 
     def __repr__(self):
-        return '{0}.{1}({2})'.format('nifake', self.__class__.__name__, self._param_list)
+        params_string = ', '.join(
+            [param + '=' + pp.pformat(self._params[param]) for param in self._params]
+        )
+        return '{0}.{1}({2})'.format('nifake', self.__class__.__name__, params_string)
 
     def __setattr__(self, key, value):
         if self._is_frozen and key not in dir(self):
@@ -793,11 +796,11 @@ class Session(_SessionBase):
         self.tclk = nitclk.SessionReference(self._vi)
 
         # Store the parameter list for later printing in __repr__
-        param_list = []
-        param_list.append("resource_name=" + pp.pformat(resource_name))
-        param_list.append("options=" + pp.pformat(options))
-        param_list.append("reset_device=" + pp.pformat(reset_device))
-        self._param_list = ', '.join(param_list)
+        self._params = {
+            'resource_name': resource_name,
+            'options': options,
+            'reset_device': reset_device,
+        }
 
         self._is_frozen = True
 

--- a/generated/nifgen/nifgen/session.py
+++ b/generated/nifgen/nifgen/session.py
@@ -1101,12 +1101,12 @@ class _SessionBase(object):
         self._encoding = encoding
 
         # Store the parameter list for later printing in __repr__
-        param_list = []
-        param_list.append("repeated_capability_list=" + pp.pformat(repeated_capability_list))
-        param_list.append("vi=" + pp.pformat(vi))
-        param_list.append("library=" + pp.pformat(library))
-        param_list.append("encoding=" + pp.pformat(encoding))
-        self._param_list = ', '.join(param_list)
+        self._params = {
+            'repeated_capability_list': repeated_capability_list,
+            'vi': vi,
+            'library': library,
+            'encoding': encoding,
+        }
 
         # Instantiate any repeated capability objects
         self.channels = _RepeatedCapabilities(self, '', repeated_capability_list)
@@ -1117,7 +1117,10 @@ class _SessionBase(object):
         self._is_frozen = freeze_it
 
     def __repr__(self):
-        return '{0}.{1}({2})'.format('nifgen', self.__class__.__name__, self._param_list)
+        params_string = ', '.join(
+            [param + '=' + pp.pformat(self._params[param]) for param in self._params]
+        )
+        return '{0}.{1}({2})'.format('nifgen', self.__class__.__name__, params_string)
 
     def __setattr__(self, key, value):
         if self._is_frozen and key not in dir(self):
@@ -3422,12 +3425,12 @@ class Session(_SessionBase):
         self.tclk = nitclk.SessionReference(self._vi)
 
         # Store the parameter list for later printing in __repr__
-        param_list = []
-        param_list.append("resource_name=" + pp.pformat(resource_name))
-        param_list.append("channel_name=" + pp.pformat(channel_name))
-        param_list.append("reset_device=" + pp.pformat(reset_device))
-        param_list.append("options=" + pp.pformat(options))
-        self._param_list = ', '.join(param_list)
+        self._params = {
+            'resource_name': resource_name,
+            'channel_name': channel_name,
+            'reset_device': reset_device,
+            'options': options,
+        }
 
         self._is_frozen = True
 

--- a/generated/niscope/niscope/session.py
+++ b/generated/niscope/niscope/session.py
@@ -1764,12 +1764,12 @@ class _SessionBase(object):
         self._encoding = encoding
 
         # Store the parameter list for later printing in __repr__
-        param_list = []
-        param_list.append("repeated_capability_list=" + pp.pformat(repeated_capability_list))
-        param_list.append("vi=" + pp.pformat(vi))
-        param_list.append("library=" + pp.pformat(library))
-        param_list.append("encoding=" + pp.pformat(encoding))
-        self._param_list = ', '.join(param_list)
+        self._params = {
+            'repeated_capability_list': repeated_capability_list,
+            'vi': vi,
+            'library': library,
+            'encoding': encoding,
+        }
 
         # Instantiate any repeated capability objects
         self.channels = _RepeatedCapabilities(self, '', repeated_capability_list)
@@ -1778,7 +1778,10 @@ class _SessionBase(object):
         self._is_frozen = freeze_it
 
     def __repr__(self):
-        return '{0}.{1}({2})'.format('niscope', self.__class__.__name__, self._param_list)
+        params_string = ', '.join(
+            [param + '=' + pp.pformat(self._params[param]) for param in self._params]
+        )
+        return '{0}.{1}({2})'.format('niscope', self.__class__.__name__, params_string)
 
     def __setattr__(self, key, value):
         if self._is_frozen and key not in dir(self):
@@ -4374,12 +4377,12 @@ class Session(_SessionBase):
         self.tclk = nitclk.SessionReference(self._vi)
 
         # Store the parameter list for later printing in __repr__
-        param_list = []
-        param_list.append("resource_name=" + pp.pformat(resource_name))
-        param_list.append("id_query=" + pp.pformat(id_query))
-        param_list.append("reset_device=" + pp.pformat(reset_device))
-        param_list.append("options=" + pp.pformat(options))
-        self._param_list = ', '.join(param_list)
+        self._params = {
+            'resource_name': resource_name,
+            'id_query': id_query,
+            'reset_device': reset_device,
+            'options': options,
+        }
 
         self._is_frozen = True
 

--- a/generated/nise/nise/session.py
+++ b/generated/nise/nise/session.py
@@ -63,17 +63,20 @@ class _SessionBase(object):
         self._encoding = encoding
 
         # Store the parameter list for later printing in __repr__
-        param_list = []
-        param_list.append("repeated_capability_list=" + pp.pformat(repeated_capability_list))
-        param_list.append("vi=" + pp.pformat(vi))
-        param_list.append("library=" + pp.pformat(library))
-        param_list.append("encoding=" + pp.pformat(encoding))
-        self._param_list = ', '.join(param_list)
+        self._params = {
+            'repeated_capability_list': repeated_capability_list,
+            'vi': vi,
+            'library': library,
+            'encoding': encoding,
+        }
 
         self._is_frozen = freeze_it
 
     def __repr__(self):
-        return '{0}.{1}({2})'.format('nise', self.__class__.__name__, self._param_list)
+        params_string = ', '.join(
+            [param + '=' + pp.pformat(self._params[param]) for param in self._params]
+        )
+        return '{0}.{1}({2})'.format('nise', self.__class__.__name__, params_string)
 
     def __setattr__(self, key, value):
         if self._is_frozen and key not in dir(self):
@@ -238,10 +241,10 @@ class Session(_SessionBase):
         self._vi = self._open_session(virtual_device_name, options)
 
         # Store the parameter list for later printing in __repr__
-        param_list = []
-        param_list.append("virtual_device_name=" + pp.pformat(virtual_device_name))
-        param_list.append("options=" + pp.pformat(options))
-        self._param_list = ', '.join(param_list)
+        self._params = {
+            'virtual_device_name': virtual_device_name,
+            'options': options,
+        }
 
         self._is_frozen = True
 

--- a/generated/niswitch/niswitch/session.py
+++ b/generated/niswitch/niswitch/session.py
@@ -592,12 +592,12 @@ class _SessionBase(object):
         self._encoding = encoding
 
         # Store the parameter list for later printing in __repr__
-        param_list = []
-        param_list.append("repeated_capability_list=" + pp.pformat(repeated_capability_list))
-        param_list.append("vi=" + pp.pformat(vi))
-        param_list.append("library=" + pp.pformat(library))
-        param_list.append("encoding=" + pp.pformat(encoding))
-        self._param_list = ', '.join(param_list)
+        self._params = {
+            'repeated_capability_list': repeated_capability_list,
+            'vi': vi,
+            'library': library,
+            'encoding': encoding,
+        }
 
         # Instantiate any repeated capability objects
         self.channels = _RepeatedCapabilities(self, '', repeated_capability_list)
@@ -605,7 +605,10 @@ class _SessionBase(object):
         self._is_frozen = freeze_it
 
     def __repr__(self):
-        return '{0}.{1}({2})'.format('niswitch', self.__class__.__name__, self._param_list)
+        params_string = ', '.join(
+            [param + '=' + pp.pformat(self._params[param]) for param in self._params]
+        )
+        return '{0}.{1}({2})'.format('niswitch', self.__class__.__name__, params_string)
 
     def __setattr__(self, key, value):
         if self._is_frozen and key not in dir(self):
@@ -1562,12 +1565,12 @@ class Session(_SessionBase):
         self._vi = self._init_with_topology(resource_name, topology, simulate, reset_device)
 
         # Store the parameter list for later printing in __repr__
-        param_list = []
-        param_list.append("resource_name=" + pp.pformat(resource_name))
-        param_list.append("topology=" + pp.pformat(topology))
-        param_list.append("simulate=" + pp.pformat(simulate))
-        param_list.append("reset_device=" + pp.pformat(reset_device))
-        self._param_list = ', '.join(param_list)
+        self._params = {
+            'resource_name': resource_name,
+            'topology': topology,
+            'simulate': simulate,
+            'reset_device': reset_device,
+        }
 
         self._is_frozen = True
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

- Store the session parameter list as a dict instead of a joined string so that they can still be accessed later
- Convert the parameter dict to a string in `__repr__()` on demand

Note: This PR is created to address the review comment at https://github.com/ni/nimi-python/pull/1754#discussion_r898506224

### What testing has been done?

Manually tested that the session params can now be accessed through `session._params` and `__repr__()` still works as expected, e.g.
```
nidcpower.Session(resource_name='dev1,dev2', channels='', reset=False, options='Simulate=1, DriverSetup=Model:4162; BoardType:PXIe', independent_channels=True)
```
