### PR TITLE
Upgrade tested version of NI-SWITCH runtime to `2022 Q4`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -343,7 +343,7 @@ NI-SWITCH Python API Status
 +-------------------------------+-------------------------+
 | NI-SWITCH (niswitch)          |                         |
 +===============================+=========================+
-| Driver Version Tested Against | 21.3.0                  |
+| Driver Version Tested Against | 2022 Q4                 |
 +-------------------------------+-------------------------+
 | PyPI Version                  | |niswitchLatestVersion| |
 +-------------------------------+-------------------------+

--- a/docs/niswitch/status.inc
+++ b/docs/niswitch/status.inc
@@ -5,7 +5,7 @@ NI-SWITCH Python API Status
 +-------------------------------+-------------------------+
 | NI-SWITCH (niswitch)          |                         |
 +===============================+=========================+
-| Driver Version Tested Against | 21.3.0                  |
+| Driver Version Tested Against | 2022 Q4                 |
 +-------------------------------+-------------------------+
 | PyPI Version                  | |niswitchLatestVersion| |
 +-------------------------------+-------------------------+

--- a/generated/niswitch/README.rst
+++ b/generated/niswitch/README.rst
@@ -70,7 +70,7 @@ NI-SWITCH Python API Status
 +-------------------------------+-------------------------+
 | NI-SWITCH (niswitch)          |                         |
 +===============================+=========================+
-| Driver Version Tested Against | 21.3.0                  |
+| Driver Version Tested Against | 2022 Q4                 |
 +-------------------------------+-------------------------+
 | PyPI Version                  | |niswitchLatestVersion| |
 +-------------------------------+-------------------------+

--- a/src/niswitch/metadata/config_addon.py
+++ b/src/niswitch/metadata/config_addon.py
@@ -1,5 +1,5 @@
 # We need to maintain the version here since it needs to be updated by the build process on GitHub
 config_additional_config = {
     'module_version': '1.4.3.dev0',
-    'latest_runtime_version_tested_against': '21.3.0',
+    'latest_runtime_version_tested_against': '2022 Q4',
 }


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Updated the version of the NI-SWITCH runtime which nimibot runs tests on.

### What testing has been done?

Ran `tox`, which succeeded.
