### PR TITLE
Clean up assert statements

### DIFF
--- a/build/helper/documentation_helper.py
+++ b/build/helper/documentation_helper.py
@@ -1518,7 +1518,7 @@ def test_square_up_tables():
     square_up_tables(local_config)
     assert len(local_config['functions']['MakeAFoo']['documentation']['table_header']) == 3
     for line in local_config['functions']['MakeAFoo']['documentation']['table_body']:
-        assert(len(line)) == 3
+        assert (len(line)) == 3
 
 
 config_for_testing = {

--- a/build/helper/documentation_helper.py
+++ b/build/helper/documentation_helper.py
@@ -1518,7 +1518,7 @@ def test_square_up_tables():
     square_up_tables(local_config)
     assert len(local_config['functions']['MakeAFoo']['documentation']['table_header']) == 3
     for line in local_config['functions']['MakeAFoo']['documentation']['table_body']:
-        assert (len(line)) == 3
+        assert len(line) == 3
 
 
 config_for_testing = {

--- a/build/templates/errors.py.mako
+++ b/build/templates/errors.py.mako
@@ -42,7 +42,7 @@ class DriverError(Error):
     '''An error originating from the ${driver_name} driver'''
 
     def __init__(self, code, description):
-        assert (_is_error(code)), "Should not raise Error if code is not fatal."
+        assert _is_error(code), "Should not raise Error if code is not fatal."
         self.code = code
         self.description = description
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
@@ -52,7 +52,7 @@ class DriverWarning(Warning):
     '''A warning originating from the ${driver_name} driver'''
 
     def __init__(self, code, description):
-        assert (_is_warning(code)), "Should not create Warning if code is not positive."
+        assert _is_warning(code), "Should not create Warning if code is not positive."
         super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 

--- a/generated/nidcpower/nidcpower/errors.py
+++ b/generated/nidcpower/nidcpower/errors.py
@@ -29,7 +29,7 @@ class DriverError(Error):
     '''An error originating from the NI-DCPower driver'''
 
     def __init__(self, code, description):
-        assert (_is_error(code)), "Should not raise Error if code is not fatal."
+        assert _is_error(code), "Should not raise Error if code is not fatal."
         self.code = code
         self.description = description
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
@@ -39,7 +39,7 @@ class DriverWarning(Warning):
     '''A warning originating from the NI-DCPower driver'''
 
     def __init__(self, code, description):
-        assert (_is_warning(code)), "Should not create Warning if code is not positive."
+        assert _is_warning(code), "Should not create Warning if code is not positive."
         super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 

--- a/generated/nidigital/nidigital/errors.py
+++ b/generated/nidigital/nidigital/errors.py
@@ -29,7 +29,7 @@ class DriverError(Error):
     '''An error originating from the NI-Digital Pattern Driver driver'''
 
     def __init__(self, code, description):
-        assert (_is_error(code)), "Should not raise Error if code is not fatal."
+        assert _is_error(code), "Should not raise Error if code is not fatal."
         self.code = code
         self.description = description
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
@@ -39,7 +39,7 @@ class DriverWarning(Warning):
     '''A warning originating from the NI-Digital Pattern Driver driver'''
 
     def __init__(self, code, description):
-        assert (_is_warning(code)), "Should not create Warning if code is not positive."
+        assert _is_warning(code), "Should not create Warning if code is not positive."
         super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 

--- a/generated/nidmm/nidmm/errors.py
+++ b/generated/nidmm/nidmm/errors.py
@@ -29,7 +29,7 @@ class DriverError(Error):
     '''An error originating from the NI-DMM driver'''
 
     def __init__(self, code, description):
-        assert (_is_error(code)), "Should not raise Error if code is not fatal."
+        assert _is_error(code), "Should not raise Error if code is not fatal."
         self.code = code
         self.description = description
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
@@ -39,7 +39,7 @@ class DriverWarning(Warning):
     '''A warning originating from the NI-DMM driver'''
 
     def __init__(self, code, description):
-        assert (_is_warning(code)), "Should not create Warning if code is not positive."
+        assert _is_warning(code), "Should not create Warning if code is not positive."
         super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 

--- a/generated/nifake/nifake/errors.py
+++ b/generated/nifake/nifake/errors.py
@@ -29,7 +29,7 @@ class DriverError(Error):
     '''An error originating from the NI-FAKE driver'''
 
     def __init__(self, code, description):
-        assert (_is_error(code)), "Should not raise Error if code is not fatal."
+        assert _is_error(code), "Should not raise Error if code is not fatal."
         self.code = code
         self.description = description
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
@@ -39,7 +39,7 @@ class DriverWarning(Warning):
     '''A warning originating from the NI-FAKE driver'''
 
     def __init__(self, code, description):
-        assert (_is_warning(code)), "Should not create Warning if code is not positive."
+        assert _is_warning(code), "Should not create Warning if code is not positive."
         super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 

--- a/generated/nifake/nifake/unit_tests/test_grpc.py
+++ b/generated/nifake/nifake/unit_tests/test_grpc.py
@@ -721,7 +721,7 @@ class TestGrpcStubInterpreter(object):
         response_object = self._set_side_effect(library_func, attribute_value=test_number)
         interpreter = self._get_initialized_stub_interpreter()
         attr_int = interpreter.get_attribute_vi_int32('', attribute_id)
-        assert(attr_int == test_number)
+        assert (attr_int == test_number)
         self._assert_call(library_func, response_object).assert_called_once_with(
             vi=GRPC_SESSION_OBJECT_FOR_TEST, channel_name='', attribute_id=attribute_id
         )
@@ -820,7 +820,7 @@ class TestGrpcStubInterpreter(object):
         response_object = self._set_side_effect(library_func, attribute_value=test_number)
         interpreter = self._get_initialized_stub_interpreter()
         attr_int = interpreter.get_attribute_vi_int64('', attribute_id)
-        assert(attr_int == test_number)
+        assert (attr_int == test_number)
         self._assert_call(library_func, response_object).assert_called_once_with(
             vi=GRPC_SESSION_OBJECT_FOR_TEST, channel_name='', attribute_id=attribute_id
         )

--- a/generated/nifake/nifake/unit_tests/test_grpc.py
+++ b/generated/nifake/nifake/unit_tests/test_grpc.py
@@ -668,8 +668,8 @@ class TestGrpcStubInterpreter(object):
         response_object = self._set_side_effect(library_func, a_string=test_string, a_number=test_number)
         interpreter = self._get_initialized_stub_interpreter()
         returned_number, returned_string = interpreter.return_a_number_and_a_string()
-        assert (returned_string == test_string)
-        assert (returned_number == test_number)
+        assert returned_string == test_string
+        assert returned_number == test_number
         self._assert_call(library_func, response_object).assert_called_once_with(vi=GRPC_SESSION_OBJECT_FOR_TEST)
 
     def test_get_an_ivi_dance_char_array(self):
@@ -721,7 +721,7 @@ class TestGrpcStubInterpreter(object):
         response_object = self._set_side_effect(library_func, attribute_value=test_number)
         interpreter = self._get_initialized_stub_interpreter()
         attr_int = interpreter.get_attribute_vi_int32('', attribute_id)
-        assert (attr_int == test_number)
+        assert attr_int == test_number
         self._assert_call(library_func, response_object).assert_called_once_with(
             vi=GRPC_SESSION_OBJECT_FOR_TEST, channel_name='', attribute_id=attribute_id
         )
@@ -820,7 +820,7 @@ class TestGrpcStubInterpreter(object):
         response_object = self._set_side_effect(library_func, attribute_value=test_number)
         interpreter = self._get_initialized_stub_interpreter()
         attr_int = interpreter.get_attribute_vi_int64('', attribute_id)
-        assert (attr_int == test_number)
+        assert attr_int == test_number
         self._assert_call(library_func, response_object).assert_called_once_with(
             vi=GRPC_SESSION_OBJECT_FOR_TEST, channel_name='', attribute_id=attribute_id
         )

--- a/generated/nifake/nifake/unit_tests/test_library_interpreter.py
+++ b/generated/nifake/nifake/unit_tests/test_library_interpreter.py
@@ -531,7 +531,7 @@ class TestLibraryInterpreter(object):
         self.side_effects_helper['GetAttributeViInt32']['attributeValue'] = test_number
         interpreter = self.get_initialized_library_interpreter()
         attr_int = interpreter.get_attribute_vi_int32('', attribute_id)
-        assert(attr_int == test_number)
+        assert (attr_int == test_number)
         self.patched_library.niFake_GetAttributeViInt32.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt32PointerMatcher())
 
     def test_set_attribute_int32(self):
@@ -606,7 +606,7 @@ class TestLibraryInterpreter(object):
         self.side_effects_helper['GetAttributeViInt64']['attributeValue'] = test_number
         interpreter = self.get_initialized_library_interpreter()
         attr_int = interpreter.get_attribute_vi_int64('', attribute_id)
-        assert(attr_int == test_number)
+        assert (attr_int == test_number)
         self.patched_library.niFake_GetAttributeViInt64.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt64PointerMatcher())
 
     def test_set_attribute_int64(self):

