### PR TITLE
Cap grpcio dependency at <1.53 for Python 3.7

### DIFF
--- a/build/templates/setup.py.mako
+++ b/build/templates/setup.py.mako
@@ -57,7 +57,7 @@ setup(
     % if grpc_supported:
     extras_require={
         'grpc': [
-            'grpcio>=1.49.1,<2.0,!=1.53;python_version=="3.7"',  # no 32-bit wheel for 1.53.0
+            'grpcio>=1.49.1,<1.53;python_version=="3.7"',  # no 32-bit wheel for 1.53.0 and later
             'grpcio>=1.49.1,<2.0;python_version>"3.7"',
             'protobuf>=4.21,<5.0'
         ],

--- a/generated/nidcpower/setup.py
+++ b/generated/nidcpower/setup.py
@@ -47,7 +47,7 @@ setup(
     ],
     extras_require={
         'grpc': [
-            'grpcio>=1.49.1,<2.0,!=1.53;python_version=="3.7"',  # no 32-bit wheel for 1.53.0
+            'grpcio>=1.49.1,<1.53;python_version=="3.7"',  # no 32-bit wheel for 1.53.0 and later
             'grpcio>=1.49.1,<2.0;python_version>"3.7"',
             'protobuf>=4.21,<5.0'
         ],

--- a/generated/nidigital/setup.py
+++ b/generated/nidigital/setup.py
@@ -48,7 +48,7 @@ setup(
     ],
     extras_require={
         'grpc': [
-            'grpcio>=1.49.1,<2.0,!=1.53;python_version=="3.7"',  # no 32-bit wheel for 1.53.0
+            'grpcio>=1.49.1,<1.53;python_version=="3.7"',  # no 32-bit wheel for 1.53.0 and later
             'grpcio>=1.49.1,<2.0;python_version>"3.7"',
             'protobuf>=4.21,<5.0'
         ],

--- a/generated/nidmm/setup.py
+++ b/generated/nidmm/setup.py
@@ -47,7 +47,7 @@ setup(
     ],
     extras_require={
         'grpc': [
-            'grpcio>=1.49.1,<2.0,!=1.53;python_version=="3.7"',  # no 32-bit wheel for 1.53.0
+            'grpcio>=1.49.1,<1.53;python_version=="3.7"',  # no 32-bit wheel for 1.53.0 and later
             'grpcio>=1.49.1,<2.0;python_version>"3.7"',
             'protobuf>=4.21,<5.0'
         ],

--- a/generated/nifake/setup.py
+++ b/generated/nifake/setup.py
@@ -48,7 +48,7 @@ setup(
     ],
     extras_require={
         'grpc': [
-            'grpcio>=1.49.1,<2.0,!=1.53;python_version=="3.7"',  # no 32-bit wheel for 1.53.0
+            'grpcio>=1.49.1,<1.53;python_version=="3.7"',  # no 32-bit wheel for 1.53.0 and later
             'grpcio>=1.49.1,<2.0;python_version>"3.7"',
             'protobuf>=4.21,<5.0'
         ],

--- a/generated/nifgen/setup.py
+++ b/generated/nifgen/setup.py
@@ -48,7 +48,7 @@ setup(
     ],
     extras_require={
         'grpc': [
-            'grpcio>=1.49.1,<2.0,!=1.53;python_version=="3.7"',  # no 32-bit wheel for 1.53.0
+            'grpcio>=1.49.1,<1.53;python_version=="3.7"',  # no 32-bit wheel for 1.53.0 and later
             'grpcio>=1.49.1,<2.0;python_version>"3.7"',
             'protobuf>=4.21,<5.0'
         ],

--- a/generated/niscope/setup.py
+++ b/generated/niscope/setup.py
@@ -48,7 +48,7 @@ setup(
     ],
     extras_require={
         'grpc': [
-            'grpcio>=1.49.1,<2.0,!=1.53;python_version=="3.7"',  # no 32-bit wheel for 1.53.0
+            'grpcio>=1.49.1,<1.53;python_version=="3.7"',  # no 32-bit wheel for 1.53.0 and later
             'grpcio>=1.49.1,<2.0;python_version>"3.7"',
             'protobuf>=4.21,<5.0'
         ],

--- a/generated/niswitch/setup.py
+++ b/generated/niswitch/setup.py
@@ -47,7 +47,7 @@ setup(
     ],
     extras_require={
         'grpc': [
-            'grpcio>=1.49.1,<2.0,!=1.53;python_version=="3.7"',  # no 32-bit wheel for 1.53.0
+            'grpcio>=1.49.1,<1.53;python_version=="3.7"',  # no 32-bit wheel for 1.53.0 and later
             'grpcio>=1.49.1,<2.0;python_version>"3.7"',
             'protobuf>=4.21,<5.0'
         ],


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
[win32 system tests are failing again](https://github.com/ni/nimi-python/actions/runs/4769024938/jobs/8478982122?pr=1950) due to the [absence of a win32 Python 3.7 wheel for grpcio 1.54.](https://pypi.org/simple/grpcio/)

The runner lacks the necessary software to build the wheel from scratch and we don't want users to have to deal with building the wheel from scratch for this optional dependency either, particularly because they don't actually need the latest grpcio.

This is a recurrence of the problem fixed by #1917, caused by the very next release of grpcio. We'll just cap the grpcio version for Python 3.7. We don't want to deal with this, again.

### List issues fixed by this Pull Request below, if any.
None

### What testing has been done?
System Tests pass
