### PR TITLE
NI-FAKE: Create get_channel_names method template

### DIFF
--- a/build/templates/session.py/get_channel_names.py.mako
+++ b/build/templates/session.py/get_channel_names.py.mako
@@ -1,0 +1,13 @@
+<%page args="f, config, method_template"/>\
+<%
+    import build.helper as helper
+
+    suffix = method_template['method_python_name_suffix']
+%>\
+    def ${f['python_name']}${suffix}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+        '''${f['python_name']}
+
+        ${helper.get_function_docstring(f, False, config, indent=8)}
+        '''
+        return self._${f['python_name']}${suffix}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_PASSTHROUGH_CALL)})
+

--- a/build/templates/session.py/get_channel_names.py.mako
+++ b/build/templates/session.py/get_channel_names.py.mako
@@ -1,5 +1,10 @@
 <%page args="f, config, method_template"/>\
 <%
+    '''Some "fancy" methods in _SessionBase need to get channel names, but get_channel_names()
+    doesn't make sense there for customers as it only applies with no repeated capabilities.
+    For that reason, some modules code-generate _get_channel_names() as private in _SessionBase and
+    then put this public wrapper in Session.
+    '''
     import build.helper as helper
 
     suffix = method_template['method_python_name_suffix']

--- a/build/templates/session.py/get_channel_names.py.mako
+++ b/build/templates/session.py/get_channel_names.py.mako
@@ -1,9 +1,10 @@
 <%page args="f, config, method_template"/>\
 <%