--- a/generated/nifake/nifake/unit_tests/test_library_interpreter.py
+++ b/generated/nifake/nifake/unit_tests/test_library_interpreter.py
@@ -464,8 +464,8 @@ class TestLibraryInterpreter(object):
         self.side_effects_helper['ReturnANumberAndAString']['aNumber'] = test_number
         interpreter = self.get_initialized_library_interpreter()
         returned_number, returned_string = interpreter.return_a_number_and_a_string()
-        assert (returned_string == test_string)
-        assert (returned_number == test_number)
+        assert returned_string == test_string
+        assert returned_number == test_number
         self.patched_library.niFake_ReturnANumberAndAString.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViInt16PointerMatcher(), _matchers.ViCharBufferMatcher(256))
 
     def test_get_an_ivi_dance_char_array(self):
@@ -531,7 +531,7 @@ class TestLibraryInterpreter(object):
         self.side_effects_helper['GetAttributeViInt32']['attributeValue'] = test_number
         interpreter = self.get_initialized_library_interpreter()
         attr_int = interpreter.get_attribute_vi_int32('', attribute_id)
-        assert (attr_int == test_number)
+        assert attr_int == test_number
         self.patched_library.niFake_GetAttributeViInt32.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt32PointerMatcher())
 
     def test_set_attribute_int32(self):
@@ -606,7 +606,7 @@ class TestLibraryInterpreter(object):
         self.side_effects_helper['GetAttributeViInt64']['attributeValue'] = test_number
         interpreter = self.get_initialized_library_interpreter()
         attr_int = interpreter.get_attribute_vi_int64('', attribute_id)
-        assert (attr_int == test_number)
+        assert attr_int == test_number
         self.patched_library.niFake_GetAttributeViInt64.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt64PointerMatcher())
 
     def test_set_attribute_int64(self):

--- a/generated/nifake/nifake/unit_tests/test_session.py
+++ b/generated/nifake/nifake/unit_tests/test_session.py
@@ -372,7 +372,7 @@ class TestSession(object):
         self.patched_library_interpreter.get_attribute_vi_int32.side_effect = [test_number]
         with nifake.Session('dev1') as session:
             attr_int = session.read_write_integer
-            assert(attr_int == test_number)
+            assert (attr_int == test_number)
             self.patched_library_interpreter.get_attribute_vi_int32.assert_called_once_with('', 1000004)
 
     def test_set_attribute_int32(self):
@@ -390,7 +390,7 @@ class TestSession(object):
         self.patched_library_interpreter.get_attribute_vi_int32.side_effect = [test_number_ms]
         with nifake.Session('dev1') as session:
             attr_timedelta = session.read_write_integer_with_converter
-            assert(attr_timedelta.total_seconds() == test_number_s)
+            assert (attr_timedelta.total_seconds() == test_number_s)
             self.patched_library_interpreter.get_attribute_vi_int32.assert_called_once_with('', attribute_id)
 
     def test_set_attribute_int32_with_converter(self):
@@ -565,7 +565,7 @@ class TestSession(object):
         attribute_id = 1000004
         with nifake.Session('dev1') as session:
             attr_int = session.channels[['0', '1']].read_write_integer
-            assert(attr_int == test_number)
+            assert (attr_int == test_number)
             self.patched_library_interpreter.get_attribute_vi_int32.assert_called_once_with('0,1', attribute_id)
 
     def test_set_attribute_channel(self):
@@ -582,7 +582,7 @@ class TestSession(object):
         self.patched_library_interpreter.get_attribute_vi_int64.side_effect = [test_number]
         with nifake.Session('dev1') as session:
             attr_int = session.read_write_int64
-            assert(attr_int == test_number)
+            assert (attr_int == test_number)
             self.patched_library_interpreter.get_attribute_vi_int64.assert_called_once_with('', attribute_id)
 
     def test_set_attribute_int64(self):
