### PR TITLE
Update `AttributeEnumWithConverter` error message

### DIFF
--- a/build/templates/_attributes.py.mako
+++ b/build/templates/_attributes.py.mako
@@ -137,7 +137,7 @@ class AttributeEnumWithConverter(AttributeEnum):
         try:
             return self._underlying_attribute_enum.__set__(session, self._setter_converter(value))
         except KeyError:
-            raise ValueError(f'{value} cannot be converted to an {str(self._underlying_attribute_enum._attribute_type.__name__)} enum value')
+            raise ValueError(f'Invalid value: {value}')
 
 
 # nitclk specific attribute type

--- a/generated/nidcpower/nidcpower/_attributes.py
+++ b/generated/nidcpower/nidcpower/_attributes.py
@@ -133,7 +133,7 @@ class AttributeEnumWithConverter(AttributeEnum):
         try:
             return self._underlying_attribute_enum.__set__(session, self._setter_converter(value))
         except KeyError:
-            raise ValueError(f'{value} cannot be converted to an {str(self._underlying_attribute_enum._attribute_type.__name__)} enum value')
+            raise ValueError(f'Invalid value: {value}')
 
 
 # nitclk specific attribute type

--- a/generated/nidigital/nidigital/_attributes.py
+++ b/generated/nidigital/nidigital/_attributes.py
@@ -133,7 +133,7 @@ class AttributeEnumWithConverter(AttributeEnum):
         try:
             return self._underlying_attribute_enum.__set__(session, self._setter_converter(value))
         except KeyError:
-            raise ValueError(f'{value} cannot be converted to an {str(self._underlying_attribute_enum._attribute_type.__name__)} enum value')
+            raise ValueError(f'Invalid value: {value}')
 
 
 # nitclk specific attribute type

--- a/generated/nidmm/nidmm/_attributes.py
+++ b/generated/nidmm/nidmm/_attributes.py
@@ -133,7 +133,7 @@ class AttributeEnumWithConverter(AttributeEnum):
         try:
             return self._underlying_attribute_enum.__set__(session, self._setter_converter(value))
         except KeyError:
-            raise ValueError(f'{value} cannot be converted to an {str(self._underlying_attribute_enum._attribute_type.__name__)} enum value')
+            raise ValueError(f'Invalid value: {value}')
 
 
 # nitclk specific attribute type

--- a/generated/nifake/nifake/_attributes.py
+++ b/generated/nifake/nifake/_attributes.py
@@ -133,7 +133,7 @@ class AttributeEnumWithConverter(AttributeEnum):
         try:
             return self._underlying_attribute_enum.__set__(session, self._setter_converter(value))
         except KeyError:
-            raise ValueError(f'{value} cannot be converted to an {str(self._underlying_attribute_enum._attribute_type.__name__)} enum value')
+            raise ValueError(f'Invalid value: {value}')
 
 
 # nitclk specific attribute type

--- a/generated/nifake/nifake/unit_tests/test_session.py
+++ b/generated/nifake/nifake/unit_tests/test_session.py
@@ -1121,7 +1121,7 @@ class TestSession(object):
 
     def test_set_attribute_enum_with_converter_invalid_input(self):
         invalid_input_value = 'invalid'
-        expected_error_description = "invalid cannot be converted to an EnumWithConverter enum value"
+        expected_error_description = "Invalid value: invalid"
         self.patched_library.niFake_SetAttributeViInt32.side_effect = self.side_effects_helper.niFake_SetAttributeViInt32
         with nifake.Session('dev1') as session:
             try:

--- a/generated/nifgen/nifgen/_attributes.py
+++ b/generated/nifgen/nifgen/_attributes.py
@@ -133,7 +133,7 @@ class AttributeEnumWithConverter(AttributeEnum):
         try:
             return self._underlying_attribute_enum.__set__(session, self._setter_converter(value))
         except KeyError:
-            raise ValueError(f'{value} cannot be converted to an {str(self._underlying_attribute_enum._attribute_type.__name__)} enum value')
+            raise ValueError(f'Invalid value: {value}')
 
 
 # nitclk specific attribute type

--- a/generated/niscope/niscope/_attributes.py
+++ b/generated/niscope/niscope/_attributes.py
@@ -133,7 +133,7 @@ class AttributeEnumWithConverter(AttributeEnum):
         try:
             return self._underlying_attribute_enum.__set__(session, self._setter_converter(value))
         except KeyError:
-            raise ValueError(f'{value} cannot be converted to an {str(self._underlying_attribute_enum._attribute_type.__name__)} enum value')
+            raise ValueError(f'Invalid value: {value}')
 
 
 # nitclk specific attribute type

--- a/generated/niswitch/niswitch/_attributes.py
+++ b/generated/niswitch/niswitch/_attributes.py
@@ -133,7 +133,7 @@ class AttributeEnumWithConverter(AttributeEnum):
         try:
             return self._underlying_attribute_enum.__set__(session, self._setter_converter(value))
         except KeyError:
-            raise ValueError(f'{value} cannot be converted to an {str(self._underlying_attribute_enum._attribute_type.__name__)} enum value')
+            raise ValueError(f'Invalid value: {value}')
 
 
 # nitclk specific attribute type

--- a/generated/nitclk/nitclk/_attributes.py
+++ b/generated/nitclk/nitclk/_attributes.py
@@ -133,7 +133,7 @@ class AttributeEnumWithConverter(AttributeEnum):
         try:
             return self._underlying_attribute_enum.__set__(session, self._setter_converter(value))
         except KeyError:
-            raise ValueError(f'{value} cannot be converted to an {str(self._underlying_attribute_enum._attribute_type.__name__)} enum value')
+            raise ValueError(f'Invalid value: {value}')
 
 
 # nitclk specific attribute type

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -1121,7 +1121,7 @@ class TestSession(object):
 
     def test_set_attribute_enum_with_converter_invalid_input(self):
         invalid_input_value = 'invalid'
-        expected_error_description = "invalid cannot be converted to an EnumWithConverter enum value"
+        expected_error_description = "Invalid value: invalid"
         self.patched_library.niFake_SetAttributeViInt32.side_effect = self.side_effects_helper.niFake_SetAttributeViInt32
         with nifake.Session('dev1') as session:
             try:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

- This PR addresses the review comment (https://github.com/ni/nimi-python/pull/1763/files/d89afe0da2347857a4516ef89eb881250b5b1061#r907609527)
  - Update setter error message for `AttributeEnumWithConverter` to exclude the mention of the internal enum

### What testing has been done?

Local build was successful. The updated tests passed successfully.