### PR TITLE
Add set_runtime_environment to nidcpower LibraryInterpreter class

### DIFF
--- a/generated/nidcpower/nidcpower/_grpc_stub_interpreter.py
+++ b/generated/nidcpower/nidcpower/_grpc_stub_interpreter.py
@@ -481,6 +481,9 @@ class GrpcStubInterpreter(object):
             grpc_types.SetAttributeViStringRequest(vi=self._vi, channel_name=channel_name, attribute_id=attribute_id, attribute_value_raw=attribute_value),
         )
 
+    def set_runtime_environment(self, environment, environment_version, reserved1, reserved2):  # noqa: N802
+        raise NotImplementedError('set_runtime_environment is not supported over gRPC')
+
     def set_sequence(self, channel_name, values, source_delays):  # noqa: N802
         self._invoke(
             self._client.SetSequence,

--- a/generated/nidcpower/nidcpower/_library_interpreter.py
+++ b/generated/nidcpower/nidcpower/_library_interpreter.py
@@ -666,6 +666,15 @@ class LibraryInterpreter(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
+    def set_runtime_environment(self, environment, environment_version, reserved1, reserved2):  # noqa: N802
+        environment_ctype = ctypes.create_string_buffer(environment.encode(self._encoding))  # case C020
+        environment_version_ctype = ctypes.create_string_buffer(environment_version.encode(self._encoding))  # case C020
+        reserved1_ctype = ctypes.create_string_buffer(reserved1.encode(self._encoding))  # case C020
+        reserved2_ctype = ctypes.create_string_buffer(reserved2.encode(self._encoding))  # case C020
+        error_code = self._library.niDCPower_SetRuntimeEnvironment(environment_ctype, environment_version_ctype, reserved1_ctype, reserved2_ctype)
+        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
+        return
+
     def set_sequence(self, channel_name, values, source_delays):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         channel_name_ctype = ctypes.create_string_buffer(channel_name.encode(self._encoding))  # case C010

--- a/src/nidcpower/metadata/functions.py
+++ b/src/nidcpower/metadata/functions.py
@@ -3496,7 +3496,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'SetRuntimeEnvironment': {
-        'codegen_method': 'library-interpreter-and-library-only',
+        'codegen_method': 'private',
         'documentation': {
             'description': 'TBD'
         },

--- a/src/nidcpower/metadata/functions.py
+++ b/src/nidcpower/metadata/functions.py
@@ -3496,11 +3496,19 @@ functions = {
         'returns': 'ViStatus'
     },
     'SetRuntimeEnvironment': {
-        'codegen_method': 'library-only',
+        'codegen_method': 'library-interpreter-and-library-only',
         'documentation': {
             'description': 'TBD'
         },
         'included_in_proto': False,
+        'method_templates': [
+            {
+                'documentation_filename': 'none',
+                'library_interpreter_filename': 'default_method',
+                'method_python_name_suffix': '',
+                'session_filename': 'none'
+            }
+        ],
         'parameters': [
             {
                 'direction': 'in',


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- ~[] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
This change adds set_runtime_environment to the nidcpower LibraryInterpreter class, so that we don't have to handcode the ctype manipulation.

### List issues fixed by this Pull Request below, if any.

### What testing has been done?
None