@@ -933,7 +933,7 @@ class TestGrpcSession(object):
         self.patched_grpc_interpreter.get_attribute_vi_int32.side_effect = [test_number]
         with nifake.Session('dev1', grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
             attr_int = session.read_write_integer
-            assert(attr_int == test_number)
+            assert (attr_int == test_number)
             self.patched_grpc_interpreter.get_attribute_vi_int32.assert_called_once_with('', 1000004)
 
 

--- a/generated/nifake/nifake/unit_tests/test_session.py
+++ b/generated/nifake/nifake/unit_tests/test_session.py
@@ -372,7 +372,7 @@ class TestSession(object):
         self.patched_library_interpreter.get_attribute_vi_int32.side_effect = [test_number]
         with nifake.Session('dev1') as session:
             attr_int = session.read_write_integer
-            assert (attr_int == test_number)
+            assert attr_int == test_number
             self.patched_library_interpreter.get_attribute_vi_int32.assert_called_once_with('', 1000004)
 
     def test_set_attribute_int32(self):
@@ -390,7 +390,7 @@ class TestSession(object):
         self.patched_library_interpreter.get_attribute_vi_int32.side_effect = [test_number_ms]
         with nifake.Session('dev1') as session:
             attr_timedelta = session.read_write_integer_with_converter
-            assert (attr_timedelta.total_seconds() == test_number_s)
+            assert attr_timedelta.total_seconds() == test_number_s
             self.patched_library_interpreter.get_attribute_vi_int32.assert_called_once_with('', attribute_id)
 
     def test_set_attribute_int32_with_converter(self):
@@ -565,7 +565,7 @@ class TestSession(object):
         attribute_id = 1000004
         with nifake.Session('dev1') as session:
             attr_int = session.channels[['0', '1']].read_write_integer
-            assert (attr_int == test_number)
+            assert attr_int == test_number
             self.patched_library_interpreter.get_attribute_vi_int32.assert_called_once_with('0,1', attribute_id)
 
     def test_set_attribute_channel(self):
@@ -582,7 +582,7 @@ class TestSession(object):
         self.patched_library_interpreter.get_attribute_vi_int64.side_effect = [test_number]
         with nifake.Session('dev1') as session:
             attr_int = session.read_write_int64
-            assert (attr_int == test_number)
+            assert attr_int == test_number
             self.patched_library_interpreter.get_attribute_vi_int64.assert_called_once_with('', attribute_id)
 
     def test_set_attribute_int64(self):
@@ -933,7 +933,7 @@ class TestGrpcSession(object):
         self.patched_grpc_interpreter.get_attribute_vi_int32.side_effect = [test_number]
         with nifake.Session('dev1', grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
             attr_int = session.read_write_integer
-            assert (attr_int == test_number)
+            assert attr_int == test_number
             self.patched_grpc_interpreter.get_attribute_vi_int32.assert_called_once_with('', 1000004)
 
 

--- a/generated/nifgen/nifgen/errors.py
+++ b/generated/nifgen/nifgen/errors.py
@@ -29,7 +29,7 @@ class DriverError(Error):
     '''An error originating from the NI-FGEN driver'''
 
     def __init__(self, code, description):
-        assert (_is_error(code)), "Should not raise Error if code is not fatal."
+        assert _is_error(code), "Should not raise Error if code is not fatal."
         self.code = code
         self.description = description
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
@@ -39,7 +39,7 @@ class DriverWarning(Warning):
     '''A warning originating from the NI-FGEN driver'''
 
     def __init__(self, code, description):
-        assert (_is_warning(code)), "Should not create Warning if code is not positive."
+        assert _is_warning(code), "Should not create Warning if code is not positive."
         super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 

--- a/generated/nimodinst/nimodinst/errors.py
+++ b/generated/nimodinst/nimodinst/errors.py
@@ -29,7 +29,7 @@ class DriverError(Error):
     '''An error originating from the NI-ModInst driver'''
 
     def __init__(self, code, description):
-        assert (_is_error(code)), "Should not raise Error if code is not fatal."
+        assert _is_error(code), "Should not raise Error if code is not fatal."
         self.code = code
         self.description = description
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
@@ -39,7 +39,7 @@ class DriverWarning(Warning):
     '''A warning originating from the NI-ModInst driver'''
 
     def __init__(self, code, description):
-        assert (_is_warning(code)), "Should not create Warning if code is not positive."
+        assert _is_warning(code), "Should not create Warning if code is not positive."
         super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 

--- a/generated/nimodinst/nimodinst/unit_tests/test_modinst.py
+++ b/generated/nimodinst/nimodinst/unit_tests/test_modinst.py
@@ -125,7 +125,7 @@ class TestSession(object):
         self.side_effects_helper['GetInstalledDeviceAttributeViInt32']['attributeValue'] = val
         with nimodinst.Session('') as session:
             attr_int = session.devices[0].chassis_number
-            assert (attr_int == val)
+            assert attr_int == val
 
     def test_get_attribute_vi_int32_for_loop_index(self):
         self.patched_library.niModInst_GetInstalledDeviceAttributeViInt32.side_effect = self.niModInst_GetInstalledDeviceAttributeViInt32_looping
@@ -134,7 +134,7 @@ class TestSession(object):
         with nimodinst.Session('') as session:
             attr_int = session.devices[index].chassis_number
             index += 1
-            assert (attr_int == self.int_vals_device_looping[self.iteration_device_looping - 1])  # Have to subtract once since it was already incremented in the callback function
+            assert attr_int == self.int_vals_device_looping[self.iteration_device_looping - 1]  # Have to subtract once since it was already incremented in the callback function
 
     def test_get_attribute_vi_string_for_loop_index(self):
         self.patched_library.niModInst_GetInstalledDeviceAttributeViString.side_effect = self.niModInst_GetInstalledDeviceAttributeViString_looping
@@ -143,7 +143,7 @@ class TestSession(object):
         with nimodinst.Session('') as session:
             attr_int = session.devices[index].device_name
             index += 1
-            assert (attr_int == self.string_vals_device_looping[self.iteration_device_looping - 1])  # Have to subtract once since it was already incremented in the callback function
+            assert attr_int == self.string_vals_device_looping[self.iteration_device_looping - 1]  # Have to subtract once since it was already incremented in the callback function
 
     def test_get_attribute_session_no_index(self):
         val = 123
@@ -163,7 +163,7 @@ class TestSession(object):
         with nimodinst.Session('') as session:
             for d in session:
                 attr_int = d.chassis_number
-                assert (attr_int == self.int_vals_device_looping[self.iteration_device_looping - 1])  # Have to subtract once since it was already incremented in the callback function
+                assert attr_int == self.int_vals_device_looping[self.iteration_device_looping - 1]  # Have to subtract once since it was already incremented in the callback function
 
     def test_get_attribute_vi_string_for_loop_multiple_devices(self):
         self.patched_library.niModInst_GetInstalledDeviceAttributeViString.side_effect = self.niModInst_GetInstalledDeviceAttributeViString_looping
@@ -171,7 +171,7 @@ class TestSession(object):
         with nimodinst.Session('') as session:
             for d in session:
                 attr_int = d.device_name
-                assert (attr_int == self.string_vals_device_looping[self.iteration_device_looping - 1])  # Have to subtract once since it was already incremented in the callback function
+                assert attr_int == self.string_vals_device_looping[self.iteration_device_looping - 1]  # Have to subtract once since it was already incremented in the callback function
 
     # Error Tests
     def test_cannot_add_properties_to_session_set(self):

--- a/generated/nimodinst/nimodinst/unit_tests/test_modinst.py
+++ b/generated/nimodinst/nimodinst/unit_tests/test_modinst.py
@@ -125,7 +125,7 @@ class TestSession(object):
         self.side_effects_helper['GetInstalledDeviceAttributeViInt32']['attributeValue'] = val
         with nimodinst.Session('') as session:
             attr_int = session.devices[0].chassis_number
-            assert(attr_int == val)
+            assert (attr_int == val)
 
     def test_get_attribute_vi_int32_for_loop_index(self):
         self.patched_library.niModInst_GetInstalledDeviceAttributeViInt32.side_effect = self.niModInst_GetInstalledDeviceAttributeViInt32_looping
@@ -134,7 +134,7 @@ class TestSession(object):
         with nimodinst.Session('') as session:
             attr_int = session.devices[index].chassis_number
             index += 1
-            assert(attr_int == self.int_vals_device_looping[self.iteration_device_looping - 1])  # Have to subtract once since it was already incremented in the callback function
+            assert (attr_int == self.int_vals_device_looping[self.iteration_device_looping - 1])  # Have to subtract once since it was already incremented in the callback function
 
     def test_get_attribute_vi_string_for_loop_index(self):
         self.patched_library.niModInst_GetInstalledDeviceAttributeViString.side_effect = self.niModInst_GetInstalledDeviceAttributeViString_looping
@@ -143,7 +143,7 @@ class TestSession(object):
         with nimodinst.Session('') as session:
             attr_int = session.devices[index].device_name
             index += 1
-            assert(attr_int == self.string_vals_device_looping[self.iteration_device_looping - 1])  # Have to subtract once since it was already incremented in the callback function
+            assert (attr_int == self.string_vals_device_looping[self.iteration_device_looping - 1])  # Have to subtract once since it was already incremented in the callback function
 
     def test_get_attribute_session_no_index(self):
         val = 123
@@ -163,7 +163,7 @@ class TestSession(object):
         with nimodinst.Session('') as session:
             for d in session:
                 attr_int = d.chassis_number
-                assert(attr_int == self.int_vals_device_looping[self.iteration_device_looping - 1])  # Have to subtract once since it was already incremented in the callback function
+                assert (attr_int == self.int_vals_device_looping[self.iteration_device_looping - 1])  # Have to subtract once since it was already incremented in the callback function
 
     def test_get_attribute_vi_string_for_loop_multiple_devices(self):
         self.patched_library.niModInst_GetInstalledDeviceAttributeViString.side_effect = self.niModInst_GetInstalledDeviceAttributeViString_looping
@@ -171,7 +171,7 @@ class TestSession(object):
         with nimodinst.Session('') as session:
             for d in session:
                 attr_int = d.device_name
-                assert(attr_int == self.string_vals_device_looping[self.iteration_device_looping - 1])  # Have to subtract once since it was already incremented in the callback function
+                assert (attr_int == self.string_vals_device_looping[self.iteration_device_looping - 1])  # Have to subtract once since it was already incremented in the callback function
 
     # Error Tests
     def test_cannot_add_properties_to_session_set(self):

--- a/generated/niscope/niscope/errors.py
+++ b/generated/niscope/niscope/errors.py
@@ -29,7 +29,7 @@ class DriverError(Error):
     '''An error originating from the NI-SCOPE driver'''
 
     def __init__(self, code, description):
-        assert (_is_error(code)), "Should not raise Error if code is not fatal."
+        assert _is_error(code), "Should not raise Error if code is not fatal."
         self.code = code
         self.description = description
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
@@ -39,7 +39,7 @@ class DriverWarning(Warning):
     '''A warning originating from the NI-SCOPE driver'''
 
     def __init__(self, code, description):
-        assert (_is_warning(code)), "Should not create Warning if code is not positive."
+        assert _is_warning(code), "Should not create Warning if code is not positive."
         super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 

--- a/generated/nise/nise/errors.py
+++ b/generated/nise/nise/errors.py
@@ -29,7 +29,7 @@ class DriverError(Error):
     '''An error originating from the NI Switch Executive driver'''
 
     def __init__(self, code, description):
-        assert (_is_error(code)), "Should not raise Error if code is not fatal."
+        assert _is_error(code), "Should not raise Error if code is not fatal."
         self.code = code
         self.description = description
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
@@ -39,7 +39,7 @@ class DriverWarning(Warning):
     '''A warning originating from the NI Switch Executive driver'''
 
     def __init__(self, code, description):
-        assert (_is_warning(code)), "Should not create Warning if code is not positive."
+        assert _is_warning(code), "Should not create Warning if code is not positive."
         super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 

--- a/generated/niswitch/niswitch/errors.py
+++ b/generated/niswitch/niswitch/errors.py
@@ -29,7 +29,7 @@ class DriverError(Error):
     '''An error originating from the NI-SWITCH driver'''
 
     def __init__(self, code, description):
-        assert (_is_error(code)), "Should not raise Error if code is not fatal."
+        assert _is_error(code), "Should not raise Error if code is not fatal."
         self.code = code
         self.description = description
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
@@ -39,7 +39,7 @@ class DriverWarning(Warning):
     '''A warning originating from the NI-SWITCH driver'''
 
     def __init__(self, code, description):
-        assert (_is_warning(code)), "Should not create Warning if code is not positive."
+        assert _is_warning(code), "Should not create Warning if code is not positive."
         super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 

--- a/generated/nitclk/nitclk/errors.py
+++ b/generated/nitclk/nitclk/errors.py
@@ -29,7 +29,7 @@ class DriverError(Error):
     '''An error originating from the NI-TClk driver'''
 
     def __init__(self, code, description):
-        assert (_is_error(code)), "Should not raise Error if code is not fatal."
+        assert _is_error(code), "Should not raise Error if code is not fatal."
         self.code = code
         self.description = description
         super(DriverError, self).__init__(str(self.code) + ": " + self.description)
@@ -39,7 +39,7 @@ class DriverWarning(Warning):
     '''A warning originating from the NI-TClk driver'''
 
     def __init__(self, code, description):
-        assert (_is_warning(code)), "Should not create Warning if code is not positive."
+        assert _is_warning(code), "Should not create Warning if code is not positive."
         super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
 
 

--- a/generated/nitclk/nitclk/unit_tests/test_nitclk.py
+++ b/generated/nitclk/nitclk/unit_tests/test_nitclk.py
@@ -189,7 +189,7 @@ class TestNitclkApi(object):
         test_number = 4.2
         self.side_effects_helper['GetAttributeViReal64']['value'] = test_number
         attr_val = session.tclk_actual_period
-        assert (attr_val == test_number)
+        assert attr_val == test_number
         self.patched_library.niTClk_GetAttributeViReal64.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViReal64PointerMatcher())
 
     def test_set_timedelta_as_vi_real64(self):
@@ -215,7 +215,7 @@ class TestNitclkApi(object):
         test_number = 4.2
         self.side_effects_helper['GetAttributeViReal64']['value'] = test_number
         attr_timedelta = session.sample_clock_delay
-        assert (attr_timedelta.total_seconds() == test_number)
+        assert attr_timedelta.total_seconds() == test_number
         self.patched_library.niTClk_GetAttributeViReal64.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViReal64PointerMatcher())
 
     def test_set_vi_string(self):
