### PR TITLE
Add get_channel_names to niscope API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ All notable changes to this project will be documented in this file.
     * #### Removed
 * ### `niscope` (NI-SCOPE)
     * #### Added
+        * `get_channel_names()`
     * #### Changed
     * #### Removed
 * ### `niswitch` (NI-SWITCH)

--- a/docs/niscope/class.rst
+++ b/docs/niscope/class.rst
@@ -1894,6 +1894,45 @@ fetch_measurement_stats
 
 
 
+get_channel_names
+-----------------
+
+    .. py:currentmodule:: niscope.Session
+
+    .. py:method:: get_channel_names(indices)
+
+            Returns a list of channel names for given channel indices.
+
+            
+
+
+
+            :param indices:
+
+
+                Index list for the channels in the session. Valid values are from zero to the total number of channels in the session minus one. The index string can be one of the following formats:
+
+                -   A comma-separated list—for example, "0,2,3,1"
+                -   A range using a hyphen—for example, "0-3"
+                -   A range using a colon—for example, "0:3 "
+
+                You can combine comma-separated lists and ranges that use a hyphen or colon. Both out-of-order and repeated indices are supported ("2,3,0," "1,2,2,3"). White space characters, including spaces, tabs, feeds, and carriage returns, are allowed between characters. Ranges can be incrementing or decrementing.
+
+                
+
+
+            :type indices: basic sequence types or str or int
+
+            :rtype: list of str
+            :return:
+
+
+                    The channel name(s) at the specified indices.
+
+                    
+
+
+
 get_equalization_filter_coefficients
 ------------------------------------
 

--- a/generated/niscope/niscope/_grpc_stub_interpreter.py
+++ b/generated/niscope/niscope/_grpc_stub_interpreter.py
@@ -307,6 +307,13 @@ class GrpcStubInterpreter(object):
         )
         return response.value
 
