### PR TITLE
Add documentation for gRPC API elements.

### DIFF
--- a/build/defines.mak
+++ b/build/defines.mak
@@ -83,6 +83,10 @@ DEFAULT_RST_FILES_TO_GENERATE := \
     toc.inc \
     errors.rst \
     rep_caps.rst \
+    $(if $(GRPC_SUPPORTED), \
+        grpc_session_options.rst \
+    ) \
+
 
 # Files for tracking parts of the build
 WHEEL_BUILD_DONE := $(LOG_DIR)/wheel_build_done

--- a/build/templates/class.rst.mako
+++ b/build/templates/class.rst.mako
@@ -2,12 +2,14 @@
     import build.helper as helper
 
     config = template_parameters['metadata'].config
-    module_name = config['module_name']
-    driver_name = config['driver_name']
     c_function_prefix = config['c_function_prefix']
+    driver_name = config['driver_name']
+    module_name = config['module_name']
 
     functions_all = template_parameters['metadata'].functions
     functions = helper.filter_public_functions(functions_all)
+
+    grpc_supported = template_parameters['include_grpc_support']
 
     if 'context_manager_name' in config:
         # Add a InitiateDoc entry - only used to add initiate() to the Session documentation
@@ -37,7 +39,26 @@
 
 ${helper.get_rst_header_snippet('Session', '=')}
 
-.. py:class:: Session(${init_method_params})
+<%
+grpc_options_param = ', *, _grpc_options=None' if grpc_supported else ''
+if grpc_supported:
+    input_params.append(
+        {
+            'default_value': None,
+            'direction': 'in',
+            'documentation': { 'description': 'MeasurementLink gRPC session options' },
+            'enum': None,
+            'is_repeated_capability': False,
+            'is_session_handle': False,
+            'python_name': '_grpc_options',
+            'size': {'mechanism': 'fixed', 'value': 1},
+            'type_in_documentation': module_name + '.grpc_session_options.GrpcSessionOptions',
+            'type_in_documentation_was_calculated': False,
+            'use_in_python_api': False,
+        },
+    )
+%>\
+.. py:class:: Session(${init_method_params}${grpc_options_param})
 
     ${helper.get_documentation_for_node_rst(init_function, config, indent=4)}
 

--- a/build/templates/class.rst.mako
+++ b/build/templates/class.rst.mako
@@ -52,7 +52,7 @@ if grpc_supported:
             'is_session_handle': False,
             'python_name': '_grpc_options',
             'size': {'mechanism': 'fixed', 'value': 1},
-            'type_in_documentation': module_name + '.grpc_session_options.GrpcSessionOptions',
+            'type_in_documentation': module_name + '.GrpcSessionOptions',
             'type_in_documentation_was_calculated': False,
             'use_in_python_api': False,
         },

--- a/build/templates/errors.py.mako
+++ b/build/templates/errors.py.mako
@@ -58,7 +58,7 @@ class DriverWarning(Warning):
 
 % if grpc_supported:
 class RpcError(Error):
-    '''An error specific to gRPC sessions'''
+    '''An error specific to sessions to the NI gRPC Device Server'''
 
     def __init__(self, rpc_code, description):
         self.rpc_code = rpc_code

--- a/build/templates/errors.rst.mako
+++ b/build/templates/errors.rst.mako
@@ -2,10 +2,11 @@
     import build.helper as helper
 
     config = template_parameters['metadata'].config
-    module_name = config['module_name']
     driver_name = config['driver_name']
     enums = config['enums']
     extra_errors_used = config['extra_errors_used']
+    module_name = config['module_name']
+
     grpc_supported = template_parameters['include_grpc_support']
 %>\
 ${helper.get_rst_header_snippet('Exceptions and Warnings', '=')}

--- a/build/templates/errors.rst.mako
+++ b/build/templates/errors.rst.mako
@@ -6,6 +6,7 @@
     driver_name = config['driver_name']
     enums = config['enums']
     extra_errors_used = config['extra_errors_used']
+    grpc_supported = template_parameters['include_grpc_support']
 %>\
 ${helper.get_rst_header_snippet('Exceptions and Warnings', '=')}
 
@@ -78,6 +79,17 @@ ${helper.get_rst_header_snippet('SelfTestError', '-')}
     .. exception:: SelfTestError
 
         An error due to a failed self-test
+
+
+% endif
+% if grpc_supported:
+${helper.get_rst_header_snippet('RpcError', '-')}
+
+    .. py:currentmodule:: ${module_name}.errors
+
+    .. exception:: RpcError
+
+        An error specific to gRPC sessions
 
 
 % endif

--- a/build/templates/errors.rst.mako
+++ b/build/templates/errors.rst.mako
@@ -90,7 +90,7 @@ ${helper.get_rst_header_snippet('RpcError', '-')}
 
     .. exception:: RpcError
 
-        An error specific to gRPC sessions
+        An error specific to sessions to the NI gRPC Device Server
 
 
 % endif

--- a/build/templates/grpc_session_options.py.mako
+++ b/build/templates/grpc_session_options.py.mako
@@ -63,7 +63,7 @@ class GrpcSessionOptions(object):
         Args:
             grpc_channel (grpc.Channel): Specifies the channel to the NI gRPC Device Server.
 
-            session_name (str): User-specified name that identifies the driver session in the NI gRPC Device
+            session_name (str): User-specified name that identifies the driver session on the NI gRPC Device
                 Server. This is different from the resource name parameter many APIs take as a separate
                 parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
                 You can use an empty string if you want to always initialize a new session on the server.
@@ -73,7 +73,7 @@ class GrpcSessionOptions(object):
 
             initialization_behavior (enum): Specifies whether it is acceptable to initialize a new
                 session or attach to an existing one, or if only one of the behaviors is desired.
-                The driver session exists in the NI gRPC Device Server.
+                The driver session exists on the NI gRPC Device Server.
         '''
         self.grpc_channel = grpc_channel
         self.session_name = session_name

--- a/build/templates/grpc_session_options.py.mako
+++ b/build/templates/grpc_session_options.py.mako
@@ -19,26 +19,29 @@ MEASUREMENTLINK_23Q1_NIMI_PYTHON_API_KEY = 'DE10751B-3EE0-44EC-A93B-800E6A3C89E4
 class SessionInitializationBehavior(IntEnum):
     AUTO = 0
     r'''
-    Attach to an existing session with the specified name if it exists, otherwise intialize a new session.
+    The NI gRPC Device Server will attach to an existing session with the specified name if it exists, otherwise the server
+    will initialize a new session.
 
     Note:
-    If this initializes a new session on the NI gRPC Device Server, then when the Python session goes out of scope,
-    it will automatically close the server session. If this attaches to an existing session on the NI gRPC Device Server,
-    then when the Python session goes out of scope, it will detach from the server session and leave it open.
+    When using the Session as a context manager and the context exits, the behavior depends on what happened when the constructor
+    was called. If it resulted in a new session being initialized on the NI gRPC Device Server, then it will automatically close the
+    server session. If it instead attached to an existing session, then it will detach from the server session and leave it open.
     '''
     INITIALIZE_SERVER_SESSION = 1
     r'''
     Require the NI gRPC Device Server to initialize a new session with the specified name.
 
     Note:
-    When the Python session goes out of scope, it will automatically close the server session.
+    When using the Session as a context manager and the context exits, it will automatically close the
+    server session.
     '''
     ATTACH_TO_SERVER_SESSION = 2
     r'''
     Require the NI gRPC Device Server to attach to an existing session with the specified name.
 
     Note:
-    When the Python session goes out of scope, it will detach from the server session and leave it open.
+    When using the Session as a context manager and the context exits, it will detach from the server session
+    and leave it open.
     '''
 
 
@@ -55,23 +58,22 @@ class GrpcSessionOptions(object):
     ):
         r'''Collection of options that specifies session behaviors related to gRPC.
 
-        Creates and returns an object you can pass to a session constructor.
+        Creates and returns an object you can pass to a Session constructor.
 
         Args:
             grpc_channel (grpc.Channel): Specifies the channel to the NI gRPC Device Server.
 
-            session_name (str): Specifies the **session name** to be used in the NI gRPC Device
-                Server. This is different from the resource name parameter many APIs take as a
-                separate parameter. Specifying a name makes it easy to share sessions across
-                multiple gRPC clients. You can use an empty string if you want to always initialize
-                a new session on the server and then close it when the Python Session instance on
-                the client goes out of scope.
+            session_name (str): User-specified name that identifies the driver session in the NI gRPC Device
+                Server. This is different from the resource name parameter many APIs take as a separate
+                parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
+                You can use an empty string if you want to always initialize a new session on the server.
+                To attach to an existing session, you must specify the session name it was initialized with.
 
             api_key (str): Specifies the API license key required by the NI gRPC Device Server.
 
             initialization_behavior (enum): Specifies whether it is acceptable to initialize a new
                 session or attach to an existing one, or if only one of the behaviors is desired.
