### PR TITLE
Update niscope system tests to be compatible with numpy 1.24+

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI Modular Instruments Python API'
-copyright = '2017-2022, National Instruments Corporation'
+copyright = '2017-2023, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -1,5 +1,5 @@
 import collections
-import math
+import copy
 import os
 import pathlib
 import sys
@@ -387,21 +387,26 @@ class TestLibrary(SystemTests):
     def session_creation_kwargs(self):
         return {}
 
-    @pytest.fixture(params=[numpy.int8, numpy.int16, numpy.int32, numpy.float64])
-    def fetch_waveform_type(self, request):
-        return request.param
-
     # not supported by grpc due to numpy usage
-    def test_fetch_into(self, multi_instrument_session, fetch_waveform_type):
+    @pytest.mark.parametrize("fetch_waveform_type,type_min_value",
+        [
+            (numpy.int8, numpy.iinfo(numpy.int8).min),
+            (numpy.int16, numpy.iinfo(numpy.int16).min),
+            (numpy.int32, numpy.iinfo(numpy.int32).min),
+            (numpy.float64, numpy.finfo(numpy.float64).min)
+        ]
+    )
+    def test_fetch_into(self, multi_instrument_session, fetch_waveform_type, type_min_value):
         test_voltage = 1.0
         test_record_length = 2000
         test_num_channels = 2
         test_starting_record_number = 2
         test_num_records_to_acquire = 5
         test_num_records_to_fetch = test_num_records_to_acquire - test_starting_record_number
-        waveform = numpy.ndarray(test_num_channels * test_num_records_to_fetch * test_record_length, dtype=fetch_waveform_type)
-        # Initialize with NaN so we can later verify all samples were overwritten by the driver.
-        waveform.fill(float('nan'))
+        init_waveform = numpy.ndarray(test_num_channels * test_num_records_to_fetch * test_record_length, dtype=fetch_waveform_type)
+        # Initialize with min supported value so we can later verify all samples were overwritten by the driver.
+        init_waveform.fill(type_min_value)
+        waveform = copy.deepcopy(init_waveform)
         multi_instrument_session.configure_vertical(test_voltage, niscope.VerticalCoupling.AC)
         multi_instrument_session.configure_horizontal_timing(50000000, test_record_length, 50.0, test_num_records_to_acquire, True)
         with multi_instrument_session.initiate():
@@ -410,8 +415,8 @@ class TestLibrary(SystemTests):
                 record_number=test_starting_record_number,
                 num_records=test_num_records_to_fetch)
 
-        for sample in waveform:
-            assert not math.isnan(sample)
+        for index, sample in enumerate(waveform):
+            assert sample != init_waveform[index]
         assert len(waveforms) == test_num_channels * test_num_records_to_fetch
 
         expected_channels = test_channels.split(',') * test_num_records_to_fetch

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -388,13 +388,14 @@ class TestLibrary(SystemTests):
         return {}
 
     # not supported by grpc due to numpy usage
-    @pytest.mark.parametrize("fetch_waveform_type,type_min_value",
+    @pytest.mark.parametrize(
+        "fetch_waveform_type,type_min_value",
         [
             (numpy.int8, numpy.iinfo(numpy.int8).min),
             (numpy.int16, numpy.iinfo(numpy.int16).min),
             (numpy.int32, numpy.iinfo(numpy.int32).min),
-            (numpy.float64, numpy.finfo(numpy.float64).min)
-        ]
+            (numpy.float64, numpy.finfo(numpy.float64).min),
+        ],
     )
     def test_fetch_into(self, multi_instrument_session, fetch_waveform_type, type_min_value):
         test_voltage = 1.0


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

[numpy 1.24 changed the array fill behavior](https://numpy.org/doc/stable/release/1.24.0-notes.html#array-fill-scalar-may-behave-slightly-different). As a result, the niscope system tests began raising an error:

>       waveform.fill(float('nan'))
>E       ValueError: cannot convert float NaN to integer

This PR changes `test_fetch_into` to no longer use waveform.fill(float('nan')). This was being done to confirm that all values were updated by the driver. Instead, the test will fill with the min supported value for the type and compare initial and final versions of the waveform to confirm that every sample has changed.

### List issues fixed by this Pull Request below, if any.

### What testing has been done?

Ran system tests.