+    def get_channel_names(self, indices):  # noqa: N802
+        response = self._invoke(
+            self._client.GetChannelNameFromString,
+            grpc_types.GetChannelNameFromStringRequest(vi=self._vi, index=indices),
+        )
+        return response.name
+
     def get_equalization_filter_coefficients(self, channel, number_of_coefficients):  # noqa: N802
         response = self._invoke(
             self._client.GetEqualizationFilterCoefficients,

--- a/generated/niscope/niscope/_library.py
+++ b/generated/niscope/niscope/_library.py
@@ -61,6 +61,7 @@ class Library(object):
         self.niScope_GetAttributeViInt64_cfunc = None
         self.niScope_GetAttributeViReal64_cfunc = None
         self.niScope_GetAttributeViString_cfunc = None
+        self.niScope_GetChannelNameFromString_cfunc = None
         self.niScope_GetEqualizationFilterCoefficients_cfunc = None
         self.niScope_GetError_cfunc = None
         self.niScope_ImportAttributeConfigurationBuffer_cfunc = None
@@ -395,6 +396,14 @@ class Library(object):
                 self.niScope_GetAttributeViString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViAttr, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_GetAttributeViString_cfunc(vi, channel_list, attribute_id, buf_size, value)
+
+    def niScope_GetChannelNameFromString(self, vi, indices, name_buffer_size, names):  # noqa: N802
+        with self._func_lock:
+            if self.niScope_GetChannelNameFromString_cfunc is None:
+                self.niScope_GetChannelNameFromString_cfunc = self._get_library_function('niScope_GetChannelNameFromString')
+                self.niScope_GetChannelNameFromString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
+                self.niScope_GetChannelNameFromString_cfunc.restype = ViStatus  # noqa: F405
+        return self.niScope_GetChannelNameFromString_cfunc(vi, indices, name_buffer_size, names)
 
     def niScope_GetEqualizationFilterCoefficients(self, vi, channel, number_of_coefficients, coefficients):  # noqa: N802
         with self._func_lock:

--- a/generated/niscope/niscope/_library.py
+++ b/generated/niscope/niscope/_library.py
@@ -397,13 +397,13 @@ class Library(object):
                 self.niScope_GetAttributeViString_cfunc.restype = ViStatus  # noqa: F405
         return self.niScope_GetAttributeViString_cfunc(vi, channel_list, attribute_id, buf_size, value)
 
-    def niScope_GetChannelNameFromString(self, vi, indices, name_buffer_size, names):  # noqa: N802
+    def niScope_GetChannelNameFromString(self, vi, indices, buffer_size, names):  # noqa: N802
         with self._func_lock:
             if self.niScope_GetChannelNameFromString_cfunc is None:
                 self.niScope_GetChannelNameFromString_cfunc = self._get_library_function('niScope_GetChannelNameFromString')
                 self.niScope_GetChannelNameFromString_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niScope_GetChannelNameFromString_cfunc.restype = ViStatus  # noqa: F405
-        return self.niScope_GetChannelNameFromString_cfunc(vi, indices, name_buffer_size, names)
+        return self.niScope_GetChannelNameFromString_cfunc(vi, indices, buffer_size, names)
 
     def niScope_GetEqualizationFilterCoefficients(self, vi, channel, number_of_coefficients, coefficients):  # noqa: N802
         with self._func_lock:

--- a/generated/niscope/niscope/_library_interpreter.py
+++ b/generated/niscope/niscope/_library_interpreter.py
@@ -486,6 +486,19 @@ class LibraryInterpreter(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return value_ctype.value.decode(self._encoding)
 
+    def get_channel_names(self, indices):  # noqa: N802
+        vi_ctype = _visatype.ViSession(self._vi)  # case S110
+        indices_ctype = ctypes.create_string_buffer(indices.encode(self._encoding))  # case C020
+        name_buffer_size_ctype = _visatype.ViInt32()  # case S170
+        names_ctype = None  # case C050
+        error_code = self._library.niScope_GetChannelNameFromString(vi_ctype, indices_ctype, name_buffer_size_ctype, names_ctype)
+        errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
+        name_buffer_size_ctype = _visatype.ViInt32(error_code)  # case S180
+        names_ctype = (_visatype.ViChar * name_buffer_size_ctype.value)()  # case C060
+        error_code = self._library.niScope_GetChannelNameFromString(vi_ctype, indices_ctype, name_buffer_size_ctype, names_ctype)
+        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
+        return names_ctype.value.decode(self._encoding)
+
     def get_equalization_filter_coefficients(self, channel, number_of_coefficients):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         channel_ctype = ctypes.create_string_buffer(channel.encode(self._encoding))  # case C010

--- a/generated/niscope/niscope/_library_interpreter.py
+++ b/generated/niscope/niscope/_library_interpreter.py
@@ -489,13 +489,13 @@ class LibraryInterpreter(object):
     def get_channel_names(self, indices):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         indices_ctype = ctypes.create_string_buffer(indices.encode(self._encoding))  # case C020
-        name_buffer_size_ctype = _visatype.ViInt32()  # case S170
+        buffer_size_ctype = _visatype.ViInt32()  # case S170
         names_ctype = None  # case C050
-        error_code = self._library.niScope_GetChannelNameFromString(vi_ctype, indices_ctype, name_buffer_size_ctype, names_ctype)
+        error_code = self._library.niScope_GetChannelNameFromString(vi_ctype, indices_ctype, buffer_size_ctype, names_ctype)
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
-        name_buffer_size_ctype = _visatype.ViInt32(error_code)  # case S180
-        names_ctype = (_visatype.ViChar * name_buffer_size_ctype.value)()  # case C060
-        error_code = self._library.niScope_GetChannelNameFromString(vi_ctype, indices_ctype, name_buffer_size_ctype, names_ctype)
+        buffer_size_ctype = _visatype.ViInt32(error_code)  # case S180
+        names_ctype = (_visatype.ViChar * buffer_size_ctype.value)()  # case C060
+        error_code = self._library.niScope_GetChannelNameFromString(vi_ctype, indices_ctype, buffer_size_ctype, names_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return names_ctype.value.decode(self._encoding)
 

--- a/generated/niscope/niscope/session.py
+++ b/generated/niscope/niscope/session.py
@@ -3421,6 +3421,30 @@ class _SessionBase(object):
         return value
 
     @ivi_synchronized
+    def get_channel_names(self, indices):
+        r'''get_channel_names
+
+        Returns a list of channel names for given channel indices.
+
+        Args:
+            indices (basic sequence types or str or int): Index list for the channels in the session. Valid values are from zero to the total number of channels in the session minus one. The index string can be one of the following formats:
+
+                -   A comma-separated list—for example, "0,2,3,1"
+                -   A range using a hyphen—for example, "0-3"
+                -   A range using a colon—for example, "0:3 "
+
+                You can combine comma-separated lists and ranges that use a hyphen or colon. Both out-of-order and repeated indices are supported ("2,3,0," "1,2,2,3"). White space characters, including spaces, tabs, feeds, and carriage returns, are allowed between characters. Ranges can be incrementing or decrementing.
+
+
+        Returns:
+            names (list of str): The channel name(s) at the specified indices.
+
+        '''
+        indices = _converters.convert_repeated_capabilities_without_prefix(indices)
+        names = self._interpreter.get_channel_names(indices)
+        return _converters.convert_comma_separated_string_to_list(names)
+
+    @ivi_synchronized
     def _get_equalization_filter_coefficients(self, number_of_coefficients):
         r'''_get_equalization_filter_coefficients
 

--- a/generated/niscope/niscope/session.py
+++ b/generated/niscope/niscope/session.py
@@ -3421,30 +3421,6 @@ class _SessionBase(object):
         return value
 
     @ivi_synchronized
-    def get_channel_names(self, indices):
-        r'''get_channel_names
-
-        Returns a list of channel names for given channel indices.
-
-        Args:
-            indices (basic sequence types or str or int): Index list for the channels in the session. Valid values are from zero to the total number of channels in the session minus one. The index string can be one of the following formats:
-
-                -   A comma-separated list—for example, "0,2,3,1"
-                -   A range using a hyphen—for example, "0-3"
-                -   A range using a colon—for example, "0:3 "
-
-                You can combine comma-separated lists and ranges that use a hyphen or colon. Both out-of-order and repeated indices are supported ("2,3,0," "1,2,2,3"). White space characters, including spaces, tabs, feeds, and carriage returns, are allowed between characters. Ranges can be incrementing or decrementing.
-
-
-        Returns:
-            names (list of str): The channel name(s) at the specified indices.
-
-        '''
-        indices = _converters.convert_repeated_capabilities_without_prefix(indices)
-        names = self._interpreter.get_channel_names(indices)
-        return _converters.convert_comma_separated_string_to_list(names)
-
-    @ivi_synchronized
     def _get_equalization_filter_coefficients(self, number_of_coefficients):
         r'''_get_equalization_filter_coefficients
 
@@ -4845,6 +4821,30 @@ class Session(_SessionBase):
         '''
 
         return self._cal_fetch_temperature(enums._CalibrationTypes.SELF.value)
+
+    @ivi_synchronized
+    def get_channel_names(self, indices):
+        r'''get_channel_names
+
+        Returns a list of channel names for given channel indices.
+
+        Args:
+            indices (basic sequence types or str or int): Index list for the channels in the session. Valid values are from zero to the total number of channels in the session minus one. The index string can be one of the following formats:
+
+                -   A comma-separated list—for example, "0,2,3,1"
+                -   A range using a hyphen—for example, "0-3"
+                -   A range using a colon—for example, "0:3 "
+
+                You can combine comma-separated lists and ranges that use a hyphen or colon. Both out-of-order and repeated indices are supported ("2,3,0," "1,2,2,3"). White space characters, including spaces, tabs, feeds, and carriage returns, are allowed between characters. Ranges can be incrementing or decrementing.
+
+
+        Returns:
+            names (list of str): The channel name(s) at the specified indices.
+
+        '''
+        indices = _converters.convert_repeated_capabilities_without_prefix(indices)
+        names = self._interpreter.get_channel_names(indices)
+        return _converters.convert_comma_separated_string_to_list(names)
 
     @ivi_synchronized
     def import_attribute_configuration_buffer(self, configuration):

--- a/generated/niscope/niscope/unit_tests/_mock_helper.py
+++ b/generated/niscope/niscope/unit_tests/_mock_helper.py
@@ -626,13 +626,13 @@ class SideEffectsHelper(object):
         value.value = self._defaults['GetAttributeViString']['value'].encode('ascii')
         return self._defaults['GetAttributeViString']['return']
 
-    def niScope_GetChannelNameFromString(self, vi, indices, name_buffer_size, names):  # noqa: N802
+    def niScope_GetChannelNameFromString(self, vi, indices, buffer_size, names):  # noqa: N802
         if self._defaults['GetChannelNameFromString']['return'] != 0:
             return self._defaults['GetChannelNameFromString']['return']
         # names
         if self._defaults['GetChannelNameFromString']['name'] is None:
             raise MockFunctionCallError("niScope_GetChannelNameFromString", param='name')
-        if name_buffer_size.value == 0:
+        if buffer_size.value == 0:
             return len(self._defaults['GetChannelNameFromString']['name'])
         names.value = self._defaults['GetChannelNameFromString']['name'].encode('ascii')
         return self._defaults['GetChannelNameFromString']['return']

--- a/generated/niscope/niscope/unit_tests/_mock_helper.py
+++ b/generated/niscope/niscope/unit_tests/_mock_helper.py
@@ -121,6 +121,9 @@ class SideEffectsHelper(object):
         self._defaults['GetAttributeViString'] = {}
         self._defaults['GetAttributeViString']['return'] = 0
         self._defaults['GetAttributeViString']['value'] = None
+        self._defaults['GetChannelNameFromString'] = {}
+        self._defaults['GetChannelNameFromString']['return'] = 0
+        self._defaults['GetChannelNameFromString']['name'] = None
         self._defaults['GetEqualizationFilterCoefficients'] = {}
         self._defaults['GetEqualizationFilterCoefficients']['return'] = 0
         self._defaults['GetEqualizationFilterCoefficients']['coefficients'] = None
@@ -623,6 +626,17 @@ class SideEffectsHelper(object):
         value.value = self._defaults['GetAttributeViString']['value'].encode('ascii')
         return self._defaults['GetAttributeViString']['return']
 
+    def niScope_GetChannelNameFromString(self, vi, indices, name_buffer_size, names):  # noqa: N802
+        if self._defaults['GetChannelNameFromString']['return'] != 0:
+            return self._defaults['GetChannelNameFromString']['return']
+        # names
+        if self._defaults['GetChannelNameFromString']['name'] is None:
+            raise MockFunctionCallError("niScope_GetChannelNameFromString", param='name')
+        if name_buffer_size.value == 0:
+            return len(self._defaults['GetChannelNameFromString']['name'])
+        names.value = self._defaults['GetChannelNameFromString']['name'].encode('ascii')
+        return self._defaults['GetChannelNameFromString']['return']
+
     def niScope_GetEqualizationFilterCoefficients(self, vi, channel, number_of_coefficients, coefficients):  # noqa: N802
         if self._defaults['GetEqualizationFilterCoefficients']['return'] != 0:
             return self._defaults['GetEqualizationFilterCoefficients']['return']
@@ -898,6 +912,8 @@ class SideEffectsHelper(object):
         mock_library.niScope_GetAttributeViReal64.return_value = 0
         mock_library.niScope_GetAttributeViString.side_effect = MockFunctionCallError("niScope_GetAttributeViString")
         mock_library.niScope_GetAttributeViString.return_value = 0
+        mock_library.niScope_GetChannelNameFromString.side_effect = MockFunctionCallError("niScope_GetChannelNameFromString")
+        mock_library.niScope_GetChannelNameFromString.return_value = 0
         mock_library.niScope_GetEqualizationFilterCoefficients.side_effect = MockFunctionCallError("niScope_GetEqualizationFilterCoefficients")
         mock_library.niScope_GetEqualizationFilterCoefficients.return_value = 0
         mock_library.niScope_GetError.side_effect = MockFunctionCallError("niScope_GetError")

--- a/src/niscope/metadata/functions_addon.py
+++ b/src/niscope/metadata/functions_addon.py
@@ -14,7 +14,63 @@ functions_override_metadata = {
         ]
     }
 }
-
+functions_additional_get_channel_name = {
+    'GetChannelNameFromString': {
+        'documentation': {
+            'description': 'Returns a list of channel names for given channel indices.\n'
+        },
+        'included_in_proto': True,
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': '\nThe instrument handle you obtain from niScope_init that identifies a\nparticular instrument session.\n'
+                },
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Index list for the channels in the session. Valid values are from zero to the total number of channels in the session minus one. The index string can be one of the following formats:\n\n-   A comma-separated list—for example, "0,2,3,1"\n-   A range using a hyphen—for example, "0-3"\n-   A range using a colon—for example, "0:3 "\n\nYou can combine comma-separated lists and ranges that use a hyphen or colon. Both out-of-order and repeated indices are supported ("2,3,0," "1,2,2,3"). White space characters, including spaces, tabs, feeds, and carriage returns, are allowed between characters. Ranges can be incrementing or decrementing.\n'
+                },
+                'grpc_name': 'index',
+                'name': 'index',
+                'python_api_converter_name': 'convert_repeated_capabilities_without_prefix',
+                'python_name': 'indices',
+                'type': 'ViConstString',
+                'type_in_documentation': 'basic sequence types or str or int',
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'The number of elements in the ViChar array you specify for name.\n'
+                },
+                'name': 'nameBufferSize',
+                'type': 'ViInt32'
+            },
+            {
+                'direction': 'out',
+                'documentation': {
+                    'description': 'The channel name(s) at the specified indices.\n'
+                },
+                'grpc_name': 'name',
+                'name': 'name',
+                'python_api_converter_name': 'convert_comma_separated_string_to_list',
+                'python_name': 'names',
+                'size': {
+                    'mechanism': 'ivi-dance',
+                    'value': 'nameBufferSize'
+                },
+                'type': 'ViChar[]',
+                'type_in_documentation': 'list of str',
+            }
+        ],
+        'python_name': 'get_channel_names',
+        'render_in_session_base': True,
+        'returns': 'ViStatus'
+    }
+}
 functions_additional_fetch_array_measurement = {
     'FancyFetchArrayMeasurement': {
         'codegen_method': 'python-only',

--- a/src/niscope/metadata/functions_addon.py
+++ b/src/niscope/metadata/functions_addon.py
@@ -19,7 +19,6 @@ functions_additional_get_channel_name = {
         'documentation': {
             'description': 'Returns a list of channel names for given channel indices.\n'
         },
-        'included_in_proto': True,
         'parameters': [
             {
                 'direction': 'in',

--- a/src/niscope/metadata/functions_addon.py
+++ b/src/niscope/metadata/functions_addon.py
@@ -67,7 +67,6 @@ functions_additional_get_channel_name = {
             }
         ],
         'python_name': 'get_channel_names',
-        'render_in_session_base': True,
         'returns': 'ViStatus'
     },
 }

--- a/src/niscope/metadata/functions_addon.py
+++ b/src/niscope/metadata/functions_addon.py
@@ -19,6 +19,7 @@ functions_additional_get_channel_name = {
         'documentation': {
             'description': 'Returns a list of channel names for given channel indices.\n'
         },
+        'included_in_proto': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -38,14 +39,14 @@ functions_additional_get_channel_name = {
                 'python_api_converter_name': 'convert_repeated_capabilities_without_prefix',
                 'python_name': 'indices',
                 'type': 'ViConstString',
-                'type_in_documentation': 'basic sequence types or str or int',
+                'type_in_documentation': 'basic sequence types or str or int'
             },
             {
                 'direction': 'in',
                 'documentation': {
                     'description': 'The number of elements in the ViChar array you specify for name.\n'
                 },
-                'name': 'nameBufferSize',
+                'name': 'bufferSize',
                 'type': 'ViInt32'
             },
             {
@@ -59,16 +60,16 @@ functions_additional_get_channel_name = {
                 'python_name': 'names',
                 'size': {
                     'mechanism': 'ivi-dance',
-                    'value': 'nameBufferSize'
+                    'value': 'bufferSize'
                 },
                 'type': 'ViChar[]',
-                'type_in_documentation': 'list of str',
+                'type_in_documentation': 'list of str'
             }
         ],
         'python_name': 'get_channel_names',
         'render_in_session_base': True,
         'returns': 'ViStatus'
-    }
+    },
 }
 functions_additional_fetch_array_measurement = {
     'FancyFetchArrayMeasurement': {

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -114,7 +114,7 @@ class SystemTests:
 
     # Basic usability tests
     def test_get_channel_names_with_single_instrument_session(self, single_instrument_session_5171):
-        expected_string = [f'FakeDevice/{x}' for x in range(8)] + [f'FakeDevice/{x}' for x in range(4)]
+        expected_string = [f'{x}' for x in range(8)]
         # Sanity test few different types of input. No need for test to be exhaustive
         # since all the various types are covered by converter unit tests.
         channel_indices = ['0-1, 2, 3:4', 5, range(6, 7), slice(7, 8)]


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- [X] I've added tests applicable for this pull request

### What does this Pull Request accomplish?
Add the `get_channel_names` method to the niscope API. Per the decision made in #1386, `get_channel_name` and `get_channel_name_from_string` will not be added. This will be the only entrypoint for translating channel indices to names.

Implementation:
Copied the current metadata from nidigital and tweaked parameter names and some hidden parameter documentation for niscope.

### List issues fixed by this Pull Request below, if any.

* Fix #1402

### What testing has been done?
* Copied `test_get_channel_names` from nidigital and modified it for niscope. It passes.