### PR TITLE
Add session_creation_kwargs fixture

### DIFF
--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -17,6 +17,26 @@ test_files_base_dir = os.path.join(os.path.dirname(__file__), 'test_files')
 
 
 class SystemTests:
+    @pytest.fixture(scope='function')
+    def multi_instrument_session(self, session_creation_kwargs):
+        with nidigital.Session(resource_name=','.join(instruments), options='Simulate=1, DriverSetup=Model:6570', **session_creation_kwargs) as simulated_session:
+            yield simulated_session
+
+    @pytest.fixture(scope='function')
+    def single_instrument_session(self, session_creation_kwargs):
+        with nidigital.Session(resource_name=instruments[0], options='Simulate=1, DriverSetup=Model:6570', **session_creation_kwargs) as simulated_session:
+            yield simulated_session
+
+    def test_close(self, session_creation_kwargs):
+        session = nidigital.Session(resource_name=','.join(instruments), options='Simulate=1, DriverSetup=Model:6570', **session_creation_kwargs)
+        session.vil = 1
+        session.close()
+        try:
+            session.vil = 1
+            assert False
+        except nidigital.Error as e:
+            assert e.code == -1074130544
+
     def test_reset(self, multi_instrument_session):
         multi_instrument_session.selected_function = nidigital.SelectedFunction.PPMU
         assert multi_instrument_session.selected_function == nidigital.SelectedFunction.PPMU
@@ -1300,26 +1320,6 @@ class TestLibrary(SystemTests):
     def session_creation_kwargs(self):
         return {}
 
-    @pytest.fixture(scope='function')
-    def multi_instrument_session(self, session_creation_kwargs):
-        with nidigital.Session(resource_name=','.join(instruments), options='Simulate=1, DriverSetup=Model:6570', **session_creation_kwargs) as simulated_session:
-            yield simulated_session
-
-    @pytest.fixture(scope='function')
-    def single_instrument_session(self, session_creation_kwargs):
-        with nidigital.Session(resource_name=instruments[0], options='Simulate=1, DriverSetup=Model:6570', **session_creation_kwargs) as simulated_session:
-            yield simulated_session
-
-    def test_close(self, session_creation_kwargs):
-        session = nidigital.Session(resource_name=','.join(instruments), options='Simulate=1, DriverSetup=Model:6570', **session_creation_kwargs)
-        session.vil = 1
-        session.close()
-        try:
-            session.vil = 1
-            assert False
-        except nidigital.Error as e:
-            assert e.code == -1074130544
-
 
 class TestGrpc(SystemTests):
     server_address = "localhost"
@@ -1357,23 +1357,3 @@ class TestGrpc(SystemTests):
     def session_creation_kwargs(self, grpc_channel):
         grpc_options = nidigital.GrpcSessionOptions(grpc_channel, "")
         return {'_grpc_options': grpc_options}
-
-    @pytest.fixture(scope='function')
-    def multi_instrument_session(self, session_creation_kwargs):
-        with nidigital.Session(resource_name=','.join(instruments), options='Simulate=1, DriverSetup=Model:6570', **session_creation_kwargs) as simulated_session:
-            yield simulated_session
-
-    @pytest.fixture(scope='function')
-    def single_instrument_session(self, session_creation_kwargs):
-        with nidigital.Session(resource_name=instruments[0], options='Simulate=1, DriverSetup=Model:6570', **session_creation_kwargs) as simulated_session:
-            yield simulated_session
-
-    def test_close(self, session_creation_kwargs):
-        session = nidigital.Session(resource_name=','.join(instruments), options='Simulate=1, DriverSetup=Model:6570', **session_creation_kwargs)
-        session.vil = 1
-        session.close()
-        try:
-            session.vil = 1
-            assert False
-        except nidigital.Error as e:
-            assert e.code == -1074130544

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -1296,18 +1296,22 @@ Per Pin Pass Fail   : [[True, True], [False, False]]
 
 
 class TestLibrary(SystemTests):
+    @pytest.fixture(scope='class')
+    def session_creation_kwargs(self):
+        return {}
+
     @pytest.fixture(scope='function')
