### PR TITLE
nidigital: Update GRPC_SERVICE_INTERFACE_NAME to use correct gRPC package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ All notable changes to this project will be documented in this file.
 * ### `nidigital` (NI-Digital Pattern Driver)
     * #### Added
     * #### Changed
+        * Update `GRPC_SERVICE_INTERFACE_NAME` to use the correct gRPC package name (`nidigitalpattern_grpc`).
     * #### Removed
 * ### `nidmm` (NI-DMM)
     * #### Added

--- a/build/templates/grpc_session_options.py.mako
+++ b/build/templates/grpc_session_options.py.mako
@@ -2,6 +2,8 @@ ${template_parameters['encoding_tag']}
 # This file was generated
 <%
     config = template_parameters['metadata'].config
+    module_name = config['module_name']
+    proto_name = config.get('proto_name', module_name)
 %>\
 
 from enum import IntEnum
@@ -9,7 +11,7 @@ from enum import IntEnum
 
 # This constant specifies the gRPC package and service used by this API.
 # Customers can pass this value to the MeasurementLink discovery service to resolve the server instance that provides this interface.
-GRPC_SERVICE_INTERFACE_NAME = '${config["module_name"]}_grpc.${config["grpc_service_class_prefix"]}'
+GRPC_SERVICE_INTERFACE_NAME = '${proto_name}_grpc.${config["grpc_service_class_prefix"]}'
 
 # This constant specifies the API license key required by the NI gRPC Device Server that comes with
 # MeasurementLink 2023 Q1.

--- a/generated/nidigital/nidigital/grpc_session_options.py
+++ b/generated/nidigital/nidigital/grpc_session_options.py
@@ -6,7 +6,7 @@ from enum import IntEnum
 
 # This constant specifies the gRPC package and service used by this API.
 # Customers can pass this value to the MeasurementLink discovery service to resolve the server instance that provides this interface.
-GRPC_SERVICE_INTERFACE_NAME = 'nidigital_grpc.NiDigital'
+GRPC_SERVICE_INTERFACE_NAME = 'nidigitalpattern_grpc.NiDigital'
 
 # This constant specifies the API license key required by the NI gRPC Device Server that comes with
 # MeasurementLink 2023 Q1.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

~~- [ ] I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

Update `nidigital.GRPC_SERVICE_INTERFACE_NAME` to use the correct gRPC package name (`nidigitalpattern_grpc`, not `nidigital_grpc`).

### List issues fixed by this Pull Request below, if any.

* Fix #1939 

### What testing has been done?

Inspected codegen.