### PR TITLE
Implement nidcpower API parity with NI-DCPower 2023 Q2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,12 @@ All notable changes to this project will be documented in this file.
 * ### `nidcpower` (NI-DCPower)
     * #### Added
         * Pass Python interpreter information if the driver runtime version supports it. This is used by NI in order to better understand client usage.
-        * API parity with NI-DCPower 2023 Q1.
+        * API parity with NI-DCPower 2023 Q2.
             * Properties added:
+                * `lcr_ac_dither_enabled`
+                * `lcr_ac_electrical_cable_length_delay`
+                * `lcr_dc_bias_transient_response`
+                * `lcr_source_aperture_time`
                 * `measure_complete_event_output_behavior`
                 * `measure_complete_event_toggle_initial_state`
                 * `sequence_engine_done_event_output_behavior`
@@ -54,8 +58,10 @@ All notable changes to this project will be documented in this file.
                 * `CurrentLimitBehavior`
                 * `EventOutputBehavior`
                 * `EventToggleInitialState`
+                * `LCRDCBiasTransientResponse`
             * Enum values added:
                 * `AS_CONFIGURED` added to enum `LCROpenShortLoadCompensationDataSource`
+                * `NI_STANDARD_0_5M` added to enum `CableLength`
             * Methods added:
                 * `configure_lcr_compensation`
                 * `get_lcr_compensation_data`

--- a/docs/nidcpower/class.rst
+++ b/docs/nidcpower/class.rst
@@ -5054,6 +5054,88 @@ lcr_actual_load_resistance
                 - LabVIEW Property: **LCR:Compensation:LCR Actual Load Resistance**
                 - C Attribute: **NIDCPOWER_ATTR_LCR_ACTUAL_LOAD_RESISTANCE**
 
+lcr_ac_dither_enabled
+---------------------
+
+    .. py:attribute:: lcr_ac_dither_enabled
+
+        Specifies whether dithering is enabled during LCR measurements.
+        Dithering adds out-of-band noise to improve measurements of small voltage and current signals.
+
+
+
+        .. note:: Hardware is only warranted to meet its accuracy specs with dither enabled. You can disable dither if the added noise interferes with your device-under-test.
+
+            This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].lcr_ac_dither_enabled`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.lcr_ac_dither_enabled`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | bool       |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **LCR:AC Stimulus:Advanced:Dither Enabled**
+                - C Attribute: **NIDCPOWER_ATTR_LCR_AC_DITHER_ENABLED**
+
+lcr_ac_electrical_cable_length_delay
+------------------------------------
+
+    .. py:attribute:: lcr_ac_electrical_cable_length_delay
+
+        Specifies the one-way electrical length delay of the cable, in seconds.
+        The default value depends on :py:attr:`nidcpower.Session.cable_length`.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].lcr_ac_electrical_cable_length_delay`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.lcr_ac_electrical_cable_length_delay`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **LCR:Compensation:LCR AC Electrical Cable Length Delay**
+                - C Attribute: **NIDCPOWER_ATTR_LCR_AC_ELECTRICAL_CABLE_LENGTH_DELAY**
+
 lcr_automatic_level_control
 ---------------------------
 
@@ -5377,6 +5459,49 @@ lcr_dc_bias_source
 
                 - LabVIEW Property: **LCR:DC Bias:Source**
                 - C Attribute: **NIDCPOWER_ATTR_LCR_DC_BIAS_SOURCE**
+
+lcr_dc_bias_transient_response
+------------------------------
+
+    .. py:attribute:: lcr_dc_bias_transient_response
+
+        For instruments in LCR mode, determines whether NI-DCPower automatically calculates and applies the transient response values for DC bias or applies the transient response you set manually.
+
+        Default Value: Search ni.com for Supported Properties by Device for the default value by instrument.
+
+        Related Topics: Transient Response
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].lcr_dc_bias_transient_response`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.lcr_dc_bias_transient_response`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+----------------------------------+
+            | Characteristic        | Value                            |
+            +=======================+==================================+
+            | Datatype              | enums.LCRDCBiasTransientResponse |
+            +-----------------------+----------------------------------+
+            | Permissions           | read-write                       |
+            +-----------------------+----------------------------------+
+            | Repeated Capabilities | channels                         |
+            +-----------------------+----------------------------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **LCR:DC Bias:Advanced:Transient Response**
+                - C Attribute: **NIDCPOWER_ATTR_LCR_DC_BIAS_TRANSIENT_RESPONSE**
 
 lcr_dc_bias_voltage_level
 -------------------------
