### PR TITLE
Fix niswitch multithreading test warnings

### DIFF
--- a/build/templates/tox-system_tests.ini.mako
+++ b/build/templates/tox-system_tests.ini.mako
@@ -105,6 +105,8 @@ passenv =
 
 [pytest]
 addopts = --verbose
+filterwarnings =
+   error::pytest.PytestUnhandledThreadExceptionWarning
 norecursedirs = .* build dist CVS _darcs {arch} *.egg venv
 junit_suite_name = nimi-python
 junit_family = xunit1

--- a/generated/nidcpower/tox-system_tests.ini
+++ b/generated/nidcpower/tox-system_tests.ini
@@ -60,6 +60,8 @@ passenv =
 
 [pytest]
 addopts = --verbose
+filterwarnings =
+   error::pytest.PytestUnhandledThreadExceptionWarning
 norecursedirs = .* build dist CVS _darcs {arch} *.egg venv
 junit_suite_name = nimi-python
 junit_family = xunit1

--- a/generated/nidigital/tox-system_tests.ini
+++ b/generated/nidigital/tox-system_tests.ini
@@ -68,6 +68,8 @@ passenv =
 
 [pytest]
 addopts = --verbose
+filterwarnings =
+   error::pytest.PytestUnhandledThreadExceptionWarning
 norecursedirs = .* build dist CVS _darcs {arch} *.egg venv
 junit_suite_name = nimi-python
 junit_family = xunit1

--- a/generated/nidmm/tox-system_tests.ini
+++ b/generated/nidmm/tox-system_tests.ini
@@ -60,6 +60,8 @@ passenv =
 
 [pytest]
 addopts = --verbose
+filterwarnings =
+   error::pytest.PytestUnhandledThreadExceptionWarning
 norecursedirs = .* build dist CVS _darcs {arch} *.egg venv
 junit_suite_name = nimi-python
 junit_family = xunit1

--- a/generated/nifake/tox-system_tests.ini
+++ b/generated/nifake/tox-system_tests.ini
@@ -68,6 +68,8 @@ passenv =
 
 [pytest]
 addopts = --verbose
+filterwarnings =
+   error::pytest.PytestUnhandledThreadExceptionWarning
 norecursedirs = .* build dist CVS _darcs {arch} *.egg venv
 junit_suite_name = nimi-python
 junit_family = xunit1

--- a/generated/nifgen/tox-system_tests.ini
+++ b/generated/nifgen/tox-system_tests.ini
@@ -68,6 +68,8 @@ passenv =
 
 [pytest]
 addopts = --verbose
+filterwarnings =
+   error::pytest.PytestUnhandledThreadExceptionWarning
 norecursedirs = .* build dist CVS _darcs {arch} *.egg venv
 junit_suite_name = nimi-python
 junit_family = xunit1

--- a/generated/nimodinst/tox-system_tests.ini
+++ b/generated/nimodinst/tox-system_tests.ini
@@ -58,6 +58,8 @@ passenv =
 
 [pytest]
 addopts = --verbose
+filterwarnings =
+   error::pytest.PytestUnhandledThreadExceptionWarning
 norecursedirs = .* build dist CVS _darcs {arch} *.egg venv
 junit_suite_name = nimi-python
 junit_family = xunit1

--- a/generated/niscope/tox-system_tests.ini
+++ b/generated/niscope/tox-system_tests.ini
@@ -68,6 +68,8 @@ passenv =
 
 [pytest]
 addopts = --verbose
+filterwarnings =
+   error::pytest.PytestUnhandledThreadExceptionWarning
 norecursedirs = .* build dist CVS _darcs {arch} *.egg venv
 junit_suite_name = nimi-python
 junit_family = xunit1

--- a/generated/nise/tox-system_tests.ini
+++ b/generated/nise/tox-system_tests.ini
@@ -58,6 +58,8 @@ passenv =
 
 [pytest]
 addopts = --verbose
+filterwarnings =
+   error::pytest.PytestUnhandledThreadExceptionWarning
 norecursedirs = .* build dist CVS _darcs {arch} *.egg venv
 junit_suite_name = nimi-python
 junit_family = xunit1

--- a/generated/niswitch/tox-system_tests.ini
+++ b/generated/niswitch/tox-system_tests.ini
@@ -60,6 +60,8 @@ passenv =
 
 [pytest]
 addopts = --verbose
+filterwarnings =
+   error::pytest.PytestUnhandledThreadExceptionWarning
 norecursedirs = .* build dist CVS _darcs {arch} *.egg venv
 junit_suite_name = nimi-python
 junit_family = xunit1

--- a/generated/nitclk/tox-system_tests.ini
+++ b/generated/nitclk/tox-system_tests.ini
@@ -66,6 +66,8 @@ passenv =
 
 [pytest]
 addopts = --verbose
