### PR TITLE
Re-enable AzDO-based nimibot

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,78 @@
+# nimibot pipeline for running all system tests as part of Continuous Integration.
+
+parameters:
+- name: win_module_names
+  type: object
+  default: # Order of the modules is based on test execution time, longest first.
+  - nidigital
+  - nitclk  
+  - nifgen
+  - nidcpower
+  - nidmm
+  - niscope
+  - nimodinst
+  - nise
+  - niswitch
+- name: rhel_module_names
+  type: object
+  default: # Order of the modules is based on test execution time, longest first.
+  - nidmm
+  - niswitch
+
+# A pipeline with no CI trigger.
+trigger: none
+
+pr:
+  branches:
+    include:
+    - master
+    - releases/*
+  paths:
+    exclude:
+    - CHANGELOG.md
+    - CONTRIBUTING.md
+    - .gitattributes
+    - LICENSE
+    - VERSION
+  drafts: false
+
+stages:
+           
+  - stage: system_tests_win64
+    dependsOn: []
+    pool:
+      name: nimibot
+      demands:
+        - nimibot -equals True
+        - platform -equals win64 # Run system tests using 64-bit Python interpreter on a 64-bit Windows 10 system.
+    jobs:
+    - ${{each module_name in parameters.win_module_names}}:
+      - template: run_module_system_tests.yml
+        parameters:
+          module_name: ${{module_name}}
+
+  - stage: system_tests_win32
+    dependsOn: []
+    pool:
+      name: nimibot
+      demands:
+        - nimibot -equals True
+        - platform -equals win32 # Run system tests using 32-bit Python interpreter on a 64-bit Windows 10 system.
+    jobs:
+    - ${{each module_name in parameters.win_module_names}}:
+      - template: run_module_system_tests.yml
+        parameters:
+          module_name: ${{module_name}}
+
+  - stage: system_tests_rhel
+    dependsOn: []
+    pool:
+      name: nimibot
+      demands:
+        - nimibot -equals True
+        - platform -equals rhel
+    jobs:
+    - ${{each module_name in parameters.rhel_module_names}}:
+      - template: run_module_system_tests.yml
+        parameters:
+          module_name: ${{module_name}}

--- a/run_module_system_tests.yml
+++ b/run_module_system_tests.yml
@@ -1,0 +1,25 @@
+# Run system tests for the specified module
+
+parameters:
+  module_name: ""
+  clone_depth: 1
+
+
+jobs:
+- job: ${{ parameters.module_name }}
+  workspace:
+    clean: all
+  steps:
+    - checkout: self  
+      clean: true
+      fetchDepth: ${{ parameters.clone_depth }}
+    - script: |
+        cd generated
+        mkdir junit
+        mkdir kibana
+        cd ${{ parameters.module_name }}
+        python -m tox -c tox-system_tests.ini
+      displayName: Run system tests
+      env:
+        TOX_PARALLEL_NO_SPINNER: 1
+


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Re-enable AzDO-based nimibot since GitHub Actions-based nimibot is currently down due to an infrastructure issue (Internal bug: [AB#2089379](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2089379))

### List issues fixed by this Pull Request below, if any.

None

### What testing has been done?

PR build