-                To attach to an existing session, you must specify a non-empty session name.
+                The driver session exists in the NI gRPC Device Server.
         '''
         self.grpc_channel = grpc_channel
         self.session_name = session_name

--- a/build/templates/grpc_session_options.rst.mako
+++ b/build/templates/grpc_session_options.rst.mako
@@ -8,7 +8,7 @@
 %>\
 ${helper.get_rst_header_snippet('gRPC Support', '=')}
 
-Support for gRPC used in ${driver_name}
+Support for using ${driver_name} over gRPC
 
 .. py:currentmodule:: ${module_name}
 

--- a/build/templates/grpc_session_options.rst.mako
+++ b/build/templates/grpc_session_options.rst.mako
@@ -13,9 +13,6 @@ Support for using ${driver_name} over gRPC
 .. py:currentmodule:: ${module_name}
 
 
-Enums
-=====
-
 
 SessionInitializationBehavior
 -----------------------------
@@ -52,8 +49,8 @@ SessionInitializationBehavior
 
 
 
-Classes
-=======
+GrpcSessionOptions
+------------------
 
 
 .. py:class:: GrpcSessionOptions(self, grpc_channel, session_name, initialization_behavior=SessionInitializationBehavior.AUTO)
@@ -98,4 +95,4 @@ Classes
 
         
 
-    :type initialization_behavior: enum
+    :type initialization_behavior: :py:data:`${module_name}.SessionInitializationBehavior`

--- a/build/templates/grpc_session_options.rst.mako
+++ b/build/templates/grpc_session_options.rst.mako
@@ -77,7 +77,7 @@ Classes
     :param session_name:
         
 
-        User-specified name that identifies the driver session in the NI gRPC Device Server.
+        User-specified name that identifies the driver session on the NI gRPC Device Server.
 
         This is different from the resource name parameter many APIs take as a separate
         parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
@@ -94,7 +94,7 @@ Classes
 
         Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired.
 
-        The driver session exists in the NI gRPC Device Server.
+        The driver session exists on the NI gRPC Device Server.
 
         
 

--- a/build/templates/grpc_session_options.rst.mako
+++ b/build/templates/grpc_session_options.rst.mako
@@ -25,37 +25,31 @@ SessionInitializationBehavior
     .. py:attribute:: SessionInitializationBehavior.AUTO
 
 
+        The NI gRPC Device Server will attach to an existing session with the specified name if it exists,
+        otherwise the server will initialize a new session.
 
-        Attach to an existing session with the specified name if it exists, otherwise intialize a new session.
-
-        .. note:: If this initializes a new session on the NI gRPC Device Server, then when the Python session goes out of scope,
-            it will automatically close the server session. If this attaches to an existing session on the NI gRPC Device Server,
-            then when the Python session goes out of scope, it will detach from the server session and leave it open.
-
-        
+        .. note:: When using the Session as a context manager and the context exits, the behavior depends on what happened when the constructor
+            was called. If it resulted in a new session being initialized on the NI gRPC Device Server, then it will automatically close the
+            server session. If it instead attached to an existing session, then it will detach from the server session and leave it open.
 
 
     .. py:attribute:: SessionInitializationBehavior.INITIALIZE_SERVER_SESSION
 
 
-
         Require the NI gRPC Device Server to initialize a new session with the specified name.
 
-        .. note:: When the Python session goes out of scope, it will automatically close the server session.
-
-        
-
+        .. note:: When using the Session as a context manager and the context exits, it will automatically close the
+            server session.
 
 
     .. py:attribute:: SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION
 
 
-
         Require the NI gRPC Device Server to attach to an existing session with the specified name.
 
-        .. note:: When the Python session goes out of scope, it will detach from the server session and leave it open.
+        .. note:: When using the Session as a context manager and the context exits, it will detach from the server session
+            and leave it open.
 
-        
 
 
 Classes
@@ -64,11 +58,10 @@ Classes
 
 .. py:class:: GrpcSessionOptions(self, grpc_channel, session_name, initialization_behavior=SessionInitializationBehavior.AUTO)
 
-    
 
     Collection of options that specifies session behaviors related to gRPC.
 
-    Creates and returns an object you can pass to a session constructor.
+    Creates and returns an object you can pass to a Session constructor.
 
 
     :param grpc_channel:
@@ -78,28 +71,31 @@ Classes
 
         
 
-
     :type grpc_channel: grpc.Channel
+
 
     :param session_name:
         
 
-        Specifies the **session name** to be used in the gRPC Device Server.
+        User-specified name that identifies the driver session in the NI gRPC Device Server.
 
-                This is different from the resource name parameter many APIs take as a separate parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients. You can use an empty string if you want to always initialize a new session and then close it when the Python session goes out of scope.
+        This is different from the resource name parameter many APIs take as a separate
+        parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
+        You can use an empty string if you want to always initialize a new session on the server.
+        To attach to an existing session, you must specify the session name it was initialized with.
 
         
 
-
     :type session_name: str
+
 
     :param initialization_behavior:
         
 
-        Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired. To attach to an existing session, you must specify a non-empty session name.
+        Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired.
+
+        The driver session exists in the NI gRPC Device Server.
 
         
 
-
     :type initialization_behavior: enum
-

--- a/build/templates/grpc_session_options.rst.mako
+++ b/build/templates/grpc_session_options.rst.mako
@@ -1,0 +1,105 @@
+<%
+    import build.helper as helper
+
+    config = template_parameters['metadata'].config
+    module_name = config['module_name']
+    driver_name = config['driver_name']
+    enums = config['enums']
+%>\
+${helper.get_rst_header_snippet('gRPC Support', '=')}
+
+Support for gRPC used in ${driver_name}
+
+.. py:currentmodule:: ${module_name}
+
+
+Enums
+=====
+
+
+SessionInitializationBehavior
+-----------------------------
+
+.. py:class:: SessionInitializationBehavior
+
+    .. py:attribute:: SessionInitializationBehavior.AUTO
+
+
+
+        Attach to an existing session with the specified name if it exists, otherwise intialize a new session.
+
+        .. note:: If this initializes a new session on the NI gRPC Device Server, then when the Python session goes out of scope,
+            it will automatically close the server session. If this attaches to an existing session on the NI gRPC Device Server,
+            then when the Python session goes out of scope, it will detach from the server session and leave it open.
+
+        
+
+
+    .. py:attribute:: SessionInitializationBehavior.INITIALIZE_SERVER_SESSION
+
+
+
+        Require the NI gRPC Device Server to initialize a new session with the specified name.
+
+        .. note:: When the Python session goes out of scope, it will automatically close the server session.
+
+        
+
+
+
+    .. py:attribute:: SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION
+
+
+
+        Require the NI gRPC Device Server to attach to an existing session with the specified name.
+
+        .. note:: When the Python session goes out of scope, it will detach from the server session and leave it open.
+
+        
+
+
+Classes
+=======
+
+
+.. py:class:: GrpcSessionOptions(self, grpc_channel, session_name, initialization_behavior=SessionInitializationBehavior.AUTO)
+
+    
+
+    Collection of options that specifies session behaviors related to gRPC.
+
+    Creates and returns an object you can pass to a session constructor.
+
+
+    :param grpc_channel:
+        
+
+        Specifies the channel to the NI gRPC Device Server.
+
+        
+
+
+    :type grpc_channel: grpc.Channel
+
+    :param session_name:
+        
+
+        Specifies the **session name** to be used in the gRPC Device Server.
+
+                This is different from the resource name parameter many APIs take as a separate parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients. You can use an empty string if you want to always initialize a new session and then close it when the Python session goes out of scope.
+
+        
+
+
+    :type session_name: str
+
+    :param initialization_behavior:
+        
+
+        Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired. To attach to an existing session, you must specify a non-empty session name.
+
+        
+
+
+    :type initialization_behavior: enum
+

--- a/build/templates/toc.inc.mako
+++ b/build/templates/toc.inc.mako
@@ -4,6 +4,7 @@
     config = template_parameters['metadata'].config
     module_name = config['module_name']
     enums = config['enums']
+    grpc_supported = template_parameters['include_grpc_support']
 %>\
 API Reference
 --------------
@@ -19,4 +20,7 @@ API Reference
 % endif
    ${module_name}/errors
    ${module_name}/examples
+% if grpc_supported:
+   ${module_name}/grpc_session_options
+% endif
 

--- a/docs/nidcpower/class.rst
+++ b/docs/nidcpower/class.rst
@@ -3,7 +3,7 @@
 Session
 =======
 
-.. py:class:: Session(self, resource_name, channels=None, reset=False, options={}, independent_channels=True)
+.. py:class:: Session(self, resource_name, channels=None, reset=False, options={}, independent_channels=True, *, _grpc_options=None)
 
     
 
@@ -148,6 +148,16 @@ Session
 
 
     :type independent_channels: bool
+
+    :param _grpc_options:
+        
+
+        MeasurementLink gRPC session options
+
+        
+
+
+    :type _grpc_options: nidcpower.grpc_session_options.GrpcSessionOptions
 
 
 Methods

--- a/docs/nidcpower/class.rst
+++ b/docs/nidcpower/class.rst
@@ -157,7 +157,7 @@ Session
         
 
 
-    :type _grpc_options: nidcpower.grpc_session_options.GrpcSessionOptions
+    :type _grpc_options: nidcpower.GrpcSessionOptions
 
 
 Methods

--- a/docs/nidcpower/errors.rst
+++ b/docs/nidcpower/errors.rst
@@ -77,6 +77,16 @@ SelfTestError
         An error due to a failed self-test
 
 
+RpcError
+--------
+
+    .. py:currentmodule:: nidcpower.errors
+
+    .. exception:: RpcError
+
+        An error specific to gRPC sessions
+
+
 DriverWarning
 -------------
 

--- a/docs/nidcpower/errors.rst
+++ b/docs/nidcpower/errors.rst
@@ -84,7 +84,7 @@ RpcError
 
     .. exception:: RpcError
 
-        An error specific to gRPC sessions
+        An error specific to sessions to the NI gRPC Device Server
 
 
 DriverWarning

--- a/docs/nidcpower/grpc_session_options.rst
+++ b/docs/nidcpower/grpc_session_options.rst
@@ -1,7 +1,7 @@
 gRPC Support
 ============
 
-Support for gRPC used in NI-DCPower
+Support for using NI-DCPower over gRPC
 
 .. py:currentmodule:: nidcpower
 

--- a/docs/nidcpower/grpc_session_options.rst
+++ b/docs/nidcpower/grpc_session_options.rst
@@ -1,0 +1,98 @@
+gRPC Support
+============
+
+Support for gRPC used in NI-DCPower
+
+.. py:currentmodule:: nidcpower
+
+
+Enums
+=====
+
+
+SessionInitializationBehavior
+-----------------------------
+
+.. py:class:: SessionInitializationBehavior
+
+    .. py:attribute:: SessionInitializationBehavior.AUTO
+
+
+
+        Attach to an existing session with the specified name if it exists, otherwise intialize a new session.
+
+        .. note:: If this initializes a new session on the NI gRPC Device Server, then when the Python session goes out of scope,
+            it will automatically close the server session. If this attaches to an existing session on the NI gRPC Device Server,
+            then when the Python session goes out of scope, it will detach from the server session and leave it open.
+
+        
+
+
+    .. py:attribute:: SessionInitializationBehavior.INITIALIZE_SERVER_SESSION
+
+
+
+        Require the NI gRPC Device Server to initialize a new session with the specified name.
+
+        .. note:: When the Python session goes out of scope, it will automatically close the server session.
+
+        
+
+
+
+    .. py:attribute:: SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION
+
+
+
+        Require the NI gRPC Device Server to attach to an existing session with the specified name.
+
+        .. note:: When the Python session goes out of scope, it will detach from the server session and leave it open.
+
+        
+
+
+Classes
+=======
+
+
+.. py:class:: GrpcSessionOptions(self, grpc_channel, session_name, initialization_behavior=SessionInitializationBehavior.AUTO)
+
+    
+
+    Collection of options that specifies session behaviors related to gRPC.
+
+    Creates and returns an object you can pass to a session constructor.
+
+
+    :param grpc_channel:
+        
+
+        Specifies the channel to the NI gRPC Device Server.
+
+        
+
+
+    :type grpc_channel: grpc.Channel
+
+    :param session_name:
+        
+
+        Specifies the **session name** to be used in the gRPC Device Server.
+
+                This is different from the resource name parameter many APIs take as a separate parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients. You can use an empty string if you want to always initialize a new session and then close it when the Python session goes out of scope.
+
+        
+
+
+    :type session_name: str
+
+    :param initialization_behavior:
+        
+
+        Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired. To attach to an existing session, you must specify a non-empty session name.
+
+        
+
+
+    :type initialization_behavior: enum
+

--- a/docs/nidcpower/grpc_session_options.rst
+++ b/docs/nidcpower/grpc_session_options.rst
@@ -6,9 +6,6 @@ Support for using NI-DCPower over gRPC
 .. py:currentmodule:: nidcpower
 
 
-Enums
-=====
-
 
 SessionInitializationBehavior
 -----------------------------
@@ -45,8 +42,8 @@ SessionInitializationBehavior
 
 
 
-Classes
-=======
+GrpcSessionOptions
+------------------
 
 
 .. py:class:: GrpcSessionOptions(self, grpc_channel, session_name, initialization_behavior=SessionInitializationBehavior.AUTO)
@@ -91,4 +88,4 @@ Classes
 
         
 
-    :type initialization_behavior: enum
+    :type initialization_behavior: :py:data:`nidcpower.SessionInitializationBehavior`

--- a/docs/nidcpower/grpc_session_options.rst
+++ b/docs/nidcpower/grpc_session_options.rst
@@ -70,7 +70,7 @@ Classes
     :param session_name:
         
 
-        User-specified name that identifies the driver session in the NI gRPC Device Server.
+        User-specified name that identifies the driver session on the NI gRPC Device Server.
 
         This is different from the resource name parameter many APIs take as a separate
         parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
@@ -87,7 +87,7 @@ Classes
 
         Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired.
 
-        The driver session exists in the NI gRPC Device Server.
+        The driver session exists on the NI gRPC Device Server.
 
         
 

--- a/docs/nidcpower/grpc_session_options.rst
+++ b/docs/nidcpower/grpc_session_options.rst
@@ -18,37 +18,31 @@ SessionInitializationBehavior
     .. py:attribute:: SessionInitializationBehavior.AUTO
 
 
+        The NI gRPC Device Server will attach to an existing session with the specified name if it exists,
+        otherwise the server will initialize a new session.
 
-        Attach to an existing session with the specified name if it exists, otherwise intialize a new session.
-
-        .. note:: If this initializes a new session on the NI gRPC Device Server, then when the Python session goes out of scope,
-            it will automatically close the server session. If this attaches to an existing session on the NI gRPC Device Server,
-            then when the Python session goes out of scope, it will detach from the server session and leave it open.
-
-        
+        .. note:: When using the Session as a context manager and the context exits, the behavior depends on what happened when the constructor
+            was called. If it resulted in a new session being initialized on the NI gRPC Device Server, then it will automatically close the
+            server session. If it instead attached to an existing session, then it will detach from the server session and leave it open.
 
 
     .. py:attribute:: SessionInitializationBehavior.INITIALIZE_SERVER_SESSION
 
 
-
         Require the NI gRPC Device Server to initialize a new session with the specified name.
 
-        .. note:: When the Python session goes out of scope, it will automatically close the server session.
-
-        
-
+        .. note:: When using the Session as a context manager and the context exits, it will automatically close the
+            server session.
 
 
     .. py:attribute:: SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION
 
 
-
         Require the NI gRPC Device Server to attach to an existing session with the specified name.
 
-        .. note:: When the Python session goes out of scope, it will detach from the server session and leave it open.
+        .. note:: When using the Session as a context manager and the context exits, it will detach from the server session
+            and leave it open.
 
-        
 
 
 Classes
@@ -57,11 +51,10 @@ Classes
 
 .. py:class:: GrpcSessionOptions(self, grpc_channel, session_name, initialization_behavior=SessionInitializationBehavior.AUTO)
 
-    
 
     Collection of options that specifies session behaviors related to gRPC.
 
-    Creates and returns an object you can pass to a session constructor.
+    Creates and returns an object you can pass to a Session constructor.
 
 
     :param grpc_channel:
@@ -71,28 +64,31 @@ Classes
 
         
 
-
     :type grpc_channel: grpc.Channel
+
 
     :param session_name:
         
 
-        Specifies the **session name** to be used in the gRPC Device Server.
+        User-specified name that identifies the driver session in the NI gRPC Device Server.
 
-                This is different from the resource name parameter many APIs take as a separate parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients. You can use an empty string if you want to always initialize a new session and then close it when the Python session goes out of scope.
+        This is different from the resource name parameter many APIs take as a separate
+        parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
+        You can use an empty string if you want to always initialize a new session on the server.
+        To attach to an existing session, you must specify the session name it was initialized with.
 
         
 
-
     :type session_name: str
+
 
     :param initialization_behavior:
         
 
-        Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired. To attach to an existing session, you must specify a non-empty session name.
+        Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired.
+
+        The driver session exists in the NI gRPC Device Server.
 
         
 
-
     :type initialization_behavior: enum
-

--- a/docs/nidcpower/toc.inc
+++ b/docs/nidcpower/toc.inc
@@ -8,4 +8,5 @@ API Reference
    nidcpower/enums
    nidcpower/errors
    nidcpower/examples
+   nidcpower/grpc_session_options
 

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -93,7 +93,7 @@ Session
         
 
 
-    :type _grpc_options: nidigital.grpc_session_options.GrpcSessionOptions
+    :type _grpc_options: nidigital.GrpcSessionOptions
 
 
 Methods

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -3,7 +3,7 @@
 Session
 =======
 
-.. py:class:: Session(self, resource_name, id_query=False, reset_device=False, options={})
+.. py:class:: Session(self, resource_name, id_query=False, reset_device=False, options={}, *, _grpc_options=None)
 
     
 
@@ -84,6 +84,16 @@ Session
 
 
     :type options: dict
+
+    :param _grpc_options:
+        
+
+        MeasurementLink gRPC session options
+
+        
+
+
+    :type _grpc_options: nidigital.grpc_session_options.GrpcSessionOptions
 
 
 Methods

--- a/docs/nidigital/errors.rst
+++ b/docs/nidigital/errors.rst
@@ -77,6 +77,16 @@ SelfTestError
         An error due to a failed self-test
 
 
+RpcError
+--------
+
+    .. py:currentmodule:: nidigital.errors
+
+    .. exception:: RpcError
+
+        An error specific to gRPC sessions
+
+
 DriverWarning
 -------------
 

--- a/docs/nidigital/errors.rst
+++ b/docs/nidigital/errors.rst
@@ -84,7 +84,7 @@ RpcError
 
     .. exception:: RpcError
 
-        An error specific to gRPC sessions
+        An error specific to sessions to the NI gRPC Device Server
 
 
 DriverWarning

--- a/docs/nidigital/grpc_session_options.rst
+++ b/docs/nidigital/grpc_session_options.rst
@@ -6,9 +6,6 @@ Support for using NI-Digital Pattern Driver over gRPC
 .. py:currentmodule:: nidigital
 
 
-Enums
-=====
-
 
 SessionInitializationBehavior
 -----------------------------
@@ -45,8 +42,8 @@ SessionInitializationBehavior
 
 
 
-Classes
-=======
+GrpcSessionOptions
+------------------
 
 
 .. py:class:: GrpcSessionOptions(self, grpc_channel, session_name, initialization_behavior=SessionInitializationBehavior.AUTO)
@@ -91,4 +88,4 @@ Classes
 
         
 
-    :type initialization_behavior: enum
+    :type initialization_behavior: :py:data:`nidigital.SessionInitializationBehavior`

--- a/docs/nidigital/grpc_session_options.rst
+++ b/docs/nidigital/grpc_session_options.rst
@@ -1,0 +1,98 @@
+gRPC Support
+============
+
+Support for gRPC used in NI-Digital Pattern Driver
+
+.. py:currentmodule:: nidigital
+
+
+Enums
+=====
+
+
+SessionInitializationBehavior
+-----------------------------
+
+.. py:class:: SessionInitializationBehavior
+
+    .. py:attribute:: SessionInitializationBehavior.AUTO
+
+
+
+        Attach to an existing session with the specified name if it exists, otherwise intialize a new session.
+
+        .. note:: If this initializes a new session on the NI gRPC Device Server, then when the Python session goes out of scope,
+            it will automatically close the server session. If this attaches to an existing session on the NI gRPC Device Server,
+            then when the Python session goes out of scope, it will detach from the server session and leave it open.
+
+        
+
+
+    .. py:attribute:: SessionInitializationBehavior.INITIALIZE_SERVER_SESSION
+
+
+
+        Require the NI gRPC Device Server to initialize a new session with the specified name.
+
+        .. note:: When the Python session goes out of scope, it will automatically close the server session.
+
+        
+
+
+
+    .. py:attribute:: SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION
+
+
+
+        Require the NI gRPC Device Server to attach to an existing session with the specified name.
+
+        .. note:: When the Python session goes out of scope, it will detach from the server session and leave it open.
+
+        
+
+
+Classes
+=======
+
+
+.. py:class:: GrpcSessionOptions(self, grpc_channel, session_name, initialization_behavior=SessionInitializationBehavior.AUTO)
+
+    
+
+    Collection of options that specifies session behaviors related to gRPC.
+
+    Creates and returns an object you can pass to a session constructor.
+
+
+    :param grpc_channel:
+        
+
+        Specifies the channel to the NI gRPC Device Server.
+
+        
+
+
+    :type grpc_channel: grpc.Channel
+
+    :param session_name:
+        
+
+        Specifies the **session name** to be used in the gRPC Device Server.
+
+                This is different from the resource name parameter many APIs take as a separate parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients. You can use an empty string if you want to always initialize a new session and then close it when the Python session goes out of scope.
+
+        
+
+
+    :type session_name: str
+
+    :param initialization_behavior:
+        
+
+        Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired. To attach to an existing session, you must specify a non-empty session name.
+
+        
+
+
+    :type initialization_behavior: enum
+

--- a/docs/nidigital/grpc_session_options.rst
+++ b/docs/nidigital/grpc_session_options.rst
@@ -70,7 +70,7 @@ Classes
     :param session_name:
         
 
-        User-specified name that identifies the driver session in the NI gRPC Device Server.
+        User-specified name that identifies the driver session on the NI gRPC Device Server.
 
         This is different from the resource name parameter many APIs take as a separate
         parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
@@ -87,7 +87,7 @@ Classes
 
         Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired.
 
-        The driver session exists in the NI gRPC Device Server.
+        The driver session exists on the NI gRPC Device Server.
 
         
 

--- a/docs/nidigital/grpc_session_options.rst
+++ b/docs/nidigital/grpc_session_options.rst
@@ -1,7 +1,7 @@
 gRPC Support
 ============
 
-Support for gRPC used in NI-Digital Pattern Driver
+Support for using NI-Digital Pattern Driver over gRPC
 
 .. py:currentmodule:: nidigital
 

--- a/docs/nidigital/grpc_session_options.rst
+++ b/docs/nidigital/grpc_session_options.rst
@@ -18,37 +18,31 @@ SessionInitializationBehavior
     .. py:attribute:: SessionInitializationBehavior.AUTO
 
 
+        The NI gRPC Device Server will attach to an existing session with the specified name if it exists,
+        otherwise the server will initialize a new session.
 
-        Attach to an existing session with the specified name if it exists, otherwise intialize a new session.
-
-        .. note:: If this initializes a new session on the NI gRPC Device Server, then when the Python session goes out of scope,
-            it will automatically close the server session. If this attaches to an existing session on the NI gRPC Device Server,
-            then when the Python session goes out of scope, it will detach from the server session and leave it open.
-
-        
+        .. note:: When using the Session as a context manager and the context exits, the behavior depends on what happened when the constructor
+            was called. If it resulted in a new session being initialized on the NI gRPC Device Server, then it will automatically close the
+            server session. If it instead attached to an existing session, then it will detach from the server session and leave it open.
 
 
     .. py:attribute:: SessionInitializationBehavior.INITIALIZE_SERVER_SESSION
 
 
-
         Require the NI gRPC Device Server to initialize a new session with the specified name.
 
-        .. note:: When the Python session goes out of scope, it will automatically close the server session.
-
-        
-
+        .. note:: When using the Session as a context manager and the context exits, it will automatically close the
+            server session.
 
 
     .. py:attribute:: SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION
 
 
-
         Require the NI gRPC Device Server to attach to an existing session with the specified name.
 
-        .. note:: When the Python session goes out of scope, it will detach from the server session and leave it open.
+        .. note:: When using the Session as a context manager and the context exits, it will detach from the server session
+            and leave it open.
 
-        
 
 
 Classes
@@ -57,11 +51,10 @@ Classes
 
 .. py:class:: GrpcSessionOptions(self, grpc_channel, session_name, initialization_behavior=SessionInitializationBehavior.AUTO)
 
-    
 
     Collection of options that specifies session behaviors related to gRPC.
 
-    Creates and returns an object you can pass to a session constructor.
+    Creates and returns an object you can pass to a Session constructor.
 
 
     :param grpc_channel:
@@ -71,28 +64,31 @@ Classes
 
         
 
-
     :type grpc_channel: grpc.Channel
+
 
     :param session_name:
         
 
-        Specifies the **session name** to be used in the gRPC Device Server.
+        User-specified name that identifies the driver session in the NI gRPC Device Server.
 
-                This is different from the resource name parameter many APIs take as a separate parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients. You can use an empty string if you want to always initialize a new session and then close it when the Python session goes out of scope.
+        This is different from the resource name parameter many APIs take as a separate
+        parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
+        You can use an empty string if you want to always initialize a new session on the server.
+        To attach to an existing session, you must specify the session name it was initialized with.
 
         
 
-
     :type session_name: str
+
 
     :param initialization_behavior:
         
 
-        Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired. To attach to an existing session, you must specify a non-empty session name.
+        Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired.
+
+        The driver session exists in the NI gRPC Device Server.
 
         
 
-
     :type initialization_behavior: enum
-

--- a/docs/nidigital/toc.inc
+++ b/docs/nidigital/toc.inc
@@ -8,4 +8,5 @@ API Reference
    nidigital/enums
    nidigital/errors
    nidigital/examples
+   nidigital/grpc_session_options
 

--- a/docs/nidmm/class.rst
+++ b/docs/nidmm/class.rst
@@ -134,7 +134,7 @@ Session
         
 
 
-    :type _grpc_options: nidmm.grpc_session_options.GrpcSessionOptions
+    :type _grpc_options: nidmm.GrpcSessionOptions
 
 
 Methods

--- a/docs/nidmm/class.rst
+++ b/docs/nidmm/class.rst
@@ -3,7 +3,7 @@
 Session
 =======
 
-.. py:class:: Session(self, resource_name, id_query=False, reset_device=False, options={})
+.. py:class:: Session(self, resource_name, id_query=False, reset_device=False, options={}, *, _grpc_options=None)
 
     
 
@@ -125,6 +125,16 @@ Session
 
 
     :type options: dict
+
+    :param _grpc_options:
+        
+
+        MeasurementLink gRPC session options
+
+        
+
+
+    :type _grpc_options: nidmm.grpc_session_options.GrpcSessionOptions
 
 
 Methods

--- a/docs/nidmm/errors.rst
+++ b/docs/nidmm/errors.rst
@@ -84,7 +84,7 @@ RpcError
 
     .. exception:: RpcError
 
-        An error specific to gRPC sessions
+        An error specific to sessions to the NI gRPC Device Server
 
 
 DriverWarning

--- a/docs/nidmm/errors.rst
+++ b/docs/nidmm/errors.rst
@@ -77,6 +77,16 @@ SelfTestError
         An error due to a failed self-test
 
 
+RpcError
+--------
+
+    .. py:currentmodule:: nidmm.errors
+
+    .. exception:: RpcError
+
+        An error specific to gRPC sessions
+
+
 DriverWarning
 -------------
 

--- a/docs/nidmm/grpc_session_options.rst
+++ b/docs/nidmm/grpc_session_options.rst
@@ -70,7 +70,7 @@ Classes
     :param session_name:
         
 
-        User-specified name that identifies the driver session in the NI gRPC Device Server.
+        User-specified name that identifies the driver session on the NI gRPC Device Server.
 
         This is different from the resource name parameter many APIs take as a separate
         parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
@@ -87,7 +87,7 @@ Classes
 
         Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired.
 
-        The driver session exists in the NI gRPC Device Server.
+        The driver session exists on the NI gRPC Device Server.
 
         
 

--- a/docs/nidmm/grpc_session_options.rst
+++ b/docs/nidmm/grpc_session_options.rst
@@ -18,37 +18,31 @@ SessionInitializationBehavior
     .. py:attribute:: SessionInitializationBehavior.AUTO
 
 
+        The NI gRPC Device Server will attach to an existing session with the specified name if it exists,
+        otherwise the server will initialize a new session.
 
-        Attach to an existing session with the specified name if it exists, otherwise intialize a new session.
-
-        .. note:: If this initializes a new session on the NI gRPC Device Server, then when the Python session goes out of scope,
-            it will automatically close the server session. If this attaches to an existing session on the NI gRPC Device Server,
-            then when the Python session goes out of scope, it will detach from the server session and leave it open.
-
-        
+        .. note:: When using the Session as a context manager and the context exits, the behavior depends on what happened when the constructor
+            was called. If it resulted in a new session being initialized on the NI gRPC Device Server, then it will automatically close the
+            server session. If it instead attached to an existing session, then it will detach from the server session and leave it open.
 
 
     .. py:attribute:: SessionInitializationBehavior.INITIALIZE_SERVER_SESSION
 
 
-
         Require the NI gRPC Device Server to initialize a new session with the specified name.
 
-        .. note:: When the Python session goes out of scope, it will automatically close the server session.
-
-        
-
+        .. note:: When using the Session as a context manager and the context exits, it will automatically close the
+            server session.
 
 
     .. py:attribute:: SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION
 
 
-
         Require the NI gRPC Device Server to attach to an existing session with the specified name.
 
-        .. note:: When the Python session goes out of scope, it will detach from the server session and leave it open.
+        .. note:: When using the Session as a context manager and the context exits, it will detach from the server session
+            and leave it open.
 
-        
 
 
 Classes
@@ -57,11 +51,10 @@ Classes
 
 .. py:class:: GrpcSessionOptions(self, grpc_channel, session_name, initialization_behavior=SessionInitializationBehavior.AUTO)
 
-    
 
     Collection of options that specifies session behaviors related to gRPC.
 
-    Creates and returns an object you can pass to a session constructor.
+    Creates and returns an object you can pass to a Session constructor.
 
 
     :param grpc_channel:
@@ -71,28 +64,31 @@ Classes
 
         
 
-
     :type grpc_channel: grpc.Channel
+
 
     :param session_name:
         
 
-        Specifies the **session name** to be used in the gRPC Device Server.
+        User-specified name that identifies the driver session in the NI gRPC Device Server.
 
-                This is different from the resource name parameter many APIs take as a separate parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients. You can use an empty string if you want to always initialize a new session and then close it when the Python session goes out of scope.
+        This is different from the resource name parameter many APIs take as a separate
+        parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
+        You can use an empty string if you want to always initialize a new session on the server.
+        To attach to an existing session, you must specify the session name it was initialized with.
 
         
 
-
     :type session_name: str
+
 
     :param initialization_behavior:
         
 
-        Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired. To attach to an existing session, you must specify a non-empty session name.
+        Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired.
+
+        The driver session exists in the NI gRPC Device Server.
 
         
 
-
     :type initialization_behavior: enum
-

--- a/docs/nidmm/grpc_session_options.rst
+++ b/docs/nidmm/grpc_session_options.rst
@@ -1,7 +1,7 @@
 gRPC Support
 ============
 
-Support for gRPC used in NI-DMM
+Support for using NI-DMM over gRPC
 
 .. py:currentmodule:: nidmm
 

--- a/docs/nidmm/grpc_session_options.rst
+++ b/docs/nidmm/grpc_session_options.rst
@@ -1,0 +1,98 @@
+gRPC Support
+============
+
+Support for gRPC used in NI-DMM
+
+.. py:currentmodule:: nidmm
+
+
+Enums
+=====
+
+
+SessionInitializationBehavior
+-----------------------------
+
+.. py:class:: SessionInitializationBehavior
+
+    .. py:attribute:: SessionInitializationBehavior.AUTO
+
+
+
+        Attach to an existing session with the specified name if it exists, otherwise intialize a new session.
+
+        .. note:: If this initializes a new session on the NI gRPC Device Server, then when the Python session goes out of scope,
+            it will automatically close the server session. If this attaches to an existing session on the NI gRPC Device Server,
+            then when the Python session goes out of scope, it will detach from the server session and leave it open.
+
+        
+
+
+    .. py:attribute:: SessionInitializationBehavior.INITIALIZE_SERVER_SESSION
+
+
+
+        Require the NI gRPC Device Server to initialize a new session with the specified name.
+
+        .. note:: When the Python session goes out of scope, it will automatically close the server session.
+
+        
+
+
+
+    .. py:attribute:: SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION
+
+
+
+        Require the NI gRPC Device Server to attach to an existing session with the specified name.
+
+        .. note:: When the Python session goes out of scope, it will detach from the server session and leave it open.
+
+        
+
+
+Classes
+=======
+
+
+.. py:class:: GrpcSessionOptions(self, grpc_channel, session_name, initialization_behavior=SessionInitializationBehavior.AUTO)
+
+    
+
+    Collection of options that specifies session behaviors related to gRPC.
+
+    Creates and returns an object you can pass to a session constructor.
+
+
+    :param grpc_channel:
+        
+
+        Specifies the channel to the NI gRPC Device Server.
+
+        
+
+
+    :type grpc_channel: grpc.Channel
+
+    :param session_name:
+        
+
+        Specifies the **session name** to be used in the gRPC Device Server.
+
+                This is different from the resource name parameter many APIs take as a separate parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients. You can use an empty string if you want to always initialize a new session and then close it when the Python session goes out of scope.
+
+        
+
+
+    :type session_name: str
+
+    :param initialization_behavior:
+        
+
+        Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired. To attach to an existing session, you must specify a non-empty session name.
+
+        
+
+
+    :type initialization_behavior: enum
+

--- a/docs/nidmm/grpc_session_options.rst
+++ b/docs/nidmm/grpc_session_options.rst
@@ -6,9 +6,6 @@ Support for using NI-DMM over gRPC
 .. py:currentmodule:: nidmm
 
 
-Enums
-=====
-
 
 SessionInitializationBehavior
 -----------------------------
@@ -45,8 +42,8 @@ SessionInitializationBehavior
 
 
 
-Classes
-=======
+GrpcSessionOptions
+------------------
 
 
 .. py:class:: GrpcSessionOptions(self, grpc_channel, session_name, initialization_behavior=SessionInitializationBehavior.AUTO)
@@ -91,4 +88,4 @@ Classes
 
         
 
-    :type initialization_behavior: enum
+    :type initialization_behavior: :py:data:`nidmm.SessionInitializationBehavior`

--- a/docs/nidmm/toc.inc
+++ b/docs/nidmm/toc.inc
@@ -7,4 +7,5 @@ API Reference
    nidmm/enums
    nidmm/errors
    nidmm/examples
+   nidmm/grpc_session_options
 

--- a/docs/nifgen/class.rst
+++ b/docs/nifgen/class.rst
@@ -3,7 +3,7 @@
 Session
 =======
 
-.. py:class:: Session(self, resource_name, channel_name=None, reset_device=False, options={})
+.. py:class:: Session(self, resource_name, channel_name=None, reset_device=False, options={}, *, _grpc_options=None)
 
     
 
@@ -133,6 +133,16 @@ Session
 
 
     :type options: dict
+
+    :param _grpc_options:
+        
+
+        MeasurementLink gRPC session options
+
+        
+
+
+    :type _grpc_options: nifgen.grpc_session_options.GrpcSessionOptions
 
 
 Methods

--- a/docs/nifgen/class.rst
+++ b/docs/nifgen/class.rst
@@ -142,7 +142,7 @@ Session
         
 
 
-    :type _grpc_options: nifgen.grpc_session_options.GrpcSessionOptions
+    :type _grpc_options: nifgen.GrpcSessionOptions
 
 
 Methods

--- a/docs/nifgen/errors.rst
+++ b/docs/nifgen/errors.rst
@@ -84,7 +84,7 @@ RpcError
 
     .. exception:: RpcError
 
-        An error specific to gRPC sessions
+        An error specific to sessions to the NI gRPC Device Server
 
 
 DriverWarning

--- a/docs/nifgen/errors.rst
+++ b/docs/nifgen/errors.rst
@@ -77,6 +77,16 @@ SelfTestError
         An error due to a failed self-test
 
 
+RpcError
+--------
+
+    .. py:currentmodule:: nifgen.errors
+
+    .. exception:: RpcError
+
+        An error specific to gRPC sessions
+
+
 DriverWarning
 -------------
 

--- a/docs/nifgen/grpc_session_options.rst
+++ b/docs/nifgen/grpc_session_options.rst
@@ -6,9 +6,6 @@ Support for using NI-FGEN over gRPC
 .. py:currentmodule:: nifgen
 
 
-Enums
-=====
-
 
 SessionInitializationBehavior
 -----------------------------
@@ -45,8 +42,8 @@ SessionInitializationBehavior
 
 
 
-Classes
-=======
+GrpcSessionOptions
+------------------
 
 
 .. py:class:: GrpcSessionOptions(self, grpc_channel, session_name, initialization_behavior=SessionInitializationBehavior.AUTO)
@@ -91,4 +88,4 @@ Classes
 
         
 
-    :type initialization_behavior: enum
+    :type initialization_behavior: :py:data:`nifgen.SessionInitializationBehavior`

--- a/docs/nifgen/grpc_session_options.rst
+++ b/docs/nifgen/grpc_session_options.rst
@@ -70,7 +70,7 @@ Classes
     :param session_name:
         
 
-        User-specified name that identifies the driver session in the NI gRPC Device Server.
+        User-specified name that identifies the driver session on the NI gRPC Device Server.
 
         This is different from the resource name parameter many APIs take as a separate
         parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
@@ -87,7 +87,7 @@ Classes
 
         Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired.
 
-        The driver session exists in the NI gRPC Device Server.
+        The driver session exists on the NI gRPC Device Server.
 
         
 

--- a/docs/nifgen/grpc_session_options.rst
+++ b/docs/nifgen/grpc_session_options.rst
@@ -1,7 +1,7 @@
 gRPC Support
 ============
 
-Support for gRPC used in NI-FGEN
+Support for using NI-FGEN over gRPC
 
 .. py:currentmodule:: nifgen
 

--- a/docs/nifgen/grpc_session_options.rst
+++ b/docs/nifgen/grpc_session_options.rst
@@ -1,0 +1,98 @@
+gRPC Support
+============
+
+Support for gRPC used in NI-FGEN
+
+.. py:currentmodule:: nifgen
+
+
+Enums
+=====
+
+
+SessionInitializationBehavior
+-----------------------------
+
+.. py:class:: SessionInitializationBehavior
+
+    .. py:attribute:: SessionInitializationBehavior.AUTO
+
+
+
+        Attach to an existing session with the specified name if it exists, otherwise intialize a new session.
+
+        .. note:: If this initializes a new session on the NI gRPC Device Server, then when the Python session goes out of scope,
+            it will automatically close the server session. If this attaches to an existing session on the NI gRPC Device Server,
+            then when the Python session goes out of scope, it will detach from the server session and leave it open.
+
+        
+
+
+    .. py:attribute:: SessionInitializationBehavior.INITIALIZE_SERVER_SESSION
+
+
+
+        Require the NI gRPC Device Server to initialize a new session with the specified name.
+
+        .. note:: When the Python session goes out of scope, it will automatically close the server session.
+
+        
+
+
+
+    .. py:attribute:: SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION
+
+
+
+        Require the NI gRPC Device Server to attach to an existing session with the specified name.
+
+        .. note:: When the Python session goes out of scope, it will detach from the server session and leave it open.
+
+        
+
+
+Classes
+=======
+
+
+.. py:class:: GrpcSessionOptions(self, grpc_channel, session_name, initialization_behavior=SessionInitializationBehavior.AUTO)
+
+    
+
+    Collection of options that specifies session behaviors related to gRPC.
+
+    Creates and returns an object you can pass to a session constructor.
+
+
+    :param grpc_channel:
+        
+
+        Specifies the channel to the NI gRPC Device Server.
+
+        
+
+
+    :type grpc_channel: grpc.Channel
+
+    :param session_name:
+        
+
+        Specifies the **session name** to be used in the gRPC Device Server.
+
+                This is different from the resource name parameter many APIs take as a separate parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients. You can use an empty string if you want to always initialize a new session and then close it when the Python session goes out of scope.
+
+        
+
+
+    :type session_name: str
+
+    :param initialization_behavior:
+        
+
+        Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired. To attach to an existing session, you must specify a non-empty session name.
+
+        
+
+
+    :type initialization_behavior: enum
+

--- a/docs/nifgen/grpc_session_options.rst
+++ b/docs/nifgen/grpc_session_options.rst
@@ -18,37 +18,31 @@ SessionInitializationBehavior
     .. py:attribute:: SessionInitializationBehavior.AUTO
 
 
+        The NI gRPC Device Server will attach to an existing session with the specified name if it exists,
+        otherwise the server will initialize a new session.
 
-        Attach to an existing session with the specified name if it exists, otherwise intialize a new session.
-
-        .. note:: If this initializes a new session on the NI gRPC Device Server, then when the Python session goes out of scope,
-            it will automatically close the server session. If this attaches to an existing session on the NI gRPC Device Server,
-            then when the Python session goes out of scope, it will detach from the server session and leave it open.
-
-        
+        .. note:: When using the Session as a context manager and the context exits, the behavior depends on what happened when the constructor
+            was called. If it resulted in a new session being initialized on the NI gRPC Device Server, then it will automatically close the
+            server session. If it instead attached to an existing session, then it will detach from the server session and leave it open.
 
 
     .. py:attribute:: SessionInitializationBehavior.INITIALIZE_SERVER_SESSION
 
 
-
         Require the NI gRPC Device Server to initialize a new session with the specified name.
 
-        .. note:: When the Python session goes out of scope, it will automatically close the server session.
-
-        
-
+        .. note:: When using the Session as a context manager and the context exits, it will automatically close the
+            server session.
 
 
     .. py:attribute:: SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION
 
 
-
         Require the NI gRPC Device Server to attach to an existing session with the specified name.
 
-        .. note:: When the Python session goes out of scope, it will detach from the server session and leave it open.
+        .. note:: When using the Session as a context manager and the context exits, it will detach from the server session
+            and leave it open.
 
-        
 
 
 Classes
@@ -57,11 +51,10 @@ Classes
 
 .. py:class:: GrpcSessionOptions(self, grpc_channel, session_name, initialization_behavior=SessionInitializationBehavior.AUTO)
 
-    
 
     Collection of options that specifies session behaviors related to gRPC.
 
-    Creates and returns an object you can pass to a session constructor.
+    Creates and returns an object you can pass to a Session constructor.
 
 
     :param grpc_channel:
@@ -71,28 +64,31 @@ Classes
 
         
 
-
     :type grpc_channel: grpc.Channel
+
 
     :param session_name:
         
 
-        Specifies the **session name** to be used in the gRPC Device Server.
+        User-specified name that identifies the driver session in the NI gRPC Device Server.
 
-                This is different from the resource name parameter many APIs take as a separate parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients. You can use an empty string if you want to always initialize a new session and then close it when the Python session goes out of scope.
+        This is different from the resource name parameter many APIs take as a separate
+        parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
+        You can use an empty string if you want to always initialize a new session on the server.
+        To attach to an existing session, you must specify the session name it was initialized with.
 
         
 
-
     :type session_name: str
+
 
     :param initialization_behavior:
         
 
-        Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired. To attach to an existing session, you must specify a non-empty session name.
+        Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired.
+
+        The driver session exists in the NI gRPC Device Server.
 
         
 
-
     :type initialization_behavior: enum
-

--- a/docs/nifgen/toc.inc
+++ b/docs/nifgen/toc.inc
@@ -8,4 +8,5 @@ API Reference
    nifgen/enums
    nifgen/errors
    nifgen/examples
+   nifgen/grpc_session_options
 

--- a/docs/niscope/class.rst
+++ b/docs/niscope/class.rst
@@ -3,7 +3,7 @@
 Session
 =======
 
-.. py:class:: Session(self, resource_name, id_query=False, reset_device=False, options={})
+.. py:class:: Session(self, resource_name, id_query=False, reset_device=False, options={}, *, _grpc_options=None)
 
     
 
@@ -157,6 +157,16 @@ Session
 
 
     :type options: dict
+
+    :param _grpc_options:
+        
+
+        MeasurementLink gRPC session options
+
+        
+
+
+    :type _grpc_options: niscope.grpc_session_options.GrpcSessionOptions
 
 
 Methods

--- a/docs/niscope/class.rst
+++ b/docs/niscope/class.rst
@@ -166,7 +166,7 @@ Session
         
 
 
-    :type _grpc_options: niscope.grpc_session_options.GrpcSessionOptions
+    :type _grpc_options: niscope.GrpcSessionOptions
 
 
 Methods

--- a/docs/niscope/errors.rst
+++ b/docs/niscope/errors.rst
@@ -77,6 +77,16 @@ SelfTestError
         An error due to a failed self-test
 
 
+RpcError
+--------
+
+    .. py:currentmodule:: niscope.errors
+
+    .. exception:: RpcError
+
+        An error specific to gRPC sessions
+
+
 DriverWarning
 -------------
 

--- a/docs/niscope/errors.rst
+++ b/docs/niscope/errors.rst
@@ -84,7 +84,7 @@ RpcError
 
     .. exception:: RpcError
 
-        An error specific to gRPC sessions
+        An error specific to sessions to the NI gRPC Device Server
 
 
 DriverWarning

--- a/docs/niscope/grpc_session_options.rst
+++ b/docs/niscope/grpc_session_options.rst
@@ -6,9 +6,6 @@ Support for using NI-SCOPE over gRPC
 .. py:currentmodule:: niscope
 
 
-Enums
-=====
-
 
 SessionInitializationBehavior
 -----------------------------
@@ -45,8 +42,8 @@ SessionInitializationBehavior
 
 
 
-Classes
-=======
+GrpcSessionOptions
+------------------
 
 
 .. py:class:: GrpcSessionOptions(self, grpc_channel, session_name, initialization_behavior=SessionInitializationBehavior.AUTO)
@@ -91,4 +88,4 @@ Classes
 
         
 
-    :type initialization_behavior: enum
+    :type initialization_behavior: :py:data:`niscope.SessionInitializationBehavior`

--- a/docs/niscope/grpc_session_options.rst
+++ b/docs/niscope/grpc_session_options.rst
@@ -70,7 +70,7 @@ Classes
     :param session_name:
         
 
-        User-specified name that identifies the driver session in the NI gRPC Device Server.
+        User-specified name that identifies the driver session on the NI gRPC Device Server.
 
         This is different from the resource name parameter many APIs take as a separate
         parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
@@ -87,7 +87,7 @@ Classes
 
         Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired.
 
-        The driver session exists in the NI gRPC Device Server.
+        The driver session exists on the NI gRPC Device Server.
 
         
 

--- a/docs/niscope/grpc_session_options.rst
+++ b/docs/niscope/grpc_session_options.rst
@@ -1,0 +1,98 @@
+gRPC Support
+============
+
+Support for gRPC used in NI-SCOPE
+
+.. py:currentmodule:: niscope
+
+
+Enums
+=====
+
+
+SessionInitializationBehavior
+-----------------------------
+
+.. py:class:: SessionInitializationBehavior
+
+    .. py:attribute:: SessionInitializationBehavior.AUTO
+
+
+
+        Attach to an existing session with the specified name if it exists, otherwise intialize a new session.
+
+        .. note:: If this initializes a new session on the NI gRPC Device Server, then when the Python session goes out of scope,
+            it will automatically close the server session. If this attaches to an existing session on the NI gRPC Device Server,
+            then when the Python session goes out of scope, it will detach from the server session and leave it open.
+
+        
+
+
+    .. py:attribute:: SessionInitializationBehavior.INITIALIZE_SERVER_SESSION
+
+
+
+        Require the NI gRPC Device Server to initialize a new session with the specified name.
+
+        .. note:: When the Python session goes out of scope, it will automatically close the server session.
+
+        
+
+
+
+    .. py:attribute:: SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION
+
+
+
+        Require the NI gRPC Device Server to attach to an existing session with the specified name.
+
+        .. note:: When the Python session goes out of scope, it will detach from the server session and leave it open.
+
+        
+
+
+Classes
+=======
+
+
+.. py:class:: GrpcSessionOptions(self, grpc_channel, session_name, initialization_behavior=SessionInitializationBehavior.AUTO)
+
+    
+
+    Collection of options that specifies session behaviors related to gRPC.
+
+    Creates and returns an object you can pass to a session constructor.
+
+
+    :param grpc_channel:
+        
+
+        Specifies the channel to the NI gRPC Device Server.
+
+        
+
+
+    :type grpc_channel: grpc.Channel
+
+    :param session_name:
+        
+
+        Specifies the **session name** to be used in the gRPC Device Server.
+
+                This is different from the resource name parameter many APIs take as a separate parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients. You can use an empty string if you want to always initialize a new session and then close it when the Python session goes out of scope.
+
+        
+
+
+    :type session_name: str
+
+    :param initialization_behavior:
+        
+
+        Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired. To attach to an existing session, you must specify a non-empty session name.
+
+        
+
+
+    :type initialization_behavior: enum
+

--- a/docs/niscope/grpc_session_options.rst
+++ b/docs/niscope/grpc_session_options.rst
@@ -18,37 +18,31 @@ SessionInitializationBehavior
     .. py:attribute:: SessionInitializationBehavior.AUTO
 
 
+        The NI gRPC Device Server will attach to an existing session with the specified name if it exists,
+        otherwise the server will initialize a new session.
 
-        Attach to an existing session with the specified name if it exists, otherwise intialize a new session.
-
-        .. note:: If this initializes a new session on the NI gRPC Device Server, then when the Python session goes out of scope,
-            it will automatically close the server session. If this attaches to an existing session on the NI gRPC Device Server,
-            then when the Python session goes out of scope, it will detach from the server session and leave it open.
-
-        
+        .. note:: When using the Session as a context manager and the context exits, the behavior depends on what happened when the constructor
+            was called. If it resulted in a new session being initialized on the NI gRPC Device Server, then it will automatically close the
+            server session. If it instead attached to an existing session, then it will detach from the server session and leave it open.
 
 
     .. py:attribute:: SessionInitializationBehavior.INITIALIZE_SERVER_SESSION
 
 
-
         Require the NI gRPC Device Server to initialize a new session with the specified name.
 
-        .. note:: When the Python session goes out of scope, it will automatically close the server session.
-
-        
-
+        .. note:: When using the Session as a context manager and the context exits, it will automatically close the
+            server session.
 
 
     .. py:attribute:: SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION
 
 
-
         Require the NI gRPC Device Server to attach to an existing session with the specified name.
 
-        .. note:: When the Python session goes out of scope, it will detach from the server session and leave it open.
+        .. note:: When using the Session as a context manager and the context exits, it will detach from the server session
+            and leave it open.
 
-        
 
 
 Classes
@@ -57,11 +51,10 @@ Classes
 
 .. py:class:: GrpcSessionOptions(self, grpc_channel, session_name, initialization_behavior=SessionInitializationBehavior.AUTO)
 
-    
 
     Collection of options that specifies session behaviors related to gRPC.
 
-    Creates and returns an object you can pass to a session constructor.
+    Creates and returns an object you can pass to a Session constructor.
 
 
     :param grpc_channel:
@@ -71,28 +64,31 @@ Classes
 
         
 
-
     :type grpc_channel: grpc.Channel
+
 
     :param session_name:
         
 
-        Specifies the **session name** to be used in the gRPC Device Server.
+        User-specified name that identifies the driver session in the NI gRPC Device Server.
 
-                This is different from the resource name parameter many APIs take as a separate parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients. You can use an empty string if you want to always initialize a new session and then close it when the Python session goes out of scope.
+        This is different from the resource name parameter many APIs take as a separate
+        parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
+        You can use an empty string if you want to always initialize a new session on the server.
+        To attach to an existing session, you must specify the session name it was initialized with.
 
         
 
-
     :type session_name: str
+
 
     :param initialization_behavior:
         
 
-        Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired. To attach to an existing session, you must specify a non-empty session name.
+        Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired.
+
+        The driver session exists in the NI gRPC Device Server.
 
         
 
-
     :type initialization_behavior: enum
-

--- a/docs/niscope/grpc_session_options.rst
+++ b/docs/niscope/grpc_session_options.rst
@@ -1,7 +1,7 @@
 gRPC Support
 ============
 
-Support for gRPC used in NI-SCOPE
+Support for using NI-SCOPE over gRPC
 
 .. py:currentmodule:: niscope
 

--- a/docs/niscope/toc.inc
+++ b/docs/niscope/toc.inc
@@ -8,4 +8,5 @@ API Reference
    niscope/enums
    niscope/errors
    niscope/examples
+   niscope/grpc_session_options
 

--- a/docs/niswitch/class.rst
+++ b/docs/niswitch/class.rst
@@ -3,7 +3,7 @@
 Session
 =======
 
-.. py:class:: Session(self, resource_name, topology="Configured Topology", simulate=False, reset_device=False)
+.. py:class:: Session(self, resource_name, topology="Configured Topology", simulate=False, reset_device=False, *, _grpc_options=None)
 
     
 
@@ -268,6 +268,16 @@ Session
 
 
     :type reset_device: bool
+
+    :param _grpc_options:
+        
+
+        MeasurementLink gRPC session options
+
+        
+
+
+    :type _grpc_options: niswitch.grpc_session_options.GrpcSessionOptions
 
 
 Methods

--- a/docs/niswitch/class.rst
+++ b/docs/niswitch/class.rst
@@ -277,7 +277,7 @@ Session
         
 
 
-    :type _grpc_options: niswitch.grpc_session_options.GrpcSessionOptions
+    :type _grpc_options: niswitch.GrpcSessionOptions
 
 
 Methods

--- a/docs/niswitch/errors.rst
+++ b/docs/niswitch/errors.rst
@@ -84,7 +84,7 @@ RpcError
 
     .. exception:: RpcError
 
-        An error specific to gRPC sessions
+        An error specific to sessions to the NI gRPC Device Server
 
 
 DriverWarning

--- a/docs/niswitch/errors.rst
+++ b/docs/niswitch/errors.rst
@@ -77,6 +77,16 @@ SelfTestError
         An error due to a failed self-test
 
 
+RpcError
+--------
+
+    .. py:currentmodule:: niswitch.errors
+
+    .. exception:: RpcError
+
+        An error specific to gRPC sessions
+
+
 DriverWarning
 -------------
 

--- a/docs/niswitch/grpc_session_options.rst
+++ b/docs/niswitch/grpc_session_options.rst
@@ -6,9 +6,6 @@ Support for using NI-SWITCH over gRPC
 .. py:currentmodule:: niswitch
 
 
-Enums
-=====
-
 
 SessionInitializationBehavior
 -----------------------------
@@ -45,8 +42,8 @@ SessionInitializationBehavior
 
 
 
-Classes
-=======
+GrpcSessionOptions
+------------------
 
 
 .. py:class:: GrpcSessionOptions(self, grpc_channel, session_name, initialization_behavior=SessionInitializationBehavior.AUTO)
@@ -91,4 +88,4 @@ Classes
 
         
 
-    :type initialization_behavior: enum
+    :type initialization_behavior: :py:data:`niswitch.SessionInitializationBehavior`

--- a/docs/niswitch/grpc_session_options.rst
+++ b/docs/niswitch/grpc_session_options.rst
@@ -1,0 +1,98 @@
+gRPC Support
+============
+
+Support for gRPC used in NI-SWITCH
+
+.. py:currentmodule:: niswitch
+
+
+Enums
+=====
+
+
+SessionInitializationBehavior
+-----------------------------
+
+.. py:class:: SessionInitializationBehavior
+
+    .. py:attribute:: SessionInitializationBehavior.AUTO
+
+
+
+        Attach to an existing session with the specified name if it exists, otherwise intialize a new session.
+
+        .. note:: If this initializes a new session on the NI gRPC Device Server, then when the Python session goes out of scope,
+            it will automatically close the server session. If this attaches to an existing session on the NI gRPC Device Server,
+            then when the Python session goes out of scope, it will detach from the server session and leave it open.
+
+        
+
+
+    .. py:attribute:: SessionInitializationBehavior.INITIALIZE_SERVER_SESSION
+
+
+
+        Require the NI gRPC Device Server to initialize a new session with the specified name.
+
+        .. note:: When the Python session goes out of scope, it will automatically close the server session.
+
+        
+
+
+
+    .. py:attribute:: SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION
+
+
+
+        Require the NI gRPC Device Server to attach to an existing session with the specified name.
+
+        .. note:: When the Python session goes out of scope, it will detach from the server session and leave it open.
+
+        
+
+
+Classes
+=======
+
+
+.. py:class:: GrpcSessionOptions(self, grpc_channel, session_name, initialization_behavior=SessionInitializationBehavior.AUTO)
+
+    
+
+    Collection of options that specifies session behaviors related to gRPC.
+
+    Creates and returns an object you can pass to a session constructor.
+
+
+    :param grpc_channel:
+        
+
+        Specifies the channel to the NI gRPC Device Server.
+
+        
+
+
+    :type grpc_channel: grpc.Channel
+
+    :param session_name:
+        
+
+        Specifies the **session name** to be used in the gRPC Device Server.
+
+                This is different from the resource name parameter many APIs take as a separate parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients. You can use an empty string if you want to always initialize a new session and then close it when the Python session goes out of scope.
+
+        
+
+
+    :type session_name: str
+
+    :param initialization_behavior:
+        
+
+        Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired. To attach to an existing session, you must specify a non-empty session name.
+
+        
+
+
+    :type initialization_behavior: enum
+

--- a/docs/niswitch/grpc_session_options.rst
+++ b/docs/niswitch/grpc_session_options.rst
@@ -70,7 +70,7 @@ Classes
     :param session_name:
         
 
-        User-specified name that identifies the driver session in the NI gRPC Device Server.
+        User-specified name that identifies the driver session on the NI gRPC Device Server.
 
         This is different from the resource name parameter many APIs take as a separate
         parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
@@ -87,7 +87,7 @@ Classes
 
         Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired.
 
-        The driver session exists in the NI gRPC Device Server.
+        The driver session exists on the NI gRPC Device Server.
 
         
 

--- a/docs/niswitch/grpc_session_options.rst
+++ b/docs/niswitch/grpc_session_options.rst
@@ -18,37 +18,31 @@ SessionInitializationBehavior
     .. py:attribute:: SessionInitializationBehavior.AUTO
 
 
+        The NI gRPC Device Server will attach to an existing session with the specified name if it exists,
+        otherwise the server will initialize a new session.
 
-        Attach to an existing session with the specified name if it exists, otherwise intialize a new session.
-
-        .. note:: If this initializes a new session on the NI gRPC Device Server, then when the Python session goes out of scope,
-            it will automatically close the server session. If this attaches to an existing session on the NI gRPC Device Server,
-            then when the Python session goes out of scope, it will detach from the server session and leave it open.
-
-        
+        .. note:: When using the Session as a context manager and the context exits, the behavior depends on what happened when the constructor
+            was called. If it resulted in a new session being initialized on the NI gRPC Device Server, then it will automatically close the
+            server session. If it instead attached to an existing session, then it will detach from the server session and leave it open.
 
 
     .. py:attribute:: SessionInitializationBehavior.INITIALIZE_SERVER_SESSION
 
 
-
         Require the NI gRPC Device Server to initialize a new session with the specified name.
 
-        .. note:: When the Python session goes out of scope, it will automatically close the server session.
-
-        
-
+        .. note:: When using the Session as a context manager and the context exits, it will automatically close the
+            server session.
 
 
     .. py:attribute:: SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION
 
 
-
         Require the NI gRPC Device Server to attach to an existing session with the specified name.
 
-        .. note:: When the Python session goes out of scope, it will detach from the server session and leave it open.
+        .. note:: When using the Session as a context manager and the context exits, it will detach from the server session
+            and leave it open.
 
-        
 
 
 Classes
@@ -57,11 +51,10 @@ Classes
 
 .. py:class:: GrpcSessionOptions(self, grpc_channel, session_name, initialization_behavior=SessionInitializationBehavior.AUTO)
 
-    
 
     Collection of options that specifies session behaviors related to gRPC.
 
-    Creates and returns an object you can pass to a session constructor.
+    Creates and returns an object you can pass to a Session constructor.
 
 
     :param grpc_channel:
@@ -71,28 +64,31 @@ Classes
 
         
 
-
     :type grpc_channel: grpc.Channel
+
 
     :param session_name:
         
 
-        Specifies the **session name** to be used in the gRPC Device Server.
+        User-specified name that identifies the driver session in the NI gRPC Device Server.
 
-                This is different from the resource name parameter many APIs take as a separate parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients. You can use an empty string if you want to always initialize a new session and then close it when the Python session goes out of scope.
+        This is different from the resource name parameter many APIs take as a separate
+        parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
+        You can use an empty string if you want to always initialize a new session on the server.
+        To attach to an existing session, you must specify the session name it was initialized with.
 
         
 
-
     :type session_name: str
+
 
     :param initialization_behavior:
         
 
-        Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired. To attach to an existing session, you must specify a non-empty session name.
+        Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired.
+
+        The driver session exists in the NI gRPC Device Server.
 
         
 
-
     :type initialization_behavior: enum
-

--- a/docs/niswitch/grpc_session_options.rst
+++ b/docs/niswitch/grpc_session_options.rst
@@ -1,7 +1,7 @@
 gRPC Support
 ============
 
-Support for gRPC used in NI-SWITCH
+Support for using NI-SWITCH over gRPC
 
 .. py:currentmodule:: niswitch
 

--- a/docs/niswitch/toc.inc
+++ b/docs/niswitch/toc.inc
@@ -8,4 +8,5 @@ API Reference
    niswitch/enums
    niswitch/errors
    niswitch/examples
+   niswitch/grpc_session_options
 

--- a/generated/nidcpower/nidcpower/errors.py
+++ b/generated/nidcpower/nidcpower/errors.py
@@ -44,7 +44,7 @@ class DriverWarning(Warning):
 
 
 class RpcError(Error):
-    '''An error specific to gRPC sessions'''
+    '''An error specific to sessions to the NI gRPC Device Server'''
 
     def __init__(self, rpc_code, description):
         self.rpc_code = rpc_code

--- a/generated/nidcpower/nidcpower/grpc_session_options.py
+++ b/generated/nidcpower/nidcpower/grpc_session_options.py
@@ -60,7 +60,7 @@ class GrpcSessionOptions(object):
         Args:
             grpc_channel (grpc.Channel): Specifies the channel to the NI gRPC Device Server.
 
-            session_name (str): User-specified name that identifies the driver session in the NI gRPC Device
+            session_name (str): User-specified name that identifies the driver session on the NI gRPC Device
                 Server. This is different from the resource name parameter many APIs take as a separate
                 parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
                 You can use an empty string if you want to always initialize a new session on the server.
@@ -70,7 +70,7 @@ class GrpcSessionOptions(object):
 
             initialization_behavior (enum): Specifies whether it is acceptable to initialize a new
                 session or attach to an existing one, or if only one of the behaviors is desired.
-                The driver session exists in the NI gRPC Device Server.
+                The driver session exists on the NI gRPC Device Server.
         '''
         self.grpc_channel = grpc_channel
         self.session_name = session_name

