### PR TITLE
Simplify NI-FGEN example and remove its use of numpy and scipy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ All notable changes to this project will be documented in this file.
 * ### ALL
     * #### Added
     * #### Changed
+        * Fix [#1811](https://github.com/ni/nimi-python/issues/1811): nimi-python uses scipy which keeps us from adding support to Python 3.10
+          * Replaced scipy usage in NI-FGEN examples with hand-crafted functions and dropped scipy installation system-test setup. 
     * #### Removed
 * ### `nidcpower` (NI-DCPower)
     * #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,6 @@ All notable changes to this project will be documented in this file.
 * ### ALL
     * #### Added
     * #### Changed
-        * Fix [#1811](https://github.com/ni/nimi-python/issues/1811): nimi-python uses scipy which keeps us from adding support to Python 3.10
-          * Replaced scipy usage in NI-FGEN examples with hand-crafted functions and dropped scipy installation system-test setup. 
     * #### Removed
 * ### `nidcpower` (NI-DCPower)
     * #### Added

--- a/build/templates/tox-system_tests.ini.mako
+++ b/build/templates/tox-system_tests.ini.mako
@@ -75,7 +75,6 @@ deps =
     ${module_name}-system_tests: coverage
     ${module_name}-system_tests: numpy
     ${module_name}-system_tests: hightime
-    ${module_name}-system_tests: scipy
     ${module_name}-system_tests: fasteners
     ${module_name}-system_tests: pytest-json
 

--- a/generated/nidcpower/tox-system_tests.ini
+++ b/generated/nidcpower/tox-system_tests.ini
@@ -38,7 +38,6 @@ deps =
     nidcpower-system_tests: coverage
     nidcpower-system_tests: numpy
     nidcpower-system_tests: hightime
-    nidcpower-system_tests: scipy
     nidcpower-system_tests: fasteners
     nidcpower-system_tests: pytest-json
 

--- a/generated/nidigital/tox-system_tests.ini
+++ b/generated/nidigital/tox-system_tests.ini
@@ -45,7 +45,6 @@ deps =
     nidigital-system_tests: coverage
     nidigital-system_tests: numpy
     nidigital-system_tests: hightime
-    nidigital-system_tests: scipy
     nidigital-system_tests: fasteners
     nidigital-system_tests: pytest-json
 

--- a/generated/nidmm/tox-system_tests.ini
+++ b/generated/nidmm/tox-system_tests.ini
@@ -38,7 +38,6 @@ deps =
     nidmm-system_tests: coverage
     nidmm-system_tests: numpy
     nidmm-system_tests: hightime
-    nidmm-system_tests: scipy
     nidmm-system_tests: fasteners
     nidmm-system_tests: pytest-json
 

--- a/generated/nifake/tox-system_tests.ini
+++ b/generated/nifake/tox-system_tests.ini
@@ -45,7 +45,6 @@ deps =
     nifake-system_tests: coverage
     nifake-system_tests: numpy
     nifake-system_tests: hightime
-    nifake-system_tests: scipy
     nifake-system_tests: fasteners
     nifake-system_tests: pytest-json
 

--- a/generated/nifgen/tox-system_tests.ini
+++ b/generated/nifgen/tox-system_tests.ini
@@ -45,7 +45,6 @@ deps =
     nifgen-system_tests: coverage
     nifgen-system_tests: numpy
     nifgen-system_tests: hightime
-    nifgen-system_tests: scipy
     nifgen-system_tests: fasteners
     nifgen-system_tests: pytest-json
 

--- a/generated/nimodinst/tox-system_tests.ini
+++ b/generated/nimodinst/tox-system_tests.ini
@@ -38,7 +38,6 @@ deps =
     nimodinst-system_tests: coverage
     nimodinst-system_tests: numpy
     nimodinst-system_tests: hightime
-    nimodinst-system_tests: scipy
     nimodinst-system_tests: fasteners
     nimodinst-system_tests: pytest-json
 

--- a/generated/niscope/tox-system_tests.ini
+++ b/generated/niscope/tox-system_tests.ini
@@ -45,7 +45,6 @@ deps =
     niscope-system_tests: coverage
     niscope-system_tests: numpy
     niscope-system_tests: hightime
-    niscope-system_tests: scipy
     niscope-system_tests: fasteners
     niscope-system_tests: pytest-json
 

--- a/generated/nise/tox-system_tests.ini
+++ b/generated/nise/tox-system_tests.ini
@@ -38,7 +38,6 @@ deps =
     nise-system_tests: coverage
     nise-system_tests: numpy
     nise-system_tests: hightime
-    nise-system_tests: scipy
     nise-system_tests: fasteners
     nise-system_tests: pytest-json
 

--- a/generated/niswitch/tox-system_tests.ini
+++ b/generated/niswitch/tox-system_tests.ini
@@ -38,7 +38,6 @@ deps =
     niswitch-system_tests: coverage
     niswitch-system_tests: numpy
     niswitch-system_tests: hightime
-    niswitch-system_tests: scipy
     niswitch-system_tests: fasteners
     niswitch-system_tests: pytest-json
 

--- a/generated/nitclk/tox-system_tests.ini
+++ b/generated/nitclk/tox-system_tests.ini
@@ -45,7 +45,6 @@ deps =
     nitclk-system_tests: coverage
     nitclk-system_tests: numpy
     nitclk-system_tests: hightime
-    nitclk-system_tests: scipy
     nitclk-system_tests: fasteners
     nitclk-system_tests: pytest-json
 

--- a/src/nifgen/examples/nifgen_script.py
+++ b/src/nifgen/examples/nifgen_script.py
@@ -9,9 +9,9 @@ import sys
 import time
 
 # waveform size should be a multiple of the quantum, which is 4, 2 or 1, for all devices
-# minimum waveform size varies with sample rate and device.
-# 512 should be enough for any device and sample rate, except certain 5450, 5451 configurations.
-NUMBER_OF_SAMPLES = 512
+# minimum waveform size needed to prevent underflow varies with sample rate and device.
+# If underflow occurs, increase this value.
+NUMBER_OF_SAMPLES = 2096
 
 
 # waveforms finish just short of 360 degrees, so that we don't repeat the first point

--- a/src/nifgen/examples/nifgen_script.py
+++ b/src/nifgen/examples/nifgen_script.py
@@ -4,10 +4,41 @@ import argparse
 import nifgen
 import numpy as np
 from scipy import signal
+
+import math
 import sys
 import time
 
 number_of_points = 256
+
+
+def equivalent_phase(phase):
+    if phase < 0:
+        phase += (abs(phase) // (2 * math.pi) + 1) * 2 * math.pi
+    elif phase > (2 * math.pi):
+        phase = phase % (2 * math.pi)
+    return phase  # phase in range [0, 2 * PI]
+
+
+def duty_cycle_is_on(phase, duty_cycle):
+    # duty_cycle is a decimal in the range [0, 1]
+    phase = equivalent_phase(phase)
+    if duty_cycle == 0:
+        return False
+    elif phase == 2 * math.pi:
+        return True
+    cycle_percentage = phase / (2 * math.pi)
+    return cycle_percentage <= duty_cycle
+
+
+def square_wave(t, duty_cycle):
+    wfm = []
+    for time in t:
+        if duty_cycle_is_on(time, duty_cycle):
+            wfm.append(1.0)
+        else:
+            wfm.append(-1.0)
+    return wfm
 
 
 def calculate_sinewave():
@@ -32,8 +63,7 @@ def calculate_rampdown():
 
 def calculate_square():
     time = np.linspace(start=0, stop=10, num=number_of_points)    # np.linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None)
-    square_build = signal.square(t=time, duty=0.5)              # signal.square(t, duty=0.5)
-    square = square_build.tolist()                              # List of Float
+    square = square_wave(t=time, duty_cycle=0.5)
     return square
 
 

--- a/src/nifgen/examples/nifgen_script.py
+++ b/src/nifgen/examples/nifgen_script.py
@@ -32,8 +32,8 @@ def duty_cycle_is_on(phase, duty_cycle):
 
 def square_wave(t, duty_cycle):
     wfm = []
-    for time in t:
-        if duty_cycle_is_on(time, duty_cycle):
+    for phase in t:  # treat time as phase
+        if duty_cycle_is_on(phase, duty_cycle):
             wfm.append(1.0)
         else:
             wfm.append(-1.0)
@@ -42,8 +42,8 @@ def square_wave(t, duty_cycle):
 
 def sawtooth_wave(t):
     wfm = []
-    for time in t:
-        phase = equivalent_phase(time)
+    for phase in t:  # treat time as phase
+        phase = equivalent_phase(phase)
         cycle_percentage = phase / (2 * math.pi)
         wfm.append(-1.0 + (2 * cycle_percentage))
     return wfm

--- a/src/nifgen/examples/nifgen_script.py
+++ b/src/nifgen/examples/nifgen_script.py
@@ -20,7 +20,7 @@ SINE_WAVE = [math.sin(math.pi * 2 * x / (NUMBER_OF_SAMPLES)) for x in range(NUMB
 RAMP_UP = [x / (NUMBER_OF_SAMPLES) for x in range(NUMBER_OF_SAMPLES)]
 RAMP_DOWN = [-1.0 * x for x in RAMP_UP]
 SQUARE_WAVE = [1.0 if x < (NUMBER_OF_SAMPLES / 2) else -1.0 for x in range(NUMBER_OF_SAMPLES)]
-SAWTOOTH_WAVE = RAMP_UP + [(-1 + x) for x in RAMP_UP]
+SAWTOOTH_WAVE = RAMP_UP[::2] + [(-1 + x) for x in RAMP_UP][::2]
 GAUSSIAN_NOISE = [random.gauss(0, 0.2) for x in range(NUMBER_OF_SAMPLES)]
 
 

--- a/src/nifgen/examples/nifgen_script.py
+++ b/src/nifgen/examples/nifgen_script.py
@@ -113,7 +113,7 @@ def example(resource_name, options, shape, channel):
         # 4 - Script to generate
         # supported shapes: SINE / SQUARE / SAWTOOTH / RAMPUP / RAMPDOWN / NOISE / MULTI
         script_name = 'script{}'.format(shape.lower())
-        num_triggers = 6 if shape.upper() == 'MULTI' else 1  # Only multi needs two triggers, all others need one
+        num_triggers = 6 if shape.upper() == 'MULTI' else 1  # Only multi needs multiple triggers, all others need one
 
         session.channels[channel].write_script(SCRIPT_ALL)
         session.script_to_generate = script_name

--- a/src/nifgen/examples/nifgen_script.py
+++ b/src/nifgen/examples/nifgen_script.py
@@ -3,7 +3,6 @@
 import argparse
 import nifgen
 import numpy as np
-from scipy import signal
 
 import math
 import sys
@@ -41,6 +40,15 @@ def square_wave(t, duty_cycle):
     return wfm
 
 
+def sawtooth_wave(t):
+    wfm = []
+    for time in t:
+        phase = equivalent_phase(time)
+        cycle_percentage = phase / (2 * math.pi)
+        wfm.append(-1.0 + (2 * cycle_percentage))
+    return wfm
+
+
 def calculate_sinewave():
     time = np.linspace(start=0, stop=10, num=number_of_points)    # np.linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None)
     amplitude = np.sin(time)
@@ -69,8 +77,7 @@ def calculate_square():
 
 def calculate_triangle():
     time = np.linspace(start=0, stop=1, num=number_of_points)     # np.linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None)
-    triangle_build = signal.sawtooth(t=time)                    # signal.sawtooth(t, width=1)
-    triangle = triangle_build.tolist()                          # List of Float
+    triangle = sawtooth_wave(t=time)
     return triangle
 
 

--- a/src/nifgen/examples/nifgen_script.py
+++ b/src/nifgen/examples/nifgen_script.py
@@ -15,7 +15,7 @@ number_of_points = 256
 def calculate_sinewave():
     # waveforms finish just short of 360 degrees, so that we don't repeat the first point
     # if we repeat the waveform
-    return [math.sin(math.pi * 2 * x / (number_of_points) for x in range(number_of_points)]
+    return [math.sin(math.pi * 2 * x / (number_of_points)) for x in range(number_of_points)]
 
 
 def calculate_rampup():

--- a/src/nifgen/examples/nifgen_script.py
+++ b/src/nifgen/examples/nifgen_script.py
@@ -13,32 +13,14 @@ import time
 number_of_samples = 256
 
 
-def calculate_sinewave():
-    # waveforms finish just short of 360 degrees, so that we don't repeat the first point
-    # if we repeat the waveform
-    return [math.sin(math.pi * 2 * x / (number_of_samples)) for x in range(number_of_samples)]
-
-
-def calculate_rampup():
-    return [x / (number_of_samples) for x in range(number_of_samples)]
-
-
-def calculate_rampdown():
-    return [-1.0 * x for x in calculate_rampup()]
-
-
-def calculate_square():
-    return [1.0 if x < (number_of_samples / 2) else -1.0 for x in range(number_of_samples)]
-
-
-def calculate_sawtooth():
-    part1 = calculate_rampup()
-    part2 = [(-1 + x) for x in part1]
-    return part1 + part2
-
-
-def calculate_gaussian_noise():
-    return [random.gauss(0, 0.2) for x in range(number_of_samples)]
+# waveforms finish just short of 360 degrees, so that we don't repeat the first point
+# if we repeat the waveform
+SINE_WAVE = [math.sin(math.pi * 2 * x / (number_of_samples)) for x in range(number_of_samples)]
+RAMP_UP = [x / (number_of_samples) for x in range(number_of_samples)]
+RAMP_DOWN = [-1.0 * x for x in RAMP_UP]
+SQUARE_WAVE = [1.0 if x < (number_of_samples / 2) else -1.0 for x in range(number_of_samples)]
+SAWTOOTH_WAVE = RAMP_UP + [(-1 + x) for x in RAMP_UP]
+GAUSSIAN_NOISE = [random.gauss(0, 0.2) for x in range(number_of_samples)]
 
 
 SCRIPT_ALL = '''
@@ -120,12 +102,12 @@ def example(resource_name, options, shape, channel):
         session.script_triggers[0].digital_edge_script_trigger_edge = nifgen.ScriptTriggerDigitalEdgeEdge.RISING  # RISING / FAILING
 
         # 3 - Calculate and write different waveform data to the device's onboard memory
-        session.channels[channel].write_waveform('sine', calculate_sinewave())        # (waveform_name, data)
-        session.channels[channel].write_waveform('rampup', calculate_rampup())
-        session.channels[channel].write_waveform('rampdown', calculate_rampdown())
-        session.channels[channel].write_waveform('square', calculate_square())
-        session.channels[channel].write_waveform('sawtooth', calculate_sawtooth())
-        session.channels[channel].write_waveform('noise', calculate_gaussian_noise())
+        session.channels[channel].write_waveform('sine', SINE_WAVE)        # (waveform_name, data)
+        session.channels[channel].write_waveform('rampup', RAMP_UP)
+        session.channels[channel].write_waveform('rampdown', RAMP_DOWN)
+        session.channels[channel].write_waveform('square', SQUARE_WAVE)
+        session.channels[channel].write_waveform('sawtooth', SAWTOOTH_WAVE)
+        session.channels[channel].write_waveform('noise', GAUSSIAN_NOISE)
 
         # 4 - Script to generate
         # supported shapes: SINE / SQUARE / SAWTOOTH / RAMPUP / RAMPDOWN / NOISE / MULTI

--- a/src/nifgen/examples/nifgen_script.py
+++ b/src/nifgen/examples/nifgen_script.py
@@ -10,17 +10,17 @@ import time
 
 # waveform size should be a multiple of the quantum, which is 4 or 8, for some devices
 # some older devices also have a 256 sample minimum waveform size
-number_of_points = 256
+number_of_samples = 256
 
 
 def calculate_sinewave():
     # waveforms finish just short of 360 degrees, so that we don't repeat the first point
     # if we repeat the waveform
-    return [math.sin(math.pi * 2 * x / (number_of_points)) for x in range(number_of_points)]
+    return [math.sin(math.pi * 2 * x / (number_of_samples)) for x in range(number_of_samples)]
 
 
 def calculate_rampup():
-    return [x / (number_of_points) for x in range(number_of_points)]
+    return [x / (number_of_samples) for x in range(number_of_samples)]
 
 
 def calculate_rampdown():
@@ -28,7 +28,7 @@ def calculate_rampdown():
 
 
 def calculate_square():
-    return [1.0 if x < (number_of_points / 2) else -1.0 for x in range(number_of_points)]
+    return [1.0 if x < (number_of_samples / 2) else -1.0 for x in range(number_of_samples)]
 
 
 def calculate_sawtooth():
@@ -38,7 +38,7 @@ def calculate_sawtooth():
 
 
 def calculate_gaussian_noise():
-    return [random.gauss(0, 0.2) for x in range(number_of_points)]
+    return [random.gauss(0, 0.2) for x in range(number_of_samples)]
 
 
 SCRIPT_ALL = '''

--- a/src/nifgen/examples/nifgen_script.py
+++ b/src/nifgen/examples/nifgen_script.py
@@ -4,6 +4,7 @@ import argparse
 import nifgen
 
 import math
+import random
 import sys
 import time
 
@@ -36,8 +37,8 @@ def calculate_sawtooth():
     return part1 + part2
 
 
-def calculate_noise():
-    return [random.uniform(-1.0, 1.0) for x in range(number_of_points)]
+def calculate_gaussian_noise():
+    return [random.gauss(0, 0.2) for x in range(number_of_points)]
 
 
 SCRIPT_ALL = '''
@@ -124,7 +125,7 @@ def example(resource_name, options, shape, channel):
         session.channels[channel].write_waveform('rampdown', calculate_rampdown())
         session.channels[channel].write_waveform('square', calculate_square())
         session.channels[channel].write_waveform('sawtooth', calculate_sawtooth())
-        session.channels[channel].write_waveform('noise', calculate_noise())
+        session.channels[channel].write_waveform('noise', calculate_gaussian_noise())
 
         # 4 - Script to generate
         # supported shapes: SINE / SQUARE / SAWTOOTH / RAMPUP / RAMPDOWN / NOISE / MULTI

--- a/src/nifgen/examples/nifgen_script.py
+++ b/src/nifgen/examples/nifgen_script.py
@@ -10,17 +10,17 @@ import time
 
 # waveform size should be a multiple of the quantum, which is 4 or 8, for some devices
 # some older devices also have a 256 sample minimum waveform size
-number_of_samples = 256
+NUMBER_OF_SAMPLES = 256
 
 
 # waveforms finish just short of 360 degrees, so that we don't repeat the first point
 # if we repeat the waveform
-SINE_WAVE = [math.sin(math.pi * 2 * x / (number_of_samples)) for x in range(number_of_samples)]
-RAMP_UP = [x / (number_of_samples) for x in range(number_of_samples)]
+SINE_WAVE = [math.sin(math.pi * 2 * x / (NUMBER_OF_SAMPLES)) for x in range(NUMBER_OF_SAMPLES)]
+RAMP_UP = [x / (NUMBER_OF_SAMPLES) for x in range(NUMBER_OF_SAMPLES)]
 RAMP_DOWN = [-1.0 * x for x in RAMP_UP]
-SQUARE_WAVE = [1.0 if x < (number_of_samples / 2) else -1.0 for x in range(number_of_samples)]
+SQUARE_WAVE = [1.0 if x < (NUMBER_OF_SAMPLES / 2) else -1.0 for x in range(NUMBER_OF_SAMPLES)]
 SAWTOOTH_WAVE = RAMP_UP + [(-1 + x) for x in RAMP_UP]
-GAUSSIAN_NOISE = [random.gauss(0, 0.2) for x in range(number_of_samples)]
+GAUSSIAN_NOISE = [random.gauss(0, 0.2) for x in range(NUMBER_OF_SAMPLES)]
 
 
 SCRIPT_ALL = '''

--- a/src/nifgen/examples/nifgen_script.py
+++ b/src/nifgen/examples/nifgen_script.py
@@ -8,9 +8,10 @@ import random
 import sys
 import time
 
-# waveform size should be a multiple of the quantum, which is 4 or 8, for some devices
-# some older devices also have a 256 sample minimum waveform size
-NUMBER_OF_SAMPLES = 256
+# waveform size should be a multiple of the quantum, which is 4, 2 or 1, for all devices
+# minimum waveform size varies with sample rate and device.
+# 512 should be enough for any device and sample rate, except certain 5450, 5451 configurations.
+NUMBER_OF_SAMPLES = 512
 
 
 # waveforms finish just short of 360 degrees, so that we don't repeat the first point


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [X] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

* Eliminates our use of numpy and scipy from the NI-FGEN example, and slightly simplifies the waveform creation, to keep the focus on the usage of NI-FGEN.
   *  The new waveforms will only be a single cycle. Previous waveforms were an arbitrary 1.x cycles, because the phase ended at 10, which is greater than 2*PI and not even a multiple of 2*PI.
* The Triangle waveform in the example was actually a sawtooth. We will now refer to it as such.
  * I could have added an actual triangle wave, but doing so with 0 offset would have been complicated enough that I worried I felt it would distract from the focus on the API usage.  3 or 4 lines, probably, but still the most complicated of the waveforms.
* [Scipy has stopped releasing Windows 32-wheels for scipy 1.8.0+ and for Python 3.10 and later](https://github.com/scipy/scipy/issues/15836). This is breaking nimi-python testing for PRs, when we try to add Python 3.10 support. This change fixes that.
  * Side note: building the  scipy Windows 32 wheel would be non-trivial.

### List issues fixed by this Pull Request below, if any.

* Fix #1811 

### What testing has been done?

- Hand-tested updated functions, because they are part of the example code and not unit-tested.
  - Examined the output (in list form) from the updated functions and they all look correct to me.
  - I plotted the noise waveform and it looked good.
  - I generated a 1000 point noise waveform with the same algorithm and I think the max absolute value was around 0.8. It never exceed the bounds of [-1, 1].