### PR TITLE
Remove mentions of python3.4; no longer supported

### DIFF
--- a/build/templates/setup.py.mako
+++ b/build/templates/setup.py.mako
@@ -48,8 +48,6 @@ setup(
     include_package_data=True,
     packages=['${config['module_name']}'],
     install_requires=[
-        'enum34;python_version<"3.4"',
-        'singledispatch;python_version<"3.4"',
         'hightime>=0.2.0',
         % if config['uses_nitclk']:
         'nitclk',

--- a/generated/nidcpower/setup.py
+++ b/generated/nidcpower/setup.py
@@ -43,8 +43,6 @@ setup(
     include_package_data=True,
     packages=['nidcpower'],
     install_requires=[
-        'enum34;python_version<"3.4"',
-        'singledispatch;python_version<"3.4"',
         'hightime>=0.2.0',
     ],
     setup_requires=['pytest-runner', ],

--- a/generated/nidigital/setup.py
+++ b/generated/nidigital/setup.py
@@ -43,8 +43,6 @@ setup(
     include_package_data=True,
     packages=['nidigital'],
     install_requires=[
-        'enum34;python_version<"3.4"',
-        'singledispatch;python_version<"3.4"',
         'hightime>=0.2.0',
         'nitclk',
     ],

--- a/generated/nidmm/setup.py
+++ b/generated/nidmm/setup.py
@@ -43,8 +43,6 @@ setup(
     include_package_data=True,
     packages=['nidmm'],
     install_requires=[
-        'enum34;python_version<"3.4"',
-        'singledispatch;python_version<"3.4"',
         'hightime>=0.2.0',
     ],
     setup_requires=['pytest-runner', ],

--- a/generated/nifake/setup.py
+++ b/generated/nifake/setup.py
@@ -43,8 +43,6 @@ setup(
     include_package_data=True,
     packages=['nifake'],
     install_requires=[
-        'enum34;python_version<"3.4"',
-        'singledispatch;python_version<"3.4"',
         'hightime>=0.2.0',
         'nitclk',
     ],

--- a/generated/nifgen/setup.py
+++ b/generated/nifgen/setup.py
@@ -43,8 +43,6 @@ setup(
     include_package_data=True,
     packages=['nifgen'],
     install_requires=[
-        'enum34;python_version<"3.4"',
-        'singledispatch;python_version<"3.4"',
         'hightime>=0.2.0',
         'nitclk',
     ],

--- a/generated/nimodinst/setup.py
+++ b/generated/nimodinst/setup.py
@@ -43,8 +43,6 @@ setup(
     include_package_data=True,
     packages=['nimodinst'],
     install_requires=[
-        'enum34;python_version<"3.4"',
-        'singledispatch;python_version<"3.4"',
         'hightime>=0.2.0',
     ],
     setup_requires=['pytest-runner', ],

--- a/generated/niscope/setup.py
+++ b/generated/niscope/setup.py
@@ -43,8 +43,6 @@ setup(
     include_package_data=True,
     packages=['niscope'],
     install_requires=[
-        'enum34;python_version<"3.4"',
-        'singledispatch;python_version<"3.4"',
         'hightime>=0.2.0',
         'nitclk',
     ],

--- a/generated/nise/setup.py
+++ b/generated/nise/setup.py
@@ -43,8 +43,6 @@ setup(
     include_package_data=True,
     packages=['nise'],
     install_requires=[
-        'enum34;python_version<"3.4"',
-        'singledispatch;python_version<"3.4"',
         'hightime>=0.2.0',
     ],
     setup_requires=['pytest-runner', ],

--- a/generated/niswitch/setup.py
+++ b/generated/niswitch/setup.py
@@ -43,8 +43,6 @@ setup(
     include_package_data=True,
     packages=['niswitch'],
     install_requires=[
-        'enum34;python_version<"3.4"',
-        'singledispatch;python_version<"3.4"',
         'hightime>=0.2.0',
     ],
     setup_requires=['pytest-runner', ],

--- a/generated/nitclk/setup.py
+++ b/generated/nitclk/setup.py
@@ -43,8 +43,6 @@ setup(
     include_package_data=True,
     packages=['nitclk'],
     install_requires=[
-        'enum34;python_version<"3.4"',
-        'singledispatch;python_version<"3.4"',
         'hightime>=0.2.0',
     ],
     setup_requires=['pytest-runner', ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-
-enum34==1.1.6 ; python_version < "3.4"
-


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
There are useless Python 3.4 requirements lingering in the repo. nimi-python no longer supports Python 3.4.

This change deletes those Python 3.4 requirements.

### List issues fixed by this Pull Request below, if any.

### What testing has been done?
None
