### PR TITLE
Enable niscope cal time and temperature tests for TestGrpc

### DIFF
--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -278,6 +278,30 @@ class SystemTests:
     def test_self_cal(self, multi_instrument_session):
         multi_instrument_session.self_cal(niscope.Option.SELF_CALIBRATE_ALL_CHANNELS)
 
+    def test_get_self_cal_last_date_time(self, single_instrument_session):
+        last_cal = single_instrument_session.get_self_cal_last_date_and_time()
+        assert last_cal.month == 12
+        assert last_cal.day == 21
+        assert last_cal.year == 1999
+        assert last_cal.hour == 0
+        assert last_cal.minute == 0
+
+    def test_get_ext_cal_last_date_time(self, single_instrument_session):
+        last_cal = single_instrument_session.get_ext_cal_last_date_and_time()
+        assert last_cal.month == 12
+        assert last_cal.day == 21
+        assert last_cal.year == 1999
+        assert last_cal.hour == 0
+        assert last_cal.minute == 0
+
+    def test_get_self_cal_last_temperature(self, single_instrument_session):
+        last_cal_temp = single_instrument_session.get_self_cal_last_temp()
+        assert last_cal_temp == 25
+
+    def test_get_ext_cal_last_temperature(self, single_instrument_session):
+        last_cal_temp = single_instrument_session.get_ext_cal_last_temp()
+        assert last_cal_temp == 25
+
     def test_probe_compensation_signal(self, multi_instrument_session):
         multi_instrument_session.probe_compensation_signal_start()
         multi_instrument_session.probe_compensation_signal_stop()
@@ -437,31 +461,6 @@ class TestLibrary(SystemTests):
                 assert record_wfm[j] == waveform[i * test_record_length + j]
             assert waveforms[i].channel == expected_channels[i]
             assert waveforms[i].record == expected_records[i]
-
-    # TODO(danestull): Move these next 4 tests back to the general system tests once added to grpc-device
-    def test_get_self_cal_last_date_time(self, single_instrument_session):
-        last_cal = single_instrument_session.get_self_cal_last_date_and_time()
-        assert last_cal.month == 12
-        assert last_cal.day == 21
-        assert last_cal.year == 1999
-        assert last_cal.hour == 0
-        assert last_cal.minute == 0
-
-    def test_get_ext_cal_last_date_time(self, single_instrument_session):
-        last_cal = single_instrument_session.get_ext_cal_last_date_and_time()
-        assert last_cal.month == 12
-        assert last_cal.day == 21
-        assert last_cal.year == 1999
-        assert last_cal.hour == 0
-        assert last_cal.minute == 0
-
-    def test_get_self_cal_last_temperature(self, single_instrument_session):
-        last_cal_temp = single_instrument_session.get_self_cal_last_temp()
-        assert last_cal_temp == 25
-
-    def test_get_ext_cal_last_temperature(self, single_instrument_session):
-        last_cal_temp = single_instrument_session.get_ext_cal_last_temp()
-        assert last_cal_temp == 25
 
     def test_configure_ref_levels(self, single_instrument_session):
         single_instrument_session._configure_ref_levels()


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- [X] I've added tests applicable for this pull request

### What does this Pull Request accomplish?
Enable the following tests for TestGrpc:
- `test_get_self_cal_last_date_time`
- `test_get_ext_cal_last_date_time`
- `test_get_self_cal_last_temperature`
- `test_get_ext_cal_last_temperature`

### List issues fixed by this Pull Request below, if any.
None

### What testing has been done?
Ran the tests on a local machine