### PR TITLE
NI-DCPower: Add LCR source AC voltage example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ All notable changes to this project will be documented in this file.
             * Custom types added:
                 * `LCRLoadCompensationSpot`
                 * `LCRMeasurement`
+        * `nidcpower_lcr_source_ac_voltage.py` example
     * #### Changed
         * Updated supported devices information in documentation for methods and properties
         * Added `channel` field to the `Measurement` namedtuple instances returned by `fetch_multiple` and `measure_multiple`

--- a/docs/nidcpower/examples.rst
+++ b/docs/nidcpower/examples.rst
@@ -12,6 +12,15 @@ nidcpower_advanced_sequence.py
    :encoding: utf8
    :caption: `(nidcpower_advanced_sequence.py) <https://github.com/ni/nimi-python/blob/master/src/nidcpower/examples/nidcpower_advanced_sequence.py>`_
 
+nidcpower_lcr_source_ac_voltage.py
+----------------------------------
+
+.. literalinclude:: ../../src/nidcpower/examples/nidcpower_lcr_source_ac_voltage.py
+   :language: python
+   :linenos:
+   :encoding: utf8
+   :caption: `(nidcpower_lcr_source_ac_voltage.py) <https://github.com/ni/nimi-python/blob/master/src/nidcpower/examples/nidcpower_lcr_source_ac_voltage.py>`_
+
 nidcpower_measure_record.py
 ---------------------------
 

