### PR TITLE
Use allowlist_externals, instead of whitelist_externals

### DIFF
--- a/tox-travis.ini
+++ b/tox-travis.ini
@@ -156,7 +156,7 @@ depends =
     test: py310-installers
     pkg: py310-installers
 
-whitelist_externals =
+allowlist_externals =
     build_test: mv
     test: mv
     codegen: make

--- a/tox.ini
+++ b/tox.ini
@@ -156,7 +156,7 @@ depends =
     test: py310-installers
     pkg: py310-installers
 
-whitelist_externals =
+allowlist_externals =
     build_test: mv
     test: mv
     codegen: make


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
Use "allowlist_externals", instead of "whitelist_externals" in our tox inis.

"whitelist_externals" externals was deprecated in tox 3.18 in favor of "allowlist_externals" which works the exact same way. "whitelist_externals" is no longer supported in tox 4.

Notes:
- It turns out we're actually installing tox 4.4 in our nimibot github-runners.
  - If we were doing more than just running our system tests, we would probably be failing without this change.
- travis-ci is still using tox 3.x and can't upgrade to 4.x due to incompatibility with tox-travis. See #1876. However, it's using tox 3.28 which supports allowlist_externals.
- My local WSL installation has tox 4.4 installed natively and I had to do a special installation of tox 3. In order to use that one instead of tox 4, I have to use `sudo`. Entering a password everytime I run tox is driving me crazy.

### List issues fixed by this Pull Request below, if any.

### What testing has been done?
None. If travis-ci and the other checks pass, then it's good.