--- a/generated/nidcpower/nidcpower/grpc_session_options.py
+++ b/generated/nidcpower/nidcpower/grpc_session_options.py
@@ -16,26 +16,29 @@ MEASUREMENTLINK_23Q1_NIMI_PYTHON_API_KEY = 'DE10751B-3EE0-44EC-A93B-800E6A3C89E4
 class SessionInitializationBehavior(IntEnum):
     AUTO = 0
     r'''
-    Attach to an existing session with the specified name if it exists, otherwise intialize a new session.
+    The NI gRPC Device Server will attach to an existing session with the specified name if it exists, otherwise the server
+    will initialize a new session.
 
     Note:
-    If this initializes a new session on the NI gRPC Device Server, then when the Python session goes out of scope,
-    it will automatically close the server session. If this attaches to an existing session on the NI gRPC Device Server,
-    then when the Python session goes out of scope, it will detach from the server session and leave it open.
+    When using the Session as a context manager and the context exits, the behavior depends on what happened when the constructor
+    was called. If it resulted in a new session being initialized on the NI gRPC Device Server, then it will automatically close the
+    server session. If it instead attached to an existing session, then it will detach from the server session and leave it open.
     '''
     INITIALIZE_SERVER_SESSION = 1
     r'''
     Require the NI gRPC Device Server to initialize a new session with the specified name.
 
     Note:
-    When the Python session goes out of scope, it will automatically close the server session.
+    When using the Session as a context manager and the context exits, it will automatically close the
+    server session.
     '''
     ATTACH_TO_SERVER_SESSION = 2
     r'''
     Require the NI gRPC Device Server to attach to an existing session with the specified name.
 
     Note:
-    When the Python session goes out of scope, it will detach from the server session and leave it open.
+    When using the Session as a context manager and the context exits, it will detach from the server session
+    and leave it open.
     '''
 
 