-    '''Some "fancy" methods in _SessionBase need to get channel names, but get_channel_names()
-    doesn't make sense there for customers as it only applies with no repeated capabilities.
-    For that reason, some modules code-generate _get_channel_names() as private in _SessionBase and
-    then put this public wrapper in Session.
+    '''Some "fancy" methods in _SessionBase need to get channel names, but exposing
+    get_channel_names() from _SessionBase as part of public API would allow
+    users to call it with "channels" repeated capability which we want to avoid.
+    For that reason, some modules code-generate _get_channel_names() as private in
+    _SessionBase and then put this public wrapper in Session.
     '''
     import build.helper as helper
 

--- a/generated/nifake/nifake/_library.py
+++ b/generated/nifake/nifake/_library.py
@@ -51,6 +51,7 @@ class Library(object):
         self.niFake_GetAttributeViString_cfunc = None
         self.niFake_GetCalDateAndTime_cfunc = None
         self.niFake_GetCalInterval_cfunc = None
+        self.niFake_GetChannelNames_cfunc = None
         self.niFake_GetCustomType_cfunc = None
         self.niFake_GetCustomTypeArray_cfunc = None
         self.niFake_GetCustomTypeTypedef_cfunc = None
@@ -301,6 +302,14 @@ class Library(object):
                 self.niFake_GetCalInterval_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niFake_GetCalInterval_cfunc.restype = ViStatus  # noqa: F405
         return self.niFake_GetCalInterval_cfunc(vi, months)
+
+    def niFake_GetChannelNames(self, vi, indices, name_size, names):  # noqa: N802
+        with self._func_lock:
+            if self.niFake_GetChannelNames_cfunc is None:
+                self.niFake_GetChannelNames_cfunc = self._get_library_function('niFake_GetChannelNames')
+                self.niFake_GetChannelNames_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
+                self.niFake_GetChannelNames_cfunc.restype = ViStatus  # noqa: F405
+        return self.niFake_GetChannelNames_cfunc(vi, indices, name_size, names)
 
     def niFake_GetCustomType(self, vi, cs):  # noqa: N802
         with self._func_lock:

--- a/generated/nifake/nifake/unit_tests/_mock_helper.py
+++ b/generated/nifake/nifake/unit_tests/_mock_helper.py
@@ -95,6 +95,9 @@ class SideEffectsHelper(object):
         self._defaults['GetCalInterval'] = {}
         self._defaults['GetCalInterval']['return'] = 0
         self._defaults['GetCalInterval']['months'] = None
+        self._defaults['GetChannelNames'] = {}
+        self._defaults['GetChannelNames']['return'] = 0
+        self._defaults['GetChannelNames']['names'] = None
         self._defaults['GetCustomType'] = {}
         self._defaults['GetCustomType']['return'] = 0
         self._defaults['GetCustomType']['cs'] = None
@@ -515,6 +518,16 @@ class SideEffectsHelper(object):
         if months is not None:
             months.contents.value = self._defaults['GetCalInterval']['months']
         return self._defaults['GetCalInterval']['return']
+
+    def niFake_GetChannelNames(self, vi, indices, name_size, names):  # noqa: N802
+        if self._defaults['GetChannelNames']['return'] != 0:
+            return self._defaults['GetChannelNames']['return']
+        if self._defaults['GetChannelNames']['names'] is None:
+            raise MockFunctionCallError("niFake_GetChannelNames", param='names')
+        if name_size.value == 0:
+            return len(self._defaults['GetChannelNames']['names'])
+        names.value = self._defaults['GetChannelNames']['names'].encode('ascii')
+        return self._defaults['GetChannelNames']['return']
 
     def niFake_GetCustomType(self, vi, cs):  # noqa: N802
         if self._defaults['GetCustomType']['return'] != 0:
@@ -945,6 +958,8 @@ class SideEffectsHelper(object):
         mock_library.niFake_GetCalDateAndTime.return_value = 0
         mock_library.niFake_GetCalInterval.side_effect = MockFunctionCallError("niFake_GetCalInterval")
         mock_library.niFake_GetCalInterval.return_value = 0
+        mock_library.niFake_GetChannelNames.side_effect = MockFunctionCallError("niFake_GetChannelNames")
+        mock_library.niFake_GetChannelNames.return_value = 0
         mock_library.niFake_GetCustomType.side_effect = MockFunctionCallError("niFake_GetCustomType")
         mock_library.niFake_GetCustomType.return_value = 0
         mock_library.niFake_GetCustomTypeArray.side_effect = MockFunctionCallError("niFake_GetCustomTypeArray")

--- a/generated/nifake/nifake/unit_tests/test_session.py
+++ b/generated/nifake/nifake/unit_tests/test_session.py
@@ -735,6 +735,34 @@ class TestSession(object):
                 assert issubclass(w[0].category, nifake.DriverWarning)
                 assert test_error_desc in str(w[0].message)
 
+    def test_get_channel_names(self):
+        channel_indices = [0, 3, 2]
+        expected_channel_names_string = '0,3,2'
+        expected_channel_names_string_size = len(expected_channel_names_string)
+        expected_channel_names = ['0', '3', '2']
+        self.patched_library.niFake_GetChannelNames.side_effect = self.side_effects_helper.niFake_GetChannelNames
+        self.side_effects_helper['GetChannelNames']['names'] = expected_channel_names_string
+        with nifake.Session('dev1') as session:
+            channel_names_from_session = session.get_channel_names(channel_indices)
+            assert channel_names_from_session == expected_channel_names
+            from unittest.mock import call
+            expected_calls = [
+                call(
+                    _matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST),
+                    _matchers.ViStringMatcher(expected_channel_names_string),
+                    _matchers.ViInt32Matcher(0),
+                    None
+                ),
+                call(
+                    _matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST),
+                    _matchers.ViStringMatcher(expected_channel_names_string),
+                    _matchers.ViInt32Matcher(expected_channel_names_string_size),
+                    _matchers.ViCharBufferMatcher(expected_channel_names_string_size)
+                )
+            ]
+            self.patched_library.niFake_GetChannelNames.assert_has_calls(expected_calls)
+            assert self.patched_library.niFake_GetChannelNames.call_count == len(expected_calls)
+
     # Retrieving buffers and strings
 
     def test_get_a_string_of_fixed_maximum_size(self):

--- a/src/nifake/metadata/attributes.py
+++ b/src/nifake/metadata/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 22.5.0d21
+# This file is generated from NI-FAKE API metadata version 22.5.0d24
 attributes = {
     1000000: {
         'access': 'read-write',

--- a/src/nifake/metadata/config.py
+++ b/src/nifake/metadata/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 22.5.0d21
+# This file is generated from NI-FAKE API metadata version 22.5.0d24
 config = {
-    'api_version': '22.5.0d21',
+    'api_version': '22.5.0d24',
     'c_function_prefix': 'niFake_',
     'close_function': 'close',
     'context_manager_name': {

--- a/src/nifake/metadata/enums.py
+++ b/src/nifake/metadata/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 22.5.0d21
+# This file is generated from NI-FAKE API metadata version 22.5.0d24
 enums = {
     'AltColor': {
         'values': [

--- a/src/nifake/metadata/functions.py
+++ b/src/nifake/metadata/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 22.5.0d9999
+# This file is generated from NI-FAKE API metadata version 22.5.0d24
 functions = {
     'Abort': {
         'codegen_method': 'public',

--- a/src/nifake/metadata/functions.py
+++ b/src/nifake/metadata/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 22.5.0d9
+# This file is generated from NI-FAKE API metadata version 22.5.0d9999
 functions = {
     'Abort': {
         'codegen_method': 'public',
@@ -975,6 +975,56 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
+    'GetChannelNames': {
+        'codegen_method': 'private',
+        'documentation': {
+            'description': 'Returns a list of channel names for the given channel indices.'
+        },
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Identifies a particular instrument session.'
+                },
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Index list for the channels in the session. Valid values are from zero to the total number of channels in the session minus one. The index string can be one of the following formats:\n\n-   A comma-separated list—for example, "0,2,3,1"\n-   A range using a hyphen—for example, "0-3"\n-   A range using a colon—for example, "0:3 "\n\nYou can combine comma-separated lists and ranges that use a hyphen or colon. Both out-of-order and repeated indices are supported ("2,3,0," "1,2,2,3"). White space characters, including spaces, tabs, feeds, and carriage returns, are allowed between characters. Ranges can be incrementing or decrementing.'
+                },
+                'name': 'indices',
+                'python_api_converter_name': 'convert_repeated_capabilities_without_prefix',
+                'type': 'ViConstString',
+                'type_in_documentation': 'basic sequence types or str or int'
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'The number of elements in the ViChar array you specify for names.'
+                },
+                'name': 'nameSize',
+                'type': 'ViInt32'
+            },
+            {
+                'direction': 'out',
+                'documentation': {
+                    'description': 'The channel name(s) at the specified indices.'
+                },
+                'name': 'names',
+                'python_api_converter_name': 'convert_comma_separated_string_to_list',
+                'size': {
+                    'mechanism': 'ivi-dance',
+                    'value': 'nameSize'
+                },
+                'type': 'ViChar[]',
+                'type_in_documentation': 'list of str'
+            }
+        ],
+        'render_in_session_base': True,
+        'returns': 'ViStatus'
+    },
     'GetCustomType': {
         'codegen_method': 'public',
         'documentation': {
@@ -1675,6 +1725,64 @@ functions = {
         ],
         'python_name': 'simple_function',
         'returns': 'ViStatus'
+    },
+    'PublicGetChannelNames': {
+        'codegen_method': 'python-only',
+        'documentation': {
+            'description': 'Returns a list of channel names for the given channel indices.'
+        },
+        'method_templates': [
+            {
+                'documentation_filename': 'default_method',
+                'method_python_name_suffix': '',
+                'session_filename': 'get_channel_names'
+            }
+        ],
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Identifies a particular instrument session.'
+                },
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Index list for the channels in the session. Valid values are from zero to the total number of channels in the session minus one. The index string can be one of the following formats:\n\n-   A comma-separated list—for example, "0,2,3,1"\n-   A range using a hyphen—for example, "0-3"\n-   A range using a colon—for example, "0:3 "\n\nYou can combine comma-separated lists and ranges that use a hyphen or colon. Both out-of-order and repeated indices are supported ("2,3,0," "1,2,2,3"). White space characters, including spaces, tabs, feeds, and carriage returns, are allowed between characters. Ranges can be incrementing or decrementing.'
+                },
+                'name': 'indices',
+                'python_api_converter_name': 'convert_repeated_capabilities_without_prefix',
+                'type': 'ViString',
+                'type_in_documentation': 'basic sequence types or str or int'
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'The number of elements in the ViChar array you specify for names.'
+                },
+                'name': 'nameSize',
+                'type': 'ViInt32'
+            },
+            {
+                'direction': 'out',
+                'documentation': {
+                    'description': 'The channel name(s) at the specified indices.'
+                },
+                'name': 'names',
+                'python_api_converter_name': 'convert_comma_separated_string_to_list',
+                'size': {
+                    'mechanism': 'ivi-dance',
+                    'value': 'nameSize'
+                },
+                'type': 'ViString',
+                'type_in_documentation': 'list of str'
+            }
+        ],
+        'python_name': 'get_channel_names',
+        'render_in_session_base': True,
+        'returns': None
     },
     'Read': {
         'codegen_method': 'public',

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -735,6 +735,34 @@ class TestSession(object):
                 assert issubclass(w[0].category, nifake.DriverWarning)
                 assert test_error_desc in str(w[0].message)
 
+    def test_get_channel_names(self):
+        channel_indices = [0, 3, 2]
+        expected_channel_names_string = '0,3,2'
+        expected_channel_names_string_size = len(expected_channel_names_string)
+        expected_channel_names = ['0', '3', '2']
+        self.patched_library.niFake_GetChannelNames.side_effect = self.side_effects_helper.niFake_GetChannelNames
+        self.side_effects_helper['GetChannelNames']['names'] = expected_channel_names_string
+        with nifake.Session('dev1') as session:
+            channel_names_from_session = session.get_channel_names(channel_indices)
+            assert channel_names_from_session == expected_channel_names
+            from unittest.mock import call
+            expected_calls = [
+                call(
+                    _matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST),
+                    _matchers.ViStringMatcher(expected_channel_names_string),
+                    _matchers.ViInt32Matcher(0),
+                    None
+                ),
+                call(
+                    _matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST),
+                    _matchers.ViStringMatcher(expected_channel_names_string),
+                    _matchers.ViInt32Matcher(expected_channel_names_string_size),
+                    _matchers.ViCharBufferMatcher(expected_channel_names_string_size)
+                )
+            ]
+            self.patched_library.niFake_GetChannelNames.assert_has_calls(expected_calls)
+            assert self.patched_library.niFake_GetChannelNames.call_count == len(expected_calls)
+
     # Retrieving buffers and strings
 
     def test_get_a_string_of_fixed_maximum_size(self):


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

- Update NI-FAKE metadata to 22.5.0d24 to include "GetChannelNames" and "PublicGetChannelNames"
- Create "get_channel_names.py.mako" method template to be used by public `get_channel_names()` in Session to call into `_get_channel_names()` in SessionBase
- Create unit test `test_get_channel_names()` for the new method template

### List issues fixed by this Pull Request below, if any.

* Part of the PRs to fix #1756

Related PR: #1757

### What testing has been done?

The new unit test passed on my local run.