@@ -233,7 +233,7 @@ class TestNitclkApi(object):
         test_string = "The answer to the ultimate question is 42"
         self.side_effects_helper['GetAttributeViString']['value'] = test_string
         attr_string = session.sync_pulse_sender_sync_pulse_source
-        assert (attr_string == test_string)
+        assert attr_string == test_string
 
         from unittest.mock import call
         calls = [call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt32Matcher(0), None), call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt32Matcher(len(test_string)), _matchers.ViCharBufferMatcher(len(test_string)))]
@@ -278,7 +278,7 @@ class TestNitclkApi(object):
         self.side_effects_helper['GetAttributeViSession']['value'] = other_session_number
         attr_session_reference = session.start_trigger_master_session
         assert type(attr_session_reference) is nitclk.SessionReference
-        assert (attr_session_reference._get_tclk_session_reference() == other_session_number)
+        assert attr_session_reference._get_tclk_session_reference() == other_session_number
         self.patched_library.niTClk_GetAttributeViSession.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViSessionPointerMatcher())
 
 

--- a/generated/nitclk/nitclk/unit_tests/test_nitclk.py
+++ b/generated/nitclk/nitclk/unit_tests/test_nitclk.py
@@ -189,7 +189,7 @@ class TestNitclkApi(object):
         test_number = 4.2
         self.side_effects_helper['GetAttributeViReal64']['value'] = test_number
         attr_val = session.tclk_actual_period