@@ -52,23 +55,22 @@ class GrpcSessionOptions(object):
     ):
         r'''Collection of options that specifies session behaviors related to gRPC.
 
-        Creates and returns an object you can pass to a session constructor.
+        Creates and returns an object you can pass to a Session constructor.
 
         Args:
             grpc_channel (grpc.Channel): Specifies the channel to the NI gRPC Device Server.
 
-            session_name (str): Specifies the **session name** to be used in the NI gRPC Device
-                Server. This is different from the resource name parameter many APIs take as a
-                separate parameter. Specifying a name makes it easy to share sessions across
-                multiple gRPC clients. You can use an empty string if you want to always initialize
-                a new session on the server and then close it when the Python Session instance on
-                the client goes out of scope.
+            session_name (str): User-specified name that identifies the driver session in the NI gRPC Device
+                Server. This is different from the resource name parameter many APIs take as a separate
+                parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
+                You can use an empty string if you want to always initialize a new session on the server.
+                To attach to an existing session, you must specify the session name it was initialized with.
 
             api_key (str): Specifies the API license key required by the NI gRPC Device Server.
 
             initialization_behavior (enum): Specifies whether it is acceptable to initialize a new
                 session or attach to an existing one, or if only one of the behaviors is desired.
-                To attach to an existing session, you must specify a non-empty session name.
+                The driver session exists in the NI gRPC Device Server.
         '''
         self.grpc_channel = grpc_channel
         self.session_name = session_name

