### PR TITLE
Fix AttributeEnumWithConverter to work with AdvSeq

### DIFF
--- a/build/templates/_attributes.py.mako
+++ b/build/templates/_attributes.py.mako
@@ -89,12 +89,12 @@ class AttributeViBoolean(Attribute):
         session._set_attribute_vi_boolean(self._attribute_id, value)
 
 
-class AttributeEnum(object):
+class AttributeEnum(Attribute):
 
     def __init__(self, underlying_attribute_meta_class, enum_meta_class, attribute_id):
+        super(AttributeEnum, self).__init__(attribute_id)
         self._underlying_attribute = underlying_attribute_meta_class(attribute_id)
         self._attribute_type = enum_meta_class
-        self._attribute_id = attribute_id
 
     def __get__(self, session, session_type):
         return self._attribute_type(self._underlying_attribute.__get__(session, session_type))
@@ -105,7 +105,7 @@ class AttributeEnum(object):
         return self._underlying_attribute.__set__(session, value.value)
 
 
-class AttributeEnumWithConverter(object):
+class AttributeEnumWithConverter(Attribute):
     '''Class for attributes that use enums internally but are exposed in the ${module_name} Python module as something else, thus need conversion.'''
 
     def __init__(self, underlying_attribute_enum, getter_converter, setter_converter):
@@ -121,8 +121,8 @@ class AttributeEnumWithConverter(object):
             setter_converter (function): The function that converts the converted value back to the
                 enum value
         '''
+        super(AttributeEnumWithConverter, self).__init__(underlying_attribute_enum._attribute_id)
         self._underlying_attribute_enum = underlying_attribute_enum
-        self._attribute_id = underlying_attribute_enum._attribute_id
         self._getter_converter = getter_converter
         self._setter_converter = setter_converter
 

--- a/build/templates/_attributes.py.mako
+++ b/build/templates/_attributes.py.mako
@@ -105,7 +105,7 @@ class AttributeEnum(object):
         return self._underlying_attribute.__set__(session, value.value)
 
 
-class AttributeEnumWithConverter(AttributeEnum):
+class AttributeEnumWithConverter(object):
     '''Class for attributes that use enums internally but are exposed in the ${module_name} Python module as something else, thus need conversion.'''
 
     def __init__(self, underlying_attribute_enum, getter_converter, setter_converter):
@@ -122,6 +122,7 @@ class AttributeEnumWithConverter(AttributeEnum):
                 enum value
         '''
         self._underlying_attribute_enum = underlying_attribute_enum
+        self._attribute_id = underlying_attribute_enum._attribute_id
         self._getter_converter = getter_converter
         self._setter_converter = setter_converter
 

--- a/generated/nidcpower/nidcpower/_attributes.py
+++ b/generated/nidcpower/nidcpower/_attributes.py
@@ -101,7 +101,7 @@ class AttributeEnum(object):
         return self._underlying_attribute.__set__(session, value.value)
 
 
-class AttributeEnumWithConverter(AttributeEnum):
+class AttributeEnumWithConverter(object):
     '''Class for attributes that use enums internally but are exposed in the nidcpower Python module as something else, thus need conversion.'''
 
     def __init__(self, underlying_attribute_enum, getter_converter, setter_converter):
@@ -118,6 +118,7 @@ class AttributeEnumWithConverter(AttributeEnum):
                 enum value
         '''
         self._underlying_attribute_enum = underlying_attribute_enum
+        self._attribute_id = underlying_attribute_enum._attribute_id
         self._getter_converter = getter_converter
         self._setter_converter = setter_converter
 

--- a/generated/nidcpower/nidcpower/_attributes.py
+++ b/generated/nidcpower/nidcpower/_attributes.py
@@ -85,12 +85,12 @@ class AttributeViBoolean(Attribute):
         session._set_attribute_vi_boolean(self._attribute_id, value)
 
 
-class AttributeEnum(object):
+class AttributeEnum(Attribute):
 
     def __init__(self, underlying_attribute_meta_class, enum_meta_class, attribute_id):
+        super(AttributeEnum, self).__init__(attribute_id)
         self._underlying_attribute = underlying_attribute_meta_class(attribute_id)
         self._attribute_type = enum_meta_class
-        self._attribute_id = attribute_id
 
     def __get__(self, session, session_type):
         return self._attribute_type(self._underlying_attribute.__get__(session, session_type))
@@ -101,7 +101,7 @@ class AttributeEnum(object):
         return self._underlying_attribute.__set__(session, value.value)
 
 
-class AttributeEnumWithConverter(object):
+class AttributeEnumWithConverter(Attribute):
     '''Class for attributes that use enums internally but are exposed in the nidcpower Python module as something else, thus need conversion.'''
 
     def __init__(self, underlying_attribute_enum, getter_converter, setter_converter):
@@ -117,8 +117,8 @@ class AttributeEnumWithConverter(object):
             setter_converter (function): The function that converts the converted value back to the
                 enum value
         '''