-        assert(attr_val == test_number)
+        assert (attr_val == test_number)
         self.patched_library.niTClk_GetAttributeViReal64.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViReal64PointerMatcher())
 
     def test_set_timedelta_as_vi_real64(self):
@@ -215,7 +215,7 @@ class TestNitclkApi(object):
         test_number = 4.2
         self.side_effects_helper['GetAttributeViReal64']['value'] = test_number
         attr_timedelta = session.sample_clock_delay
-        assert(attr_timedelta.total_seconds() == test_number)
+        assert (attr_timedelta.total_seconds() == test_number)
         self.patched_library.niTClk_GetAttributeViReal64.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViReal64PointerMatcher())
 
     def test_set_vi_string(self):
@@ -233,7 +233,7 @@ class TestNitclkApi(object):
         test_string = "The answer to the ultimate question is 42"
         self.side_effects_helper['GetAttributeViString']['value'] = test_string
         attr_string = session.sync_pulse_sender_sync_pulse_source
-        assert(attr_string == test_string)
+        assert (attr_string == test_string)
 
         from unittest.mock import call
         calls = [call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt32Matcher(0), None), call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt32Matcher(len(test_string)), _matchers.ViCharBufferMatcher(len(test_string)))]
@@ -278,7 +278,7 @@ class TestNitclkApi(object):
         self.side_effects_helper['GetAttributeViSession']['value'] = other_session_number
         attr_session_reference = session.start_trigger_master_session
         assert type(attr_session_reference) is nitclk.SessionReference
-        assert(attr_session_reference._get_tclk_session_reference() == other_session_number)
+        assert (attr_session_reference._get_tclk_session_reference() == other_session_number)
         self.patched_library.niTClk_GetAttributeViSession.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViSessionPointerMatcher())
 
 

--- a/src/nifake/unit_tests/test_grpc.py
+++ b/src/nifake/unit_tests/test_grpc.py
@@ -721,7 +721,7 @@ class TestGrpcStubInterpreter(object):
         response_object = self._set_side_effect(library_func, attribute_value=test_number)
         interpreter = self._get_initialized_stub_interpreter()
         attr_int = interpreter.get_attribute_vi_int32('', attribute_id)
-        assert(attr_int == test_number)
+        assert (attr_int == test_number)
         self._assert_call(library_func, response_object).assert_called_once_with(
             vi=GRPC_SESSION_OBJECT_FOR_TEST, channel_name='', attribute_id=attribute_id
         )
@@ -820,7 +820,7 @@ class TestGrpcStubInterpreter(object):
         response_object = self._set_side_effect(library_func, attribute_value=test_number)
         interpreter = self._get_initialized_stub_interpreter()
         attr_int = interpreter.get_attribute_vi_int64('', attribute_id)
-        assert(attr_int == test_number)
+        assert (attr_int == test_number)
         self._assert_call(library_func, response_object).assert_called_once_with(
             vi=GRPC_SESSION_OBJECT_FOR_TEST, channel_name='', attribute_id=attribute_id
         )

--- a/src/nifake/unit_tests/test_grpc.py
+++ b/src/nifake/unit_tests/test_grpc.py
@@ -668,8 +668,8 @@ class TestGrpcStubInterpreter(object):
         response_object = self._set_side_effect(library_func, a_string=test_string, a_number=test_number)
         interpreter = self._get_initialized_stub_interpreter()
         returned_number, returned_string = interpreter.return_a_number_and_a_string()
-        assert (returned_string == test_string)
-        assert (returned_number == test_number)
+        assert returned_string == test_string
+        assert returned_number == test_number
         self._assert_call(library_func, response_object).assert_called_once_with(vi=GRPC_SESSION_OBJECT_FOR_TEST)
 
     def test_get_an_ivi_dance_char_array(self):
@@ -721,7 +721,7 @@ class TestGrpcStubInterpreter(object):
         response_object = self._set_side_effect(library_func, attribute_value=test_number)
         interpreter = self._get_initialized_stub_interpreter()
         attr_int = interpreter.get_attribute_vi_int32('', attribute_id)
-        assert (attr_int == test_number)
+        assert attr_int == test_number
         self._assert_call(library_func, response_object).assert_called_once_with(
             vi=GRPC_SESSION_OBJECT_FOR_TEST, channel_name='', attribute_id=attribute_id
         )
