### PR TITLE
Remove underscore prefix from grpc_options parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file.
 * ### ALL
     * #### Added
         * Support for Python 3.10
+        * MeasurementLink support
     * #### Changed
     * #### Removed
         * Support for Python 3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,25 +33,28 @@ All notable changes to this project will be documented in this file.
 * ### ALL
     * #### Added
         * Support for Python 3.10
-        * MeasurementLink support
     * #### Changed
     * #### Removed
         * Support for Python 3.6
 * ### `nidcpower` (NI-DCPower)
     * #### Added
+        * MeasurementLink support
     * #### Changed
         * Binary compatibility change for type `LCRLoadCompensationSpot` on Linux. Client code using method `nidcpower.Session.perform_lcr_load_compensation` on Linux now requires NI-DCPower 2023 Q1 driver runtime or newer.
     * #### Removed
 * ### `nidigital` (NI-Digital Pattern Driver)
     * #### Added
+        * MeasurementLink support
     * #### Changed
     * #### Removed
 * ### `nidmm` (NI-DMM)
     * #### Added
+        * MeasurementLink support
     * #### Changed
     * #### Removed
 * ### `nifgen` (NI-FGEN)
     * #### Added
+        * MeasurementLink support
     * #### Changed
     * #### Removed
 * ### `nimodinst` (NI-ModInst)
@@ -60,10 +63,12 @@ All notable changes to this project will be documented in this file.
     * #### Removed
 * ### `niscope` (NI-SCOPE)
     * #### Added
+        * MeasurementLink support
     * #### Changed
     * #### Removed
 * ### `niswitch` (NI-SWITCH)
     * #### Added
+        * MeasurementLink support
     * #### Changed
     * #### Removed
 * ### `nise` (NI Switch Executive)

--- a/build/templates/class.rst.mako
+++ b/build/templates/class.rst.mako
@@ -40,7 +40,7 @@
 ${helper.get_rst_header_snippet('Session', '=')}
 
 <%