+        super(AttributeEnumWithConverter, self).__init__(underlying_attribute_enum._attribute_id)
         self._underlying_attribute_enum = underlying_attribute_enum
-        self._attribute_id = underlying_attribute_enum._attribute_id
         self._getter_converter = getter_converter
         self._setter_converter = setter_converter
 

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -4880,7 +4880,7 @@ class _SessionBase(object):
         for prop in property_names:
             if prop not in Session.__base__.__dict__:
                 raise KeyError('{0} is not an property on the nidcpower.Session'.format(prop))
-            if not isinstance(Session.__base__.__dict__[prop], _attributes.Attribute) and not isinstance(Session.__base__.__dict__[prop], _attributes.AttributeEnum):
+            if not isinstance(Session.__base__.__dict__[prop], _attributes.Attribute) and not isinstance(Session.__base__.__dict__[prop], _attributes.AttributeEnum) and not isinstance(Session.__base__.__dict__[prop], _attributes.AttributeEnumWithConverter):
                 raise TypeError('{0} is not a valid property: {1}'.format(prop, type(Session.__base__.__dict__[prop])))
             attribute_ids_used.add(Session.__base__.__dict__[prop]._attribute_id)
 

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -4880,7 +4880,7 @@ class _SessionBase(object):
         for prop in property_names:
             if prop not in Session.__base__.__dict__:
                 raise KeyError('{0} is not an property on the nidcpower.Session'.format(prop))
-            if not isinstance(Session.__base__.__dict__[prop], _attributes.Attribute) and not isinstance(Session.__base__.__dict__[prop], _attributes.AttributeEnum) and not isinstance(Session.__base__.__dict__[prop], _attributes.AttributeEnumWithConverter):
+            if not isinstance(Session.__base__.__dict__[prop], _attributes.Attribute):
                 raise TypeError('{0} is not a valid property: {1}'.format(prop, type(Session.__base__.__dict__[prop])))
             attribute_ids_used.add(Session.__base__.__dict__[prop]._attribute_id)
 

--- a/generated/nidigital/nidigital/_attributes.py
+++ b/generated/nidigital/nidigital/_attributes.py
@@ -85,12 +85,12 @@ class AttributeViBoolean(Attribute):
         session._set_attribute_vi_boolean(self._attribute_id, value)
 
 
-class AttributeEnum(object):
+class AttributeEnum(Attribute):
 
     def __init__(self, underlying_attribute_meta_class, enum_meta_class, attribute_id):
+        super(AttributeEnum, self).__init__(attribute_id)
         self._underlying_attribute = underlying_attribute_meta_class(attribute_id)
         self._attribute_type = enum_meta_class
-        self._attribute_id = attribute_id
 
     def __get__(self, session, session_type):
         return self._attribute_type(self._underlying_attribute.__get__(session, session_type))
@@ -101,7 +101,7 @@ class AttributeEnum(object):
         return self._underlying_attribute.__set__(session, value.value)
 
 
-class AttributeEnumWithConverter(object):
+class AttributeEnumWithConverter(Attribute):
     '''Class for attributes that use enums internally but are exposed in the nidigital Python module as something else, thus need conversion.'''
 
     def __init__(self, underlying_attribute_enum, getter_converter, setter_converter):