-    def multi_instrument_session(self):
-        with nidigital.Session(resource_name=','.join(instruments), options='Simulate=1, DriverSetup=Model:6570') as simulated_session:
+    def multi_instrument_session(self, session_creation_kwargs):
+        with nidigital.Session(resource_name=','.join(instruments), options='Simulate=1, DriverSetup=Model:6570', **session_creation_kwargs) as simulated_session:
             yield simulated_session
 
     @pytest.fixture(scope='function')
-    def single_instrument_session(self):
-        with nidigital.Session(resource_name=instruments[0], options='Simulate=1, DriverSetup=Model:6570') as simulated_session:
+    def single_instrument_session(self, session_creation_kwargs):
+        with nidigital.Session(resource_name=instruments[0], options='Simulate=1, DriverSetup=Model:6570', **session_creation_kwargs) as simulated_session:
             yield simulated_session
 
-    def test_close(self):
-        session = nidigital.Session(resource_name=','.join(instruments), options='Simulate=1, DriverSetup=Model:6570')
+    def test_close(self, session_creation_kwargs):
+        session = nidigital.Session(resource_name=','.join(instruments), options='Simulate=1, DriverSetup=Model:6570', **session_creation_kwargs)
         session.vil = 1
         session.close()
         try:
@@ -1349,21 +1353,23 @@ class TestGrpc(SystemTests):
         finally:
             proc.kill()
 
+    @pytest.fixture(scope='class')
+    def session_creation_kwargs(self, grpc_channel):
+        grpc_options = nidigital.GrpcSessionOptions(grpc_channel, "")
+        return {'_grpc_options': grpc_options}
+
     @pytest.fixture(scope='function')
-    def multi_instrument_session(self, grpc_channel):
-        grpc_options = nidigital.GrpcSessionOptions(grpc_channel, '')
-        with nidigital.Session(resource_name=','.join(instruments), options='Simulate=1, DriverSetup=Model:6570', _grpc_options=grpc_options) as simulated_session:
+    def multi_instrument_session(self, session_creation_kwargs):
+        with nidigital.Session(resource_name=','.join(instruments), options='Simulate=1, DriverSetup=Model:6570', **session_creation_kwargs) as simulated_session:
             yield simulated_session
 
     @pytest.fixture(scope='function')
-    def single_instrument_session(self, grpc_channel):
-        grpc_options = nidigital.GrpcSessionOptions(grpc_channel, '')
-        with nidigital.Session(resource_name=instruments[0], options='Simulate=1, DriverSetup=Model:6570', _grpc_options=grpc_options) as simulated_session:
+    def single_instrument_session(self, session_creation_kwargs):
+        with nidigital.Session(resource_name=instruments[0], options='Simulate=1, DriverSetup=Model:6570', **session_creation_kwargs) as simulated_session:
             yield simulated_session
 