--- a/generated/nidigital/nidigital/errors.py
+++ b/generated/nidigital/nidigital/errors.py
@@ -44,7 +44,7 @@ class DriverWarning(Warning):
 
 
 class RpcError(Error):
-    '''An error specific to gRPC sessions'''
+    '''An error specific to sessions to the NI gRPC Device Server'''
 
     def __init__(self, rpc_code, description):
         self.rpc_code = rpc_code

--- a/generated/nidigital/nidigital/grpc_session_options.py
+++ b/generated/nidigital/nidigital/grpc_session_options.py
@@ -60,7 +60,7 @@ class GrpcSessionOptions(object):
         Args:
             grpc_channel (grpc.Channel): Specifies the channel to the NI gRPC Device Server.
 
-            session_name (str): User-specified name that identifies the driver session in the NI gRPC Device
+            session_name (str): User-specified name that identifies the driver session on the NI gRPC Device
                 Server. This is different from the resource name parameter many APIs take as a separate
                 parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
                 You can use an empty string if you want to always initialize a new session on the server.
@@ -70,7 +70,7 @@ class GrpcSessionOptions(object):
 
             initialization_behavior (enum): Specifies whether it is acceptable to initialize a new
                 session or attach to an existing one, or if only one of the behaviors is desired.
-                The driver session exists in the NI gRPC Device Server.
+                The driver session exists on the NI gRPC Device Server.
         '''
         self.grpc_channel = grpc_channel
         self.session_name = session_name

--- a/generated/nidigital/nidigital/grpc_session_options.py
+++ b/generated/nidigital/nidigital/grpc_session_options.py
@@ -16,26 +16,29 @@ MEASUREMENTLINK_23Q1_NIMI_PYTHON_API_KEY = 'DE10751B-3EE0-44EC-A93B-800E6A3C89E4
 class SessionInitializationBehavior(IntEnum):
     AUTO = 0
     r'''