@@ -117,8 +117,8 @@ class AttributeEnumWithConverter(object):
             setter_converter (function): The function that converts the converted value back to the
                 enum value
         '''
+        super(AttributeEnumWithConverter, self).__init__(underlying_attribute_enum._attribute_id)
         self._underlying_attribute_enum = underlying_attribute_enum
-        self._attribute_id = underlying_attribute_enum._attribute_id
         self._getter_converter = getter_converter
         self._setter_converter = setter_converter
 

--- a/generated/nidigital/nidigital/_attributes.py
+++ b/generated/nidigital/nidigital/_attributes.py
@@ -101,7 +101,7 @@ class AttributeEnum(object):
         return self._underlying_attribute.__set__(session, value.value)
 
 
-class AttributeEnumWithConverter(AttributeEnum):
+class AttributeEnumWithConverter(object):
     '''Class for attributes that use enums internally but are exposed in the nidigital Python module as something else, thus need conversion.'''
 
     def __init__(self, underlying_attribute_enum, getter_converter, setter_converter):
@@ -118,6 +118,7 @@ class AttributeEnumWithConverter(AttributeEnum):
                 enum value
         '''
         self._underlying_attribute_enum = underlying_attribute_enum
+        self._attribute_id = underlying_attribute_enum._attribute_id
         self._getter_converter = getter_converter
         self._setter_converter = setter_converter
 

--- a/generated/nidmm/nidmm/_attributes.py
+++ b/generated/nidmm/nidmm/_attributes.py
@@ -101,7 +101,7 @@ class AttributeEnum(object):
         return self._underlying_attribute.__set__(session, value.value)
 
 
-class AttributeEnumWithConverter(AttributeEnum):
+class AttributeEnumWithConverter(object):
     '''Class for attributes that use enums internally but are exposed in the nidmm Python module as something else, thus need conversion.'''
 
     def __init__(self, underlying_attribute_enum, getter_converter, setter_converter):
@@ -118,6 +118,7 @@ class AttributeEnumWithConverter(AttributeEnum):
                 enum value
         '''
         self._underlying_attribute_enum = underlying_attribute_enum
+        self._attribute_id = underlying_attribute_enum._attribute_id
         self._getter_converter = getter_converter
         self._setter_converter = setter_converter
 

--- a/generated/nidmm/nidmm/_attributes.py
+++ b/generated/nidmm/nidmm/_attributes.py
@@ -85,12 +85,12 @@ class AttributeViBoolean(Attribute):
         session._set_attribute_vi_boolean(self._attribute_id, value)
 
 
-class AttributeEnum(object):
+class AttributeEnum(Attribute):
 
     def __init__(self, underlying_attribute_meta_class, enum_meta_class, attribute_id):
+        super(AttributeEnum, self).__init__(attribute_id)
         self._underlying_attribute = underlying_attribute_meta_class(attribute_id)
         self._attribute_type = enum_meta_class
-        self._attribute_id = attribute_id
 
     def __get__(self, session, session_type):
         return self._attribute_type(self._underlying_attribute.__get__(session, session_type))
@@ -101,7 +101,7 @@ class AttributeEnum(object):
         return self._underlying_attribute.__set__(session, value.value)
 
 
-class AttributeEnumWithConverter(object):
+class AttributeEnumWithConverter(Attribute):
     '''Class for attributes that use enums internally but are exposed in the nidmm Python module as something else, thus need conversion.'''
 
     def __init__(self, underlying_attribute_enum, getter_converter, setter_converter):
@@ -117,8 +117,8 @@ class AttributeEnumWithConverter(object):
             setter_converter (function): The function that converts the converted value back to the
                 enum value
         '''
+        super(AttributeEnumWithConverter, self).__init__(underlying_attribute_enum._attribute_id)
         self._underlying_attribute_enum = underlying_attribute_enum
-        self._attribute_id = underlying_attribute_enum._attribute_id
         self._getter_converter = getter_converter
         self._setter_converter = setter_converter
 

--- a/generated/nifake/nifake/_attributes.py
+++ b/generated/nifake/nifake/_attributes.py
@@ -85,12 +85,12 @@ class AttributeViBoolean(Attribute):
         session._set_attribute_vi_boolean(self._attribute_id, value)
 
 