@@ -820,7 +820,7 @@ class TestGrpcStubInterpreter(object):
         response_object = self._set_side_effect(library_func, attribute_value=test_number)
         interpreter = self._get_initialized_stub_interpreter()
         attr_int = interpreter.get_attribute_vi_int64('', attribute_id)
-        assert (attr_int == test_number)
+        assert attr_int == test_number
         self._assert_call(library_func, response_object).assert_called_once_with(
             vi=GRPC_SESSION_OBJECT_FOR_TEST, channel_name='', attribute_id=attribute_id
         )

--- a/src/nifake/unit_tests/test_library_interpreter.py
+++ b/src/nifake/unit_tests/test_library_interpreter.py
@@ -531,7 +531,7 @@ class TestLibraryInterpreter(object):
         self.side_effects_helper['GetAttributeViInt32']['attributeValue'] = test_number
         interpreter = self.get_initialized_library_interpreter()
         attr_int = interpreter.get_attribute_vi_int32('', attribute_id)
-        assert(attr_int == test_number)
+        assert (attr_int == test_number)
         self.patched_library.niFake_GetAttributeViInt32.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt32PointerMatcher())
 
     def test_set_attribute_int32(self):
@@ -606,7 +606,7 @@ class TestLibraryInterpreter(object):
         self.side_effects_helper['GetAttributeViInt64']['attributeValue'] = test_number
         interpreter = self.get_initialized_library_interpreter()
         attr_int = interpreter.get_attribute_vi_int64('', attribute_id)
-        assert(attr_int == test_number)
+        assert (attr_int == test_number)
         self.patched_library.niFake_GetAttributeViInt64.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt64PointerMatcher())
 
     def test_set_attribute_int64(self):

--- a/src/nifake/unit_tests/test_library_interpreter.py
+++ b/src/nifake/unit_tests/test_library_interpreter.py
@@ -464,8 +464,8 @@ class TestLibraryInterpreter(object):
         self.side_effects_helper['ReturnANumberAndAString']['aNumber'] = test_number
         interpreter = self.get_initialized_library_interpreter()
         returned_number, returned_string = interpreter.return_a_number_and_a_string()
-        assert (returned_string == test_string)
-        assert (returned_number == test_number)
+        assert returned_string == test_string
+        assert returned_number == test_number
         self.patched_library.niFake_ReturnANumberAndAString.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViInt16PointerMatcher(), _matchers.ViCharBufferMatcher(256))
 
     def test_get_an_ivi_dance_char_array(self):
@@ -531,7 +531,7 @@ class TestLibraryInterpreter(object):
         self.side_effects_helper['GetAttributeViInt32']['attributeValue'] = test_number
         interpreter = self.get_initialized_library_interpreter()
         attr_int = interpreter.get_attribute_vi_int32('', attribute_id)
-        assert (attr_int == test_number)
+        assert attr_int == test_number
         self.patched_library.niFake_GetAttributeViInt32.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt32PointerMatcher())
 
     def test_set_attribute_int32(self):
@@ -606,7 +606,7 @@ class TestLibraryInterpreter(object):
         self.side_effects_helper['GetAttributeViInt64']['attributeValue'] = test_number
         interpreter = self.get_initialized_library_interpreter()
         attr_int = interpreter.get_attribute_vi_int64('', attribute_id)
-        assert (attr_int == test_number)
+        assert attr_int == test_number
         self.patched_library.niFake_GetAttributeViInt64.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt64PointerMatcher())
 
     def test_set_attribute_int64(self):

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -372,7 +372,7 @@ class TestSession(object):
         self.patched_library_interpreter.get_attribute_vi_int32.side_effect = [test_number]
         with nifake.Session('dev1') as session:
             attr_int = session.read_write_integer
-            assert(attr_int == test_number)
+            assert (attr_int == test_number)
             self.patched_library_interpreter.get_attribute_vi_int32.assert_called_once_with('', 1000004)
 
     def test_set_attribute_int32(self):
@@ -390,7 +390,7 @@ class TestSession(object):
         self.patched_library_interpreter.get_attribute_vi_int32.side_effect = [test_number_ms]
         with nifake.Session('dev1') as session:
             attr_timedelta = session.read_write_integer_with_converter
-            assert(attr_timedelta.total_seconds() == test_number_s)
+            assert (attr_timedelta.total_seconds() == test_number_s)
             self.patched_library_interpreter.get_attribute_vi_int32.assert_called_once_with('', attribute_id)
 
     def test_set_attribute_int32_with_converter(self):
@@ -565,7 +565,7 @@ class TestSession(object):
         attribute_id = 1000004
         with nifake.Session('dev1') as session:
             attr_int = session.channels[['0', '1']].read_write_integer
-            assert(attr_int == test_number)
+            assert (attr_int == test_number)
             self.patched_library_interpreter.get_attribute_vi_int32.assert_called_once_with('0,1', attribute_id)
 
     def test_set_attribute_channel(self):
@@ -582,7 +582,7 @@ class TestSession(object):
         self.patched_library_interpreter.get_attribute_vi_int64.side_effect = [test_number]
         with nifake.Session('dev1') as session:
             attr_int = session.read_write_int64
-            assert(attr_int == test_number)
+            assert (attr_int == test_number)
             self.patched_library_interpreter.get_attribute_vi_int64.assert_called_once_with('', attribute_id)
 
     def test_set_attribute_int64(self):
