### PR TITLE
Restore previous lock, unlock behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
 * ### ALL
     * #### Added
     * #### Changed
+        * Fix [#1888](https://github.com/ni/nimi-python/issues/1888): Deadlock on multithreaded usage due to UnlockSession always being called with callerHasLock=False.
     * #### Removed
 * ### `nidcpower` (NI-DCPower)
     * #### Added

--- a/build/templates/_library_interpreter.py/lock.py.mako
+++ b/build/templates/_library_interpreter.py/lock.py.mako
@@ -1,2 +1,21 @@
 <%page args="f, config, method_template"/>\
-<%include file="/_library_interpreter.py/default_method.py.mako" args="f=f, config=config, method_template=method_template" />\
+<%
+    '''Renders a LibraryInterpreter lock method.
+    
+    The Session class doesn't keep track of the callerHasLock pointer,
+    so we should just pass None.
+    '''
+
+    import build.helper as helper
+
+    param_names_method = helper.get_params_snippet(f, helper.ParameterUsageOptions.INTERPRETER_METHOD_DECLARATION)
+
+    full_func_name = f['interpreter_name'] + method_template['method_python_name_suffix']
+    c_func_name = config['c_function_prefix'] + f['name']
+%>\
+
+    def ${full_func_name}(${param_names_method}):  # noqa: N802
+        vi_ctype = _visatype.ViSession(self._vi)  # case S110
+        error_code = self._library.${c_func_name}(vi_ctype, None)
+        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=${f['is_error_handling']})
+        return

--- a/build/templates/_library_interpreter.py/unlock.py.mako
+++ b/build/templates/_library_interpreter.py/unlock.py.mako
@@ -1,2 +1,21 @@
 <%page args="f, config, method_template"/>\