-class AttributeEnum(object):
+class AttributeEnum(Attribute):
 
     def __init__(self, underlying_attribute_meta_class, enum_meta_class, attribute_id):
+        super(AttributeEnum, self).__init__(attribute_id)
         self._underlying_attribute = underlying_attribute_meta_class(attribute_id)
         self._attribute_type = enum_meta_class
-        self._attribute_id = attribute_id
 
     def __get__(self, session, session_type):
         return self._attribute_type(self._underlying_attribute.__get__(session, session_type))
@@ -101,7 +101,7 @@ class AttributeEnum(object):
         return self._underlying_attribute.__set__(session, value.value)
 
 
-class AttributeEnumWithConverter(object):
+class AttributeEnumWithConverter(Attribute):
     '''Class for attributes that use enums internally but are exposed in the nifake Python module as something else, thus need conversion.'''
 
     def __init__(self, underlying_attribute_enum, getter_converter, setter_converter):
@@ -117,8 +117,8 @@ class AttributeEnumWithConverter(object):
             setter_converter (function): The function that converts the converted value back to the
                 enum value
         '''
+        super(AttributeEnumWithConverter, self).__init__(underlying_attribute_enum._attribute_id)
         self._underlying_attribute_enum = underlying_attribute_enum
-        self._attribute_id = underlying_attribute_enum._attribute_id
         self._getter_converter = getter_converter
         self._setter_converter = setter_converter
 

--- a/generated/nifake/nifake/_attributes.py
+++ b/generated/nifake/nifake/_attributes.py
@@ -101,7 +101,7 @@ class AttributeEnum(object):
         return self._underlying_attribute.__set__(session, value.value)
 
 
-class AttributeEnumWithConverter(AttributeEnum):
+class AttributeEnumWithConverter(object):
     '''Class for attributes that use enums internally but are exposed in the nifake Python module as something else, thus need conversion.'''
 
     def __init__(self, underlying_attribute_enum, getter_converter, setter_converter):
@@ -118,6 +118,7 @@ class AttributeEnumWithConverter(AttributeEnum):
                 enum value
         '''
         self._underlying_attribute_enum = underlying_attribute_enum
+        self._attribute_id = underlying_attribute_enum._attribute_id
         self._getter_converter = getter_converter
         self._setter_converter = setter_converter
 

--- a/generated/nifgen/nifgen/_attributes.py
+++ b/generated/nifgen/nifgen/_attributes.py
@@ -85,12 +85,12 @@ class AttributeViBoolean(Attribute):
         session._set_attribute_vi_boolean(self._attribute_id, value)
 
 
-class AttributeEnum(object):
+class AttributeEnum(Attribute):
 
     def __init__(self, underlying_attribute_meta_class, enum_meta_class, attribute_id):
+        super(AttributeEnum, self).__init__(attribute_id)
         self._underlying_attribute = underlying_attribute_meta_class(attribute_id)
         self._attribute_type = enum_meta_class
-        self._attribute_id = attribute_id
 
     def __get__(self, session, session_type):
         return self._attribute_type(self._underlying_attribute.__get__(session, session_type))
@@ -101,7 +101,7 @@ class AttributeEnum(object):
         return self._underlying_attribute.__set__(session, value.value)
 
 
-class AttributeEnumWithConverter(object):
+class AttributeEnumWithConverter(Attribute):
     '''Class for attributes that use enums internally but are exposed in the nifgen Python module as something else, thus need conversion.'''
 
     def __init__(self, underlying_attribute_enum, getter_converter, setter_converter):