@@ -6256,6 +6381,45 @@ lcr_short_resistance
 
                 - LabVIEW Property: **LCR:Compensation:Short:Resistance**
                 - C Attribute: **NIDCPOWER_ATTR_LCR_SHORT_RESISTANCE**
+
+lcr_source_aperture_time
+------------------------
+
+    .. py:attribute:: lcr_source_aperture_time
+
+        Specifies the LCR source aperture time for a channel, in seconds.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].lcr_source_aperture_time`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.lcr_source_aperture_time`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **LCR:AC Stimulus:Advanced:Source Aperture Time**
+                - C Attribute: **NIDCPOWER_ATTR_LCR_SOURCE_APERTURE_TIME**
 
 lcr_source_delay_mode
 ---------------------

--- a/docs/nidcpower/enums.rst
+++ b/docs/nidcpower/enums.rst
@@ -241,6 +241,16 @@ CableLength
 
 
 
+    .. py:attribute:: CableLength.NI_STANDARD_0_5M
+
+
+
+        Uses predefined cable compensation data for an NI standard 0.5m coaxial cable.
+
+        
+
+
+
     .. py:attribute:: CableLength.NI_STANDARD_1M
 
 
@@ -621,6 +631,31 @@ LCRDCBiasSource
 
 
         Applies a constant current bias, as defined by the :py:attr:`nidcpower.Session.lcr_dc_bias_current_level` property.
+
+        
+
+
+
+LCRDCBiasTransientResponse
+--------------------------
+
+.. py:class:: LCRDCBiasTransientResponse
+
+    .. py:attribute:: LCRDCBiasTransientResponse.NORMAL
+
+
+
+        NI-DCPower automatically applies transient response values for DC bias.
+
+        
+
+
+
+    .. py:attribute:: LCRDCBiasTransientResponse.CUSTOM
+
+
+
+        NI-DCPower applies the transient response that you set manually with :py:attr:`nidcpower.Session.transient_response` for DC bias. Search ni.com for information on configuring transient response.
 
         
 

--- a/generated/nidcpower/nidcpower/enums.py
+++ b/generated/nidcpower/nidcpower/enums.py
@@ -103,6 +103,10 @@ class CableLength(Enum):
     r'''
     Uses predefined cable compensation data for a 0m cable (direct connection).
     '''
+    NI_STANDARD_0_5M = 1153
+    r'''
+    Uses predefined cable compensation data for an NI standard 0.5m coaxial cable.
+    '''
     NI_STANDARD_1M = 1122
     r'''
     Uses predefined cable compensation data for an NI standard 1m coaxial cable.
@@ -276,6 +280,17 @@ class LCRDCBiasSource(Enum):
     CURRENT = 1067
     r'''
     Applies a constant current bias, as defined by the lcr_dc_bias_current_level property.
+    '''
+
+
+class LCRDCBiasTransientResponse(Enum):
+    NORMAL = 1151
+    r'''
+    NI-DCPower automatically applies transient response values for DC bias.
+    '''
+    CUSTOM = 1152
+    r'''
+    NI-DCPower applies the transient response that you set manually with transient_response for DC bias. Search ni.com for information on configuring transient response.
     '''
 
 

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -1135,6 +1135,46 @@ class _SessionBase(object):
 
     Example: :py:attr:`my_session.lcr_actual_load_resistance`
     '''