@@ -933,7 +933,7 @@ class TestGrpcSession(object):
         self.patched_grpc_interpreter.get_attribute_vi_int32.side_effect = [test_number]
         with nifake.Session('dev1', grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
             attr_int = session.read_write_integer
-            assert(attr_int == test_number)
+            assert (attr_int == test_number)
             self.patched_grpc_interpreter.get_attribute_vi_int32.assert_called_once_with('', 1000004)
 
 

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -372,7 +372,7 @@ class TestSession(object):
         self.patched_library_interpreter.get_attribute_vi_int32.side_effect = [test_number]
         with nifake.Session('dev1') as session:
             attr_int = session.read_write_integer
-            assert (attr_int == test_number)
+            assert attr_int == test_number
             self.patched_library_interpreter.get_attribute_vi_int32.assert_called_once_with('', 1000004)
 
     def test_set_attribute_int32(self):
@@ -390,7 +390,7 @@ class TestSession(object):
         self.patched_library_interpreter.get_attribute_vi_int32.side_effect = [test_number_ms]
         with nifake.Session('dev1') as session:
             attr_timedelta = session.read_write_integer_with_converter
-            assert (attr_timedelta.total_seconds() == test_number_s)
+            assert attr_timedelta.total_seconds() == test_number_s
             self.patched_library_interpreter.get_attribute_vi_int32.assert_called_once_with('', attribute_id)
 
     def test_set_attribute_int32_with_converter(self):
@@ -565,7 +565,7 @@ class TestSession(object):
         attribute_id = 1000004
         with nifake.Session('dev1') as session:
             attr_int = session.channels[['0', '1']].read_write_integer
-            assert (attr_int == test_number)
+            assert attr_int == test_number
             self.patched_library_interpreter.get_attribute_vi_int32.assert_called_once_with('0,1', attribute_id)
 
     def test_set_attribute_channel(self):
@@ -582,7 +582,7 @@ class TestSession(object):
         self.patched_library_interpreter.get_attribute_vi_int64.side_effect = [test_number]
         with nifake.Session('dev1') as session:
             attr_int = session.read_write_int64
-            assert (attr_int == test_number)
+            assert attr_int == test_number
             self.patched_library_interpreter.get_attribute_vi_int64.assert_called_once_with('', attribute_id)
 
     def test_set_attribute_int64(self):
@@ -933,7 +933,7 @@ class TestGrpcSession(object):
         self.patched_grpc_interpreter.get_attribute_vi_int32.side_effect = [test_number]
         with nifake.Session('dev1', grpc_options=nifake.GrpcSessionOptions(object(), '')) as session:
             attr_int = session.read_write_integer
-            assert (attr_int == test_number)
+            assert attr_int == test_number
             self.patched_grpc_interpreter.get_attribute_vi_int32.assert_called_once_with('', 1000004)
 
 

--- a/src/nimodinst/system_tests/test_system_nimodinst.py
+++ b/src/nimodinst/system_tests/test_system_nimodinst.py
@@ -65,7 +65,7 @@ def test_serial_number_attribute():
         assert len(session) > 0, 'This test expects an instrument in the system (real or simulated).'
         pattern = r'^[0-9A-F]+$'
         assert isinstance(session.devices[0].serial_number, str)
-        assert (len(session.devices[0].serial_number) == 0) | (re.search(pattern, session.devices[0].serial_number) is not None)  # NI Serial numbers hex unless it is simulated than it is 0
+        assert (len(session.devices[0].serial_number) == 0) or (re.search(pattern, session.devices[0].serial_number) is not None)  # NI Serial numbers hex unless it is simulated than it is 0
 
 
 def test_bus_number_attribute():

--- a/src/nimodinst/unit_tests/test_modinst.py
+++ b/src/nimodinst/unit_tests/test_modinst.py
@@ -125,7 +125,7 @@ class TestSession(object):
         self.side_effects_helper['GetInstalledDeviceAttributeViInt32']['attributeValue'] = val
         with nimodinst.Session('') as session:
             attr_int = session.devices[0].chassis_number
-            assert (attr_int == val)
+            assert attr_int == val
 
     def test_get_attribute_vi_int32_for_loop_index(self):
         self.patched_library.niModInst_GetInstalledDeviceAttributeViInt32.side_effect = self.niModInst_GetInstalledDeviceAttributeViInt32_looping
@@ -134,7 +134,7 @@ class TestSession(object):
         with nimodinst.Session('') as session:
             attr_int = session.devices[index].chassis_number
             index += 1
-            assert (attr_int == self.int_vals_device_looping[self.iteration_device_looping - 1])  # Have to subtract once since it was already incremented in the callback function
+            assert attr_int == self.int_vals_device_looping[self.iteration_device_looping - 1]  # Have to subtract once since it was already incremented in the callback function
 
     def test_get_attribute_vi_string_for_loop_index(self):
         self.patched_library.niModInst_GetInstalledDeviceAttributeViString.side_effect = self.niModInst_GetInstalledDeviceAttributeViString_looping
@@ -143,7 +143,7 @@ class TestSession(object):
         with nimodinst.Session('') as session:
             attr_int = session.devices[index].device_name
             index += 1
-            assert (attr_int == self.string_vals_device_looping[self.iteration_device_looping - 1])  # Have to subtract once since it was already incremented in the callback function
+            assert attr_int == self.string_vals_device_looping[self.iteration_device_looping - 1]  # Have to subtract once since it was already incremented in the callback function
 
     def test_get_attribute_session_no_index(self):
         val = 123
@@ -163,7 +163,7 @@ class TestSession(object):
         with nimodinst.Session('') as session:
             for d in session:
                 attr_int = d.chassis_number
-                assert (attr_int == self.int_vals_device_looping[self.iteration_device_looping - 1])  # Have to subtract once since it was already incremented in the callback function
+                assert attr_int == self.int_vals_device_looping[self.iteration_device_looping - 1]  # Have to subtract once since it was already incremented in the callback function
 
     def test_get_attribute_vi_string_for_loop_multiple_devices(self):
         self.patched_library.niModInst_GetInstalledDeviceAttributeViString.side_effect = self.niModInst_GetInstalledDeviceAttributeViString_looping
@@ -171,7 +171,7 @@ class TestSession(object):
         with nimodinst.Session('') as session:
             for d in session:
                 attr_int = d.device_name
-                assert (attr_int == self.string_vals_device_looping[self.iteration_device_looping - 1])  # Have to subtract once since it was already incremented in the callback function
+                assert attr_int == self.string_vals_device_looping[self.iteration_device_looping - 1]  # Have to subtract once since it was already incremented in the callback function
 
     # Error Tests
     def test_cannot_add_properties_to_session_set(self):

--- a/src/nimodinst/unit_tests/test_modinst.py
+++ b/src/nimodinst/unit_tests/test_modinst.py
@@ -125,7 +125,7 @@ class TestSession(object):
         self.side_effects_helper['GetInstalledDeviceAttributeViInt32']['attributeValue'] = val
         with nimodinst.Session('') as session:
             attr_int = session.devices[0].chassis_number
-            assert(attr_int == val)
+            assert (attr_int == val)
 
     def test_get_attribute_vi_int32_for_loop_index(self):
         self.patched_library.niModInst_GetInstalledDeviceAttributeViInt32.side_effect = self.niModInst_GetInstalledDeviceAttributeViInt32_looping
@@ -134,7 +134,7 @@ class TestSession(object):
         with nimodinst.Session('') as session:
             attr_int = session.devices[index].chassis_number
             index += 1
-            assert(attr_int == self.int_vals_device_looping[self.iteration_device_looping - 1])  # Have to subtract once since it was already incremented in the callback function
+            assert (attr_int == self.int_vals_device_looping[self.iteration_device_looping - 1])  # Have to subtract once since it was already incremented in the callback function
 
     def test_get_attribute_vi_string_for_loop_index(self):
         self.patched_library.niModInst_GetInstalledDeviceAttributeViString.side_effect = self.niModInst_GetInstalledDeviceAttributeViString_looping
@@ -143,7 +143,7 @@ class TestSession(object):
         with nimodinst.Session('') as session:
             attr_int = session.devices[index].device_name
             index += 1
-            assert(attr_int == self.string_vals_device_looping[self.iteration_device_looping - 1])  # Have to subtract once since it was already incremented in the callback function
+            assert (attr_int == self.string_vals_device_looping[self.iteration_device_looping - 1])  # Have to subtract once since it was already incremented in the callback function
 
     def test_get_attribute_session_no_index(self):
         val = 123
@@ -163,7 +163,7 @@ class TestSession(object):
         with nimodinst.Session('') as session:
             for d in session:
                 attr_int = d.chassis_number
-                assert(attr_int == self.int_vals_device_looping[self.iteration_device_looping - 1])  # Have to subtract once since it was already incremented in the callback function
+                assert (attr_int == self.int_vals_device_looping[self.iteration_device_looping - 1])  # Have to subtract once since it was already incremented in the callback function
 
     def test_get_attribute_vi_string_for_loop_multiple_devices(self):
         self.patched_library.niModInst_GetInstalledDeviceAttributeViString.side_effect = self.niModInst_GetInstalledDeviceAttributeViString_looping
@@ -171,7 +171,7 @@ class TestSession(object):
         with nimodinst.Session('') as session:
             for d in session:
                 attr_int = d.device_name
-                assert(attr_int == self.string_vals_device_looping[self.iteration_device_looping - 1])  # Have to subtract once since it was already incremented in the callback function
+                assert (attr_int == self.string_vals_device_looping[self.iteration_device_looping - 1])  # Have to subtract once since it was already incremented in the callback function
 
     # Error Tests
     def test_cannot_add_properties_to_session_set(self):

--- a/src/nitclk/unit_tests/test_nitclk.py
+++ b/src/nitclk/unit_tests/test_nitclk.py
@@ -189,7 +189,7 @@ class TestNitclkApi(object):
         test_number = 4.2
         self.side_effects_helper['GetAttributeViReal64']['value'] = test_number
         attr_val = session.tclk_actual_period
-        assert (attr_val == test_number)
+        assert attr_val == test_number
         self.patched_library.niTClk_GetAttributeViReal64.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViReal64PointerMatcher())
 
     def test_set_timedelta_as_vi_real64(self):
