### PR TITLE
Add test that verifies you can perform an operation with multiple locks

### DIFF
--- a/src/nidmm/system_tests/test_system_nidmm.py
+++ b/src/nidmm/system_tests/test_system_nidmm.py
@@ -276,6 +276,12 @@ class SystemTests:
         interval = session.get_ext_cal_recommended_interval()
         assert interval.days == 730
 
+    def test_locks_are_reentrant(self, session):
+        with session.lock():
+            with session.lock():
+                interval = session.get_ext_cal_recommended_interval()
+                assert interval.days == 730
+
 
 class TestLibrary(SystemTests):
     @pytest.fixture(scope='function')

--- a/src/niswitch/system_tests/test_system_niswitch.py
+++ b/src/niswitch/system_tests/test_system_niswitch.py
@@ -127,6 +127,12 @@ class SystemTests:
         # We should not get an assert if self_test passes
         session.self_test()
 
+    def test_locks_are_reentrant(self, session):
+        with session.lock():
+            with session.lock():
+                # We should not get an assert if self_test passes
+                session.self_test()
+
     def test_functions_get_path(self, session):
         channel1 = 'r0'
         channel2 = 'c0'


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~

Just adding tests, not applicable to the change log.

- [X] I've added tests applicable for this pull request

Specifically this verifies one of our acceptance criteria, that locks must be reentrant. Verifying that the user can acquire the lock multiple times and perform an operation, for both native and gRPC code bases, should do the trick.

### What does this Pull Request accomplish?

Add tests that verify the behavior of `lock()`

### List issues fixed by this Pull Request below, if any.

N/A

### What testing has been done?

Add `test_locks_are_reentrant()` to both DMM and SWITCH tests.