### PR TITLE
NI-DCPower: Enable LCR range attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
     * #### Removed
 * ### `nidcpower` (NI-DCPower)
     * #### Added
-        * Partial API parity with NI-DCPower 21.8.0.
+        * Partial API parity with NI-DCPower 2022 Q3.
             * Properties added:
                 * `aperture_time_auto_mode`
                 * `autorange_maximum_delay_after_range_change`
@@ -46,12 +46,16 @@ All notable changes to this project will be documented in this file.
                 * `lcr_actual_load_resistance`
                 * `lcr_automatic_level_control`
                 * `lcr_current_amplitude`
+                * `lcr_current_range`
                 * `lcr_custom_measurement_time`
                 * `lcr_dc_bias_automatic_level_control`
                 * `lcr_dc_bias_current_level`
+                * `lcr_dc_bias_current_range`
                 * `lcr_dc_bias_source`
                 * `lcr_dc_bias_voltage_level`
+                * `lcr_dc_bias_voltage_range`
                 * `lcr_frequency`
+                * `lcr_impedance_auto_range`
                 * `lcr_impedance_range`
                 * `lcr_impedance_range_source`
                 * `lcr_load_capacitance`
@@ -72,6 +76,7 @@ All notable changes to this project will be documented in this file.
                 * `lcr_source_delay_mode`
                 * `lcr_stimulus_function`
                 * `lcr_voltage_amplitude`
+                * `lcr_voltage_range`
             * Enums added:
                 * `ApertureTimeAutoMode`
                 * `CableLength`

--- a/docs/nidcpower/class.rst
+++ b/docs/nidcpower/class.rst
@@ -4754,6 +4754,47 @@ lcr_current_amplitude
                 - LabVIEW Property: **LCR:AC Stimulus:Current Amplitude**
                 - C Attribute: **NIDCPOWER_ATTR_LCR_CURRENT_AMPLITUDE**
 
+lcr_current_range
+-----------------
+
+    .. py:attribute:: lcr_current_range
+
+        Specifies the current range, in amps RMS, for the specified channel(s).
+        The range defines the valid values to which you can set the :py:attr:`nidcpower.Session.lcr_current_amplitude`.
+        For valid ranges, refer to the specifications for your instrument.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].lcr_current_range`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.lcr_current_range`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **LCR:AC Stimulus:Advanced:Current Range**
+                - C Attribute: **NIDCPOWER_ATTR_LCR_CURRENT_RANGE**
+
 lcr_custom_measurement_time
 ---------------------------
 
@@ -4873,6 +4914,47 @@ lcr_dc_bias_current_level
                 - LabVIEW Property: **LCR:DC Bias:Current Level**
                 - C Attribute: **NIDCPOWER_ATTR_LCR_DC_BIAS_CURRENT_LEVEL**
 
+lcr_dc_bias_current_range
+-------------------------
+
+    .. py:attribute:: lcr_dc_bias_current_range
+
+        Specifies the DC Bias current range, in amps, for the specified channel(s).
+        The range defines the valid values to which you can set the :py:attr:`nidcpower.Session.lcr_dc_bias_current_level`.
+        For valid ranges, refer to the specifications for your instrument.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].lcr_dc_bias_current_range`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.lcr_dc_bias_current_range`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **LCR:DC Bias:Advanced:Current Range**
+                - C Attribute: **NIDCPOWER_ATTR_LCR_DC_BIAS_CURRENT_RANGE**
+
 lcr_dc_bias_source
 ------------------
 
@@ -4951,6 +5033,47 @@ lcr_dc_bias_voltage_level
                 - LabVIEW Property: **LCR:DC Bias:Voltage Level**
                 - C Attribute: **NIDCPOWER_ATTR_LCR_DC_BIAS_VOLTAGE_LEVEL**
 
+lcr_dc_bias_voltage_range
+-------------------------
+
+    .. py:attribute:: lcr_dc_bias_voltage_range
+
+        Specifies the DC Bias voltage range, in volts, for the specified channel(s).
+        The range defines the valid values to which you can set the :py:attr:`nidcpower.Session.lcr_dc_bias_voltage_level`.
+        For valid ranges, refer to the specifications for your instrument.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].lcr_dc_bias_voltage_range`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.lcr_dc_bias_voltage_range`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **LCR:DC Bias:Advanced:Voltage Range**
+                - C Attribute: **NIDCPOWER_ATTR_LCR_DC_BIAS_VOLTAGE_RANGE**
+
 lcr_frequency
 -------------
 
