### PR TITLE
Clip the gaussian noise in nifgen_script to avoid errors

### DIFF
--- a/src/nifgen/examples/nifgen_script.py
+++ b/src/nifgen/examples/nifgen_script.py
@@ -21,7 +21,7 @@ RAMP_UP = [x / (NUMBER_OF_SAMPLES) for x in range(NUMBER_OF_SAMPLES)]
 RAMP_DOWN = [-1.0 * x for x in RAMP_UP]
 SQUARE_WAVE = [1.0 if x < (NUMBER_OF_SAMPLES / 2) else -1.0 for x in range(NUMBER_OF_SAMPLES)]
 SAWTOOTH_WAVE = RAMP_UP[::2] + [(-1 + x) for x in RAMP_UP][::2]
-GAUSSIAN_NOISE = [random.gauss(0, 0.2) for x in range(NUMBER_OF_SAMPLES)]
+GAUSSIAN_NOISE = [sorted(-1.0, random.gauss(0, 0.2), 1.0)[1] for x in range(NUMBER_OF_SAMPLES)]
 
 
 SCRIPT_ALL = '''


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
A PR Check recently failed with 

>        if _is_error(code):
>>           raise DriverError(code, description)
>E           nifgen.errors.DriverError: -1074135024: IVI: Invalid value for parameter or property.
E           
E           Invalid Value: 1.008848
E           Maximum Value: 1.0
E           Minimum Value: -1.0
E           Index: 825

while writing the GAUSSIAN_NOISE waveform in nifgen_script.py.

This was a random failure, because we are generating random noise, which may randomly fall outside of our bounds, despite the low standard deviation of 0.2 from the mean of 0.

To prevent this from a happening again, this change will clamp the generated values between -1.0 and 1.0.

`max(upper_bound,  min(x, lower_bound))` (the standard way of doing this) was considered but it was very hard to read because of the random.gauss() call.

### List issues fixed by this Pull Request below, if any.
None

### What testing has been done?
None