### PR TITLE
Link to current version of tox.ini in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,19 +26,19 @@ In order to have the ability to build and run the tests you will need a few thin
   - GNU Make: ``sudo apt-get install make``
   - zip: ``sudo apt-get install zip``
   - 64-bit [Python](https://www.python.org/downloads/)
-    -- Use the version that `build_test` uses. See [tox.ini](https://github.com/ni/nimi-python/blob/e13087eb67e2399de2dfa83fd504f8ebd0e0e263/tox.ini#L10)
+    -- Use the version that `build_test` uses. See `envlist` definition in [tox.ini](./tox.ini)
 
 ### macOS:
 
 - Install [Xcode](https://itunes.apple.com/us/app/xcode/id497799835?mt=12)
 - Install command line developer tools
 - Install [Python](https://www.python.org/downloads/)
-    - Use the version that `build_test` uses. See [tox.ini](https://github.com/ni/nimi-python/blob/e13087eb67e2399de2dfa83fd504f8ebd0e0e263/tox.ini#L10)
+    - Use the version that `build_test` uses. See `envlist` definition in [tox.ini](./tox.ini)
 
 ### Linux:
 
 - Install Python: ``sudo apt-get install python3-pip``
-    - Use the version that `build_test` uses. See [tox.ini](https://github.com/ni/nimi-python/blob/e13087eb67e2399de2dfa83fd504f8ebd0e0e263/tox.ini#L10)
+    - Use the version that `build_test` uses. See `envlist` definition in [tox.ini](./tox.ini)
 
 ### All:
 


### PR DESCRIPTION
Someone contacted me for help building nimi-python because they followed the CONTRIBUTING doc and couldn't build. They did not have python 3.10 installed, because our link was stale.

- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Changes the CONTRIBUTING.md to link to the current version of the tox.ini so that we don't link to a stale copy and lead users to try to build with the wrong version of Python.

### List issues fixed by this Pull Request below, if any.

### What testing has been done?

Eyeball Test.