### PR TITLE
Simplify `_add_enum_codegen_method()`

### DIFF
--- a/build/helper/metadata_add_all.py
+++ b/build/helper/metadata_add_all.py
@@ -457,11 +457,12 @@ def _add_enum_codegen_method(enums, config):
     enum_to_client_functions = _get_functions_that_use_enums(enums, config)
     enum_to_client_attributes = _get_attributes_that_use_enums(enums, config)
     for e in enums:
-        least_restrictive_codegen_method = _get_least_restrictive_codegen_method([
-            config['functions'][f]['codegen_method'] for f in enum_to_client_functions[e]
-        ] + [
-            config['attributes'][a]['codegen_method'] for a in enum_to_client_attributes[e]
-        ])
+        least_restrictive_codegen_method = _get_least_restrictive_codegen_method(
+            set.union(
+                set(config['functions'][f]['codegen_method'] for f in enum_to_client_functions[e]),
+                set(config['attributes'][a]['codegen_method'] for a in enum_to_client_attributes[e])
+            )
+        )
         if 'codegen_method' not in enums[e]:
             enums[e]['codegen_method'] = least_restrictive_codegen_method
         else:
@@ -514,9 +515,9 @@ def _get_attributes_that_use_enums(enums, config):
 
 
 def _get_least_restrictive_codegen_method(codegen_methods):
-    '''Get the least restrictive codegen_method among the input codegen_methods list.
+    '''Get the least restrictive codegen_method among the input codegen_methods.
 
-    If the input codegen_methods list, return 'no'.
+    If the codegen_methods parameter is empty, return 'no'.
     The restrictiveness of the codegen_method is as follows (most restrictive -> least restrictive):
     'no' -> 'private' -> 'public' / 'python-only' (will be converted to 'public')
     '''


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

This PR is created mainly to address the comment https://github.com/ni/nimi-python/pull/1738#discussion_r905676737

- Update `_add_enum_codegen_method()` to no longer override explicitly specified codegen-method, raise ValueError instead
- Create sub-functions for `_add_enum_codegen_method()`
  - `_get_functions_that_use_enums()`
  - `_get_attributes_that_use_enums()`
  - `_get_least_restrictive_codegen_method()`
- Update their function docstrings accordingly
- Update unit tests in "metadata_add_all.py":
  - Add 'EnumWithConverter' to the unit test input
  - Create `_setup_inputs_for_enum_codegen_method_tests()` to prepare the input metadata to test the new functions
  - Create new unit tests:
    - `test_add_enum_codegen_method()`
    - `test_add_enum_codegen_method_error()`
    - `test_get_functions_that_use_enums()`
    - `test_get_attributes_that_use_enums()`
    - `test_get_least_restrictive_codegen_method()`

### What testing has been done?

Local build was successful, all the new build tests passed.