--- a/src/nidcpower/examples/nidcpower_lcr_source_ac_voltage.py
+++ b/src/nidcpower/examples/nidcpower_lcr_source_ac_voltage.py
@@ -1,0 +1,108 @@
+#!/usr/bin/python
+
+import argparse
+import nidcpower
+import sys
+
+
+def example(
+    resource_name,
+    options,
+    lcr_frequency,
+    lcr_impedance_range,
+    cable_length,
+    lcr_voltage_rms,
+    lcr_dc_bias_source,
+    lcr_dc_bias_voltage_level,
+    lcr_measurement_time,
+    lcr_custom_measurement_time,
+    lcr_source_delay_mode,
+    source_delay,
+):
+    with nidcpower.Session(resource_name=resource_name, options=options) as session:
+        # Configure the session.
+        session.instrument_mode = nidcpower.InstrumentMode.LCR
+        session.lcr_stimulus_function = nidcpower.LCRStimulusFunction.VOLTAGE
+        session.lcr_frequency = lcr_frequency
+        session.lcr_impedance_range = lcr_impedance_range
+        session.cable_length = cable_length
+        session.lcr_voltage_amplitude = lcr_voltage_rms
+        session.lcr_dc_bias_source = lcr_dc_bias_source
+        session.lcr_dc_bias_voltage_level = lcr_dc_bias_voltage_level
+        session.lcr_measurement_time = lcr_measurement_time
+        session.lcr_custom_measurement_time = lcr_custom_measurement_time
+        session.lcr_source_delay_mode = lcr_source_delay_mode
+        session.source_delay = source_delay
+
+        with session.initiate():
+            session.wait_for_event(nidcpower.Event.SOURCE_COMPLETE, 21.0)
+            measurements = session.measure_multiple_lcr()
+            for measurement in measurements:
+                print(measurement)
+
+        session.reset()
+
+
+def _main(argsv):
+    parser = argparse.ArgumentParser(
+        description='Output the specified AC voltage and DC bias voltage, then takes LCR measurements',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument('-n', '--resource-name', default='PXI1Slot2/0', help='Resource names of NI SMUs')
+    parser.add_argument('-f', '--lcr-frequency', default=10.0e3, type=float, help='LCR frequency (Hz)')
+    parser.add_argument('-i', '--lcr-impedance-range', default=100.0, type=float, help='LCR impedance range (Ohm)')
+    parser.add_argument('-c', '--cable-length', default='NI_STANDARD_2M', type=str, choices=tuple(nidcpower.CableLength.__members__.keys()), help='Cable length')
+    parser.add_argument('-v', '--lcr-voltage-rms', default=700.0e-3, type=float, help='LCR voltage RMS (V RMS)')
+    parser.add_argument('-d', '--lcr-dc-bias-source', default='OFF', type=str, choices=tuple(nidcpower.LCRDCBiasSource.__members__.keys()), help='LCR DC bias source')
+    parser.add_argument('-dv', '--lcr-dc-bias-voltage_level', default=0.0, type=float, help='LCR DC bias voltage (V)')
+    parser.add_argument('-t', '--lcr-measurement-time', default='MEDIUM', type=str, choices=tuple(nidcpower.LCRMeasurementTime.__members__.keys()), help='LCR measurement time')
+    parser.add_argument('-ct', '--lcr-custom-measurement-time', default=10.0e-3, type=float, help='LCR custom measurement time (s)')
+    parser.add_argument('-sm', '--lcr-source-delay-mode', default='AUTOMATIC', type=str, choices=tuple(nidcpower.LCRSourceDelayMode.__members__.keys()), help='LCR source delay mode')
+    parser.add_argument('-s', '--source-delay', default=16.66e-3, type=float, help='Source delay (s)')
+    parser.add_argument('-op', '--option-string', default='', type=str, help='Option string')
+    args = parser.parse_args(argsv)
+    example(
+        args.resource_name,
+        args.option_string,
+        args.lcr_frequency,
+        args.lcr_impedance_range,
+        getattr(nidcpower.CableLength, args.cable_length),
+        args.lcr_voltage_rms,
+        getattr(nidcpower.LCRDCBiasSource, args.lcr_dc_bias_source),
+        args.lcr_dc_bias_voltage_level,
+        getattr(nidcpower.LCRMeasurementTime, args.lcr_measurement_time),
+        args.lcr_custom_measurement_time,
+        getattr(nidcpower.LCRSourceDelayMode, args.lcr_source_delay_mode),
+        args.source_delay,
+    )
+
+
+def main():
+    _main(sys.argv[1:])
+
+
+def test_example():
+    options = {'simulate': True, 'driver_setup': {'Model': '4190', 'BoardType': 'PXIe', }, }
+    example(
+        'PXI1Slot2/0',
+        options,
+        10.0e3,
+        100.0,
+        nidcpower.CableLength.NI_STANDARD_2M,
+        700.0e-3,
+        nidcpower.LCRDCBiasSource.OFF,
+        0.0,
+        nidcpower.LCRMeasurementTime.MEDIUM,
+        10.0e-3,
+        nidcpower.LCRSourceDelayMode.AUTOMATIC,
+        16.66e-3,
+    )
+
+
+def test_main():
+    cmd_line = ['--option-string', 'Simulate=1, DriverSetup=Model:4190; BoardType:PXIe', ]
+    _main(cmd_line)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/nidcpower/examples/nidcpower_lcr_source_ac_voltage.py
+++ b/src/nidcpower/examples/nidcpower_lcr_source_ac_voltage.py
@@ -35,7 +35,7 @@ def example(
         session.source_delay = source_delay
 
         with session.initiate():
-            session.wait_for_event(nidcpower.Event.SOURCE_COMPLETE, 21.0)
+            session.wait_for_event(event_id=nidcpower.Event.SOURCE_COMPLETE, timeout=21.0)
             measurements = session.measure_multiple_lcr()
             for measurement in measurements:
                 print(measurement)
@@ -62,18 +62,18 @@ def _main(argsv):
     parser.add_argument('-op', '--option-string', default='', type=str, help='Option string')
     args = parser.parse_args(argsv)
     example(
-        args.resource_name,
-        args.option_string,
-        args.lcr_frequency,
-        args.lcr_impedance_range,
-        getattr(nidcpower.CableLength, args.cable_length),
-        args.lcr_voltage_rms,
-        getattr(nidcpower.LCRDCBiasSource, args.lcr_dc_bias_source),
-        args.lcr_dc_bias_voltage_level,
-        getattr(nidcpower.LCRMeasurementTime, args.lcr_measurement_time),
-        args.lcr_custom_measurement_time,
-        getattr(nidcpower.LCRSourceDelayMode, args.lcr_source_delay_mode),
-        args.source_delay,
+        resource_name=args.resource_name,
+        options=args.option_string,
+        lcr_frequency=args.lcr_frequency,
+        lcr_impedance_range=args.lcr_impedance_range,
+        cable_length=getattr(nidcpower.CableLength, args.cable_length),
+        lcr_voltage_rms=args.lcr_voltage_rms,
+        lcr_dc_bias_source=getattr(nidcpower.LCRDCBiasSource, args.lcr_dc_bias_source),
+        lcr_dc_bias_voltage_level=args.lcr_dc_bias_voltage_level,
+        lcr_measurement_time=getattr(nidcpower.LCRMeasurementTime, args.lcr_measurement_time),
+        lcr_custom_measurement_time=args.lcr_custom_measurement_time,
+        lcr_source_delay_mode=getattr(nidcpower.LCRSourceDelayMode, args.lcr_source_delay_mode),
+        source_delay=args.source_delay,
     )
 
 
@@ -82,20 +82,19 @@ def main():
 
 
 def test_example():
-    options = {'simulate': True, 'driver_setup': {'Model': '4190', 'BoardType': 'PXIe', }, }
     example(
-        'PXI1Slot2/0',
-        options,
-        10.0e3,
-        100.0,
-        nidcpower.CableLength.NI_STANDARD_2M,
-        700.0e-3,
-        nidcpower.LCRDCBiasSource.OFF,
-        0.0,
-        nidcpower.LCRMeasurementTime.MEDIUM,
-        10.0e-3,
-        nidcpower.LCRSourceDelayMode.AUTOMATIC,
-        16.66e-3,
+        resource_name='PXI1Slot2/0',
+        options={'simulate': True, 'driver_setup': {'Model': '4190', 'BoardType': 'PXIe', }, },
+        lcr_frequency=10.0e3,
+        lcr_impedance_range=100.0,
+        cable_length=nidcpower.CableLength.NI_STANDARD_2M,
+        lcr_voltage_rms=700.0e-3,
+        lcr_dc_bias_source=nidcpower.LCRDCBiasSource.OFF,
+        lcr_dc_bias_voltage_level=0.0,
+        lcr_measurement_time=nidcpower.LCRMeasurementTime.MEDIUM,
+        lcr_custom_measurement_time=10.0e-3,
+        lcr_source_delay_mode=nidcpower.LCRSourceDelayMode.AUTOMATIC,
+        source_delay=16.66e-3,
     )
 
 

--- a/src/nidcpower/examples/nidcpower_lcr_source_ac_voltage.py
+++ b/src/nidcpower/examples/nidcpower_lcr_source_ac_voltage.py
@@ -50,7 +50,7 @@ def _main(argsv):
     )
     parser.add_argument('-n', '--resource-name', default='PXI1Slot2/0', help='Resource names of NI SMUs')
     parser.add_argument('-f', '--lcr-frequency', default=10.0e3, type=float, help='LCR frequency (Hz)')
-    parser.add_argument('-i', '--lcr-impedance-range', default=100.0, type=float, help='LCR impedance range (Ohm)')
+    parser.add_argument('-i', '--lcr-impedance-range', default=100.0, type=float, help='LCR impedance range (Ω)')
     parser.add_argument('-c', '--cable-length', default='NI_STANDARD_2M', type=str, choices=tuple(nidcpower.CableLength.__members__.keys()), help='Cable length')
     parser.add_argument('-v', '--lcr-voltage-rms', default=700.0e-3, type=float, help='LCR voltage RMS (V RMS)')
     parser.add_argument('-d', '--lcr-dc-bias-source', default='OFF', type=str, choices=tuple(nidcpower.LCRDCBiasSource.__members__.keys()), help='LCR DC bias source')

--- a/src/nidcpower/examples/nidcpower_lcr_source_ac_voltage.py
+++ b/src/nidcpower/examples/nidcpower_lcr_source_ac_voltage.py
@@ -35,7 +35,9 @@ def example(
         session.source_delay = source_delay
 
         with session.initiate():
-            session.wait_for_event(event_id=nidcpower.Event.SOURCE_COMPLETE, timeout=21.0)
+            # Low frequencies require longer settling times than the default timeout for
+            # wait_for_event(), hence 5.0s is set here as a reasonable timeout value
+            session.wait_for_event(event_id=nidcpower.Event.SOURCE_COMPLETE, timeout=5.0)
             measurements = session.measure_multiple_lcr()
             for measurement in measurements:
                 print(measurement)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

- Add "nidcpower_lcr_source_ac_voltage.py" example to demonstrate how to perform a simple AC voltage sourcing and take LCR measurements.

### What testing has been done?

- Unit tests added as part of the example file passed.
- Ran the example manually, the output was as follows:
```
> python nidcpower_lcr_source_ac_voltage.py -n 4190 -c NI_STANDARD_1M
Channel             : 4190/0
DC voltage          : 4.34928e-07 V
DC current          : 1.77324e-08 A
Stimulus frequency  : 10,000 Hz
AC voltage          : 0.7+0j V RMS
AC current          : 7.12116e-05+1.68737e-07j A RMS
Impedance           : 9,829.81-23.292j Ω
Impedance magnitude : 9,829.84 Ω
Impedance phase     : -0.135763 °
Admittance          : 0.000101731+2.41053e-07j S
Admittance magnitude: 0.000101731 S
Admittance phase    : 0.135763 °
Series inductance   : -0.000370703 H
Series capacitance  : 6.83304e-07 F
Series resistance   : 9,829.81 Ω
Parallel inductance : -66.0248 H
Parallel capacitance: 3.83648e-12 F
Parallel resistance : 9,829.86 Ω
Dissipation factor  : 422.026
Quality factor      : 0.00236952
Measurement mode    : LCR
DC in compliance    : False
AC in compliance    : False
Unbalanced          : False
```