-    Attach to an existing session with the specified name if it exists, otherwise intialize a new session.
+    The NI gRPC Device Server will attach to an existing session with the specified name if it exists, otherwise the server
+    will initialize a new session.
 
     Note:
-    If this initializes a new session on the NI gRPC Device Server, then when the Python session goes out of scope,
-    it will automatically close the server session. If this attaches to an existing session on the NI gRPC Device Server,
-    then when the Python session goes out of scope, it will detach from the server session and leave it open.
+    When using the Session as a context manager and the context exits, the behavior depends on what happened when the constructor
+    was called. If it resulted in a new session being initialized on the NI gRPC Device Server, then it will automatically close the
+    server session. If it instead attached to an existing session, then it will detach from the server session and leave it open.
     '''
     INITIALIZE_SERVER_SESSION = 1
     r'''
     Require the NI gRPC Device Server to initialize a new session with the specified name.
 
     Note:
-    When the Python session goes out of scope, it will automatically close the server session.
+    When using the Session as a context manager and the context exits, it will automatically close the
+    server session.
     '''
     ATTACH_TO_SERVER_SESSION = 2
     r'''
     Require the NI gRPC Device Server to attach to an existing session with the specified name.
 
     Note:
-    When the Python session goes out of scope, it will detach from the server session and leave it open.
+    When using the Session as a context manager and the context exits, it will detach from the server session
+    and leave it open.
     '''
 
 
@@ -52,23 +55,22 @@ class GrpcSessionOptions(object):
     ):
         r'''Collection of options that specifies session behaviors related to gRPC.
 
