### PR TITLE
NI-DCPower: Update LCRLoadCompensationSpot byte packing alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ All notable changes to this project will be documented in this file.
 * ### `nidcpower` (NI-DCPower)
     * #### Added
     * #### Changed
-        * The byte packing alignment of `struct_NILCRLoadCompensationSpot` is changed from 4-byte to 8-byte in Linux.
+        * Binary compatibility change for type `LCRLoadCompensationSpot` on Linux. Client code using method `nidcpower.Session.perform_lcr_load_compensation` on Linux now requires NI-DCPower 2023 Q1 driver runtime or newer.
     * #### Removed
 * ### `nidigital` (NI-Digital Pattern Driver)
     * #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 * ### `nidcpower` (NI-DCPower)
     * #### Added
     * #### Changed
+        * The byte packing alignment of `struct_NILCRLoadCompensationSpot` is changed from 4-byte to 8-byte in Linux.
     * #### Removed
 * ### `nidigital` (NI-Digital Pattern Driver)
     * #### Added

--- a/generated/nidcpower/nidcpower/lcr_load_compensation_spot.py
+++ b/generated/nidcpower/nidcpower/lcr_load_compensation_spot.py
@@ -8,10 +8,9 @@ import nidcpower.enums as enums
 # This class is an internal ctypes implementation detail that corresponds to
 # NILCRLoadCompensationSpot in the C API
 class struct_NILCRLoadCompensationSpot(ctypes.Structure):  # noqa N801
-    if platform.system() == "Windows" and platform.architecture()[0] == "64bit":
+    if (platform.system() == "Windows" and platform.architecture()[0] == "64bit") or \
+            platform.system() == "Linux" or platform.system() == "Darwin":
         _pack_ = 8
-    elif platform.system() == "Linux" or platform.system() == "Darwin":
-        _pack_ = 4
     else:
         _pack_ = 1
     _fields_ = [

--- a/generated/nidcpower/nidcpower/unit_tests/test_nidcpower.py
+++ b/generated/nidcpower/nidcpower/unit_tests/test_nidcpower.py
@@ -1,4 +1,5 @@
 import cmath
+import platform
 import pytest
 
 import nidcpower
@@ -334,3 +335,18 @@ def test_lcr_load_compensation_spot(
     ctype_instance = nidcpower.struct_NILCRLoadCompensationSpot(python_instance)
     for member in expected_ctype_members:
         assert getattr(ctype_instance, member) == pytest.approx(expected_ctype_members[member])
+
+
+def test_lcr_load_compensation_spot_byte_packing_alignment():
+    if (platform.system() == "Windows" and platform.architecture()[0] == "64bit") or \
+            platform.system() == "Linux" or platform.system() == "Darwin":
+        expected_bytes_len = 32
+    else:
+        expected_bytes_len = 28
+    python_spot = nidcpower.LCRLoadCompensationSpot(
+        frequency=1_000.0,
+        reference_value_type=nidcpower.LCRReferenceValueType.IMPEDANCE,
+        reference_value=complex(1.0, 2.0)
+    )
+    ctype_spot = nidcpower.struct_NILCRLoadCompensationSpot(python_spot)
+    assert len(bytes(ctype_spot)) == expected_bytes_len

--- a/src/nidcpower/custom_types/lcr_load_compensation_spot.py
+++ b/src/nidcpower/custom_types/lcr_load_compensation_spot.py
@@ -8,10 +8,9 @@ import nidcpower.enums as enums
 # This class is an internal ctypes implementation detail that corresponds to
 # NILCRLoadCompensationSpot in the C API
 class struct_NILCRLoadCompensationSpot(ctypes.Structure):  # noqa N801
-    if platform.system() == "Windows" and platform.architecture()[0] == "64bit":
+    if (platform.system() == "Windows" and platform.architecture()[0] == "64bit") or \
+            platform.system() == "Linux" or platform.system() == "Darwin":
         _pack_ = 8
-    elif platform.system() == "Linux" or platform.system() == "Darwin":
-        _pack_ = 4
     else:
         _pack_ = 1
     _fields_ = [

--- a/src/nidcpower/unit_tests/test_nidcpower.py
+++ b/src/nidcpower/unit_tests/test_nidcpower.py
@@ -1,4 +1,5 @@
 import cmath
+import platform
 import pytest
 
 import nidcpower
@@ -334,3 +335,18 @@ def test_lcr_load_compensation_spot(
     ctype_instance = nidcpower.struct_NILCRLoadCompensationSpot(python_instance)
     for member in expected_ctype_members:
         assert getattr(ctype_instance, member) == pytest.approx(expected_ctype_members[member])
+
+
+def test_lcr_load_compensation_spot_byte_packing_alignment():
+    if (platform.system() == "Windows" and platform.architecture()[0] == "64bit") or \
+            platform.system() == "Linux" or platform.system() == "Darwin":
+        expected_bytes_len = 32
+    else:
+        expected_bytes_len = 28
+    python_spot = nidcpower.LCRLoadCompensationSpot(
+        frequency=1_000.0,
+        reference_value_type=nidcpower.LCRReferenceValueType.IMPEDANCE,
+        reference_value=complex(1.0, 2.0)
+    )
+    ctype_spot = nidcpower.struct_NILCRLoadCompensationSpot(python_spot)
+    assert len(bytes(ctype_spot)) == expected_bytes_len


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

NI-DCPower: Update LCRLoadCompensationSpot byte packing alignment

- Update the byte packing alignment of `struct_NILCRLoadCompensationSpot` from 4 bytes to 8 bytes for Linux and MacOS
  - Update CHANGELOG.md
- Create `test_lcr_load_compensation_spot_byte_packing_alignment()` unit test to test the byte packing alignment of `struct_NILCRLoadCompensationSpot`

### What testing has been done?

Ran the newly created unit test on Windows 10 and Ubuntu 20.04, it passed on both OSes.