-    def test_close(self, grpc_channel):
-        grpc_options = nidigital.GrpcSessionOptions(grpc_channel, '')
-        session = nidigital.Session(resource_name=','.join(instruments), options='Simulate=1, DriverSetup=Model:6570', _grpc_options=grpc_options)
+    def test_close(self, session_creation_kwargs):
+        session = nidigital.Session(resource_name=','.join(instruments), options='Simulate=1, DriverSetup=Model:6570', **session_creation_kwargs)
         session.vil = 1
         session.close()
         try:

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -39,6 +39,19 @@ invalid_waveforms = ['Not waveform data',
 
 
 class SystemTests:
+    @pytest.fixture(scope='function')
+    def session(self, session_creation_kwargs):
+        with nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe', **session_creation_kwargs) as simulated_session:
+            yield simulated_session
+
+    @pytest.fixture(scope='function')
+    def session_5421(self, session_creation_kwargs):
+        with daqmx_sim_db_lock:
+            simulated_session = nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:5421;BoardType:PXI', **session_creation_kwargs)
+        yield simulated_session
+        with daqmx_sim_db_lock:
+            simulated_session.close()
+
     def test_self_test(self, session):
         # We should not get an assert if self_test passes
         session.self_test()
@@ -46,6 +59,15 @@ class SystemTests:
     def test_get_attribute_string(self, session):
         model = session.instrument_model
         assert model == 'NI PXIe-5433 (2CH)'
+
+    def test_error_message(self, session_creation_kwargs):
+        try:
+            # We pass in an invalid model name to force going to error_message
+            with nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:invalid_model (2CH);BoardType:PXIe', **session_creation_kwargs):
+                assert False
+        except nifgen.Error as e:
+            assert e.code == -1074134944
+            assert e.description.find('Insufficient location information or resource not present in the system.') != -1
 
     def test_get_error(self, session):
         try:
@@ -283,6 +305,19 @@ class SystemTests:
         session.define_user_standard_waveform(wfm_points)
         session.clear_user_standard_waveform()
 
+    ''' Removed due to OSP disabled - #891
+    def test_fir_filter_coefficients(self, session_creation_kwargs):
+        with nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:5441;BoardType:PXI', **session_creation_kwargs) as session:
+            coeff_array = [0 for i in range(95)]
+            coeff_array[0] = -1.0
+            coeff_array[2] = 1.0
+            session.configure_custom_fir_filter_coefficients(coeff_array)
+            session.commit()
+            array = session.get_fir_filter_coefficients()
+            assert len(array) == len(coeff_array)
+            assert array == coeff_array
+    '''
+
     def test_send_software_edge_trigger_start_deprecated(self, session):
         warnings.filterwarnings("always", category=DeprecationWarning)
 
@@ -323,6 +358,18 @@ class SystemTests:
         with session.initiate():
             session.send_software_edge_trigger(nifgen.Trigger.SCRIPT, 'ScriptTrigger0')
 
+    def test_channel_format_types(self, session_creation_kwargs):
+        with nifgen.Session('', [0, 1], False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe', **session_creation_kwargs) as simulated_session:
+            assert simulated_session.channel_count == 2
+        with nifgen.Session('', range(2), False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe', **session_creation_kwargs) as simulated_session:
+            assert simulated_session.channel_count == 2
+        with nifgen.Session('', '0,1', False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe', **session_creation_kwargs) as simulated_session:
+            assert simulated_session.channel_count == 2
+        with nifgen.Session('', None, False, 'Simulate=1, DriverSetup=Model:5433 (2CH); BoardType:PXIe', **session_creation_kwargs) as simulated_session:
+            assert simulated_session.channel_count == 2
+        with nifgen.Session(resource_name='', reset_device=False, options='Simulate=1, DriverSetup=Model:5433 (2CH); BoardType:PXIe', **session_creation_kwargs) as simulated_session:
+            assert simulated_session.channel_count == 2
+
     def test_get_channel_name(self, session):
         name = session.get_channel_name(1)
         assert name == '0'
@@ -341,28 +388,6 @@ class TestLibrary(SystemTests):
     def session_creation_kwargs(self):
         return {}
 
-    @pytest.fixture(scope='function')
-    def session(self, session_creation_kwargs):
-        with nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe', **session_creation_kwargs) as simulated_session:
-            yield simulated_session
-
-    @pytest.fixture(scope='function')
-    def session_5421(self, session_creation_kwargs):
-        with daqmx_sim_db_lock:
-            simulated_session = nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:5421;BoardType:PXI', **session_creation_kwargs)
-        yield simulated_session
-        with daqmx_sim_db_lock:
-            simulated_session.close()
-
-    def test_error_message(self, session_creation_kwargs):
-        try:
-            # We pass in an invalid model name to force going to error_message
-            with nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:invalid_model (2CH);BoardType:PXIe', **session_creation_kwargs):
-                assert False
-        except nifgen.Error as e:
-            assert e.code == -1074134944
-            assert e.description.find('Insufficient location information or resource not present in the system.') != -1
-
     # Test doesn't run over gRPC due to incorrect attribute name for attribute_value.
     def test_channels_rep_cap(self, session_creation_kwargs):
         with nifgen.Session('', '', False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe', **session_creation_kwargs) as session:
@@ -372,31 +397,6 @@ class TestLibrary(SystemTests):
             session.channels[0].func_amplitude = 1
             assert session.channels[0].func_amplitude == 1
             assert session.channels[1].func_amplitude == 0.5
-
-    ''' Removed due to OSP disabled - #891
-    def test_fir_filter_coefficients(self, session_creation_kwargs):
-        with nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:5441;BoardType:PXI', **session_creation_kwargs) as session:
-            coeff_array = [0 for i in range(95)]
-            coeff_array[0] = -1.0
-            coeff_array[2] = 1.0
-            session.configure_custom_fir_filter_coefficients(coeff_array)
-            session.commit()
-            array = session.get_fir_filter_coefficients()
-            assert len(array) == len(coeff_array)
-            assert array == coeff_array
-    '''
-
-    def test_channel_format_types(self, session_creation_kwargs):
-        with nifgen.Session('', [0, 1], False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe', **session_creation_kwargs) as simulated_session:
-            assert simulated_session.channel_count == 2
-        with nifgen.Session('', range(2), False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe', **session_creation_kwargs) as simulated_session:
-            assert simulated_session.channel_count == 2
-        with nifgen.Session('', '0,1', False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe', **session_creation_kwargs) as simulated_session:
-            assert simulated_session.channel_count == 2
-        with nifgen.Session('', None, False, 'Simulate=1, DriverSetup=Model:5433 (2CH); BoardType:PXIe', **session_creation_kwargs) as simulated_session:
-            assert simulated_session.channel_count == 2
-        with nifgen.Session(resource_name='', reset_device=False, options='Simulate=1, DriverSetup=Model:5433 (2CH); BoardType:PXIe', **session_creation_kwargs) as simulated_session:
-            assert simulated_session.channel_count == 2
 
     # Test doesn't run over gRPC because numpy isn't supported by gRPC.
     def test_create_waveform_from_numpy_array_float64(self, session):
@@ -560,50 +560,3 @@ class TestGrpc(SystemTests):
     def session_creation_kwargs(self, grpc_channel):
         grpc_options = nifgen.GrpcSessionOptions(grpc_channel, "")
         return {'_grpc_options': grpc_options}
-
-    @pytest.fixture(scope='function')
-    def session(self, session_creation_kwargs):
-        with nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe', **session_creation_kwargs) as simulated_session:
-            yield simulated_session
-
-    @pytest.fixture(scope='function')
-    def session_5421(self, session_creation_kwargs):
-        with daqmx_sim_db_lock:
-            simulated_session = nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:5421;BoardType:PXI', **session_creation_kwargs)
-        yield simulated_session
-        with daqmx_sim_db_lock:
-            simulated_session.close()
-
-    def test_error_message(self, session_creation_kwargs):
-        try:
-            # We pass in an invalid model name to force going to error_message
-            with nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:invalid_model (2CH);BoardType:PXIe', **session_creation_kwargs):
-                assert False
-        except nifgen.Error as e:
-            assert e.code == -1074134944
-            assert e.description.find('Insufficient location information or resource not present in the system.') != -1
-
-    ''' Removed due to OSP disabled - #891
-    def test_fir_filter_coefficients(self, session_creation_kwargs):
-        with nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:5441;BoardType:PXI', **session_creation_kwargs) as session:
-            coeff_array = [0 for i in range(95)]
-            coeff_array[0] = -1.0
-            coeff_array[2] = 1.0
-            session.configure_custom_fir_filter_coefficients(coeff_array)
-            session.commit()
-            array = session.get_fir_filter_coefficients()
-            assert len(array) == len(coeff_array)
-            assert array == coeff_array
-    '''
-
-    def test_channel_format_types(self, session_creation_kwargs):
-        with nifgen.Session('', [0, 1], False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe', **session_creation_kwargs) as simulated_session:
-            assert simulated_session.channel_count == 2
-        with nifgen.Session('', range(2), False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe', **session_creation_kwargs) as simulated_session:
-            assert simulated_session.channel_count == 2
-        with nifgen.Session('', '0,1', False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe', **session_creation_kwargs) as simulated_session:
-            assert simulated_session.channel_count == 2
-        with nifgen.Session('', None, False, 'Simulate=1, DriverSetup=Model:5433 (2CH); BoardType:PXIe', **session_creation_kwargs) as simulated_session:
-            assert simulated_session.channel_count == 2
-        with nifgen.Session(resource_name='', reset_device=False, options='Simulate=1, DriverSetup=Model:5433 (2CH); BoardType:PXIe', **session_creation_kwargs) as simulated_session:
-            assert simulated_session.channel_count == 2

--- a/src/niswitch/system_tests/test_system_niswitch.py
+++ b/src/niswitch/system_tests/test_system_niswitch.py
@@ -24,6 +24,19 @@ daqmx_sim_db_lock = fasteners.InterProcessLock(daqmx_sim_db_lock_file)
 
 
 class SystemTests:
+    @pytest.fixture(scope='function')
+    def session(self, session_creation_kwargs):
+        with niswitch.Session('', '2737/2-Wire 4x64 Matrix', True, True, **session_creation_kwargs) as simulated_session:
+            yield simulated_session
+
+    @pytest.fixture(scope='function')
+    def session_2532(self, session_creation_kwargs):
+        with daqmx_sim_db_lock:
+            simulated_session = niswitch.Session('', '2532/1-Wire 4x128 Matrix', True, False, **session_creation_kwargs)
+        yield simulated_session
+        with daqmx_sim_db_lock:
+            simulated_session.close()
+
     # Basic Use Case Tests
     def test_relayclose(self, session):
         relay_name = 'kr0c0'
@@ -153,25 +166,6 @@ class SystemTests:
         session.disable()   # expect no errors
         assert session.can_connect(channel1, channel2) == niswitch.PathCapability.PATH_AVAILABLE
 
-
-class TestLibrary(SystemTests):
-    @pytest.fixture(scope='class')
-    def session_creation_kwargs(self):
-        return {}
-
-    @pytest.fixture(scope='function')
-    def session(self, session_creation_kwargs):
-        with niswitch.Session('', '2737/2-Wire 4x64 Matrix', True, True, **session_creation_kwargs) as simulated_session:
-            yield simulated_session
-
-    @pytest.fixture(scope='function')
-    def session_2532(self, session_creation_kwargs):
-        with daqmx_sim_db_lock:
-            simulated_session = niswitch.Session('', '2532/1-Wire 4x128 Matrix', True, False, **session_creation_kwargs)
-        yield simulated_session
-        with daqmx_sim_db_lock:
-            simulated_session.close()
-
     def test_error_message(self, session_creation_kwargs):
         try:
             # We pass in an invalid model name to force going to error_message
@@ -180,6 +174,12 @@ class TestLibrary(SystemTests):
         except niswitch.Error as e:
             assert e.code == -1074118654
             assert e.description.find('Invalid resource name.') != -1
+
+
+class TestLibrary(SystemTests):
+    @pytest.fixture(scope='class')
+    def session_creation_kwargs(self):
+        return {}
 
 
 class TestGrpc(SystemTests):
@@ -218,25 +218,3 @@ class TestGrpc(SystemTests):
     def session_creation_kwargs(self, grpc_channel):
         grpc_options = niswitch.GrpcSessionOptions(grpc_channel, "")
         return {'_grpc_options': grpc_options}
-
-    @pytest.fixture(scope='function')
-    def session(self, session_creation_kwargs):
-        with niswitch.Session('', '2737/2-Wire 4x64 Matrix', True, True, **session_creation_kwargs) as simulated_session:
-            yield simulated_session
-
-    @pytest.fixture(scope='function')
-    def session_2532(self, session_creation_kwargs):
-        with daqmx_sim_db_lock:
-            simulated_session = niswitch.Session('', '2532/1-Wire 4x128 Matrix', True, False, **session_creation_kwargs)
-        yield simulated_session
-        with daqmx_sim_db_lock:
-            simulated_session.close()
-
-    def test_error_message(self, session_creation_kwargs):
-        try:
-            # We pass in an invalid model name to force going to error_message
-            with niswitch.Session('', 'Invalid Topology', True, True, **session_creation_kwargs):
-                assert False
-        except niswitch.Error as e:
-            assert e.code == -1074118654
-            assert e.description.find('Invalid resource name.') != -1


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

Adds session_creation_kwargs fixture to all TestLibrary/TestGrpc classes, for consistency and for reduced redundancy.

### List issues fixed by this Pull Request below, if any.

None

### What testing has been done?

None