-<%include file="/_library_interpreter.py/default_method.py.mako" args="f=f, config=config, method_template=method_template" />\
+<%
+    '''Renders a LibraryInterpreter unlock method.
+
+    The Session class doesn't keep track of the callerHasLock pointer,
+    so we should just pass None.
+    '''
+
+    import build.helper as helper
+
+    param_names_method = helper.get_params_snippet(f, helper.ParameterUsageOptions.INTERPRETER_METHOD_DECLARATION)
+
+    full_func_name = f['interpreter_name'] + method_template['method_python_name_suffix']
+    c_func_name = config['c_function_prefix'] + f['name']
+%>\
+
+    def ${full_func_name}(${param_names_method}):  # noqa: N802
+        vi_ctype = _visatype.ViSession(self._vi)  # case S110
+        error_code = self._library.${c_func_name}(vi_ctype, None)
+        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=${f['is_error_handling']})
+        return

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI Modular Instruments Python API'
-copyright = '2017-2022, National Instruments Corporation'
+copyright = '2017-2023, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/generated/nidcpower/nidcpower/_library_interpreter.py
+++ b/generated/nidcpower/nidcpower/_library_interpreter.py
@@ -450,10 +450,9 @@ class LibraryInterpreter(object):
 
     def lock(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        caller_has_lock_ctype = _visatype.ViBoolean()  # case S220
-        error_code = self._library.niDCPower_LockSession(vi_ctype, None if caller_has_lock_ctype is None else (ctypes.pointer(caller_has_lock_ctype)))
+        error_code = self._library.niDCPower_LockSession(vi_ctype, None)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return bool(caller_has_lock_ctype.value)
+        return
 
     def measure(self, channel_name, measurement_type):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -679,10 +678,9 @@ class LibraryInterpreter(object):
 
     def unlock(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        caller_has_lock_ctype = _visatype.ViBoolean()  # case S220
-        error_code = self._library.niDCPower_UnlockSession(vi_ctype, None if caller_has_lock_ctype is None else (ctypes.pointer(caller_has_lock_ctype)))
+        error_code = self._library.niDCPower_UnlockSession(vi_ctype, None)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return bool(caller_has_lock_ctype.value)
+        return
 
     def wait_for_event(self, channel_name, event_id, timeout):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110

--- a/generated/nidigital/nidigital/_library_interpreter.py
+++ b/generated/nidigital/nidigital/_library_interpreter.py
@@ -747,10 +747,9 @@ class LibraryInterpreter(object):
 
     def lock(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        caller_has_lock_ctype = _visatype.ViBoolean()  # case S220
-        error_code = self._library.niDigital_LockSession(vi_ctype, None if caller_has_lock_ctype is None else (ctypes.pointer(caller_has_lock_ctype)))
+        error_code = self._library.niDigital_LockSession(vi_ctype, None)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return bool(caller_has_lock_ctype.value)
+        return
 
     def ppmu_measure(self, channel_list, measurement_type):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -903,10 +902,9 @@ class LibraryInterpreter(object):
 
     def unlock(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        caller_has_lock_ctype = _visatype.ViBoolean()  # case S220
-        error_code = self._library.niDigital_UnlockSession(vi_ctype, None if caller_has_lock_ctype is None else (ctypes.pointer(caller_has_lock_ctype)))
+        error_code = self._library.niDigital_UnlockSession(vi_ctype, None)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return bool(caller_has_lock_ctype.value)
+        return
 
     def wait_until_done(self, timeout):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110

--- a/generated/nidmm/nidmm/_library_interpreter.py
+++ b/generated/nidmm/nidmm/_library_interpreter.py
@@ -377,10 +377,9 @@ class LibraryInterpreter(object):
 
     def lock(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        caller_has_lock_ctype = _visatype.ViBoolean()  # case S220
-        error_code = self._library.niDMM_LockSession(vi_ctype, None if caller_has_lock_ctype is None else (ctypes.pointer(caller_has_lock_ctype)))
+        error_code = self._library.niDMM_LockSession(vi_ctype, None)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return bool(caller_has_lock_ctype.value)
+        return
 
     def perform_open_cable_comp(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -494,10 +493,9 @@ class LibraryInterpreter(object):
 
     def unlock(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        caller_has_lock_ctype = _visatype.ViBoolean()  # case S220
-        error_code = self._library.niDMM_UnlockSession(vi_ctype, None if caller_has_lock_ctype is None else (ctypes.pointer(caller_has_lock_ctype)))
+        error_code = self._library.niDMM_UnlockSession(vi_ctype, None)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return bool(caller_has_lock_ctype.value)
+        return
 
     def close(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110

--- a/generated/nifake/nifake/_library_interpreter.py
+++ b/generated/nifake/nifake/_library_interpreter.py
@@ -445,10 +445,9 @@ class LibraryInterpreter(object):
 
     def lock(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        caller_has_lock_ctype = _visatype.ViBoolean()  # case S220
-        error_code = self._library.niFake_LockSession(vi_ctype, None if caller_has_lock_ctype is None else (ctypes.pointer(caller_has_lock_ctype)))
+        error_code = self._library.niFake_LockSession(vi_ctype, None)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return bool(caller_has_lock_ctype.value)
+        return
 
     def method_using_whole_and_fractional_numbers(self):  # noqa: N802
         whole_number_ctype = _visatype.ViInt32()  # case S220
@@ -659,10 +658,9 @@ class LibraryInterpreter(object):
 
     def unlock(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        caller_has_lock_ctype = _visatype.ViBoolean()  # case S220
-        error_code = self._library.niFake_UnlockSession(vi_ctype, None if caller_has_lock_ctype is None else (ctypes.pointer(caller_has_lock_ctype)))
+        error_code = self._library.niFake_UnlockSession(vi_ctype, None)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return bool(caller_has_lock_ctype.value)
+        return
 
     def use64_bit_number(self, input):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110

--- a/generated/nifgen/nifgen/_library_interpreter.py
+++ b/generated/nifgen/nifgen/_library_interpreter.py
@@ -501,10 +501,9 @@ class LibraryInterpreter(object):
 
     def lock(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        caller_has_lock_ctype = _visatype.ViBoolean()  # case S220
-        error_code = self._library.niFgen_LockSession(vi_ctype, None if caller_has_lock_ctype is None else (ctypes.pointer(caller_has_lock_ctype)))
+        error_code = self._library.niFgen_LockSession(vi_ctype, None)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return bool(caller_has_lock_ctype.value)
+        return
 
     def query_arb_seq_capabilities(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -629,10 +628,9 @@ class LibraryInterpreter(object):
 
     def unlock(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        caller_has_lock_ctype = _visatype.ViBoolean()  # case S220
-        error_code = self._library.niFgen_UnlockSession(vi_ctype, None if caller_has_lock_ctype is None else (ctypes.pointer(caller_has_lock_ctype)))
+        error_code = self._library.niFgen_UnlockSession(vi_ctype, None)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return bool(caller_has_lock_ctype.value)
+        return
 
     def wait_until_done(self, max_time):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110

--- a/generated/niscope/niscope/_library_interpreter.py
+++ b/generated/niscope/niscope/_library_interpreter.py
@@ -543,10 +543,9 @@ class LibraryInterpreter(object):
 
     def lock(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        caller_has_lock_ctype = _visatype.ViBoolean()  # case S220
-        error_code = self._library.niScope_LockSession(vi_ctype, None if caller_has_lock_ctype is None else (ctypes.pointer(caller_has_lock_ctype)))
+        error_code = self._library.niScope_LockSession(vi_ctype, None)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return bool(caller_has_lock_ctype.value)
+        return
 
     def probe_compensation_signal_start(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -640,10 +639,9 @@ class LibraryInterpreter(object):
 
     def unlock(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        caller_has_lock_ctype = _visatype.ViBoolean()  # case S220
-        error_code = self._library.niScope_UnlockSession(vi_ctype, None if caller_has_lock_ctype is None else (ctypes.pointer(caller_has_lock_ctype)))
+        error_code = self._library.niScope_UnlockSession(vi_ctype, None)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return bool(caller_has_lock_ctype.value)
+        return
 
     def close(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110

--- a/generated/niswitch/niswitch/_library_interpreter.py
+++ b/generated/niswitch/niswitch/_library_interpreter.py
@@ -283,10 +283,9 @@ class LibraryInterpreter(object):
 
     def lock(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        caller_has_lock_ctype = _visatype.ViBoolean()  # case S220
-        error_code = self._library.niSwitch_LockSession(vi_ctype, None if caller_has_lock_ctype is None else (ctypes.pointer(caller_has_lock_ctype)))
+        error_code = self._library.niSwitch_LockSession(vi_ctype, None)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return bool(caller_has_lock_ctype.value)
+        return
 
     def relay_control(self, relay_name, relay_action):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -371,10 +370,9 @@ class LibraryInterpreter(object):
 
     def unlock(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        caller_has_lock_ctype = _visatype.ViBoolean()  # case S220
-        error_code = self._library.niSwitch_UnlockSession(vi_ctype, None if caller_has_lock_ctype is None else (ctypes.pointer(caller_has_lock_ctype)))
+        error_code = self._library.niSwitch_UnlockSession(vi_ctype, None)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return bool(caller_has_lock_ctype.value)
+        return
 
     def wait_for_debounce(self, maximum_time_ms):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -2,8 +2,6 @@ import os
 import pathlib
 import sys
 import tempfile
-import threading
-import time
 
 import grpc
 import hightime
@@ -12,7 +10,7 @@ import pytest
 import nidcpower
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent / 'shared'))
-from system_test_utilities import GrpcServerProcess  # noqa: E402
+import system_test_utilities  # noqa: E402
 
 
 def pytest_generate_tests(metafunc):
@@ -1067,47 +1065,11 @@ class SystemTests:
 
     # Multi-Threading tests
     def test_multi_threading_lock_unlock(self, session):
-        release_lock = threading.Event()
-
-        def lock_wait_unlock():
-            session.lock()
-            release_lock.wait()
-            session.unlock()
-
-        def lock_unlock():
-            session.lock()
-            session.unlock()
-
-        # test that lock, unlock functions work properly
-        # No need to test locking for driver, but the gRPC_interpeter doesn't use the driver to lock
-        t1 = threading.Thread(target=lock_wait_unlock)
-        t2 = threading.Thread(target=lock_unlock)
-
-        t1.start()
-        t2.start()
-
-        t1.join(0.5)
-        time.sleep(0.5)
-        # t1 is blocked by the event, t2 should be blocked by t1's lock
-        assert t2.is_alive()
-        release_lock.set()
-        t2.join(0.5)
-
-        assert not t1.is_alive()
-        assert not t2.is_alive()
+        system_test_utilities.impl_test_multi_threading_lock_unlock(session)
 
     def test_multi_threading_ivi_synchronized_wrapper_releases_lock(self, session):
-        # test that the 2nd thread doesn't hang
-        t1 = threading.Thread(target=session.commit)
-        t2 = threading.Thread(target=session.commit)
-
-        t1.start()
-        t1.join(0.5)
-        assert not t1.is_alive()
-
-        t2.start()
-        t2.join(0.5)
-        assert not t2.is_alive()
+        system_test_utilities.impl_test_multi_threading_ivi_synchronized_wrapper_releases_lock(
+            session)
 
 
 class TestLibrary(SystemTests):
@@ -1119,7 +1081,7 @@ class TestLibrary(SystemTests):
 class TestGrpc(SystemTests):
     @pytest.fixture(scope='class')
     def grpc_channel(self):
-        with GrpcServerProcess() as proc:
+        with system_test_utilities.GrpcServerProcess() as proc:
             channel = grpc.insecure_channel(f"localhost:{proc.server_port}")
             yield channel
 

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -3,6 +3,7 @@ import pathlib
 import sys
 import tempfile
 import threading
+import time
 
 import grpc
 import hightime
@@ -1065,8 +1066,38 @@ class SystemTests:
         assert last_compensation_datetime.minute == 0
 
     # Multi-Threading tests
-    def test_multi_threading(self, session):
+    def test_multi_threading_lock_unlock(self, session):
+        release_lock = threading.Event()
+
+        def lock_wait_unlock():
+            session.lock()
+            release_lock.wait()
+            session.unlock()
+
+        def lock_unlock():
+            session.lock()
+            session.unlock()
+
         # test that lock, unlock functions work properly
+        # No need to test locking for driver, but the gRPC_interpeter doesn't use the driver to lock
+        t1 = threading.Thread(target=lock_wait_unlock)
+        t2 = threading.Thread(target=lock_unlock)
+
+        t1.start()
+        t2.start()
+
+        t1.join(0.5)
+        time.sleep(0.5)
+        # t1 is blocked by the event, t2 should be blocked by t1's lock
+        assert t2.is_alive()
+        release_lock.set()
+        t2.join(0.5)
+
+        assert not t1.is_alive()
+        assert not t2.is_alive()
+
+    def test_multi_threading_ivi_synchronized_wrapper_releases_lock(self, session):
+        # test that the 2nd thread doesn't hang
         t1 = threading.Thread(target=session.commit)
         t2 = threading.Thread(target=session.commit)
 

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 import sys
 import tempfile
+import threading
 
 import grpc
 import hightime
@@ -1062,6 +1063,20 @@ class SystemTests:
         assert last_compensation_datetime.day == 1
         assert last_compensation_datetime.hour == 0
         assert last_compensation_datetime.minute == 0
+
+    # Multi-Threading tests
+    def test_multi_threading(self, session):
+        # test that lock, unlock functions work properly
+        t1 = threading.Thread(target=session.commit)
+        t2 = threading.Thread(target=session.commit)
+
+        t1.start()
+        t1.join(0.5)
+        assert not t1.is_alive()
+
+        t2.start()
+        t2.join(0.5)
+        assert not t2.is_alive()
 
 
 class TestLibrary(SystemTests):

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -4,6 +4,7 @@ import os
 import pathlib
 import sys
 import threading
+import time
 
 import grpc
 import hightime
@@ -1318,8 +1319,38 @@ Per Pin Pass Fail   : [[True, True], [False, False]]
             initial_state_tristate_pins='HI1, HI2')
 
     # Multi-Threading tests
-    def test_multi_threading(self, multi_instrument_session):
+    def test_multi_threading_lock_unlock(self, multi_instrument_session):
+        release_lock = threading.Event()
+
+        def lock_wait_unlock():
+            multi_instrument_session.lock()
+            release_lock.wait()
+            multi_instrument_session.unlock()
+
+        def lock_unlock():
+            multi_instrument_session.lock()
+            multi_instrument_session.unlock()
+
         # test that lock, unlock functions work properly
+        # No need to test locking for driver, but the gRPC_interpeter doesn't use the driver to lock
+        t1 = threading.Thread(target=lock_wait_unlock)
+        t2 = threading.Thread(target=lock_unlock)
+
+        t1.start()
+        t2.start()
+
+        t1.join(0.5)
+        time.sleep(0.5)
+        # t1 is blocked by the event, t2 should be blocked by t1's lock
+        assert t2.is_alive()
+        release_lock.set()
+        t2.join(0.5)
+
+        assert not t1.is_alive()
+        assert not t2.is_alive()
+
+    def test_multi_threading_ivi_synchronized_wrapper_releases_lock(self, multi_instrument_session):
+        # test that the 2nd thread doesn't hang
         t1 = threading.Thread(target=multi_instrument_session.commit)
         t2 = threading.Thread(target=multi_instrument_session.commit)
 

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -3,6 +3,7 @@ import collections
 import os
 import pathlib
 import sys
+import threading
 
 import grpc
 import hightime
@@ -1315,6 +1316,20 @@ Per Pin Pass Fail   : [[True, True], [False, False]]
             timing_sheet='timing',
             initial_state_high_pins=['HI0', 'LowPins'],
             initial_state_tristate_pins='HI1, HI2')
+
+    # Multi-Threading tests
+    def test_multi_threading(self, multi_instrument_session):
+        # test that lock, unlock functions work properly
+        t1 = threading.Thread(target=multi_instrument_session.commit)
+        t2 = threading.Thread(target=multi_instrument_session.commit)
+
+        t1.start()
+        t1.join(0.5)
+        assert not t1.is_alive()
+
+        t2.start()
+        t2.join(0.5)
+        assert not t2.is_alive()
 
 
 class TestLibrary(SystemTests):

--- a/src/nidmm/system_tests/test_system_nidmm.py
+++ b/src/nidmm/system_tests/test_system_nidmm.py
@@ -3,7 +3,6 @@ import os
 import pathlib
 import sys
 import tempfile
-import threading
 import time
 
 import grpc
@@ -14,7 +13,7 @@ import pytest
 import nidmm
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent / 'shared'))
-from system_test_utilities import GrpcServerProcess  # noqa: E402
+import system_test_utilities  # noqa: E402
 
 
 class SystemTests:
@@ -304,47 +303,11 @@ class SystemTests:
 
     # Multi-Threading tests
     def test_multi_threading_lock_unlock(self, session):
-        release_lock = threading.Event()
-
-        def lock_wait_unlock():
-            session.lock()
-            release_lock.wait()
-            session.unlock()
-
-        def lock_unlock():
-            session.lock()
-            session.unlock()
-
-        # test that lock, unlock functions work properly
-        # No need to test locking for driver, but the gRPC_interpeter doesn't use the driver to lock
-        t1 = threading.Thread(target=lock_wait_unlock)
-        t2 = threading.Thread(target=lock_unlock)
-
-        t1.start()
-        t2.start()
-
-        t1.join(0.5)
-        time.sleep(0.5)
-        # t1 is blocked by the event, t2 should be blocked by t1's lock
-        assert t2.is_alive()
-        release_lock.set()
-        t2.join(0.5)
-
-        assert not t1.is_alive()
-        assert not t2.is_alive()
+        system_test_utilities.impl_test_multi_threading_lock_unlock(session)
 
     def test_multi_threading_ivi_synchronized_wrapper_releases_lock(self, session):
-        # test that the 2nd thread doesn't hang
-        t1 = threading.Thread(target=session.abort)
-        t2 = threading.Thread(target=session.abort)
-
-        t1.start()
-        t1.join(0.5)
-        assert not t1.is_alive()
-
-        t2.start()
-        t2.join(0.5)
-        assert not t2.is_alive()
+        system_test_utilities.impl_test_multi_threading_ivi_synchronized_wrapper_releases_lock(
+            session)
 
 
 class TestLibrary(SystemTests):
@@ -367,7 +330,7 @@ class TestLibrary(SystemTests):
 class TestGrpc(SystemTests):
     @pytest.fixture(scope='class')
     def grpc_channel(self):
-        with GrpcServerProcess() as proc:
+        with system_test_utilities.GrpcServerProcess() as proc:
             channel = grpc.insecure_channel(f"localhost:{proc.server_port}")
             yield channel
 

--- a/src/nidmm/system_tests/test_system_nidmm.py
+++ b/src/nidmm/system_tests/test_system_nidmm.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 import sys
 import tempfile
+import threading
 import time
 
 import grpc
@@ -300,6 +301,20 @@ class SystemTests:
             with session.lock():
                 interval = session.get_ext_cal_recommended_interval()
                 assert interval.days == 730
+
+    # Multi-Threading tests
+    def test_multi_threading(self, session):
+        # test that lock, unlock functions work properly
+        t1 = threading.Thread(target=session.abort)
+        t2 = threading.Thread(target=session.abort)
+
+        t1.start()
+        t1.join(0.5)
+        assert not t1.is_alive()
+
+        t2.start()
+        t2.join(0.5)
+        assert not t2.is_alive()
 
 
 class TestLibrary(SystemTests):

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 import sys
 import tempfile
+import threading
 import warnings
 
 import fasteners
@@ -474,6 +475,20 @@ class SystemTests:
             session_5421.create_advanced_arb_sequence(waveform_handles_array, loop_counts_array=loop_counts_array, marker_location_array=marker_location_array)
         assert exc_info.value.args[0] == 'Length of marker_location_array and waveform_handles_array parameters do not match.'
         assert str(exc_info.value) == 'Length of marker_location_array and waveform_handles_array parameters do not match.'
+
+    # Multi-Threading tests
+    def test_multi_threading(self, session):
+        # test that lock, unlock functions work properly
+        t1 = threading.Thread(target=session.commit)
+        t2 = threading.Thread(target=session.commit)
+
+        t1.start()
+        t1.join(0.5)
+        assert not t1.is_alive()
+
+        t2.start()
+        t2.join(0.5)
+        assert not t2.is_alive()
 
 
 class TestLibrary(SystemTests):

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -2,8 +2,6 @@ import os
 import pathlib
 import sys
 import tempfile
-import threading
-import time
 import warnings
 
 import fasteners
@@ -15,7 +13,7 @@ import pytest
 import nifgen
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent / 'shared'))
-from system_test_utilities import GrpcServerProcess  # noqa: E402
+import system_test_utilities  # noqa: E402
 
 
 # Set up some global information we need
@@ -479,47 +477,11 @@ class SystemTests:
 
     # Multi-Threading tests
     def test_multi_threading_lock_unlock(self, session):
-        release_lock = threading.Event()
-
-        def lock_wait_unlock():
-            session.lock()
-            release_lock.wait()
-            session.unlock()
-
-        def lock_unlock():
-            session.lock()
-            session.unlock()
-
-        # test that lock, unlock functions work properly
-        # No need to test locking for driver, but the gRPC_interpeter doesn't use the driver to lock
-        t1 = threading.Thread(target=lock_wait_unlock)
-        t2 = threading.Thread(target=lock_unlock)
-
-        t1.start()
-        t2.start()
-
-        t1.join(0.5)
-        time.sleep(0.5)
-        # t1 is blocked by the event, t2 should be blocked by t1's lock
-        assert t2.is_alive()
-        release_lock.set()
-        t2.join(0.5)
-
-        assert not t1.is_alive()
-        assert not t2.is_alive()
+        system_test_utilities.impl_test_multi_threading_lock_unlock(session)
 
     def test_multi_threading_ivi_synchronized_wrapper_releases_lock(self, session):
-        # test that the 2nd thread doesn't hang
-        t1 = threading.Thread(target=session.commit)
-        t2 = threading.Thread(target=session.commit)
-
-        t1.start()
-        t1.join(0.5)
-        assert not t1.is_alive()
-
-        t2.start()
-        t2.join(0.5)
-        assert not t2.is_alive()
+        system_test_utilities.impl_test_multi_threading_ivi_synchronized_wrapper_releases_lock(
+            session)
 
 
 class TestLibrary(SystemTests):
@@ -569,7 +531,7 @@ class TestLibrary(SystemTests):
 class TestGrpc(SystemTests):
     @pytest.fixture(scope='class')
     def grpc_channel(self):
-        with GrpcServerProcess() as proc:
+        with system_test_utilities.GrpcServerProcess() as proc:
             channel = grpc.insecure_channel(f"localhost:{proc.server_port}")
             yield channel
 

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -3,6 +3,7 @@ import pathlib
 import sys
 import tempfile
 import threading
+import time
 import warnings
 
 import fasteners
@@ -477,8 +478,38 @@ class SystemTests:
         assert str(exc_info.value) == 'Length of marker_location_array and waveform_handles_array parameters do not match.'
 
     # Multi-Threading tests
-    def test_multi_threading(self, session):
+    def test_multi_threading_lock_unlock(self, session):
+        release_lock = threading.Event()
+
+        def lock_wait_unlock():
+            session.lock()
+            release_lock.wait()
+            session.unlock()
+
+        def lock_unlock():
+            session.lock()
+            session.unlock()
+
         # test that lock, unlock functions work properly
+        # No need to test locking for driver, but the gRPC_interpeter doesn't use the driver to lock
+        t1 = threading.Thread(target=lock_wait_unlock)
+        t2 = threading.Thread(target=lock_unlock)
+
+        t1.start()
+        t2.start()
+
+        t1.join(0.5)
+        time.sleep(0.5)
+        # t1 is blocked by the event, t2 should be blocked by t1's lock
+        assert t2.is_alive()
+        release_lock.set()
+        t2.join(0.5)
+
+        assert not t1.is_alive()
+        assert not t2.is_alive()
+
+    def test_multi_threading_ivi_synchronized_wrapper_releases_lock(self, session):
+        # test that the 2nd thread doesn't hang
         t1 = threading.Thread(target=session.commit)
         t2 = threading.Thread(target=session.commit)
 

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -4,8 +4,6 @@ import os
 import pathlib
 import sys
 import tempfile
-import threading
-import time
 
 import fasteners
 import grpc
@@ -16,7 +14,7 @@ import pytest
 import niscope
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent / 'shared'))
-from system_test_utilities import GrpcServerProcess  # noqa: E402
+import system_test_utilities  # noqa: E402
 
 
 instruments = ['FakeDevice1', 'FakeDevice2']
@@ -385,47 +383,11 @@ class SystemTests:
 
     # Multi-Threading tests
     def test_multi_threading_lock_unlock(self, multi_instrument_session):
-        release_lock = threading.Event()
-
-        def lock_wait_unlock():
-            multi_instrument_session.lock()
-            release_lock.wait()
-            multi_instrument_session.unlock()
-
-        def lock_unlock():
-            multi_instrument_session.lock()
-            multi_instrument_session.unlock()
-
-        # test that lock, unlock functions work properly
-        # No need to test locking for driver, but the gRPC_interpeter doesn't use the driver to lock
-        t1 = threading.Thread(target=lock_wait_unlock)
-        t2 = threading.Thread(target=lock_unlock)
-
-        t1.start()
-        t2.start()
-
-        t1.join(0.5)
-        time.sleep(0.5)
-        # t1 is blocked by the event, t2 should be blocked by t1's lock
-        assert t2.is_alive()
-        release_lock.set()
-        t2.join(0.5)
-
-        assert not t1.is_alive()
-        assert not t2.is_alive()
+        system_test_utilities.impl_test_multi_threading_lock_unlock(multi_instrument_session)
 
     def test_multi_threading_ivi_synchronized_wrapper_releases_lock(self, multi_instrument_session):
-        # test that the 2nd thread doesn't hang
-        t1 = threading.Thread(target=multi_instrument_session.commit)
-        t2 = threading.Thread(target=multi_instrument_session.commit)
-
-        t1.start()
-        t1.join(0.5)
-        assert not t1.is_alive()
-
-        t2.start()
-        t2.join(0.5)
-        assert not t2.is_alive()
+        system_test_utilities.impl_test_multi_threading_ivi_synchronized_wrapper_releases_lock(
+            multi_instrument_session)
 
 
 class TestLibrary(SystemTests):
@@ -554,7 +516,7 @@ class TestLibrary(SystemTests):
 class TestGrpc(SystemTests):
     @pytest.fixture(scope='class')
     def grpc_channel(self):
-        with GrpcServerProcess() as proc:
+        with system_test_utilities.GrpcServerProcess() as proc:
             channel = grpc.insecure_channel(f"localhost:{proc.server_port}")
             yield channel
 

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -4,6 +4,7 @@ import os
 import pathlib
 import sys
 import tempfile
+import threading
 
 import fasteners
 import grpc
@@ -380,6 +381,20 @@ class SystemTests:
         multi_instrument_session.configure_trigger_window(trigger_source, 0, 5, niscope.TriggerWindowMode.ENTERING, niscope.TriggerCoupling.DC)
         assert trigger_source == multi_instrument_session.trigger_source
         assert niscope.TriggerWindowMode.ENTERING == multi_instrument_session.trigger_window_mode
+
+    # Multi-Threading tests
+    def test_multi_threading(self, multi_instrument_session):
+        # test that lock, unlock functions work properly
+        t1 = threading.Thread(target=multi_instrument_session.commit)
+        t2 = threading.Thread(target=multi_instrument_session.commit)
+
+        t1.start()
+        t1.join(0.5)
+        assert not t1.is_alive()
+
+        t2.start()
+        t2.join(0.5)
+        assert not t2.is_alive()
 
 
 class TestLibrary(SystemTests):

--- a/src/niswitch/system_tests/test_system_niswitch.py
+++ b/src/niswitch/system_tests/test_system_niswitch.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 import sys
 import tempfile
+import threading
 
 import fasteners
 import grpc
@@ -176,6 +177,20 @@ class SystemTests:
         except niswitch.Error as e:
             assert e.code == -1074118654
             assert e.description.find('Invalid resource name.') != -1
+
+    # Multi-Threading tests
+    def test_multi_threading(self, session):
+        # test that lock, unlock functions work properly
+        t1 = threading.Thread(target=session.commit)
+        t2 = threading.Thread(target=session.commit)
+
+        t1.start()
+        t1.join(0.5)
+        assert not t1.is_alive()
+
+        t2.start()
+        t2.join(0.5)
+        assert not t2.is_alive()
 
 
 class TestLibrary(SystemTests):

--- a/src/niswitch/system_tests/test_system_niswitch.py
+++ b/src/niswitch/system_tests/test_system_niswitch.py
@@ -3,6 +3,7 @@ import pathlib
 import sys
 import tempfile
 import threading
+import time
 
 import fasteners
 import grpc
@@ -179,8 +180,38 @@ class SystemTests:
             assert e.description.find('Invalid resource name.') != -1
 
     # Multi-Threading tests
-    def test_multi_threading(self, session):
+    def test_multi_threading_lock_unlock(self, session):
+        release_lock = threading.Event()
+
+        def lock_wait_unlock():
+            session.lock()
+            release_lock.wait()
+            session.unlock()
+
+        def lock_unlock():
+            session.lock()
+            session.unlock()
+
         # test that lock, unlock functions work properly
+        # No need to test locking for driver, but the gRPC_interpeter doesn't use the driver to lock
+        t1 = threading.Thread(target=lock_wait_unlock)
+        t2 = threading.Thread(target=lock_unlock)
+
+        t1.start()
+        t2.start()
+
+        t1.join(0.5)
+        time.sleep(0.5)
+        # t1 is blocked by the event, t2 should be blocked by t1's lock
+        assert t2.is_alive()
+        release_lock.set()
+        t2.join(0.5)
+
+        assert not t1.is_alive()
+        assert not t2.is_alive()
+
+    def test_multi_threading_ivi_synchronized_wrapper_releases_lock(self, session):
+        # test that the 2nd thread doesn't hang
         t1 = threading.Thread(target=session.commit)
         t2 = threading.Thread(target=session.commit)
 

--- a/src/niswitch/system_tests/test_system_niswitch.py
+++ b/src/niswitch/system_tests/test_system_niswitch.py
@@ -2,8 +2,6 @@ import os
 import pathlib
 import sys
 import tempfile
-import threading
-import time
 
 import fasteners
 import grpc
@@ -13,7 +11,7 @@ import pytest
 import niswitch
 
 sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent / 'shared'))
-from system_test_utilities import GrpcServerProcess  # noqa: E402
+import system_test_utilities  # noqa: E402
 
 # We need a lock file so multiple tests aren't hitting the db at the same time
 # Trying to create simulated DAQmx devices at the same time (which can happen when running
@@ -181,47 +179,11 @@ class SystemTests:
 
     # Multi-Threading tests
     def test_multi_threading_lock_unlock(self, session):
-        release_lock = threading.Event()
-
-        def lock_wait_unlock():
-            session.lock()
-            release_lock.wait()
-            session.unlock()
-
-        def lock_unlock():
-            session.lock()
-            session.unlock()
-
-        # test that lock, unlock functions work properly
-        # No need to test locking for driver, but the gRPC_interpeter doesn't use the driver to lock
-        t1 = threading.Thread(target=lock_wait_unlock)
-        t2 = threading.Thread(target=lock_unlock)
-
-        t1.start()
-        t2.start()
-
-        t1.join(0.5)
-        time.sleep(0.5)
-        # t1 is blocked by the event, t2 should be blocked by t1's lock
-        assert t2.is_alive()
-        release_lock.set()
-        t2.join(0.5)
-
-        assert not t1.is_alive()
-        assert not t2.is_alive()
+        system_test_utilities.impl_test_multi_threading_lock_unlock(session)
 
     def test_multi_threading_ivi_synchronized_wrapper_releases_lock(self, session):
-        # test that the 2nd thread doesn't hang
-        t1 = threading.Thread(target=session.commit)
-        t2 = threading.Thread(target=session.commit)
-
-        t1.start()
-        t1.join(0.5)
-        assert not t1.is_alive()
-
-        t2.start()
-        t2.join(0.5)
-        assert not t2.is_alive()
+        system_test_utilities.impl_test_multi_threading_ivi_synchronized_wrapper_releases_lock(
+            session)
 
 
 class TestLibrary(SystemTests):
@@ -233,7 +195,7 @@ class TestLibrary(SystemTests):
 class TestGrpc(SystemTests):
     @pytest.fixture(scope='class')
     def grpc_channel(self):
-        with GrpcServerProcess() as proc:
+        with system_test_utilities.GrpcServerProcess() as proc:
             channel = grpc.insecure_channel(f"localhost:{proc.server_port}")
             yield channel
 

--- a/src/shared/system_test_utilities.py
+++ b/src/shared/system_test_utilities.py
@@ -65,7 +65,6 @@ def impl_test_multi_threading_lock_unlock(session):
         session.unlock()
 
     # test that lock, unlock functions work properly
-    # No need to test locking for driver, but the gRPC_interpeter doesn't use the driver to lock
     t1 = threading.Thread(target=lock_wait_unlock)
     t2 = threading.Thread(target=lock_unlock)
 

--- a/src/shared/system_test_utilities.py
+++ b/src/shared/system_test_utilities.py
@@ -57,11 +57,13 @@ def impl_test_multi_threading_lock_unlock(session):
 
     def lock_wait_unlock():
         session.lock()
+        assert session.instrument_manufacturer != ''
         release_lock.wait()
         session.unlock()
 
     def lock_unlock():
         session.lock()
+        assert session.instrument_model != ''
         session.unlock()
 
     # test that lock, unlock functions work properly


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- [X] I've added tests applicable for this pull request
  - Added multi_threading system tests `test_multi_threading_ivi_synchronized_wrapper_releases_lock` that will hang if an unmanaged callerHasLock pointer is passed to _LockSession, _UnlockSession entry points.
    - Tried various timeout mechanisms, but could not find a way to test the behavior without a fail hanging the tests
  - Added multi_threading system test `test_multi_threading_lock_unlock` to validate locking behavior 

### What does this Pull Request accomplish?

Restores the lock, unlock behavior that was present prior to the 1.4.3 release.

### List issues fixed by this Pull Request below, if any.

* Fix #1888 

### What testing has been done?

* Wrote the NI-SCOPE multi_threading system test and ran without the fix.
  * Test hanged pytest
* Implemented the fix and ran the tests again
  * Test passed and did not hang.
* Wrote tests for the other APIs but did not run them locally. They will be run automatically by the PR.