### PR TITLE
Workaround for nidcpower self_cal test failure due to driver runtime bug

### DIFF
--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -72,7 +72,7 @@ def test_self_test(session):
 
 
 # Workaround for driver runtime bug. See issue #1798 for details.
-@pytest.mark.resource_name('')
+@pytest.mark.legacy_session_only
 def test_self_cal(session):
     session.self_cal()
 

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -71,6 +71,8 @@ def test_self_test(session):
     session.self_test()
 
 
+# Workaround for driver runtime bug. See issue #1798 for details.
+@pytest.mark.resource_name('')
 def test_self_cal(session):
     session.self_cal()
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

As part of #1788, we need to update driver runtimes on nimibot. But due to a bug in NI-DCPower driver runtime, we need a workaround. See #1798 for details.

### List issues fixed by this Pull Request below, if any.

None

### What testing has been done?

PR build