-        Creates and returns an object you can pass to a session constructor.
+        Creates and returns an object you can pass to a Session constructor.
 
         Args:
             grpc_channel (grpc.Channel): Specifies the channel to the NI gRPC Device Server.
 
-            session_name (str): Specifies the **session name** to be used in the NI gRPC Device
-                Server. This is different from the resource name parameter many APIs take as a
-                separate parameter. Specifying a name makes it easy to share sessions across
-                multiple gRPC clients. You can use an empty string if you want to always initialize
-                a new session on the server and then close it when the Python Session instance on
-                the client goes out of scope.
+            session_name (str): User-specified name that identifies the driver session in the NI gRPC Device
+                Server. This is different from the resource name parameter many APIs take as a separate
+                parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
+                You can use an empty string if you want to always initialize a new session on the server.
+                To attach to an existing session, you must specify the session name it was initialized with.
 
             api_key (str): Specifies the API license key required by the NI gRPC Device Server.
 
             initialization_behavior (enum): Specifies whether it is acceptable to initialize a new
                 session or attach to an existing one, or if only one of the behaviors is desired.
-                To attach to an existing session, you must specify a non-empty session name.
+                The driver session exists in the NI gRPC Device Server.
         '''
         self.grpc_channel = grpc_channel
         self.session_name = session_name

--- a/generated/nidmm/nidmm/errors.py
+++ b/generated/nidmm/nidmm/errors.py
@@ -44,7 +44,7 @@ class DriverWarning(Warning):
 
 
 class RpcError(Error):
-    '''An error specific to gRPC sessions'''
+    '''An error specific to sessions to the NI gRPC Device Server'''
 
     def __init__(self, rpc_code, description):
         self.rpc_code = rpc_code

--- a/generated/nidmm/nidmm/grpc_session_options.py
+++ b/generated/nidmm/nidmm/grpc_session_options.py
@@ -60,7 +60,7 @@ class GrpcSessionOptions(object):
         Args:
             grpc_channel (grpc.Channel): Specifies the channel to the NI gRPC Device Server.
 
-            session_name (str): User-specified name that identifies the driver session in the NI gRPC Device
+            session_name (str): User-specified name that identifies the driver session on the NI gRPC Device
                 Server. This is different from the resource name parameter many APIs take as a separate
                 parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
                 You can use an empty string if you want to always initialize a new session on the server.
@@ -70,7 +70,7 @@ class GrpcSessionOptions(object):
 
             initialization_behavior (enum): Specifies whether it is acceptable to initialize a new
                 session or attach to an existing one, or if only one of the behaviors is desired.
-                The driver session exists in the NI gRPC Device Server.
+                The driver session exists on the NI gRPC Device Server.
         '''
         self.grpc_channel = grpc_channel
         self.session_name = session_name

--- a/generated/nidmm/nidmm/grpc_session_options.py
+++ b/generated/nidmm/nidmm/grpc_session_options.py
@@ -16,26 +16,29 @@ MEASUREMENTLINK_23Q1_NIMI_PYTHON_API_KEY = 'DE10751B-3EE0-44EC-A93B-800E6A3C89E4
 class SessionInitializationBehavior(IntEnum):
     AUTO = 0
     r'''
-    Attach to an existing session with the specified name if it exists, otherwise intialize a new session.
+    The NI gRPC Device Server will attach to an existing session with the specified name if it exists, otherwise the server
+    will initialize a new session.
 
     Note:
-    If this initializes a new session on the NI gRPC Device Server, then when the Python session goes out of scope,
-    it will automatically close the server session. If this attaches to an existing session on the NI gRPC Device Server,
-    then when the Python session goes out of scope, it will detach from the server session and leave it open.
+    When using the Session as a context manager and the context exits, the behavior depends on what happened when the constructor
+    was called. If it resulted in a new session being initialized on the NI gRPC Device Server, then it will automatically close the
+    server session. If it instead attached to an existing session, then it will detach from the server session and leave it open.
     '''
     INITIALIZE_SERVER_SESSION = 1
     r'''
     Require the NI gRPC Device Server to initialize a new session with the specified name.
 
     Note:
-    When the Python session goes out of scope, it will automatically close the server session.
+    When using the Session as a context manager and the context exits, it will automatically close the
+    server session.
     '''
     ATTACH_TO_SERVER_SESSION = 2
     r'''
     Require the NI gRPC Device Server to attach to an existing session with the specified name.
 
     Note:
-    When the Python session goes out of scope, it will detach from the server session and leave it open.
+    When using the Session as a context manager and the context exits, it will detach from the server session
+    and leave it open.
     '''
 
 
@@ -52,23 +55,22 @@ class GrpcSessionOptions(object):
     ):
         r'''Collection of options that specifies session behaviors related to gRPC.
 
-        Creates and returns an object you can pass to a session constructor.
+        Creates and returns an object you can pass to a Session constructor.
 
         Args:
             grpc_channel (grpc.Channel): Specifies the channel to the NI gRPC Device Server.
 
-            session_name (str): Specifies the **session name** to be used in the NI gRPC Device
-                Server. This is different from the resource name parameter many APIs take as a
-                separate parameter. Specifying a name makes it easy to share sessions across
-                multiple gRPC clients. You can use an empty string if you want to always initialize
-                a new session on the server and then close it when the Python Session instance on
-                the client goes out of scope.
+            session_name (str): User-specified name that identifies the driver session in the NI gRPC Device
+                Server. This is different from the resource name parameter many APIs take as a separate
+                parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
+                You can use an empty string if you want to always initialize a new session on the server.
+                To attach to an existing session, you must specify the session name it was initialized with.
 
             api_key (str): Specifies the API license key required by the NI gRPC Device Server.
 
             initialization_behavior (enum): Specifies whether it is acceptable to initialize a new
                 session or attach to an existing one, or if only one of the behaviors is desired.
-                To attach to an existing session, you must specify a non-empty session name.
+                The driver session exists in the NI gRPC Device Server.
         '''
         self.grpc_channel = grpc_channel
         self.session_name = session_name

--- a/generated/nifake/nifake/errors.py
+++ b/generated/nifake/nifake/errors.py
@@ -44,7 +44,7 @@ class DriverWarning(Warning):
 
 
 class RpcError(Error):
-    '''An error specific to gRPC sessions'''
+    '''An error specific to sessions to the NI gRPC Device Server'''
 
     def __init__(self, rpc_code, description):
         self.rpc_code = rpc_code

--- a/generated/nifake/nifake/grpc_session_options.py
+++ b/generated/nifake/nifake/grpc_session_options.py
@@ -60,7 +60,7 @@ class GrpcSessionOptions(object):
         Args:
             grpc_channel (grpc.Channel): Specifies the channel to the NI gRPC Device Server.
 
-            session_name (str): User-specified name that identifies the driver session in the NI gRPC Device
+            session_name (str): User-specified name that identifies the driver session on the NI gRPC Device
                 Server. This is different from the resource name parameter many APIs take as a separate
                 parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
                 You can use an empty string if you want to always initialize a new session on the server.
@@ -70,7 +70,7 @@ class GrpcSessionOptions(object):
 
             initialization_behavior (enum): Specifies whether it is acceptable to initialize a new
                 session or attach to an existing one, or if only one of the behaviors is desired.
-                The driver session exists in the NI gRPC Device Server.
+                The driver session exists on the NI gRPC Device Server.
         '''
         self.grpc_channel = grpc_channel
         self.session_name = session_name

--- a/generated/nifake/nifake/grpc_session_options.py
+++ b/generated/nifake/nifake/grpc_session_options.py
@@ -16,26 +16,29 @@ MEASUREMENTLINK_23Q1_NIMI_PYTHON_API_KEY = 'DE10751B-3EE0-44EC-A93B-800E6A3C89E4
 class SessionInitializationBehavior(IntEnum):
     AUTO = 0
     r'''
-    Attach to an existing session with the specified name if it exists, otherwise intialize a new session.
+    The NI gRPC Device Server will attach to an existing session with the specified name if it exists, otherwise the server
+    will initialize a new session.
 
     Note:
-    If this initializes a new session on the NI gRPC Device Server, then when the Python session goes out of scope,
-    it will automatically close the server session. If this attaches to an existing session on the NI gRPC Device Server,
-    then when the Python session goes out of scope, it will detach from the server session and leave it open.
+    When using the Session as a context manager and the context exits, the behavior depends on what happened when the constructor
+    was called. If it resulted in a new session being initialized on the NI gRPC Device Server, then it will automatically close the
+    server session. If it instead attached to an existing session, then it will detach from the server session and leave it open.
     '''
     INITIALIZE_SERVER_SESSION = 1
     r'''
     Require the NI gRPC Device Server to initialize a new session with the specified name.
 
     Note:
-    When the Python session goes out of scope, it will automatically close the server session.
+    When using the Session as a context manager and the context exits, it will automatically close the
+    server session.
     '''
     ATTACH_TO_SERVER_SESSION = 2
     r'''
     Require the NI gRPC Device Server to attach to an existing session with the specified name.
 
     Note:
-    When the Python session goes out of scope, it will detach from the server session and leave it open.
+    When using the Session as a context manager and the context exits, it will detach from the server session
+    and leave it open.
     '''
 
 
@@ -52,23 +55,22 @@ class GrpcSessionOptions(object):
     ):
         r'''Collection of options that specifies session behaviors related to gRPC.
 
-        Creates and returns an object you can pass to a session constructor.
+        Creates and returns an object you can pass to a Session constructor.
 
         Args:
             grpc_channel (grpc.Channel): Specifies the channel to the NI gRPC Device Server.
 
-            session_name (str): Specifies the **session name** to be used in the NI gRPC Device
-                Server. This is different from the resource name parameter many APIs take as a
-                separate parameter. Specifying a name makes it easy to share sessions across
-                multiple gRPC clients. You can use an empty string if you want to always initialize
-                a new session on the server and then close it when the Python Session instance on
-                the client goes out of scope.
+            session_name (str): User-specified name that identifies the driver session in the NI gRPC Device
+                Server. This is different from the resource name parameter many APIs take as a separate
+                parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
+                You can use an empty string if you want to always initialize a new session on the server.
+                To attach to an existing session, you must specify the session name it was initialized with.
 
             api_key (str): Specifies the API license key required by the NI gRPC Device Server.
 
             initialization_behavior (enum): Specifies whether it is acceptable to initialize a new
                 session or attach to an existing one, or if only one of the behaviors is desired.
-                To attach to an existing session, you must specify a non-empty session name.
+                The driver session exists in the NI gRPC Device Server.
         '''
         self.grpc_channel = grpc_channel
         self.session_name = session_name

--- a/generated/nifgen/nifgen/errors.py
+++ b/generated/nifgen/nifgen/errors.py
@@ -44,7 +44,7 @@ class DriverWarning(Warning):
 
 
 class RpcError(Error):
-    '''An error specific to gRPC sessions'''
+    '''An error specific to sessions to the NI gRPC Device Server'''
 
     def __init__(self, rpc_code, description):
         self.rpc_code = rpc_code

--- a/generated/nifgen/nifgen/grpc_session_options.py
+++ b/generated/nifgen/nifgen/grpc_session_options.py
@@ -60,7 +60,7 @@ class GrpcSessionOptions(object):
         Args:
             grpc_channel (grpc.Channel): Specifies the channel to the NI gRPC Device Server.
 
-            session_name (str): User-specified name that identifies the driver session in the NI gRPC Device
+            session_name (str): User-specified name that identifies the driver session on the NI gRPC Device
                 Server. This is different from the resource name parameter many APIs take as a separate
                 parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
                 You can use an empty string if you want to always initialize a new session on the server.
@@ -70,7 +70,7 @@ class GrpcSessionOptions(object):
 
             initialization_behavior (enum): Specifies whether it is acceptable to initialize a new
                 session or attach to an existing one, or if only one of the behaviors is desired.
-                The driver session exists in the NI gRPC Device Server.
+                The driver session exists on the NI gRPC Device Server.
         '''
         self.grpc_channel = grpc_channel
         self.session_name = session_name