+filterwarnings =
+   error::pytest.PytestUnhandledThreadExceptionWarning
 norecursedirs = .* build dist CVS _darcs {arch} *.egg venv
 junit_suite_name = nimi-python
 junit_family = xunit1

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -1069,7 +1069,7 @@ class SystemTests:
 
     def test_multi_threading_ivi_synchronized_wrapper_releases_lock(self, session):
         system_test_utilities.impl_test_multi_threading_ivi_synchronized_wrapper_releases_lock(
-            session)
+            session.abort)
 
 
 class TestLibrary(SystemTests):

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -1322,7 +1322,7 @@ Per Pin Pass Fail   : [[True, True], [False, False]]
 
     def test_multi_threading_ivi_synchronized_wrapper_releases_lock(self, multi_instrument_session):
         system_test_utilities.impl_test_multi_threading_ivi_synchronized_wrapper_releases_lock(
-            multi_instrument_session)
+            multi_instrument_session.abort)
 
 
 class TestLibrary(SystemTests):

--- a/src/nidmm/system_tests/test_system_nidmm.py
+++ b/src/nidmm/system_tests/test_system_nidmm.py
@@ -307,7 +307,7 @@ class SystemTests:
 
     def test_multi_threading_ivi_synchronized_wrapper_releases_lock(self, session):
         system_test_utilities.impl_test_multi_threading_ivi_synchronized_wrapper_releases_lock(
-            session)
+            session.abort)
 
 
 class TestLibrary(SystemTests):

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -481,7 +481,7 @@ class SystemTests:
 
     def test_multi_threading_ivi_synchronized_wrapper_releases_lock(self, session):
         system_test_utilities.impl_test_multi_threading_ivi_synchronized_wrapper_releases_lock(
-            session)
+            session.abort)
 
 
 class TestLibrary(SystemTests):

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -387,7 +387,7 @@ class SystemTests:
 
     def test_multi_threading_ivi_synchronized_wrapper_releases_lock(self, multi_instrument_session):
         system_test_utilities.impl_test_multi_threading_ivi_synchronized_wrapper_releases_lock(
-            multi_instrument_session)
+            multi_instrument_session.abort)
 
 
 class TestLibrary(SystemTests):

--- a/src/niswitch/system_tests/test_system_niswitch.py
+++ b/src/niswitch/system_tests/test_system_niswitch.py
@@ -183,7 +183,7 @@ class SystemTests:
 
     def test_multi_threading_ivi_synchronized_wrapper_releases_lock(self, session):
         system_test_utilities.impl_test_multi_threading_ivi_synchronized_wrapper_releases_lock(
-            session)
+            session.self_test)
 
 
 class TestLibrary(SystemTests):

--- a/src/shared/system_test_utilities.py
+++ b/src/shared/system_test_utilities.py
@@ -85,10 +85,10 @@ def impl_test_multi_threading_lock_unlock(session):
     assert not t1.is_alive()
     assert not t2.is_alive()
 
-def impl_test_multi_threading_ivi_synchronized_wrapper_releases_lock(session):
+def impl_test_multi_threading_ivi_synchronized_wrapper_releases_lock(ivi_method_to_call):
     # test that the 2nd thread doesn't hang
-    t1 = threading.Thread(target=session.abort)
-    t2 = threading.Thread(target=session.abort)
+    t1 = threading.Thread(target=ivi_method_to_call)
+    t2 = threading.Thread(target=ivi_method_to_call)
 
     t1.start()
     t1.join()


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- [X] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

The [`test_multi_threading_ivi_synchronized_wrapper_releases_lock` test in niswitch system tests is currently raising `pytest.PytestUnhandledThreadExceptionWarning`](https://github.com/ni/nimi-python/actions/runs/4567686137/jobs/8209768533) in Python 3.8 (earliest version where pytest catches these exceptions) and later due to ` niswitch.errors.DriverError: -1074135023: IVI: Function or method not supported.`. This is caused by the simulated device not supporting abort. The other simulated device typically used in niswitch system tests supports abort but will also raise a DriverError if called immediately after initialization due to no scans being in progress.

This change does 2 things:
* Updates tox-system_tests.ini so that `pytest.PytestUnhandledThreadExceptionWarning` will be elevated to an error and fail a test that causes it
* Updates `impl_test_multi_threading_ivi_synchronized_wrapper_releases_lock` to accept the method to call, instead of the session
  * niswitch system tests will call `session.self_test`
  * other apis will continue to call `session.abort`

### List issues fixed by this Pull Request below, if any.

### What testing has been done?
* Manually tested that the tox change would result in test failures for niswitch.
* Manually tested that the test change would fix the niswitch test failures