@@ -117,8 +117,8 @@ class AttributeEnumWithConverter(object):
             setter_converter (function): The function that converts the converted value back to the
                 enum value
         '''
+        super(AttributeEnumWithConverter, self).__init__(underlying_attribute_enum._attribute_id)
         self._underlying_attribute_enum = underlying_attribute_enum
-        self._attribute_id = underlying_attribute_enum._attribute_id
         self._getter_converter = getter_converter
         self._setter_converter = setter_converter
 

--- a/generated/nifgen/nifgen/_attributes.py
+++ b/generated/nifgen/nifgen/_attributes.py
@@ -101,7 +101,7 @@ class AttributeEnum(object):
         return self._underlying_attribute.__set__(session, value.value)
 
 
-class AttributeEnumWithConverter(AttributeEnum):
+class AttributeEnumWithConverter(object):
     '''Class for attributes that use enums internally but are exposed in the nifgen Python module as something else, thus need conversion.'''
 
     def __init__(self, underlying_attribute_enum, getter_converter, setter_converter):
@@ -118,6 +118,7 @@ class AttributeEnumWithConverter(AttributeEnum):
                 enum value
         '''
         self._underlying_attribute_enum = underlying_attribute_enum
+        self._attribute_id = underlying_attribute_enum._attribute_id
         self._getter_converter = getter_converter
         self._setter_converter = setter_converter
 

--- a/generated/niscope/niscope/_attributes.py
+++ b/generated/niscope/niscope/_attributes.py
@@ -85,12 +85,12 @@ class AttributeViBoolean(Attribute):
         session._set_attribute_vi_boolean(self._attribute_id, value)
 
 
-class AttributeEnum(object):
+class AttributeEnum(Attribute):
 
     def __init__(self, underlying_attribute_meta_class, enum_meta_class, attribute_id):
+        super(AttributeEnum, self).__init__(attribute_id)
         self._underlying_attribute = underlying_attribute_meta_class(attribute_id)
         self._attribute_type = enum_meta_class
-        self._attribute_id = attribute_id
 
     def __get__(self, session, session_type):
         return self._attribute_type(self._underlying_attribute.__get__(session, session_type))
@@ -101,7 +101,7 @@ class AttributeEnum(object):
         return self._underlying_attribute.__set__(session, value.value)
 
 
-class AttributeEnumWithConverter(object):
+class AttributeEnumWithConverter(Attribute):
     '''Class for attributes that use enums internally but are exposed in the niscope Python module as something else, thus need conversion.'''
 
     def __init__(self, underlying_attribute_enum, getter_converter, setter_converter):
@@ -117,8 +117,8 @@ class AttributeEnumWithConverter(object):
             setter_converter (function): The function that converts the converted value back to the
                 enum value
         '''
+        super(AttributeEnumWithConverter, self).__init__(underlying_attribute_enum._attribute_id)
         self._underlying_attribute_enum = underlying_attribute_enum
-        self._attribute_id = underlying_attribute_enum._attribute_id
         self._getter_converter = getter_converter
         self._setter_converter = setter_converter
 

--- a/generated/niscope/niscope/_attributes.py
+++ b/generated/niscope/niscope/_attributes.py
@@ -101,7 +101,7 @@ class AttributeEnum(object):
         return self._underlying_attribute.__set__(session, value.value)
 
 
-class AttributeEnumWithConverter(AttributeEnum):
+class AttributeEnumWithConverter(object):
     '''Class for attributes that use enums internally but are exposed in the niscope Python module as something else, thus need conversion.'''
 
     def __init__(self, underlying_attribute_enum, getter_converter, setter_converter):
@@ -118,6 +118,7 @@ class AttributeEnumWithConverter(AttributeEnum):
                 enum value
         '''
         self._underlying_attribute_enum = underlying_attribute_enum
+        self._attribute_id = underlying_attribute_enum._attribute_id
         self._getter_converter = getter_converter
         self._setter_converter = setter_converter
 

--- a/generated/niswitch/niswitch/_attributes.py
+++ b/generated/niswitch/niswitch/_attributes.py
@@ -85,12 +85,12 @@ class AttributeViBoolean(Attribute):
         session._set_attribute_vi_boolean(self._attribute_id, value)
 
 
-class AttributeEnum(object):
+class AttributeEnum(Attribute):
 
     def __init__(self, underlying_attribute_meta_class, enum_meta_class, attribute_id):
+        super(AttributeEnum, self).__init__(attribute_id)
         self._underlying_attribute = underlying_attribute_meta_class(attribute_id)
         self._attribute_type = enum_meta_class
-        self._attribute_id = attribute_id
 
     def __get__(self, session, session_type):
         return self._attribute_type(self._underlying_attribute.__get__(session, session_type))
