### PR TITLE
Skip test_lcr_custom_cable_compensation_data

### DIFF
--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -1027,6 +1027,7 @@ class SystemTests:
     def test_perform_lcr_open_short_custom_cable_compensation(self, session, compensation_function):
         compensation_function(session)
 
+    @pytest.mark.skip(reason="TODO(jfitzger): Skip until we have a way to successfully call configure with a simulated device. GitHub issue #1908")
     @pytest.mark.resource_name("4190/0")
     @pytest.mark.options("Simulate=1, DriverSetup=Model:4190; BoardType:PXIe")
     def test_lcr_custom_cable_compensation_data(self, session):


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
**TL;DR**: This disables a test as a pre-requisite for updating nimibot driver runtimes.

-----------------------

The nidcpower system test `test_lcr_custom_cable_compensation_data` fails with the latest driver runtime as documented in #1908.

@marcoskirch and I discussed this offline and agreed to disable the test for now.

As part of the process for updating driver runtimes, we clone the nimi-python repo and run the system tests with the updated driver runtimes. If this fails, it will prevent us from deploying the driver runtime changes.

Therefore we must disable this test **before** we update our driver runtimes.

### List issues fixed by this Pull Request below, if any.

### What testing has been done?
None