--- a/generated/nifgen/nifgen/grpc_session_options.py
+++ b/generated/nifgen/nifgen/grpc_session_options.py
@@ -16,26 +16,29 @@ MEASUREMENTLINK_23Q1_NIMI_PYTHON_API_KEY = 'DE10751B-3EE0-44EC-A93B-800E6A3C89E4
 class SessionInitializationBehavior(IntEnum):
     AUTO = 0
     r'''
-    Attach to an existing session with the specified name if it exists, otherwise intialize a new session.
+    The NI gRPC Device Server will attach to an existing session with the specified name if it exists, otherwise the server
+    will initialize a new session.
 
     Note:
-    If this initializes a new session on the NI gRPC Device Server, then when the Python session goes out of scope,
-    it will automatically close the server session. If this attaches to an existing session on the NI gRPC Device Server,
-    then when the Python session goes out of scope, it will detach from the server session and leave it open.
+    When using the Session as a context manager and the context exits, the behavior depends on what happened when the constructor
+    was called. If it resulted in a new session being initialized on the NI gRPC Device Server, then it will automatically close the
+    server session. If it instead attached to an existing session, then it will detach from the server session and leave it open.
     '''
     INITIALIZE_SERVER_SESSION = 1
     r'''
     Require the NI gRPC Device Server to initialize a new session with the specified name.
 
     Note:
-    When the Python session goes out of scope, it will automatically close the server session.
+    When using the Session as a context manager and the context exits, it will automatically close the
+    server session.
     '''
     ATTACH_TO_SERVER_SESSION = 2
     r'''
     Require the NI gRPC Device Server to attach to an existing session with the specified name.
 
     Note:
-    When the Python session goes out of scope, it will detach from the server session and leave it open.
+    When using the Session as a context manager and the context exits, it will detach from the server session
+    and leave it open.
     '''
 
 
@@ -52,23 +55,22 @@ class GrpcSessionOptions(object):
     ):
         r'''Collection of options that specifies session behaviors related to gRPC.
 
-        Creates and returns an object you can pass to a session constructor.
+        Creates and returns an object you can pass to a Session constructor.
 
         Args:
             grpc_channel (grpc.Channel): Specifies the channel to the NI gRPC Device Server.
 
-            session_name (str): Specifies the **session name** to be used in the NI gRPC Device
-                Server. This is different from the resource name parameter many APIs take as a
-                separate parameter. Specifying a name makes it easy to share sessions across
-                multiple gRPC clients. You can use an empty string if you want to always initialize
-                a new session on the server and then close it when the Python Session instance on
-                the client goes out of scope.
+            session_name (str): User-specified name that identifies the driver session in the NI gRPC Device
+                Server. This is different from the resource name parameter many APIs take as a separate
+                parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
+                You can use an empty string if you want to always initialize a new session on the server.
+                To attach to an existing session, you must specify the session name it was initialized with.
 
             api_key (str): Specifies the API license key required by the NI gRPC Device Server.
 
             initialization_behavior (enum): Specifies whether it is acceptable to initialize a new
                 session or attach to an existing one, or if only one of the behaviors is desired.
-                To attach to an existing session, you must specify a non-empty session name.
+                The driver session exists in the NI gRPC Device Server.
         '''
         self.grpc_channel = grpc_channel
         self.session_name = session_name

--- a/generated/niscope/niscope/errors.py
+++ b/generated/niscope/niscope/errors.py
@@ -44,7 +44,7 @@ class DriverWarning(Warning):
 
 
 class RpcError(Error):
-    '''An error specific to gRPC sessions'''
+    '''An error specific to sessions to the NI gRPC Device Server'''
 
     def __init__(self, rpc_code, description):
         self.rpc_code = rpc_code

--- a/generated/niscope/niscope/grpc_session_options.py
+++ b/generated/niscope/niscope/grpc_session_options.py
@@ -60,7 +60,7 @@ class GrpcSessionOptions(object):
         Args:
             grpc_channel (grpc.Channel): Specifies the channel to the NI gRPC Device Server.
 
-            session_name (str): User-specified name that identifies the driver session in the NI gRPC Device
+            session_name (str): User-specified name that identifies the driver session on the NI gRPC Device
                 Server. This is different from the resource name parameter many APIs take as a separate
                 parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
                 You can use an empty string if you want to always initialize a new session on the server.
@@ -70,7 +70,7 @@ class GrpcSessionOptions(object):
 
             initialization_behavior (enum): Specifies whether it is acceptable to initialize a new
                 session or attach to an existing one, or if only one of the behaviors is desired.
-                The driver session exists in the NI gRPC Device Server.
+                The driver session exists on the NI gRPC Device Server.
         '''
         self.grpc_channel = grpc_channel
         self.session_name = session_name

--- a/generated/niscope/niscope/grpc_session_options.py
+++ b/generated/niscope/niscope/grpc_session_options.py
@@ -16,26 +16,29 @@ MEASUREMENTLINK_23Q1_NIMI_PYTHON_API_KEY = 'DE10751B-3EE0-44EC-A93B-800E6A3C89E4
 class SessionInitializationBehavior(IntEnum):
     AUTO = 0
     r'''
-    Attach to an existing session with the specified name if it exists, otherwise intialize a new session.
+    The NI gRPC Device Server will attach to an existing session with the specified name if it exists, otherwise the server
+    will initialize a new session.
 
     Note:
-    If this initializes a new session on the NI gRPC Device Server, then when the Python session goes out of scope,
-    it will automatically close the server session. If this attaches to an existing session on the NI gRPC Device Server,
-    then when the Python session goes out of scope, it will detach from the server session and leave it open.
+    When using the Session as a context manager and the context exits, the behavior depends on what happened when the constructor
+    was called. If it resulted in a new session being initialized on the NI gRPC Device Server, then it will automatically close the
+    server session. If it instead attached to an existing session, then it will detach from the server session and leave it open.
     '''
     INITIALIZE_SERVER_SESSION = 1
     r'''
     Require the NI gRPC Device Server to initialize a new session with the specified name.
 
     Note:
-    When the Python session goes out of scope, it will automatically close the server session.
+    When using the Session as a context manager and the context exits, it will automatically close the
+    server session.
     '''
     ATTACH_TO_SERVER_SESSION = 2
     r'''
     Require the NI gRPC Device Server to attach to an existing session with the specified name.
 
     Note:
-    When the Python session goes out of scope, it will detach from the server session and leave it open.
+    When using the Session as a context manager and the context exits, it will detach from the server session
+    and leave it open.
     '''
 
 
@@ -52,23 +55,22 @@ class GrpcSessionOptions(object):
     ):
         r'''Collection of options that specifies session behaviors related to gRPC.
 
-        Creates and returns an object you can pass to a session constructor.
+        Creates and returns an object you can pass to a Session constructor.
 
         Args:
             grpc_channel (grpc.Channel): Specifies the channel to the NI gRPC Device Server.
 
-            session_name (str): Specifies the **session name** to be used in the NI gRPC Device
-                Server. This is different from the resource name parameter many APIs take as a
-                separate parameter. Specifying a name makes it easy to share sessions across
-                multiple gRPC clients. You can use an empty string if you want to always initialize
-                a new session on the server and then close it when the Python Session instance on
-                the client goes out of scope.
+            session_name (str): User-specified name that identifies the driver session in the NI gRPC Device
+                Server. This is different from the resource name parameter many APIs take as a separate
+                parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
+                You can use an empty string if you want to always initialize a new session on the server.
+                To attach to an existing session, you must specify the session name it was initialized with.
 
             api_key (str): Specifies the API license key required by the NI gRPC Device Server.
 
             initialization_behavior (enum): Specifies whether it is acceptable to initialize a new
                 session or attach to an existing one, or if only one of the behaviors is desired.
-                To attach to an existing session, you must specify a non-empty session name.
+                The driver session exists in the NI gRPC Device Server.
         '''
         self.grpc_channel = grpc_channel
         self.session_name = session_name

--- a/generated/niswitch/niswitch/errors.py
+++ b/generated/niswitch/niswitch/errors.py
@@ -44,7 +44,7 @@ class DriverWarning(Warning):
 
 
 class RpcError(Error):
-    '''An error specific to gRPC sessions'''
+    '''An error specific to sessions to the NI gRPC Device Server'''
 
     def __init__(self, rpc_code, description):
         self.rpc_code = rpc_code

--- a/generated/niswitch/niswitch/grpc_session_options.py
+++ b/generated/niswitch/niswitch/grpc_session_options.py
@@ -60,7 +60,7 @@ class GrpcSessionOptions(object):
         Args:
             grpc_channel (grpc.Channel): Specifies the channel to the NI gRPC Device Server.
 
-            session_name (str): User-specified name that identifies the driver session in the NI gRPC Device
+            session_name (str): User-specified name that identifies the driver session on the NI gRPC Device
                 Server. This is different from the resource name parameter many APIs take as a separate
                 parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
                 You can use an empty string if you want to always initialize a new session on the server.
@@ -70,7 +70,7 @@ class GrpcSessionOptions(object):
 
             initialization_behavior (enum): Specifies whether it is acceptable to initialize a new
                 session or attach to an existing one, or if only one of the behaviors is desired.
-                The driver session exists in the NI gRPC Device Server.
+                The driver session exists on the NI gRPC Device Server.
         '''
         self.grpc_channel = grpc_channel
         self.session_name = session_name

--- a/generated/niswitch/niswitch/grpc_session_options.py
+++ b/generated/niswitch/niswitch/grpc_session_options.py
@@ -16,26 +16,29 @@ MEASUREMENTLINK_23Q1_NIMI_PYTHON_API_KEY = 'DE10751B-3EE0-44EC-A93B-800E6A3C89E4
 class SessionInitializationBehavior(IntEnum):
     AUTO = 0
     r'''
-    Attach to an existing session with the specified name if it exists, otherwise intialize a new session.
+    The NI gRPC Device Server will attach to an existing session with the specified name if it exists, otherwise the server
+    will initialize a new session.
 
     Note:
-    If this initializes a new session on the NI gRPC Device Server, then when the Python session goes out of scope,
-    it will automatically close the server session. If this attaches to an existing session on the NI gRPC Device Server,
-    then when the Python session goes out of scope, it will detach from the server session and leave it open.
+    When using the Session as a context manager and the context exits, the behavior depends on what happened when the constructor
+    was called. If it resulted in a new session being initialized on the NI gRPC Device Server, then it will automatically close the
+    server session. If it instead attached to an existing session, then it will detach from the server session and leave it open.
     '''
     INITIALIZE_SERVER_SESSION = 1
     r'''
     Require the NI gRPC Device Server to initialize a new session with the specified name.
 
     Note:
-    When the Python session goes out of scope, it will automatically close the server session.
+    When using the Session as a context manager and the context exits, it will automatically close the
+    server session.
     '''
     ATTACH_TO_SERVER_SESSION = 2
     r'''
     Require the NI gRPC Device Server to attach to an existing session with the specified name.
 
     Note:
-    When the Python session goes out of scope, it will detach from the server session and leave it open.
+    When using the Session as a context manager and the context exits, it will detach from the server session
+    and leave it open.
     '''
 
 
@@ -52,23 +55,22 @@ class GrpcSessionOptions(object):
     ):
         r'''Collection of options that specifies session behaviors related to gRPC.
 
-        Creates and returns an object you can pass to a session constructor.
+        Creates and returns an object you can pass to a Session constructor.
 
         Args:
             grpc_channel (grpc.Channel): Specifies the channel to the NI gRPC Device Server.
 
-            session_name (str): Specifies the **session name** to be used in the NI gRPC Device
-                Server. This is different from the resource name parameter many APIs take as a
-                separate parameter. Specifying a name makes it easy to share sessions across
-                multiple gRPC clients. You can use an empty string if you want to always initialize
-                a new session on the server and then close it when the Python Session instance on
-                the client goes out of scope.
+            session_name (str): User-specified name that identifies the driver session in the NI gRPC Device
+                Server. This is different from the resource name parameter many APIs take as a separate
+                parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
+                You can use an empty string if you want to always initialize a new session on the server.
+                To attach to an existing session, you must specify the session name it was initialized with.
 
             api_key (str): Specifies the API license key required by the NI gRPC Device Server.
 
             initialization_behavior (enum): Specifies whether it is acceptable to initialize a new
                 session or attach to an existing one, or if only one of the behaviors is desired.
-                To attach to an existing session, you must specify a non-empty session name.
+                The driver session exists in the NI gRPC Device Server.
         '''
         self.grpc_channel = grpc_channel
         self.session_name = session_name


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~

~~- [ ] I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

This adds documentation for most public-facing gRPC API elements:
- `RpcError` exception
- `SessionInitializationBehavior` enumeration
- `GrpcSessionOptions` class
- Parameter `_grpc_options` to the session constructor.

### List issues fixed by this Pull Request below, if any.

[Task 2190966](https://ni.visualstudio.com/DevCentral/_workitems/edit/2190966): Add docs for new API behaviors

### What testing has been done?

Built locally. Attaching snippets of pictures of generated .html files below, using NI-DCPower as an example.

---

![image](https://user-images.githubusercontent.com/27234531/203410093-c9eec1f6-c4a0-4ff8-b67f-f12839382a1f.png)

---

![image](https://user-images.githubusercontent.com/27234531/203410289-2bea0361-2fae-4ddf-849e-559ae47599d1.png)

![image](https://user-images.githubusercontent.com/27234531/203410378-145bf7e1-2567-4d64-bf3a-2180f7f7c742.png)

---

![image](https://user-images.githubusercontent.com/27234531/203410525-b462c215-de79-4821-bb6f-400049388f85.png)