@@ -101,7 +101,7 @@ class AttributeEnum(object):
         return self._underlying_attribute.__set__(session, value.value)
 
 
-class AttributeEnumWithConverter(object):
+class AttributeEnumWithConverter(Attribute):
     '''Class for attributes that use enums internally but are exposed in the niswitch Python module as something else, thus need conversion.'''
 
     def __init__(self, underlying_attribute_enum, getter_converter, setter_converter):
@@ -117,8 +117,8 @@ class AttributeEnumWithConverter(object):
             setter_converter (function): The function that converts the converted value back to the
                 enum value
         '''
+        super(AttributeEnumWithConverter, self).__init__(underlying_attribute_enum._attribute_id)
         self._underlying_attribute_enum = underlying_attribute_enum
-        self._attribute_id = underlying_attribute_enum._attribute_id
         self._getter_converter = getter_converter
         self._setter_converter = setter_converter
 

--- a/generated/niswitch/niswitch/_attributes.py
+++ b/generated/niswitch/niswitch/_attributes.py
@@ -101,7 +101,7 @@ class AttributeEnum(object):
         return self._underlying_attribute.__set__(session, value.value)
 
 
-class AttributeEnumWithConverter(AttributeEnum):
+class AttributeEnumWithConverter(object):
     '''Class for attributes that use enums internally but are exposed in the niswitch Python module as something else, thus need conversion.'''
 
     def __init__(self, underlying_attribute_enum, getter_converter, setter_converter):
@@ -118,6 +118,7 @@ class AttributeEnumWithConverter(AttributeEnum):
                 enum value
         '''
         self._underlying_attribute_enum = underlying_attribute_enum
+        self._attribute_id = underlying_attribute_enum._attribute_id
         self._getter_converter = getter_converter
         self._setter_converter = setter_converter
 

--- a/generated/nitclk/nitclk/_attributes.py
+++ b/generated/nitclk/nitclk/_attributes.py
@@ -85,12 +85,12 @@ class AttributeViBoolean(Attribute):
         session._set_attribute_vi_boolean(self._attribute_id, value)
 
 
-class AttributeEnum(object):
+class AttributeEnum(Attribute):
 
     def __init__(self, underlying_attribute_meta_class, enum_meta_class, attribute_id):
+        super(AttributeEnum, self).__init__(attribute_id)
         self._underlying_attribute = underlying_attribute_meta_class(attribute_id)
         self._attribute_type = enum_meta_class
-        self._attribute_id = attribute_id
 
     def __get__(self, session, session_type):
         return self._attribute_type(self._underlying_attribute.__get__(session, session_type))
@@ -101,7 +101,7 @@ class AttributeEnum(object):
         return self._underlying_attribute.__set__(session, value.value)
 
 
-class AttributeEnumWithConverter(object):
+class AttributeEnumWithConverter(Attribute):
     '''Class for attributes that use enums internally but are exposed in the nitclk Python module as something else, thus need conversion.'''
 
     def __init__(self, underlying_attribute_enum, getter_converter, setter_converter):
@@ -117,8 +117,8 @@ class AttributeEnumWithConverter(object):
             setter_converter (function): The function that converts the converted value back to the
                 enum value
         '''
+        super(AttributeEnumWithConverter, self).__init__(underlying_attribute_enum._attribute_id)
         self._underlying_attribute_enum = underlying_attribute_enum
-        self._attribute_id = underlying_attribute_enum._attribute_id
         self._getter_converter = getter_converter
         self._setter_converter = setter_converter
 

--- a/generated/nitclk/nitclk/_attributes.py
+++ b/generated/nitclk/nitclk/_attributes.py
@@ -101,7 +101,7 @@ class AttributeEnum(object):
         return self._underlying_attribute.__set__(session, value.value)
 
 
-class AttributeEnumWithConverter(AttributeEnum):
+class AttributeEnumWithConverter(object):
     '''Class for attributes that use enums internally but are exposed in the nitclk Python module as something else, thus need conversion.'''
 
     def __init__(self, underlying_attribute_enum, getter_converter, setter_converter):
@@ -118,6 +118,7 @@ class AttributeEnumWithConverter(AttributeEnum):
                 enum value
         '''
         self._underlying_attribute_enum = underlying_attribute_enum