+    lcr_ac_dither_enabled = _attributes.AttributeViBoolean(1150348)
+    '''Type: bool
+
+    Specifies whether dithering is enabled during LCR measurements.
+    Dithering adds out-of-band noise to improve measurements of small voltage and current signals.
+
+    Note:
+    Hardware is only warranted to meet its accuracy specs with dither enabled. You can disable dither if the added noise interferes with your device-under-test.
+
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].lcr_ac_dither_enabled`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.lcr_ac_dither_enabled`
+    '''
+    lcr_ac_electrical_cable_length_delay = _attributes.AttributeViReal64(1150309)
+    '''Type: float
+
+    Specifies the one-way electrical length delay of the cable, in seconds.
+    The default value depends on cable_length.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].lcr_ac_electrical_cable_length_delay`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.lcr_ac_electrical_cable_length_delay`
+    '''
     lcr_automatic_level_control = _attributes.AttributeViInt32(1150290)
     '''Type: bool
 
@@ -1290,6 +1330,28 @@ class _SessionBase(object):
     To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
 
     Example: :py:attr:`my_session.lcr_dc_bias_source`
+    '''
+    lcr_dc_bias_transient_response = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.LCRDCBiasTransientResponse, 1150347)
+    '''Type: enums.LCRDCBiasTransientResponse
+
+    For instruments in LCR mode, determines whether NI-DCPower automatically calculates and applies the transient response values for DC bias or applies the transient response you set manually.
+
+    Default Value: Search ni.com for Supported Properties by Device for the default value by instrument.
+
+    Related Topics: Transient Response
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].lcr_dc_bias_transient_response`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.lcr_dc_bias_transient_response`
     '''
     lcr_dc_bias_voltage_level = _attributes.AttributeViReal64(1150214)
     '''Type: float
@@ -1731,6 +1793,24 @@ class _SessionBase(object):
     To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
 
     Example: :py:attr:`my_session.lcr_short_resistance`
+    '''
+    lcr_source_aperture_time = _attributes.AttributeViReal64(1150349)
+    '''Type: float
+
+    Specifies the LCR source aperture time for a channel, in seconds.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].lcr_source_aperture_time`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.lcr_source_aperture_time`
     '''
     lcr_source_delay_mode = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.LCRSourceDelayMode, 1150315)
     '''Type: enums.LCRSourceDelayMode

--- a/src/nidcpower/metadata/attributes.py
+++ b/src/nidcpower/metadata/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 23.5.0d58
+# This file is generated from NI-DCPower API metadata version 23.5.0d79
 attributes = {
     1050003: {
         'access': 'read-write',
@@ -2385,6 +2385,19 @@ attributes = {
         'type': 'ViInt32',
         'type_in_documentation': 'bool'
     },
+    1150309: {
+        'access': 'read-write',
+        'documentation': {
+            'description': '\nSpecifies the one-way electrical length delay of the cable, in seconds.\nThe default value depends on NIDCPOWER_ATTR_CABLE_LENGTH.\n',
+            'note': '\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device.\n'
+        },
+        'lv_property': 'LCR:Compensation:LCR AC Electrical Cable Length Delay',
+        'name': 'LCR_AC_ELECTRICAL_CABLE_LENGTH_DELAY',
+        'supported_rep_caps': [
+            'channels'
+        ],
+        'type': 'ViReal64'
+    },
     1150314: {
         'access': 'read-write',
         'documentation': {
@@ -2600,6 +2613,46 @@ attributes = {
             'channels'
         ],
         'type': 'ViInt32'
+    },
+    1150347: {
+        'access': 'read-write',
+        'documentation': {
+            'description': '\nFor instruments in LCR mode, determines whether NI-DCPower automatically calculates and applies the transient response values for DC bias or applies the transient response you set manually.\n\nDefault Value: Search ni.com for Supported Attributes by Device for the default value by instrument.\n\nRelated Topics: Transient Response\n',
+            'note': '\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device.\n'
+        },
+        'enum': 'LCRDCBiasTransientResponse',
+        'lv_property': 'LCR:DC Bias:Advanced:Transient Response',
+        'name': 'LCR_DC_BIAS_TRANSIENT_RESPONSE',
+        'supported_rep_caps': [
+            'channels'
+        ],
+        'type': 'ViInt32'
+    },
+    1150348: {
+        'access': 'read-write',
+        'documentation': {
+            'description': '\nSpecifies whether dithering is enabled during LCR measurements.\nDithering adds out-of-band noise to improve measurements of small voltage and current signals.\n',
+            'note': '\nHardware is only warranted to meet its accuracy specs with dither enabled. You can disable dither if the added noise interferes with your device-under-test.\n\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device.\n'
+        },
+        'lv_property': 'LCR:AC Stimulus:Advanced:Dither Enabled',
+        'name': 'LCR_AC_DITHER_ENABLED',
+        'supported_rep_caps': [
+            'channels'
+        ],
+        'type': 'ViBoolean'
+    },
+    1150349: {
+        'access': 'read-write',
+        'documentation': {
+            'description': '\nSpecifies the LCR source aperture time for a channel, in seconds.\n',
+            'note': '\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device.\n'
+        },
+        'lv_property': 'LCR:AC Stimulus:Advanced:Source Aperture Time',
+        'name': 'LCR_SOURCE_APERTURE_TIME',
+        'supported_rep_caps': [
+            'channels'
+        ],
+        'type': 'ViReal64'
     },
     1250001: {
         'access': 'read-write',

--- a/src/nidcpower/metadata/config.py
+++ b/src/nidcpower/metadata/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 23.5.0d58
+# This file is generated from NI-DCPower API metadata version 23.5.0d79
 config = {
-    'api_version': '23.5.0d58',
+    'api_version': '23.5.0d79',
     'c_function_prefix': 'niDCPower_',
     'close_function': 'close',
     'context_manager_name': {

--- a/src/nidcpower/metadata/enums.py
+++ b/src/nidcpower/metadata/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 23.5.0d58
+# This file is generated from NI-DCPower API metadata version 23.5.0d79
 enums = {
     'ApertureTimeAutoMode': {
         'values': [
@@ -166,6 +166,13 @@ enums = {
                 },
                 'name': 'NIDCPOWER_VAL_ZERO_M',
                 'value': 1121
+            },
+            {
+                'documentation': {
+                    'description': 'Uses predefined cable compensation data for an NI standard 0.5m coaxial cable.'
+                },
+                'name': 'NIDCPOWER_VAL_NI_STANDARD_0_5M',
+                'value': 1153
             },
             {
                 'documentation': {
@@ -577,6 +584,24 @@ enums = {
                 },
                 'name': 'NIDCPOWER_VAL_DC_BIAS_CURRENT',
                 'value': 1067
+            }
+        ]
+    },
+    'LCRDCBiasTransientResponse': {
+        'values': [
+            {
+                'documentation': {
+                    'description': 'NI-DCPower automatically applies transient response values for DC bias.'
+                },
+                'name': 'NIDCPOWER_VAL_LCR_DC_BIAS_TRANSIENT_RESPONSE_NORMAL',
+                'value': 1151
+            },
+            {
+                'documentation': {
+                    'description': 'NI-DCPower applies the transient response that you set manually with NIDCPOWER_ATTR_TRANSIENT_RESPONSE for DC bias. Search ni.com for information on configuring transient response.'
+                },
+                'name': 'NIDCPOWER_VAL_LCR_DC_BIAS_TRANSIENT_RESPONSE_CUSTOM',
+                'value': 1152
             }
         ]
     },

--- a/src/nidcpower/metadata/functions.py
+++ b/src/nidcpower/metadata/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 23.5.0d58
+# This file is generated from NI-DCPower API metadata version 23.5.0d79
 functions = {
     'AbortWithChannels': {
         'documentation': {


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- ~[ ] I've added tests applicable for this pull request~
  - No new methods added to warrant a new test

### What does this Pull Request accomplish?
- Add entrypoints for NI-DCPower 23.3 driver runtime

### List issues fixed by this Pull Request below, if any.
None

### What testing has been done?
Just manual analysis
1. At the time of internal metadata updates, a diff of nidcpower.h was analyzed for changes
>Analysis of Diff
>
>Added Attributes (all enabled by this changed)
>* NIDCPOWER_ATTR_LCR_AC_ELECTRICAL_CABLE_LENGTH_DELAY: enabled by this change
>* NIDCPOWER_ATTR_LCR_DC_BIAS_TRANSIENT_RESPONSE
>* NIDCPOWER_ATTR_LCR_AC_DITHER_ENABLED
>* NIDCPOWER_ATTR_LCR_SOURCE_APERTURE_TIME
>
>Added Enums / Enum Values (all enabled by this change)
>* NIDCPOWER_VAL_NI_STANDARD_0_5M (value for NIDCPOWER_ATTR_CABLE_LENGTH)
>* NIDCPOWER_ATTR_LCR_DC_BIAS_TRANSIENT_RESPONSE (enum)
>   * NIDCPOWER_VAL_LCR_DC_BIAS_TRANSIENT_RESPONSE_NORMAL
>   * NIDCPOWER_VAL_LCR_DC_BIAS_TRANSIENT_RESPONSE_CUSTOM
>
>Reordered Enum Values (Change already consumed by nimi-python repo)
>* NIDCPOWER_VAL_CUSTOM_ONBOARD_STORAGE (value for NIDCPOWER_ATTR_CABLE_LENGTH)
>* NIDCPOWER_VAL_CUSTOM_AS_CONFIGURED (value for NIDCPOWER_ATTR_CABLE_LENGTH)

2. When updating the CHANGELOG, each change seen in the .rsts was listed
3. Every change from the nidcpower.h diff analysis is represented in the CHANGELOG