### PR TITLE
NI-DCPower: Add system test for channel ordering

### DIFF
--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -320,24 +320,51 @@ def test_measure_multiple_channels(
             assert [measurement.channel for measurement in measurements] == expected_measured_channels
 
 
-@pytest.mark.parametrize('independent_channels', [True, False])
-def test_measure_multiple_channel_ordering(independent_channels):
-    with nidcpower.Session(
-        resource_name="Dev1, Dev2",
-        channels="",
-        options="Simulate=1, DriverSetup=Model:4162; BoardType:PXIe",
-        independent_channels=independent_channels
-    ) as session:
-        for instrument in (1, 2):
-            for channel in range(12):
-                session.channels[f"Dev{instrument}/{channel}"].voltage_level = instrument + channel * 0.01
-        with session.initiate():
-            measurements = session.channels["Dev2/3-5, Dev1/0, Dev2/7"].measure_multiple()
-            assert measurements[0].voltage == pytest.approx(2.03)
-            assert measurements[1].voltage == pytest.approx(2.04)
-            assert measurements[2].voltage == pytest.approx(2.05)
-            assert measurements[3].voltage == pytest.approx(1.00)
-            assert measurements[4].voltage == pytest.approx(2.07)
+@pytest.mark.resource_name('Dev1,Dev2')
+def test_measure_multiple_channel_ordering(session):
+    for instrument in (1, 2):
+        for channel in range(12):
+            session.channels[f"Dev{instrument}/{channel}"].voltage_level = instrument + channel * 0.01
+    with session.initiate():
+        measurements = session.channels["Dev2/3-5, Dev1/0, Dev2/7"].measure_multiple()
+        expected_measured_voltages_and_channels = (
+            (2.03, "Dev2/3"),
+            (2.04, "Dev2/4"),
+            (2.05, "Dev2/5"),
+            (1.00, "Dev1/0"),
+            (2.07, "Dev2/7")
+        )
+        assert len(measurements) == len(expected_measured_voltages_and_channels)
+        for measurement, expected_measured_voltage_and_channel in zip(
+            measurements,
+            expected_measured_voltages_and_channels
+        ):
+            expected_measured_voltage, expected_channel = expected_measured_voltage_and_channel
+            assert measurement.voltage == pytest.approx(expected_measured_voltage)
+            assert measurement.channel == expected_channel
+
+
+@pytest.mark.independent_channels(False)
+def test_measure_multiple_channel_ordering_non_independent_channels(session):
+    for channel in range(12):
+        session.channels[f"{channel}"].voltage_level = channel * 0.01
+    with session.initiate():
+        measurements = session.channels["3-4, 0, 7, 1"].measure_multiple()
+        expected_measured_voltages_and_channels = (
+            (0.03, "3"),
+            (0.04, "4"),
+            (0.00, "0"),
+            (0.07, "7"),
+            (0.01, "1")
+        )
+        assert len(measurements) == len(expected_measured_voltages_and_channels)
+        for measurement, expected_measured_voltage_and_channel in zip(
+            measurements,
+            expected_measured_voltages_and_channels
+        ):
+            expected_measured_voltage, expected_channel = expected_measured_voltage_and_channel
+            assert measurement.voltage == pytest.approx(expected_measured_voltage)
+            assert measurement.channel == expected_channel
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

- Add `test_measure_multiple_channel_ordering()` system test to ensure that the measurements returned by `measure_multiple()` match the order of the channels specified in the channel string

### What testing has been done?

Local run of the new tests was successful.