### PR TITLE
Add Grpc tests for recently added nidcpower methods

### DIFF
--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -1109,3 +1109,15 @@ class TestGrpc(SystemTests):
     def session_creation_kwargs(self, grpc_channel):
         grpc_options = nidcpower.GrpcSessionOptions(grpc_channel, "")
         return {'grpc_options': grpc_options}
+
+    def test_get_lcr_compensation_data(self, session):
+        with pytest.raises(NotImplementedError) as exc_info:
+            session.get_lcr_compensation_data()
+        assert exc_info.value.args[0] == 'get_lcr_compensation_data is not supported over gRPC'
+        assert str(exc_info.value) == 'get_lcr_compensation_data is not supported over gRPC'
+
+    def test_configure_lcr_compensation(self, session):
+        with pytest.raises(NotImplementedError) as exc_info:
+            session.configure_lcr_compensation([])
+        assert exc_info.value.args[0] == 'configure_lcr_compensation is not supported over gRPC'
+        assert str(exc_info.value) == 'configure_lcr_compensation is not supported over gRPC'


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- [X] I've added tests applicable for this pull request

### What does this Pull Request accomplish?
Add tests to TestGrpc for `get_lcr_compensation_data`, `configure_lcr_compensation` to confirm that we error properly.

This is just a consistency thing. We have similar tests for unsupported methods in niscope.

### List issues fixed by this Pull Request below, if any.
None

### What testing has been done?
Ran the tests on a local machine.