@@ -4989,6 +5112,56 @@ lcr_frequency
 
                 - LabVIEW Property: **LCR:AC Stimulus:Frequency**
                 - C Attribute: **NIDCPOWER_ATTR_LCR_FREQUENCY**
+
+lcr_impedance_auto_range
+------------------------
+
+    .. py:attribute:: lcr_impedance_auto_range
+
+        Defines whether an instrument in LCR mode automatically selects the best impedance range for each given LCR measurement.
+
+        Impedance autoranging may be enabled only when both:
+
+        - The :py:attr:`nidcpower.Session.source_mode` property is set to :py:data:`~nidcpower.SourceMode.SINGLE_POINT`
+        - :py:attr:`nidcpower.Session.measure_when` is set to a value other than :py:data:`~nidcpower.MeasureWhen.ON_MEASURE_TRIGGER`
+
+        You can read :py:attr:`nidcpower.Session.lcr_impedance_range` back after a measurement to determine the actual range used.
+
+        When enabled, impedance autoranging overrides impedance range settings you configure manually with any other properties.
+
+        Default Value: Search ni.com for Supported Properties by Device for the default value by instrument.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].lcr_impedance_auto_range`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.lcr_impedance_auto_range`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | bool       |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **LCR:Impedance Range:Impedance Autorange**
+                - C Attribute: **NIDCPOWER_ATTR_LCR_IMPEDANCE_AUTO_RANGE**
 
 lcr_impedance_range
 -------------------
@@ -5819,6 +5992,47 @@ lcr_voltage_amplitude
 
                 - LabVIEW Property: **LCR:AC Stimulus:Voltage Amplitude**
                 - C Attribute: **NIDCPOWER_ATTR_LCR_VOLTAGE_AMPLITUDE**
+
+lcr_voltage_range
+-----------------
+
+    .. py:attribute:: lcr_voltage_range
+
+        Specifies the voltage range, in volts RMS, for the specified channel(s).
+        The range defines the valid values to which you can set the :py:attr:`nidcpower.Session.lcr_voltage_amplitude`.
+        For valid ranges, refer to the specifications for your instrument.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].lcr_voltage_range`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.lcr_voltage_range`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **LCR:AC Stimulus:Advanced:Voltage Range**
+                - C Attribute: **NIDCPOWER_ATTR_LCR_VOLTAGE_RANGE**
 
 logical_name
 ------------

--- a/generated/nidcpower/nidcpower/_converters.py
+++ b/generated/nidcpower/nidcpower/_converters.py
@@ -290,3 +290,17 @@ def convert_to_isolation_state_enum(value):
     }[value]
 
 
+def convert_from_lcr_impedance_auto_range_enum(value):
+    return {
+        enums._LCRImpedanceAutoRange.OFF: False,
+        enums._LCRImpedanceAutoRange.ON: True,
+    }[value]
+
+
+def convert_to_lcr_impedance_auto_range_enum(value):
+    return {
+        False: enums._LCRImpedanceAutoRange.OFF,
+        True: enums._LCRImpedanceAutoRange.ON,
+    }[value]
+
+

--- a/generated/nidcpower/nidcpower/enums.py
+++ b/generated/nidcpower/nidcpower/enums.py
@@ -228,6 +228,11 @@ class LCRDCBiasSource(Enum):
     '''
 
 
+class _LCRImpedanceAutoRange(Enum):
+    OFF = 1068
+    ON = 1070
+
+
 class LCRImpedanceRangeSource(Enum):
     IMPEDANCE_RANGE = 1142
     r'''

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -1199,6 +1199,26 @@ class _SessionBase(object):
 
     Example: :py:attr:`my_session.lcr_current_amplitude`
     '''
+    lcr_current_range = _attributes.AttributeViReal64(1150267)
+    '''Type: float
+
+    Specifies the current range, in amps RMS, for the specified channel(s).
+    The range defines the valid values to which you can set the lcr_current_amplitude.
+    For valid ranges, refer to the specifications for your instrument.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].lcr_current_range`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.lcr_current_range`
+    '''
     lcr_custom_measurement_time = _attributes.AttributeViReal64TimeDeltaSeconds(1150258)
     '''Type: hightime.timedelta, datetime.timedelta, or float in seconds
 