@@ -215,7 +215,7 @@ class TestNitclkApi(object):
         test_number = 4.2
         self.side_effects_helper['GetAttributeViReal64']['value'] = test_number
         attr_timedelta = session.sample_clock_delay
-        assert (attr_timedelta.total_seconds() == test_number)
+        assert attr_timedelta.total_seconds() == test_number
         self.patched_library.niTClk_GetAttributeViReal64.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViReal64PointerMatcher())
 
     def test_set_vi_string(self):
@@ -233,7 +233,7 @@ class TestNitclkApi(object):
         test_string = "The answer to the ultimate question is 42"
         self.side_effects_helper['GetAttributeViString']['value'] = test_string
         attr_string = session.sync_pulse_sender_sync_pulse_source
-        assert (attr_string == test_string)
+        assert attr_string == test_string
 
         from unittest.mock import call
         calls = [call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt32Matcher(0), None), call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt32Matcher(len(test_string)), _matchers.ViCharBufferMatcher(len(test_string)))]
@@ -278,7 +278,7 @@ class TestNitclkApi(object):
         self.side_effects_helper['GetAttributeViSession']['value'] = other_session_number
         attr_session_reference = session.start_trigger_master_session
         assert type(attr_session_reference) is nitclk.SessionReference
-        assert (attr_session_reference._get_tclk_session_reference() == other_session_number)
+        assert attr_session_reference._get_tclk_session_reference() == other_session_number
         self.patched_library.niTClk_GetAttributeViSession.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViSessionPointerMatcher())
 
 

--- a/src/nitclk/unit_tests/test_nitclk.py
+++ b/src/nitclk/unit_tests/test_nitclk.py
@@ -189,7 +189,7 @@ class TestNitclkApi(object):
         test_number = 4.2
         self.side_effects_helper['GetAttributeViReal64']['value'] = test_number
         attr_val = session.tclk_actual_period
-        assert(attr_val == test_number)
+        assert (attr_val == test_number)
         self.patched_library.niTClk_GetAttributeViReal64.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViReal64PointerMatcher())
 
     def test_set_timedelta_as_vi_real64(self):
@@ -215,7 +215,7 @@ class TestNitclkApi(object):
         test_number = 4.2
         self.side_effects_helper['GetAttributeViReal64']['value'] = test_number
         attr_timedelta = session.sample_clock_delay
-        assert(attr_timedelta.total_seconds() == test_number)
+        assert (attr_timedelta.total_seconds() == test_number)
         self.patched_library.niTClk_GetAttributeViReal64.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViReal64PointerMatcher())
 
     def test_set_vi_string(self):
@@ -233,7 +233,7 @@ class TestNitclkApi(object):
         test_string = "The answer to the ultimate question is 42"
         self.side_effects_helper['GetAttributeViString']['value'] = test_string
         attr_string = session.sync_pulse_sender_sync_pulse_source
-        assert(attr_string == test_string)
+        assert (attr_string == test_string)
 
         from unittest.mock import call
         calls = [call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt32Matcher(0), None), call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViInt32Matcher(len(test_string)), _matchers.ViCharBufferMatcher(len(test_string)))]
@@ -278,7 +278,7 @@ class TestNitclkApi(object):
         self.side_effects_helper['GetAttributeViSession']['value'] = other_session_number
         attr_session_reference = session.start_trigger_master_session
         assert type(attr_session_reference) is nitclk.SessionReference
-        assert(attr_session_reference._get_tclk_session_reference() == other_session_number)
+        assert (attr_session_reference._get_tclk_session_reference() == other_session_number)
         self.patched_library.niTClk_GetAttributeViSession.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViStringMatcher(''), _matchers.ViAttrMatcher(attribute_id), _matchers.ViSessionPointerMatcher())
 
 


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
TL;DR: Fix flake8 PR Check failures by adding a space between `assert` and `(`. Also do some optional cleanup of issues we noticed in asserts.

Due to a bump in the version of flake8 used in our travis-ci runs  (seems to be caused by a version bump of another depedency), we are now using flake8 5.0.4.

Aside: Previously, we used flake8 4.0.1 and there is already a 6.0.0.

Due to the version bump, flake8 now raises the complaint "E275 missing whitespace after keyword" on `assert(`. Apparently `assert` is only a keyword, not a method.

Fixes:
* space between `assert` and `(`
* Remove redundant parentheses in assert statements
   * Most parentheses in assert statements are redundant
* Correct `test_serial_number_attribute` assert's use of `|`. It should be `or`

### List issues fixed by this Pull Request below, if any.
None

### What testing has been done?
Locally ran `tox -e build_test` and `tox -e flake8`.