### PR TITLE
Enable `nifgen` tests for gRPC.

### DIFF
--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -1,10 +1,14 @@
 import fasteners
+import grpc
 import hightime
 import nifgen
 import numpy
 import os
+import pathlib
 import pytest
+import subprocess
 import tempfile
+import time
 import warnings
 
 
@@ -33,7 +37,6 @@ invalid_waveforms = ['Not waveform data',
                      42,
                      3.14159, ]
 
-
 class SystemTests:
     def test_self_test(self, session):
         # We should not get an assert if self_test passes
@@ -42,15 +45,6 @@ class SystemTests:
     def test_get_attribute_string(self, session):
         model = session.instrument_model
         assert model == 'NI PXIe-5433 (2CH)'
-
-    def test_error_message(self):
-        try:
-            # We pass in an invalid model name to force going to error_message
-            with nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:invalid_model (2CH);BoardType:PXIe'):
-                assert False
-        except nifgen.Error as e:
-            assert e.code == -1074134944
-            assert e.description.find('Insufficient location information or resource not present in the system.') != -1
 
     def test_get_error(self, session):
         try:
@@ -73,15 +67,6 @@ class SystemTests:
 
     def test_self_cal(self, session):
         session.self_cal()
-
-    def test_channels_rep_cap(self):
-        with nifgen.Session('', '', False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe') as session:
-            session.func_amplitude = 0.5
-            assert session.channels[0:1].func_amplitude == 0.5
-
-            session.channels[0].func_amplitude = 1
-            assert session.channels[0].func_amplitude == 1
-            assert session.channels[1].func_amplitude == 0.5
 
     def test_markers_rep_cap(self, session):
         assert '' == session.markers[0].marker_event_output_terminal
@@ -118,41 +103,12 @@ class SystemTests:
             assert session.func_start_phase == 0.0
             assert session.is_done() is False
 
-    def test_frequency_list(self, session):
-        session.output_mode = nifgen.OutputMode.FREQ_LIST
-        duration_array = [0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
-        frequency_array = [1000, 100900, 200800, 300700, 400600, 500500, 600400, 700300, 800200, 900100]
-        waveform_handle = session.create_freq_list(nifgen.Waveform.SQUARE, frequency_array, duration_array)
-        session.configure_freq_list(waveform_handle, 2.0, 0, 0)
-        session.trigger_mode = nifgen.TriggerMode.CONTINUOUS
-        session.output_enabled = True
-        assert session.func_waveform == nifgen.Waveform.SQUARE
-        assert session.func_amplitude == 2.0
-
     def test_clear_freq_list(self, session):
         session.clear_freq_list(-1)
 
     def test_create_waveform_from_list(self, session):
         data = [0.1] * 10000
         assert type(session.create_waveform(data)) is int
-
-    def test_create_waveform_from_numpy_array_float64(self, session):
-        data = numpy.ndarray(10000, dtype=numpy.float64)
-        data.fill(0.5)
-        assert type(session.create_waveform(data)) is int
-
-    def test_create_waveform_numpy_array_int16(self, session):
-        data = numpy.ndarray(10000, dtype=numpy.int16)
-        data.fill(256)
-        assert type(session.create_waveform(data)) is int
-
-    def test_create_waveform_wrong_type(self, session):
-        for data in invalid_waveforms:
-            try:
-                session.create_waveform(data)
-                assert False
-            except (TypeError, ValueError):
-                pass
 
     def test_configure_arb_waveform(self, session):
         waveform_data = [x * (1.0 / 256.0) for x in range(256)]
@@ -252,40 +208,6 @@ class SystemTests:
         assert (marker_location_array, seq_handle_base + 2) == session_5421.create_advanced_arb_sequence(waveform_handles_array, loop_counts_array=loop_counts_array, marker_location_array=marker_location_array)
         assert (marker_location_array, seq_handle_base + 3) == session_5421.create_advanced_arb_sequence(waveform_handles_array, loop_counts_array=loop_counts_array, sample_counts_array=sample_counts_array, marker_location_array=marker_location_array)
 
-    # TODO(sbethur): When internal bug# 227842 is fixed, update the test to use PXIe-5433 (Tracked on GitHub by #1376)
-    def test_create_advanced_arb_sequence_wrong_size(self, session_5421):
-        waveform_data = [x * (1.0 / 256.0) for x in range(256)]
-        waveform_handles_array = [session_5421.create_waveform(waveform_data), session_5421.create_waveform(waveform_data), session_5421.create_waveform(waveform_data)]
-        marker_location_array = [0, 16]
-        loop_counts_array = [10, 20, 30]
-        session_5421.output_mode = nifgen.OutputMode.SEQ
-        # Test relies on value of sequence handles starting at a known value and incrementing sequentially. Hardly ideal.
-        try:
-            session_5421.create_advanced_arb_sequence(waveform_handles_array, loop_counts_array=loop_counts_array, marker_location_array=marker_location_array)
-            assert False
-        except ValueError:
-            pass
-
-    def test_arb_script(self, session):
-        waveform_data = [x * (1.0 / 256.0) for x in range(256)]
-        session.output_mode = nifgen.OutputMode.SCRIPT
-        session.script_triggers[0].digital_edge_script_trigger_source = 'PFI0'
-        session.script_triggers[0].digital_edge_script_trigger_edge = nifgen.ScriptTriggerDigitalEdgeEdge.RISING
-        session.write_waveform('wfmSine', waveform_data)
-        session.arb_sample_rate = 10000000
-        script = '''script myScript0
-        repeat 3
-        Generate wfmSine
-        end repeat
-        end script'''
-        session.write_script(script)
-        session.script_to_generate = 'myScript0'
-        session.commit()
-        session.delete_script('myScript0')
-        actual_sample_rate = session.arb_sample_rate
-        in_range = abs(actual_sample_rate - 10000000) <= max(1e-09 * max(abs(actual_sample_rate), abs(10000000)), 0.0)   # https://stackoverflow.com/questions/5595425/what-is-the-best-way-to-compare-floats-for-almost-equality-in-python
-        assert in_range is True
-
     def test_reset(self, session):
         default_output_mode = session.output_mode
         assert default_output_mode == nifgen.OutputMode.ARB
@@ -303,43 +225,12 @@ class SystemTests:
         session.reset_device()
         assert session.trigger_mode == nifgen.TriggerMode.CONTINUOUS
 
-    def test_reset_with_default(self, session):
-        default_sample_rate = session.arb_sample_rate
-        assert default_sample_rate == 250000000.0
-        session.arb_sample_rate = 100000000.0
-        non_default_arb_sample_rate = session.arb_sample_rate
-        assert non_default_arb_sample_rate == 100000000.0
-        session.reset_with_defaults()
-        assert session.arb_sample_rate == 250000000.0
-
     def test_write_waveform_from_list(self, session):
         data = [0.1] * 10000
         session.write_waveform(session.allocate_waveform(len(data)), data)
 
-    def test_write_waveform_from_numpy_array_float64(self, session):
-        data = numpy.ndarray(10000, dtype=numpy.float64)
-        data.fill(0.5)
-        session.write_waveform(session.allocate_waveform(len(data)), data)
-
-    def test_write_waveform_numpy_array_int16(self, session):
-        data = numpy.ndarray(10000, dtype=numpy.int16)
-        data.fill(256)
-        session.write_waveform(session.allocate_waveform(len(data)), data)
-
     def test_write_named_waveform_from_list(self, session):
         data = [0.1] * 10000
-        session.allocate_named_waveform('foo', len(data))
-        session.write_waveform('foo', data)
-
-    def test_write_named_waveform_from_numpy_array_float64(self, session):
-        data = numpy.ndarray(10000, dtype=numpy.float64)
-        data.fill(0.5)
-        session.allocate_named_waveform('foo', len(data))
-        session.write_waveform('foo', data)
-
-    def test_write_named_waveform_numpy_array_int16(self, session):
-        data = numpy.ndarray(10000, dtype=numpy.int16)
-        data.fill(256)
         session.allocate_named_waveform('foo', len(data))
         session.write_waveform('foo', data)
 
@@ -391,19 +282,6 @@ class SystemTests:
         session.define_user_standard_waveform(wfm_points)
         session.clear_user_standard_waveform()
 
-    ''' Removed due to OSP disabled - #891
-    def test_fir_filter_coefficients(self):
-        with nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:5441;BoardType:PXI') as session:
-            coeff_array = [0 for i in range(95)]
-            coeff_array[0] = -1.0
-            coeff_array[2] = 1.0
-            session.configure_custom_fir_filter_coefficients(coeff_array)
-            session.commit()
-            array = session.get_fir_filter_coefficients()
-            assert len(array) == len(coeff_array)
-            assert array == coeff_array
-    '''
-
     def test_send_software_edge_trigger_start_deprecated(self, session):
         warnings.filterwarnings("always", category=DeprecationWarning)
 
@@ -444,48 +322,17 @@ class SystemTests:
         with session.initiate():
             session.send_software_edge_trigger(nifgen.Trigger.SCRIPT, 'ScriptTrigger0')
 
-    def test_channel_format_types(self):
-        with nifgen.Session('', [0, 1], False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe') as simulated_session:
-            assert simulated_session.channel_count == 2
-        with nifgen.Session('', range(2), False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe') as simulated_session:
-            assert simulated_session.channel_count == 2
-        with nifgen.Session('', '0,1', False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe') as simulated_session:
-            assert simulated_session.channel_count == 2
-        with nifgen.Session('', None, False, 'Simulate=1, DriverSetup=Model:5433 (2CH); BoardType:PXIe') as simulated_session:
-            assert simulated_session.channel_count == 2
-        with nifgen.Session(resource_name='', reset_device=False, options='Simulate=1, DriverSetup=Model:5433 (2CH); BoardType:PXIe') as simulated_session:
-            assert simulated_session.channel_count == 2
-
-    def test_import_export_buffer(self, session):
-        test_value_1 = 1.0
-        test_value_2 = 2.0
-        session.arb_gain = test_value_1
-        assert session.arb_gain == test_value_1
-        buffer = session.export_attribute_configuration_buffer()
-        session.arb_gain = test_value_2
-        assert session.arb_gain == test_value_2
-        session.import_attribute_configuration_buffer(buffer)
-        assert session.arb_gain == test_value_1
-
-    def test_import_export_file(self, session):
-        test_value_1 = 2.0
-        test_value_2 = 3.0
-        temp_file = tempfile.NamedTemporaryFile(suffix='.txt', delete=False)
-        # NamedTemporaryFile() returns the file already opened, so we need to close it before we can use it
-        temp_file.close()
-        path = temp_file.name
-        session.arb_gain = test_value_1
-        assert session.arb_gain == test_value_1
-        session.export_attribute_configuration_file(path)
-        session.arb_gain = test_value_2
-        assert session.arb_gain == test_value_2
-        session.import_attribute_configuration_file(path)
-        assert session.arb_gain == test_value_1
-        os.remove(path)
-
     def test_get_channel_name(self, session):
         name = session.get_channel_name(1)
         assert name == '0'
+
+    def test_create_waveform_wrong_type(self, session):
+        for data in invalid_waveforms:
+            try:
+                session.create_waveform(data)
+                assert False
+            except (TypeError, ValueError):
+                pass
 
 
 class TestLibrary(SystemTests):
@@ -502,3 +349,262 @@ class TestLibrary(SystemTests):
         with daqmx_sim_db_lock:
             simulated_session.close()
 
+    def test_error_message(self):
+        try:
+            # We pass in an invalid model name to force going to error_message
+            with nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:invalid_model (2CH);BoardType:PXIe'):
+                assert False
+        except nifgen.Error as e:
+            assert e.code == -1074134944
+            assert e.description.find('Insufficient location information or resource not present in the system.') != -1
+
+    # Test doesn't run over gRPC due to incorrect attribute name for attribute_value.
+    def test_channels_rep_cap(self):
+        with nifgen.Session('', '', False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe') as session:
+            session.func_amplitude = 0.5
+            assert session.channels[0:1].func_amplitude == 0.5
+
+            session.channels[0].func_amplitude = 1
+            assert session.channels[0].func_amplitude == 1
+            assert session.channels[1].func_amplitude == 0.5
+
+    ''' Removed due to OSP disabled - #891
+    def test_fir_filter_coefficients(self):
+        with nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:5441;BoardType:PXI') as session:
+            coeff_array = [0 for i in range(95)]
+            coeff_array[0] = -1.0
+            coeff_array[2] = 1.0
+            session.configure_custom_fir_filter_coefficients(coeff_array)
+            session.commit()
+            array = session.get_fir_filter_coefficients()
+            assert len(array) == len(coeff_array)
+            assert array == coeff_array
+    '''
+
+    def test_channel_format_types(self):
+        with nifgen.Session('', [0, 1], False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe') as simulated_session:
+            assert simulated_session.channel_count == 2
+        with nifgen.Session('', range(2), False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe') as simulated_session:
+            assert simulated_session.channel_count == 2
+        with nifgen.Session('', '0,1', False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe') as simulated_session:
+            assert simulated_session.channel_count == 2
+        with nifgen.Session('', None, False, 'Simulate=1, DriverSetup=Model:5433 (2CH); BoardType:PXIe') as simulated_session:
+            assert simulated_session.channel_count == 2
+        with nifgen.Session(resource_name='', reset_device=False, options='Simulate=1, DriverSetup=Model:5433 (2CH); BoardType:PXIe') as simulated_session:
+            assert simulated_session.channel_count == 2
+
+    # Test doesn't run over gRPC because numpy isn't supported by gRPC.
+    def test_create_waveform_from_numpy_array_float64(self, session):
+        data = numpy.ndarray(10000, dtype=numpy.float64)
+        data.fill(0.5)
+        assert type(session.create_waveform(data)) is int
+
+    # Test doesn't run over gRPC because numpy isn't supported by gRPC.
+    def test_create_waveform_numpy_array_int16(self, session):
+        data = numpy.ndarray(10000, dtype=numpy.int16)
+        data.fill(256)
+        assert type(session.create_waveform(data)) is int
+
+    # Test doesn't run over gRPC because numpy isn't supported by gRPC.
+    def test_create_waveform_numpy_array_int16(self, session):
+        data = numpy.ndarray(10000, dtype=numpy.int16)
+        data.fill(256)
+        assert type(session.create_waveform(data)) is int
+
+    # Test doesn't run over gRPC because numpy isn't supported by gRPC.
+    def test_write_waveform_from_numpy_array_float64(self, session):
+        data = numpy.ndarray(10000, dtype=numpy.float64)
+        data.fill(0.5)
+        session.write_waveform(session.allocate_waveform(len(data)), data)
+
+    # Test doesn't run over gRPC because numpy isn't supported by gRPC.
+    def test_write_waveform_numpy_array_int16(self, session):
+        data = numpy.ndarray(10000, dtype=numpy.int16)
+        data.fill(256)
+        session.write_waveform(session.allocate_waveform(len(data)), data)
+
+    # Test doesn't run over gRPC because numpy isn't supported by gRPC.
+    def test_write_named_waveform_from_numpy_array_float64(self, session):
+        data = numpy.ndarray(10000, dtype=numpy.float64)
+        data.fill(0.5)
+        session.allocate_named_waveform('foo', len(data))
+        session.write_waveform('foo', data)
+
+    # Test doesn't run over gRPC because numpy isn't supported by gRPC.
+    def test_write_named_waveform_numpy_array_int16(self, session):
+        data = numpy.ndarray(10000, dtype=numpy.int16)
+        data.fill(256)
+        session.allocate_named_waveform('foo', len(data))
+        session.write_waveform('foo', data)
+
+    # Test doesn't run over gRPC because the exception isn't caught from create_advanced_arb_sequence().
+    # TODO(sbethur): When internal bug# 227842 is fixed, update the test to use PXIe-5433 (Tracked on GitHub by #1376)
+    def test_create_advanced_arb_sequence_wrong_size(self, session_5421):
+        waveform_data = [x * (1.0 / 256.0) for x in range(256)]
+        waveform_handles_array = [session_5421.create_waveform(waveform_data), session_5421.create_waveform(waveform_data), session_5421.create_waveform(waveform_data)]
+        marker_location_array = [0, 16]
+        loop_counts_array = [10, 20, 30]
+        session_5421.output_mode = nifgen.OutputMode.SEQ
+        # Test relies on value of sequence handles starting at a known value and incrementing sequentially. Hardly ideal.
+        try:
+            session_5421.create_advanced_arb_sequence(waveform_handles_array, loop_counts_array=loop_counts_array, marker_location_array=marker_location_array)
+            assert False
+        except ValueError:
+            pass
+
+    # Test doesn't run over gRPC due to incorrect attribute name for attribute_value.
+    def test_frequency_list(self, session):
+        session.output_mode = nifgen.OutputMode.FREQ_LIST
+        duration_array = [0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
+        frequency_array = [1000, 100900, 200800, 300700, 400600, 500500, 600400, 700300, 800200, 900100]
+        waveform_handle = session.create_freq_list(nifgen.Waveform.SQUARE, frequency_array, duration_array)
+        session.configure_freq_list(waveform_handle, 2.0, 0, 0)
+        session.trigger_mode = nifgen.TriggerMode.CONTINUOUS
+        session.output_enabled = True
+        assert session.func_waveform == nifgen.Waveform.SQUARE
+        assert session.func_amplitude == 2.0
+
+    # Test doesn't run over gRPC due to incorrect attribute name for attribute_value.
+    def test_arb_script(self, session):
+        waveform_data = [x * (1.0 / 256.0) for x in range(256)]
+        session.output_mode = nifgen.OutputMode.SCRIPT
+        session.script_triggers[0].digital_edge_script_trigger_source = 'PFI0'
+        session.script_triggers[0].digital_edge_script_trigger_edge = nifgen.ScriptTriggerDigitalEdgeEdge.RISING
+        session.write_waveform('wfmSine', waveform_data)
+        session.arb_sample_rate = 10000000
+        script = '''script myScript0
+        repeat 3
+        Generate wfmSine
+        end repeat
+        end script'''
+        session.write_script(script)
+        session.script_to_generate = 'myScript0'
+        session.commit()
+        session.delete_script('myScript0')
+        actual_sample_rate = session.arb_sample_rate
+        in_range = abs(actual_sample_rate - 10000000) <= max(1e-09 * max(abs(actual_sample_rate), abs(10000000)), 0.0)   # https://stackoverflow.com/questions/5595425/what-is-the-best-way-to-compare-floats-for-almost-equality-in-python
+        assert in_range is True
+
+    # Test doesn't run over gRPC due to incorrect attribute name for attribute_value.
+    def test_reset_with_default(self, session):
+        default_sample_rate = session.arb_sample_rate
+        assert default_sample_rate == 250000000.0
+        session.arb_sample_rate = 100000000.0
+        non_default_arb_sample_rate = session.arb_sample_rate
+        assert non_default_arb_sample_rate == 100000000.0
+        session.reset_with_defaults()
+        assert session.arb_sample_rate == 250000000.0
+
+    # Test doesn't run over gRPC due to incorrect attribute name for attribute_value.
+    def test_import_export_buffer(self, session):
+        test_value_1 = 1.0
+        test_value_2 = 2.0
+        session.arb_gain = test_value_1
+        assert session.arb_gain == test_value_1
+        buffer = session.export_attribute_configuration_buffer()
+        session.arb_gain = test_value_2
+        assert session.arb_gain == test_value_2
+        session.import_attribute_configuration_buffer(buffer)
+        assert session.arb_gain == test_value_1
+
+    # Test doesn't run over gRPC due to incorrect attribute name for attribute_value.
+    def test_import_export_file(self, session):
+        test_value_1 = 2.0
+        test_value_2 = 3.0
+        temp_file = tempfile.NamedTemporaryFile(suffix='.txt', delete=False)
+        # NamedTemporaryFile() returns the file already opened, so we need to close it before we can use it
+        temp_file.close()
+        path = temp_file.name
+        session.arb_gain = test_value_1
+        assert session.arb_gain == test_value_1
+        session.export_attribute_configuration_file(path)
+        session.arb_gain = test_value_2
+        assert session.arb_gain == test_value_2
+        session.import_attribute_configuration_file(path)
+        assert session.arb_gain == test_value_1
+        os.remove(path)
+
+
+class TestGrpc(SystemTests):
+    server_address = "localhost"
+    server_port = "31763"
+
+    def _get_grpc_server_exe(self):
+        if os.name != "nt":
+            pytest.skip("Only supported on Windows")
+        import winreg
+        try:
+            reg = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
+            read64key = winreg.KEY_READ | winreg.KEY_WOW64_64KEY
+            with winreg.OpenKey(reg, r"SOFTWARE\National Instruments\Common\Installer", access=read64key) as key:
+                shared_dir, _ = winreg.QueryValueEx(key, "NISHAREDDIR64")
+        except OSError:
+            pytest.skip("NI gRPC Device Server not installed")
+        server_exe = pathlib.Path(shared_dir) / "NI gRPC Device Server" / "ni_grpc_device_server.exe"
+        if not server_exe.exists():
+            pytest.skip("NI gRPC Device Server not installed")
+        return server_exe
+
+    @pytest.fixture(scope='class')
+    def grpc_channel(self):
+        # TODO(DavidCurtiss): Remove the next 3 lines once (and the above method) the server is started automatically
+        server_exe = self._get_grpc_server_exe()
+        proc = subprocess.Popen([str(server_exe)])
+        time.sleep(3)
+        try:
+            channel = grpc.insecure_channel(f"{self.server_address}:{self.server_port}")
+            yield channel
+        finally:
+            proc.kill()
+
+    @pytest.fixture(scope='function')
+    def session(self, grpc_channel):
+        grpc_options = nifgen.GrpcSessionOptions(grpc_channel, "")
+        with nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe', _grpc_options=grpc_options) as simulated_session:
+            yield simulated_session
+
+    @pytest.fixture(scope='function')
+    def session_5421(self, grpc_channel):
+        with daqmx_sim_db_lock:
+            grpc_options = nifgen.GrpcSessionOptions(grpc_channel, "")
+            simulated_session = nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:5421;BoardType:PXI', _grpc_options=grpc_options)
+        yield simulated_session
+        with daqmx_sim_db_lock:
+            simulated_session.close()
+
+    def test_error_message(self, grpc_channel):
+        try:
+            grpc_options = nifgen.GrpcSessionOptions(grpc_channel, "")
+            # We pass in an invalid model name to force going to error_message
+            with nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:invalid_model (2CH);BoardType:PXIe', _grpc_options=grpc_options):
+                assert False
+        except nifgen.Error as e:
+            assert e.code == -1074134944
+            assert e.description.find('Insufficient location information or resource not present in the system.') != -1
+
+    ''' Removed due to OSP disabled - #891
+    def test_fir_filter_coefficients(self, grpc_channel):
+        grpc_options = nifgen.GrpcSessionOptions(grpc_channel, "")
+        with nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:5441;BoardType:PXI', _grpc_options=grpc_options) as session:
+            coeff_array = [0 for i in range(95)]
+            coeff_array[0] = -1.0
+            coeff_array[2] = 1.0
+            session.configure_custom_fir_filter_coefficients(coeff_array)
+            session.commit()
+            array = session.get_fir_filter_coefficients()
+            assert len(array) == len(coeff_array)
+            assert array == coeff_array
+    '''
+
+    def test_channel_format_types(self, grpc_channel):
+        grpc_options = nifgen.GrpcSessionOptions(grpc_channel, "")
+        with nifgen.Session('', [0, 1], False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe', _grpc_options=grpc_options) as simulated_session:
+            assert simulated_session.channel_count == 2
+        with nifgen.Session('', range(2), False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe', _grpc_options=grpc_options) as simulated_session:
+            assert simulated_session.channel_count == 2
+        with nifgen.Session('', '0,1', False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe', _grpc_options=grpc_options) as simulated_session:
+            assert simulated_session.channel_count == 2
+        with nifgen.Session('', None, False, 'Simulate=1, DriverSetup=Model:5433 (2CH); BoardType:PXIe', _grpc_options=grpc_options) as simulated_session:
+            assert simulated_session.channel_count == 2
+        with nifgen.Session(resource_name='', reset_device=False, options='Simulate=1, DriverSetup=Model:5433 (2CH); BoardType:PXIe', _grpc_options=grpc_options) as simulated_session:
+            assert simulated_session.channel_count == 2

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -406,12 +406,6 @@ class TestLibrary(SystemTests):
         assert type(session.create_waveform(data)) is int
 
     # Test doesn't run over gRPC because numpy isn't supported by gRPC.
-    def test_create_waveform_numpy_array_int16(self, session):
-        data = numpy.ndarray(10000, dtype=numpy.int16)
-        data.fill(256)
-        assert type(session.create_waveform(data)) is int
-
-    # Test doesn't run over gRPC because numpy isn't supported by gRPC.
     def test_write_waveform_from_numpy_array_float64(self, session):
         data = numpy.ndarray(10000, dtype=numpy.float64)
         data.fill(0.5)

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -37,6 +37,7 @@ invalid_waveforms = ['Not waveform data',
                      42,
                      3.14159, ]
 
+
 class SystemTests:
     def test_self_test(self, session):
         # We should not get an assert if self_test passes


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

This change does not need to be customer-facing.

~- [ ] I've added tests applicable for this pull request~

This change just enables several existing tests.

### What does this Pull Request accomplish?

This is meant to be a cleaner and more up-to-date version of #1838 . That PR has gotten too messy and unmanageable, since it's attempting to handle several upstream code issues that have been detected and either fixed or worked around during the length of time that the PR's been open. Repeated attempts to get it into a clean state have not worked, so I'm hoping that spinning off a new branch can help get the fundamental change submitted more quickly--then we can use other work items to double back and fix individual test failures as needed.

I've created [internal NI bug 2208439](https://ni.visualstudio.com/DevCentral/_workitems/edit/2208439) to address the issues with `attribute_value` separately, and for now I'm keeping those tests local-only.

Tests in the SystemTests class run both ways. Tests in the TestLibrary class only run locally, and tests in the TestGrpc class only run over gRPC.

For tests that can't run over gRPC, there is a comment before each test on why it doesn't run over gRPC.

### List issues fixed by this Pull Request below, if any.

* [Internal NI bug 2160601](https://ni.visualstudio.com/DevCentral/_workitems/edit/2160601)

### What testing has been done?

107 system tests run and pass now instead of 60 as before. Both gRPC and local tests are running.
