### PR TITLE
Use tox 3 in travis-ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
   - travis_retry sudo apt-get -y install python3-pip
   - travis_retry pip install --upgrade pip
   # tox 4.0 broke plugin compatibility
+  # TODO(ni-jfitzger): When tox-travis has a release compatible with tox>=4.0, remove the tox version specifier (Tracked on GitHub by #1876)
   - travis_retry pip install --upgrade tox==3.* tox-travis codecov
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
 install:
   - travis_retry sudo apt-get -y install python3-pip
   - travis_retry pip install --upgrade pip
-  - travis_retry pip install --upgrade tox tox-travis codecov
+  - travis_retry pip install --upgrade tox<4.0.0 tox-travis codecov
 
 before_script:
   - python tools/ensure_codegen_up_to_date.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ matrix:
 install:
   - travis_retry sudo apt-get -y install python3-pip
   - travis_retry pip install --upgrade pip
-  - travis_retry pip install --upgrade tox<4.0.0 tox-travis codecov
+  # tox 4.0 broke plugin compatibility
+  - travis_retry pip install --upgrade tox==3.* tox-travis codecov
 
 before_script:
   - python tools/ensure_codegen_up_to_date.py


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
Tox 4.0.0 recently released and broke travis-ci builds, which now fail with

```
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.10.4/bin/tox", line 8, in <module>
    sys.exit(run())
  File "/home/travis/virtualenv/python3.10.4/lib/python3.10/site-packages/tox/run.py", line 19, in run
    result = main(sys.argv[1:] if args is None else args)
  File "/home/travis/virtualenv/python3.10.4/lib/python3.10/site-packages/tox/run.py", line 38, in main
    state = setup_state(args)
  File "/home/travis/virtualenv/python3.10.4/lib/python3.10/site-packages/tox/run.py", line 53, in setup_state
    options = get_options(*args)
  File "/home/travis/virtualenv/python3.10.4/lib/python3.10/site-packages/tox/config/cli/parse.py", line 38, in get_options
    guess_verbosity, log_handler, source = _get_base(args)
  File "/home/travis/virtualenv/python3.10.4/lib/python3.10/site-packages/tox/config/cli/parse.py", line 61, in _get_base
    MANAGER.load_plugins(source.path)
  File "/home/travis/virtualenv/python3.10.4/lib/python3.10/site-packages/tox/plugin/manager.py", line 83, in load_plugins
    self._register_plugins(inline)
  File "/home/travis/virtualenv/python3.10.4/lib/python3.10/site-packages/tox/plugin/manager.py", line 37, in _register_plugins
    self.manager.load_setuptools_entrypoints(NAME)
  File "/home/travis/virtualenv/python3.10.4/lib/python3.10/site-packages/pluggy/_manager.py", line 287, in load_setuptools_entrypoints
    plugin = ep.load()
  File "/opt/python/3.10.4/lib/python3.10/importlib/metadata/__init__.py", line 171, in load
    module = import_module(match.group('module'))
  File "/opt/python/3.10.4/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/travis/virtualenv/python3.10.4/lib/python3.10/site-packages/tox_travis/hooks.py", line 6, in <module>
    from .envlist import (
  File "/home/travis/virtualenv/python3.10.4/lib/python3.10/site-packages/tox_travis/envlist.py", line 10, in <module>
    from tox.config import _split_env as split_env
ImportError: cannot import name '_split_env' from 'tox.config' (/home/travis/virtualenv/python3.10.4/lib/python3.10/site-packages/tox/config/__init__.py)
```

According to the [Tox FAQ](https://tox.wiki/en/latest/faq.html#tox-4-new-plugin-system) Tox 4 has a new plugin system.
Excerpt:
>tox 4 - new plugin system
tox 4 is a grounds up rewrite of the code base, and while we kept the configuration layer compatibility no such effort has been made for the programmatic API. Therefore, all plugins will need to redo their integration against the new code base. If you’re a plugin developer refer to the [plugin documentation](https://tox.wiki/en/latest/plugins.html) for more information.

Based on this, it can be assumed that tox-travis 0.12 won't work with tox 4. In order to fix travis-ci builds, we will specify "tox==3.*" to continue installing tox 3, as before.

### List issues fixed by this Pull Request below, if any.

### What testing has been done?
