### PR TITLE
Exclude gprcio 1.53 from test dependencies to fix win32 system test failures

### DIFF
--- a/build/templates/tox-system_tests.ini.mako
+++ b/build/templates/tox-system_tests.ini.mako
@@ -82,7 +82,7 @@ deps =
     ${module_name}-system_tests: fasteners
     ${module_name}-system_tests: pytest-json
 % if grpc_supported:
-    ${module_name}-system_tests: grpcio
+    ${module_name}-system_tests: grpcio != 1.53 # no Python 3.7 win32 wheel
     ${module_name}-system_tests: protobuf
 % endif
 

--- a/generated/nidcpower/tox-system_tests.ini
+++ b/generated/nidcpower/tox-system_tests.ini
@@ -41,7 +41,7 @@ deps =
     nidcpower-system_tests: hightime
     nidcpower-system_tests: fasteners
     nidcpower-system_tests: pytest-json
-    nidcpower-system_tests: grpcio
+    nidcpower-system_tests: grpcio != 1.53 # no Python 3.7 win32 wheel
     nidcpower-system_tests: protobuf
 
     nidcpower-coverage: coverage

--- a/generated/nidigital/tox-system_tests.ini
+++ b/generated/nidigital/tox-system_tests.ini
@@ -48,7 +48,7 @@ deps =
     nidigital-system_tests: hightime
     nidigital-system_tests: fasteners
     nidigital-system_tests: pytest-json
-    nidigital-system_tests: grpcio
+    nidigital-system_tests: grpcio != 1.53 # no Python 3.7 win32 wheel
     nidigital-system_tests: protobuf
 
     nidigital-coverage: coverage

--- a/generated/nidmm/tox-system_tests.ini
+++ b/generated/nidmm/tox-system_tests.ini
@@ -41,7 +41,7 @@ deps =
     nidmm-system_tests: hightime
     nidmm-system_tests: fasteners
     nidmm-system_tests: pytest-json
-    nidmm-system_tests: grpcio
+    nidmm-system_tests: grpcio != 1.53 # no Python 3.7 win32 wheel
     nidmm-system_tests: protobuf
 
     nidmm-coverage: coverage

--- a/generated/nifake/tox-system_tests.ini
+++ b/generated/nifake/tox-system_tests.ini
@@ -48,7 +48,7 @@ deps =
     nifake-system_tests: hightime
     nifake-system_tests: fasteners
     nifake-system_tests: pytest-json
-    nifake-system_tests: grpcio
+    nifake-system_tests: grpcio != 1.53 # no Python 3.7 win32 wheel
     nifake-system_tests: protobuf
 
     nifake-coverage: coverage

--- a/generated/nifgen/tox-system_tests.ini
+++ b/generated/nifgen/tox-system_tests.ini
@@ -48,7 +48,7 @@ deps =
     nifgen-system_tests: hightime
     nifgen-system_tests: fasteners
     nifgen-system_tests: pytest-json
-    nifgen-system_tests: grpcio
+    nifgen-system_tests: grpcio != 1.53 # no Python 3.7 win32 wheel
     nifgen-system_tests: protobuf
 
     nifgen-coverage: coverage

--- a/generated/niscope/tox-system_tests.ini
+++ b/generated/niscope/tox-system_tests.ini
@@ -48,7 +48,7 @@ deps =
     niscope-system_tests: hightime
     niscope-system_tests: fasteners
     niscope-system_tests: pytest-json
-    niscope-system_tests: grpcio
+    niscope-system_tests: grpcio != 1.53 # no Python 3.7 win32 wheel
     niscope-system_tests: protobuf
 
     niscope-coverage: coverage

--- a/generated/niswitch/tox-system_tests.ini
+++ b/generated/niswitch/tox-system_tests.ini
@@ -41,7 +41,7 @@ deps =
     niswitch-system_tests: hightime
     niswitch-system_tests: fasteners
     niswitch-system_tests: pytest-json
-    niswitch-system_tests: grpcio
+    niswitch-system_tests: grpcio != 1.53 # no Python 3.7 win32 wheel
     niswitch-system_tests: protobuf
 
     niswitch-coverage: coverage


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
[win32 system tests are failing](https://github.com/ni/nimi-python/actions/runs/4661450262/jobs/8250740177?pr=1916) due to the [absence of a win32 Python 3.7 wheel for grpcio 1.53.](https://pypi.org/simple/grpcio/)


>grpcio-1.53.0-cp311-cp311-win32.whl
grpcio-1.53.0-cp311-cp311-win_amd64.whl
grpcio-1.53.0-cp37-cp37m-linux_armv7l.whl
grpcio-1.53.0-cp37-cp37m-macosx_10_10_universal2.whl
grpcio-1.53.0-cp37-cp37m-manylinux_2_17_aarch64.whl
grpcio-1.53.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl
grpcio-1.53.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
grpcio-1.53.0-cp37-cp37m-musllinux_1_1_i686.whl
grpcio-1.53.0-cp37-cp37m-musllinux_1_1_x86_64.whl
grpcio-1.53.0-cp37-cp37m-win_amd64.whl
grpcio-1.53.0-cp38-cp38-linux_armv7l.whl

The runner lacks the necessary software to build the wheel from scratch.

In order to fix the test failures, this change simply excludes 1.53 from the versions of grpcio that we're willing to install from our test dependencies.

As part of #1916, we will ultimately do something nicer by only excluding 1.53 for Python 3.7, when we start providing optional dependencies.

### List issues fixed by this Pull Request below, if any.
None

### What testing has been done?
System Tests pass