-grpc_options_param = ', *, _grpc_options=None' if grpc_supported else ''
+grpc_options_param = ', *, grpc_options=None' if grpc_supported else ''
 if grpc_supported:
     input_params.append(
         {
@@ -50,7 +50,7 @@ if grpc_supported:
             'enum': None,
             'is_repeated_capability': False,
             'is_session_handle': False,
-            'python_name': '_grpc_options',
+            'python_name': 'grpc_options',
             'size': {'mechanism': 'fixed', 'value': 1},
             'type_in_documentation': module_name + '.GrpcSessionOptions',
             'type_in_documentation_was_calculated': False,

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -221,7 +221,7 @@ constructor_params = helper.filter_parameters(init_function['parameters'], helpe
 class Session(_SessionBase):
     '''${config['session_class_description']}'''
 
-<% grpc_options_param = ', *, _grpc_options=None' if grpc_supported else '' %>\
+<% grpc_options_param = ', *, grpc_options=None' if grpc_supported else '' %>\
     def __init__(${init_method_params}${grpc_options_param}):
         r'''${config['session_class_description']}
 
@@ -238,7 +238,7 @@ if grpc_supported:
             'enum': None,
             'is_repeated_capability': False,
             'is_session_handle': False,
-            'python_name': '_grpc_options',
+            'python_name': 'grpc_options',
             'size': {'mechanism': 'fixed', 'value': 1},
             'type_in_documentation': module_name + '.grpc_session_options.GrpcSessionOptions',
             'type_in_documentation_was_calculated': False,
@@ -249,9 +249,9 @@ if grpc_supported:
         ${helper.get_function_docstring(ctor_for_docs, False, config, indent=8)}
         '''
 % if grpc_supported:
-        if _grpc_options:
+        if grpc_options:
             import ${module_name}._grpc_stub_interpreter as _grpc_stub_interpreter
-            interpreter = _grpc_stub_interpreter.GrpcStubInterpreter(_grpc_options)
+            interpreter = _grpc_stub_interpreter.GrpcStubInterpreter(grpc_options)
         else:
             interpreter = _library_interpreter.LibraryInterpreter(encoding='windows-1251')
 % else:
@@ -281,7 +281,7 @@ if grpc_supported:
 % if config['uses_nitclk']:
 %   if grpc_supported:
         # NI-TClk does not work over NI gRPC Device Server
-        if not _grpc_options:
+        if not grpc_options:
             self.tclk = nitclk.SessionReference(self._interpreter.get_session_handle())
 %   else:
         self.tclk = nitclk.SessionReference(self._interpreter.get_session_handle())

--- a/docs/nidcpower/class.rst
+++ b/docs/nidcpower/class.rst
@@ -3,7 +3,7 @@
 Session
 =======
 
-.. py:class:: Session(self, resource_name, channels=None, reset=False, options={}, independent_channels=True, *, _grpc_options=None)
+.. py:class:: Session(self, resource_name, channels=None, reset=False, options={}, independent_channels=True, *, grpc_options=None)
 
     
 
@@ -149,7 +149,7 @@ Session
 
     :type independent_channels: bool
 
-    :param _grpc_options:
+    :param grpc_options:
         
 
         MeasurementLink gRPC session options
@@ -157,7 +157,7 @@ Session
         
 
 
-    :type _grpc_options: nidcpower.GrpcSessionOptions
+    :type grpc_options: nidcpower.GrpcSessionOptions
 
 
 Methods

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -3,7 +3,7 @@
 Session
 =======
 
-.. py:class:: Session(self, resource_name, id_query=False, reset_device=False, options={}, *, _grpc_options=None)
+.. py:class:: Session(self, resource_name, id_query=False, reset_device=False, options={}, *, grpc_options=None)
 
     
 
@@ -85,7 +85,7 @@ Session
 
     :type options: dict
 
-    :param _grpc_options:
+    :param grpc_options:
         
 
         MeasurementLink gRPC session options
@@ -93,7 +93,7 @@ Session
         
 
 
-    :type _grpc_options: nidigital.GrpcSessionOptions
+    :type grpc_options: nidigital.GrpcSessionOptions
 
 
 Methods

--- a/docs/nidmm/class.rst
+++ b/docs/nidmm/class.rst
@@ -3,7 +3,7 @@
 Session
 =======
 
-.. py:class:: Session(self, resource_name, id_query=False, reset_device=False, options={}, *, _grpc_options=None)
+.. py:class:: Session(self, resource_name, id_query=False, reset_device=False, options={}, *, grpc_options=None)
 
     
 
@@ -126,7 +126,7 @@ Session
 
     :type options: dict
 
-    :param _grpc_options:
+    :param grpc_options:
         
 
         MeasurementLink gRPC session options
@@ -134,7 +134,7 @@ Session
         
 
 
-    :type _grpc_options: nidmm.GrpcSessionOptions
+    :type grpc_options: nidmm.GrpcSessionOptions
 
 
 Methods

--- a/docs/nifgen/class.rst
+++ b/docs/nifgen/class.rst
@@ -3,7 +3,7 @@
 Session
 =======
 
-.. py:class:: Session(self, resource_name, channel_name=None, reset_device=False, options={}, *, _grpc_options=None)
+.. py:class:: Session(self, resource_name, channel_name=None, reset_device=False, options={}, *, grpc_options=None)
 
     
 
@@ -134,7 +134,7 @@ Session
 
     :type options: dict
 
-    :param _grpc_options:
+    :param grpc_options:
         
 
         MeasurementLink gRPC session options
@@ -142,7 +142,7 @@ Session
         
 
 
-    :type _grpc_options: nifgen.GrpcSessionOptions
+    :type grpc_options: nifgen.GrpcSessionOptions
 
 
 Methods

--- a/docs/niscope/class.rst
+++ b/docs/niscope/class.rst
@@ -3,7 +3,7 @@
 Session
 =======
 
-.. py:class:: Session(self, resource_name, id_query=False, reset_device=False, options={}, *, _grpc_options=None)
+.. py:class:: Session(self, resource_name, id_query=False, reset_device=False, options={}, *, grpc_options=None)
 
     
 
@@ -158,7 +158,7 @@ Session
 
     :type options: dict
 
-    :param _grpc_options:
+    :param grpc_options:
         
 
         MeasurementLink gRPC session options
@@ -166,7 +166,7 @@ Session
         
 
 
-    :type _grpc_options: niscope.GrpcSessionOptions
+    :type grpc_options: niscope.GrpcSessionOptions
 
 
 Methods

--- a/docs/niswitch/class.rst
+++ b/docs/niswitch/class.rst
@@ -3,7 +3,7 @@
 Session
 =======
 
-.. py:class:: Session(self, resource_name, topology="Configured Topology", simulate=False, reset_device=False, *, _grpc_options=None)
+.. py:class:: Session(self, resource_name, topology="Configured Topology", simulate=False, reset_device=False, *, grpc_options=None)
 
     
 
@@ -269,7 +269,7 @@ Session
 
     :type reset_device: bool
 
-    :param _grpc_options:
+    :param grpc_options:
         
 
         MeasurementLink gRPC session options
@@ -277,7 +277,7 @@ Session
         
 
 
-    :type _grpc_options: niswitch.GrpcSessionOptions
+    :type grpc_options: niswitch.GrpcSessionOptions
 
 
 Methods

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -6752,7 +6752,7 @@ class _SessionBase(object):
 class Session(_SessionBase):
     '''An NI-DCPower session to an NI programmable power supply or source measure unit.'''
 
-    def __init__(self, resource_name, channels=None, reset=False, options={}, independent_channels=True, *, _grpc_options=None):
+    def __init__(self, resource_name, channels=None, reset=False, options={}, independent_channels=True, *, grpc_options=None):
         r'''An NI-DCPower session to an NI programmable power supply or source measure unit.
 
         Creates and returns a new NI-DCPower session to the instrument(s) and channel(s) specified
@@ -6856,16 +6856,16 @@ class Session(_SessionBase):
                 independent channels. Set this argument to False on legacy applications or if you
                 are unable to upgrade your NI-DCPower driver runtime to 20.6 or higher.
 
-            _grpc_options (nidcpower.grpc_session_options.GrpcSessionOptions): MeasurementLink gRPC session options
+            grpc_options (nidcpower.grpc_session_options.GrpcSessionOptions): MeasurementLink gRPC session options
 
 
         Returns:
             session (nidcpower.Session): A session object representing the device.
 
         '''
-        if _grpc_options:
+        if grpc_options:
             import nidcpower._grpc_stub_interpreter as _grpc_stub_interpreter
-            interpreter = _grpc_stub_interpreter.GrpcStubInterpreter(_grpc_options)
+            interpreter = _grpc_stub_interpreter.GrpcStubInterpreter(grpc_options)
         else:
             interpreter = _library_interpreter.LibraryInterpreter(encoding='windows-1251')
 

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -3205,7 +3205,7 @@ class _SessionBase(object):
 class Session(_SessionBase):
     '''An NI-Digital Pattern Driver session'''
 
-    def __init__(self, resource_name, id_query=False, reset_device=False, options={}, *, _grpc_options=None):
+    def __init__(self, resource_name, id_query=False, reset_device=False, options={}, *, grpc_options=None):
         r'''An NI-Digital Pattern Driver session
 
         Creates and returns a new session to the specified digital pattern instrument to use in all subsequent method calls. To place the instrument in a known startup state when creating a new session, set the reset parameter to True, which is equivalent to calling the reset method immediately after initializing the session.
@@ -3253,16 +3253,16 @@ class Session(_SessionBase):
                 | driver_setup            | {}      |
                 +-------------------------+---------+
 
-            _grpc_options (nidigital.grpc_session_options.GrpcSessionOptions): MeasurementLink gRPC session options
+            grpc_options (nidigital.grpc_session_options.GrpcSessionOptions): MeasurementLink gRPC session options
 
 
         Returns:
             new_vi (int): The returned instrument session.
 
         '''
-        if _grpc_options:
+        if grpc_options:
             import nidigital._grpc_stub_interpreter as _grpc_stub_interpreter
-            interpreter = _grpc_stub_interpreter.GrpcStubInterpreter(_grpc_options)
+            interpreter = _grpc_stub_interpreter.GrpcStubInterpreter(grpc_options)
         else:
             interpreter = _library_interpreter.LibraryInterpreter(encoding='windows-1251')
 
@@ -3283,7 +3283,7 @@ class Session(_SessionBase):
         self._interpreter.set_session_handle(self._init_with_options(resource_name, id_query, reset_device, options))
 
         # NI-TClk does not work over NI gRPC Device Server
-        if not _grpc_options:
+        if not grpc_options:
             self.tclk = nitclk.SessionReference(self._interpreter.get_session_handle())
 
         # Store the parameter list for later printing in __repr__

--- a/generated/nidmm/nidmm/session.py
+++ b/generated/nidmm/nidmm/session.py
@@ -927,7 +927,7 @@ class _SessionBase(object):
 class Session(_SessionBase):
     '''An NI-DMM session to an NI digital multimeter'''
 
-    def __init__(self, resource_name, id_query=False, reset_device=False, options={}, *, _grpc_options=None):
+    def __init__(self, resource_name, id_query=False, reset_device=False, options={}, *, grpc_options=None):
         r'''An NI-DMM session to an NI digital multimeter
 
         This method completes the following tasks:
@@ -1022,16 +1022,16 @@ class Session(_SessionBase):
                 | driver_setup            | {}      |
                 +-------------------------+---------+
 
-            _grpc_options (nidmm.grpc_session_options.GrpcSessionOptions): MeasurementLink gRPC session options
+            grpc_options (nidmm.grpc_session_options.GrpcSessionOptions): MeasurementLink gRPC session options
 
 
         Returns:
             session (nidmm.Session): A session object representing the device.
 
         '''
-        if _grpc_options:
+        if grpc_options:
             import nidmm._grpc_stub_interpreter as _grpc_stub_interpreter
-            interpreter = _grpc_stub_interpreter.GrpcStubInterpreter(_grpc_options)
+            interpreter = _grpc_stub_interpreter.GrpcStubInterpreter(grpc_options)
         else:
             interpreter = _library_interpreter.LibraryInterpreter(encoding='windows-1251')
 

--- a/generated/nifake/nifake/session.py
+++ b/generated/nifake/nifake/session.py
@@ -635,7 +635,7 @@ class _SessionBase(object):
 class Session(_SessionBase):
     '''An NI-FAKE session to a fake MI driver whose sole purpose is to test nimi-python code generation'''
 
-    def __init__(self, resource_name, options={}, id_query=False, reset_device=False, *, _grpc_options=None):
+    def __init__(self, resource_name, options={}, id_query=False, reset_device=False, *, grpc_options=None):
         r'''An NI-FAKE session to a fake MI driver whose sole purpose is to test nimi-python code generation
 
         Creates a new IVI instrument driver session.
@@ -689,16 +689,16 @@ class Session(_SessionBase):
                 | False          | 0 | Don't Reset  |
                 +----------------+---+--------------+
 
-            _grpc_options (nifake.grpc_session_options.GrpcSessionOptions): MeasurementLink gRPC session options
+            grpc_options (nifake.grpc_session_options.GrpcSessionOptions): MeasurementLink gRPC session options
 
 
         Returns:
             session (nifake.Session): A session object representing the device.
 
         '''
-        if _grpc_options:
+        if grpc_options:
             import nifake._grpc_stub_interpreter as _grpc_stub_interpreter
-            interpreter = _grpc_stub_interpreter.GrpcStubInterpreter(_grpc_options)
+            interpreter = _grpc_stub_interpreter.GrpcStubInterpreter(grpc_options)
         else:
             interpreter = _library_interpreter.LibraryInterpreter(encoding='windows-1251')
 
@@ -719,7 +719,7 @@ class Session(_SessionBase):
         self._interpreter.set_session_handle(self._init_with_options(resource_name, options, id_query, reset_device))
 
         # NI-TClk does not work over NI gRPC Device Server
-        if not _grpc_options:
+        if not grpc_options:
             self.tclk = nitclk.SessionReference(self._interpreter.get_session_handle())
 
         # Store the parameter list for later printing in __repr__

--- a/generated/nifake/nifake/unit_tests/test_session.py
+++ b/generated/nifake/nifake/unit_tests/test_session.py
@@ -874,7 +874,7 @@ class TestGrpcSession(object):
     # Session management
 
     def test_init_with_options_and_close(self):
-        session = nifake.Session('dev1', _grpc_options=nifake.GrpcSessionOptions(object(), ''))
+        session = nifake.Session('dev1', grpc_options=nifake.GrpcSessionOptions(object(), ''))
         self.patched_grpc_interpreter.init_with_options.assert_called_once_with('dev1', False, False, '')
         assert session._interpreter._vi == GRPC_SESSION_OBJECT_FOR_TEST
         session.close()
@@ -883,24 +883,24 @@ class TestGrpcSession(object):
     # Session locking
 
     def test_lock_session_none(self):
-        with nifake.Session('dev1', _grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
+        with nifake.Session('dev1', grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
             session.lock()
             self.patched_grpc_interpreter.lock.assert_called_once_with()
 
     def test_unlock_session_none(self):
-        with nifake.Session('dev1', _grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
+        with nifake.Session('dev1', grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
             session.unlock()
             self.patched_grpc_interpreter.unlock.assert_called_once_with()
 
     def test_lock_context_manager(self):
-        with nifake.Session('dev1', _grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
+        with nifake.Session('dev1', grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
             with session.lock():
                 pass
             self.patched_grpc_interpreter.lock.assert_called_once_with()
             self.patched_grpc_interpreter.unlock.assert_called_once_with()
 
     def test_lock_context_manager_abnormal_exit(self):
-        with nifake.Session('dev1', _grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
+        with nifake.Session('dev1', grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
             try:
                 with session.lock():
                     raise nifake.Error('Fake exception')
@@ -914,13 +914,13 @@ class TestGrpcSession(object):
     def test_self_test(self):
         test_error_code = 0
         self.patched_grpc_interpreter.self_test.side_effect = [(test_error_code, '')]
-        with nifake.Session('dev1', _grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
+        with nifake.Session('dev1', grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
             session.self_test()
 
     def test_export_attribute_configuration_buffer(self):
         expected_buffer = b'abcd'
         self.patched_grpc_interpreter.export_attribute_configuration_buffer.side_effect = [expected_buffer]
-        with nifake.Session('dev1', _grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
+        with nifake.Session('dev1', grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
             actual_configuration = session.export_attribute_configuration_buffer()
             assert type(actual_configuration) is bytes
             assert actual_configuration == bytes(expected_buffer)
@@ -931,7 +931,7 @@ class TestGrpcSession(object):
     def test_get_attribute_int32(self):
         test_number = 3
         self.patched_grpc_interpreter.get_attribute_vi_int32.side_effect = [test_number]
-        with nifake.Session('dev1', _grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
+        with nifake.Session('dev1', grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
             attr_int = session.read_write_integer
             assert(attr_int == test_number)
             self.patched_grpc_interpreter.get_attribute_vi_int32.assert_called_once_with('', 1000004)

--- a/generated/nifgen/nifgen/session.py
+++ b/generated/nifgen/nifgen/session.py
@@ -2974,7 +2974,7 @@ class _SessionBase(object):
 class Session(_SessionBase):
     '''An NI-FGEN session to an NI signal generator.'''
 
-    def __init__(self, resource_name, channel_name=None, reset_device=False, options={}, *, _grpc_options=None):
+    def __init__(self, resource_name, channel_name=None, reset_device=False, options={}, *, grpc_options=None):
         r'''An NI-FGEN session to an NI signal generator.
 
         Creates and returns a new NI-FGEN session to the specified channel of a
@@ -3076,16 +3076,16 @@ class Session(_SessionBase):
                 | driver_setup            | {}      |
                 +-------------------------+---------+
 
-            _grpc_options (nifgen.grpc_session_options.GrpcSessionOptions): MeasurementLink gRPC session options
+            grpc_options (nifgen.grpc_session_options.GrpcSessionOptions): MeasurementLink gRPC session options
 
 
         Returns:
             session (nifgen.Session): A session object representing the device.
 
         '''
-        if _grpc_options:
+        if grpc_options:
             import nifgen._grpc_stub_interpreter as _grpc_stub_interpreter
-            interpreter = _grpc_stub_interpreter.GrpcStubInterpreter(_grpc_options)
+            interpreter = _grpc_stub_interpreter.GrpcStubInterpreter(grpc_options)
         else:
             interpreter = _library_interpreter.LibraryInterpreter(encoding='windows-1251')
 
@@ -3107,7 +3107,7 @@ class Session(_SessionBase):
         self._interpreter.set_session_handle(self._initialize_with_channels(resource_name, channel_name, reset_device, options))
 
         # NI-TClk does not work over NI gRPC Device Server
-        if not _grpc_options:
+        if not grpc_options:
             self.tclk = nitclk.SessionReference(self._interpreter.get_session_handle())
 
         # Store the parameter list for later printing in __repr__

--- a/generated/niscope/niscope/session.py
+++ b/generated/niscope/niscope/session.py
@@ -3857,7 +3857,7 @@ class _SessionBase(object):
 class Session(_SessionBase):
     '''An NI-SCOPE session to an NI digitizer.'''
 
-    def __init__(self, resource_name, id_query=False, reset_device=False, options={}, *, _grpc_options=None):
+    def __init__(self, resource_name, id_query=False, reset_device=False, options={}, *, grpc_options=None):
         r'''An NI-SCOPE session to an NI digitizer.
 
         Performs the following initialization actions:
@@ -3982,16 +3982,16 @@ class Session(_SessionBase):
                 | driver_setup            | {}      |
                 +-------------------------+---------+
 
-            _grpc_options (niscope.grpc_session_options.GrpcSessionOptions): MeasurementLink gRPC session options
+            grpc_options (niscope.grpc_session_options.GrpcSessionOptions): MeasurementLink gRPC session options
 
 
         Returns:
             session (niscope.Session): A session object representing the device.
 
         '''
-        if _grpc_options:
+        if grpc_options:
             import niscope._grpc_stub_interpreter as _grpc_stub_interpreter
-            interpreter = _grpc_stub_interpreter.GrpcStubInterpreter(_grpc_options)
+            interpreter = _grpc_stub_interpreter.GrpcStubInterpreter(grpc_options)
         else:
             interpreter = _library_interpreter.LibraryInterpreter(encoding='windows-1251')
 
@@ -4012,7 +4012,7 @@ class Session(_SessionBase):
         self._interpreter.set_session_handle(self._init_with_options(resource_name, id_query, reset_device, options))
 
         # NI-TClk does not work over NI gRPC Device Server
-        if not _grpc_options:
+        if not grpc_options:
             self.tclk = nitclk.SessionReference(self._interpreter.get_session_handle())
 
         # Store the parameter list for later printing in __repr__

--- a/generated/niswitch/niswitch/session.py
+++ b/generated/niswitch/niswitch/session.py
@@ -1149,7 +1149,7 @@ class _SessionBase(object):
 class Session(_SessionBase):
     '''An NI-SWITCH session to an NI switch module.'''
 
-    def __init__(self, resource_name, topology="Configured Topology", simulate=False, reset_device=False, *, _grpc_options=None):
+    def __init__(self, resource_name, topology="Configured Topology", simulate=False, reset_device=False, *, grpc_options=None):
         r'''An NI-SWITCH session to an NI switch module.
 
         Returns a session handle used to identify the switch in all subsequent
@@ -1379,16 +1379,16 @@ class Session(_SessionBase):
                 process. Valid Values: True - Reset Device (Default Value) False
                 - Currently unsupported. The device will not reset.
 
-            _grpc_options (niswitch.grpc_session_options.GrpcSessionOptions): MeasurementLink gRPC session options
+            grpc_options (niswitch.grpc_session_options.GrpcSessionOptions): MeasurementLink gRPC session options
 
 
         Returns:
             session (niswitch.Session): A session object representing the device.
 
         '''
-        if _grpc_options:
+        if grpc_options:
             import niswitch._grpc_stub_interpreter as _grpc_stub_interpreter
-            interpreter = _grpc_stub_interpreter.GrpcStubInterpreter(_grpc_options)
+            interpreter = _grpc_stub_interpreter.GrpcStubInterpreter(grpc_options)
         else:
             interpreter = _library_interpreter.LibraryInterpreter(encoding='windows-1251')
 

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -1080,4 +1080,4 @@ class TestGrpc(SystemTests):
     @pytest.fixture(scope='class')
     def session_creation_kwargs(self, grpc_channel):
         grpc_options = nidcpower.GrpcSessionOptions(grpc_channel, "")
-        return {'_grpc_options': grpc_options}
+        return {'grpc_options': grpc_options}

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -1333,4 +1333,4 @@ class TestGrpc(SystemTests):
     @pytest.fixture(scope='class')
     def session_creation_kwargs(self, grpc_channel):
         grpc_options = nidigital.GrpcSessionOptions(grpc_channel, "")
-        return {'_grpc_options': grpc_options}
+        return {'grpc_options': grpc_options}

--- a/src/nidmm/system_tests/test_system_nidmm.py
+++ b/src/nidmm/system_tests/test_system_nidmm.py
@@ -329,7 +329,7 @@ class TestGrpc(SystemTests):
     @pytest.fixture(scope='class')
     def session_creation_kwargs(self, grpc_channel):
         grpc_options = nidmm.GrpcSessionOptions(grpc_channel, '')
-        return {'_grpc_options': grpc_options}
+        return {'grpc_options': grpc_options}
 
     def test_new_session_already_exists(self, grpc_channel):
         session_name = 'existing_session'
@@ -337,9 +337,9 @@ class TestGrpc(SystemTests):
         expected_grpc_error = grpc.StatusCode.ALREADY_EXISTS
         init_behavior = nidmm.SessionInitializationBehavior.INITIALIZE_SERVER_SESSION
         grpc_options = nidmm.GrpcSessionOptions(grpc_channel, session_name, initialization_behavior=init_behavior)
-        with nidmm.Session('FakeDevice', False, True, 'Simulate=1, DriverSetup=Model:4082; BoardType:PXIe', _grpc_options=grpc_options):
+        with nidmm.Session('FakeDevice', False, True, 'Simulate=1, DriverSetup=Model:4082; BoardType:PXIe', grpc_options=grpc_options):
             try:
-                with nidmm.Session('FakeDevice', False, True, 'Simulate=1, DriverSetup=Model:4082; BoardType:PXIe', _grpc_options=grpc_options):
+                with nidmm.Session('FakeDevice', False, True, 'Simulate=1, DriverSetup=Model:4082; BoardType:PXIe', grpc_options=grpc_options):
                     assert False
             except nidmm.Error as e:
                 assert e.rpc_code == expected_grpc_error
@@ -353,7 +353,7 @@ class TestGrpc(SystemTests):
         init_behavior = nidmm.SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION
         grpc_options = nidmm.GrpcSessionOptions(grpc_channel, session_name, initialization_behavior=init_behavior)
         try:
-            with nidmm.Session('FakeDevice', False, True, 'Simulate=1, DriverSetup=Model:4082; BoardType:PXIe', _grpc_options=grpc_options):
+            with nidmm.Session('FakeDevice', False, True, 'Simulate=1, DriverSetup=Model:4082; BoardType:PXIe', grpc_options=grpc_options):
                 assert False
         except nidmm.Error as e:
             assert e.rpc_code == expected_grpc_error

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -874,7 +874,7 @@ class TestGrpcSession(object):
     # Session management
 
     def test_init_with_options_and_close(self):
-        session = nifake.Session('dev1', _grpc_options=nifake.GrpcSessionOptions(object(), ''))
+        session = nifake.Session('dev1', grpc_options=nifake.GrpcSessionOptions(object(), ''))
         self.patched_grpc_interpreter.init_with_options.assert_called_once_with('dev1', False, False, '')
         assert session._interpreter._vi == GRPC_SESSION_OBJECT_FOR_TEST
         session.close()
@@ -883,24 +883,24 @@ class TestGrpcSession(object):
     # Session locking
 
     def test_lock_session_none(self):
-        with nifake.Session('dev1', _grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
+        with nifake.Session('dev1', grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
             session.lock()
             self.patched_grpc_interpreter.lock.assert_called_once_with()
 
     def test_unlock_session_none(self):
-        with nifake.Session('dev1', _grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
+        with nifake.Session('dev1', grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
             session.unlock()
             self.patched_grpc_interpreter.unlock.assert_called_once_with()
 
     def test_lock_context_manager(self):
-        with nifake.Session('dev1', _grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
+        with nifake.Session('dev1', grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
             with session.lock():
                 pass
             self.patched_grpc_interpreter.lock.assert_called_once_with()
             self.patched_grpc_interpreter.unlock.assert_called_once_with()
 
     def test_lock_context_manager_abnormal_exit(self):
-        with nifake.Session('dev1', _grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
+        with nifake.Session('dev1', grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
             try:
                 with session.lock():
                     raise nifake.Error('Fake exception')
@@ -914,13 +914,13 @@ class TestGrpcSession(object):
     def test_self_test(self):
         test_error_code = 0
         self.patched_grpc_interpreter.self_test.side_effect = [(test_error_code, '')]
-        with nifake.Session('dev1', _grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
+        with nifake.Session('dev1', grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
             session.self_test()
 
     def test_export_attribute_configuration_buffer(self):
         expected_buffer = b'abcd'
         self.patched_grpc_interpreter.export_attribute_configuration_buffer.side_effect = [expected_buffer]
-        with nifake.Session('dev1', _grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
+        with nifake.Session('dev1', grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
             actual_configuration = session.export_attribute_configuration_buffer()
             assert type(actual_configuration) is bytes
             assert actual_configuration == bytes(expected_buffer)
@@ -931,7 +931,7 @@ class TestGrpcSession(object):
     def test_get_attribute_int32(self):
         test_number = 3
         self.patched_grpc_interpreter.get_attribute_vi_int32.side_effect = [test_number]
-        with nifake.Session('dev1', _grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
+        with nifake.Session('dev1', grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
             attr_int = session.read_write_integer
             assert(attr_int == test_number)
             self.patched_grpc_interpreter.get_attribute_vi_int32.assert_called_once_with('', 1000004)

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -530,4 +530,4 @@ class TestGrpc(SystemTests):
     @pytest.fixture(scope='class')
     def session_creation_kwargs(self, grpc_channel):
         grpc_options = nifgen.GrpcSessionOptions(grpc_channel, '')
-        return {'_grpc_options': grpc_options}
+        return {'grpc_options': grpc_options}

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -509,7 +509,7 @@ class TestGrpc(SystemTests):
     @pytest.fixture(scope='class')
     def session_creation_kwargs(self, grpc_channel):
         grpc_options = niscope.GrpcSessionOptions(grpc_channel, "")
-        return {'_grpc_options': grpc_options}
+        return {'grpc_options': grpc_options}
 
     def test_configure_ref_levels(self, single_instrument_session):
         with pytest.raises(NotImplementedError) as exc_info:

--- a/src/niswitch/system_tests/test_system_niswitch.py
+++ b/src/niswitch/system_tests/test_system_niswitch.py
@@ -194,4 +194,4 @@ class TestGrpc(SystemTests):
     @pytest.fixture(scope='class')
     def session_creation_kwargs(self, grpc_channel):
         grpc_options = niswitch.GrpcSessionOptions(grpc_channel, "")
-        return {'_grpc_options': grpc_options}
+        return {'grpc_options': grpc_options}


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

~~- [ ] I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

Renames the optional `_grpc_options` Session parameter to `grpc_options`

### List issues fixed by this Pull Request below, if any.

None

### What testing has been done?

Unit tests, etc.