@@ -1255,6 +1275,26 @@ class _SessionBase(object):
 
     Example: :py:attr:`my_session.lcr_dc_bias_current_level`
     '''
+    lcr_dc_bias_current_range = _attributes.AttributeViReal64(1150274)
+    '''Type: float
+
+    Specifies the DC Bias current range, in amps, for the specified channel(s).
+    The range defines the valid values to which you can set the lcr_dc_bias_current_level.
+    For valid ranges, refer to the specifications for your instrument.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].lcr_dc_bias_current_range`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.lcr_dc_bias_current_range`
+    '''
     lcr_dc_bias_source = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.LCRDCBiasSource, 1150213)
     '''Type: enums.LCRDCBiasSource
 
@@ -1291,6 +1331,26 @@ class _SessionBase(object):
 
     Example: :py:attr:`my_session.lcr_dc_bias_voltage_level`
     '''
+    lcr_dc_bias_voltage_range = _attributes.AttributeViReal64(1150266)
+    '''Type: float
+
+    Specifies the DC Bias voltage range, in volts, for the specified channel(s).
+    The range defines the valid values to which you can set the lcr_dc_bias_voltage_level.
+    For valid ranges, refer to the specifications for your instrument.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].lcr_dc_bias_voltage_range`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.lcr_dc_bias_voltage_range`
+    '''
     lcr_frequency = _attributes.AttributeViReal64(1150210)
     '''Type: float
 
@@ -1308,6 +1368,35 @@ class _SessionBase(object):
     To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
 
     Example: :py:attr:`my_session.lcr_frequency`
+    '''
+    lcr_impedance_auto_range = _attributes.AttributeEnumWithConverter(_attributes.AttributeEnum(_attributes.AttributeViInt32, enums._LCRImpedanceAutoRange, 1150216), _converters.convert_from_lcr_impedance_auto_range_enum, _converters.convert_to_lcr_impedance_auto_range_enum)
+    '''Type: bool
+
+    Defines whether an instrument in LCR mode automatically selects the best impedance range for each given LCR measurement.
+
+    Impedance autoranging may be enabled only when both:
+
+    - The source_mode property is set to SourceMode.SINGLE_POINT
+    - measure_when is set to a value other than MeasureWhen.ON_MEASURE_TRIGGER
+
+    You can read lcr_impedance_range back after a measurement to determine the actual range used.
+
+    When enabled, impedance autoranging overrides impedance range settings you configure manually with any other properties.
+
+    Default Value: Search ni.com for Supported Properties by Device for the default value by instrument.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].lcr_impedance_auto_range`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.lcr_impedance_auto_range`
     '''
     lcr_impedance_range = _attributes.AttributeViReal64(1150217)
     '''Type: float
@@ -1720,6 +1809,26 @@ class _SessionBase(object):
     To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
 
     Example: :py:attr:`my_session.lcr_voltage_amplitude`
+    '''
+    lcr_voltage_range = _attributes.AttributeViReal64(1150265)
+    '''Type: float
+
+    Specifies the voltage range, in volts RMS, for the specified channel(s).
+    The range defines the valid values to which you can set the lcr_voltage_amplitude.
+    For valid ranges, refer to the specifications for your instrument.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].lcr_voltage_range`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.lcr_voltage_range`
     '''
     logical_name = _attributes.AttributeViString(1050305)
     '''Type: str

--- a/src/nidcpower/metadata/attributes_addon.py
+++ b/src/nidcpower/metadata/attributes_addon.py
@@ -2,10 +2,4 @@
 # Any changes to the API should be made here. attributes.py is code generated
 
 attributes_override_metadata = {
-    # Disable the new attributes
-    1150216: {"codegen_method": "no"},
-    1150265: {"codegen_method": "no"},
-    1150266: {"codegen_method": "no"},
-    1150267: {"codegen_method": "no"},
-    1150274: {"codegen_method": "no"}
 }

--- a/src/nidcpower/metadata/enums_addon.py
+++ b/src/nidcpower/metadata/enums_addon.py
@@ -4,7 +4,6 @@
 enums_override_metadata = {
     # TODO(olsl21): Temporarily disable the new enums (#1715), they will be re-enabled in
     #  subsequent smaller PRs
-    "LCRImpedanceAutoRange": {"codegen_method": "no"},
     "LCRReferenceValueType": {"codegen_method": "no"}
 }
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

- Enable `lcr_current_range`, `lcr_dc_bias_current_range`, `lcr_dc_bias_voltage_range` and `lcr_voltage_range` attributes
- Enable `lcr_impedance_auto_range` attribute and its associated enum with converter
- Update CHANGELOG

### What testing has been done?

Local build was successful. Manually tested that the new attributes work as expected.