+        self._attribute_id = underlying_attribute_enum._attribute_id
         self._getter_converter = getter_converter
         self._setter_converter = setter_converter
 

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -521,6 +521,25 @@ def test_create_and_delete_advanced_sequence_bad_type(session):
         session.create_advanced_sequence(sequence_name=sequence_name, property_names=properties_used, set_as_active_sequence=True)
 
 
+@pytest.mark.resource_name("4190/0")
+@pytest.mark.options("Simulate=1, DriverSetup=Model:4190; BoardType:PXIe")
+def test_create_and_delete_advanced_sequence_attribute_enum_with_converter(session):
+    properties_used = ['lcr_impedance_auto_range']
+    sequence_name = 'my_sequence'
+    session.source_mode = nidcpower.SourceMode.SEQUENCE
+    session.create_advanced_sequence(
+        sequence_name=sequence_name,
+        property_names=properties_used,
+        set_as_active_sequence=True
+    )
+    session.create_advanced_sequence_step(set_as_active_step=True)
+    assert session.active_advanced_sequence == sequence_name
+    session.lcr_impedance_auto_range = True
+    session.delete_advanced_sequence(sequence_name=sequence_name)
+    with pytest.raises(nidcpower.errors.DriverError):
+        session.active_advanced_sequence = sequence_name
+
+
 @pytest.mark.legacy_session_only
 def test_send_software_edge_trigger_error(session):
     with pytest.raises(nidcpower.Error) as e:

--- a/src/nidcpower/templates/session.py/fancy_advanced_sequence.py.mako
+++ b/src/nidcpower/templates/session.py/fancy_advanced_sequence.py.mako
@@ -20,7 +20,7 @@
         for prop in property_names:
             if prop not in Session.__base__.__dict__:
                 raise KeyError('{0} is not an property on the nidcpower.Session'.format(prop))
-            if not isinstance(Session.__base__.__dict__[prop], _attributes.Attribute) and not isinstance(Session.__base__.__dict__[prop], _attributes.AttributeEnum) and not isinstance(Session.__base__.__dict__[prop], _attributes.AttributeEnumWithConverter):
+            if not isinstance(Session.__base__.__dict__[prop], _attributes.Attribute):
                 raise TypeError('{0} is not a valid property: {1}'.format(prop, type(Session.__base__.__dict__[prop])))
             attribute_ids_used.add(Session.__base__.__dict__[prop]._attribute_id)
 

--- a/src/nidcpower/templates/session.py/fancy_advanced_sequence.py.mako
+++ b/src/nidcpower/templates/session.py/fancy_advanced_sequence.py.mako
@@ -20,7 +20,7 @@
         for prop in property_names:
             if prop not in Session.__base__.__dict__:
                 raise KeyError('{0} is not an property on the nidcpower.Session'.format(prop))
-            if not isinstance(Session.__base__.__dict__[prop], _attributes.Attribute) and not isinstance(Session.__base__.__dict__[prop], _attributes.AttributeEnum):
+            if not isinstance(Session.__base__.__dict__[prop], _attributes.Attribute) and not isinstance(Session.__base__.__dict__[prop], _attributes.AttributeEnum) and not isinstance(Session.__base__.__dict__[prop], _attributes.AttributeEnumWithConverter):
                 raise TypeError('{0} is not a valid property: {1}'.format(prop, type(Session.__base__.__dict__[prop])))
             attribute_ids_used.add(Session.__base__.__dict__[prop]._attribute_id)
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

- Make `AttributeEnumWithConverter` inherits from `object` instead of `AttributeEnum`
- Add `_attribute_id` property to `AttributeEnumWithConverter` to be accessed by `create_advanced_sequence` method in NI-DCPower
- Update `fancy_advanced_sequence.py.mako` method template to consider `AttributeEnumWithConverter` a valid attribute class
- Add `test_create_and_delete_advanced_sequence_attribute_enum_with_converter()` system test to NI-DCPower to ensure that attribute that uses enum with converter can be used in an advanced sequence

### What testing has been done?

The newly added system test passed.