### PR TITLE
Remove mentions of Python 2 and 3 from niscope module docs

### DIFF
--- a/docs/_static/niscope_usage.inc
+++ b/docs/_static/niscope_usage.inc
@@ -89,10 +89,6 @@ The waveform_infos returned from `fetch_into <niscope/class.html#fetch-into>`_ i
 
         - **samples** (numpy array of datatype used) floating point array of samples. Length will be of the actual samples acquired
 
-            .. note::
-
-                Python 3 only
-
     - Such that all record 0 waveforms are first. For example, with a channel list of 0,1, you would have the following index values:
 
         - index 0 = record 0, channel 0
@@ -100,16 +96,6 @@ The waveform_infos returned from `fetch_into <niscope/class.html#fetch-into>`_ i
         - index 2 = record 1, channel 0
         - index 3 = record 1, channel 1
         - etc.
-
-
-.. note:: When using Python 2, the waveform_infos objects do not include the waveform for that record. Instead, samples are in the waveform passed into the function using the following layout:
-
-    - index 0 = record 0, channel 0
-    - index *x* = record 0, channel 1
-    - index 2\ *x* = record 1, channel 0
-    - index 3\ *x* = record 1, channel 1
-    - etc.
-    - Where *x* = the record length
 
 
 `Other usage examples can be found on GitHub. <https://github.com/ni/nimi-python/tree/master/src/niscope/examples>`_

--- a/generated/niscope/README.rst
+++ b/generated/niscope/README.rst
@@ -216,10 +216,6 @@ The waveform_infos returned from `fetch_into <niscope/class.html#fetch-into>`_ i
 
         - **samples** (numpy array of datatype used) floating point array of samples. Length will be of the actual samples acquired
 
-            .. note::
-
-                Python 3 only
-
     - Such that all record 0 waveforms are first. For example, with a channel list of 0,1, you would have the following index values:
 
         - index 0 = record 0, channel 0
@@ -227,16 +223,6 @@ The waveform_infos returned from `fetch_into <niscope/class.html#fetch-into>`_ i
         - index 2 = record 1, channel 0
         - index 3 = record 1, channel 1
         - etc.
-
-
-.. note:: When using Python 2, the waveform_infos objects do not include the waveform for that record. Instead, samples are in the waveform passed into the function using the following layout:
-
-    - index 0 = record 0, channel 0
-    - index *x* = record 0, channel 1
-    - index 2\ *x* = record 1, channel 0
-    - index 3\ *x* = record 1, channel 1
-    - etc.
-    - Where *x* = the record length
 
 
 `Other usage examples can be found on GitHub. <https://github.com/ni/nimi-python/tree/master/src/niscope/examples>`_


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

We had mentions of Python 2 and Python 3 in the niscope module docs that are no longer relevant. This removes them.

### List issues fixed by this Pull Request below, if any.

### What testing has been done?

Built the documentation locally and examined the part that was changed. Looked good to me.
