### PR TITLE
niscope: expand channels repeated_capability before populating channel and record info in fetched data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ All notable changes to this project will be documented in this file.
 * ### `niscope` (NI-SCOPE)
     * #### Added
     * #### Changed
+        * Fix [#1770](https://github.com/ni/nimi-python/issues/1770): fetch(), read(), and friends return wrong data when called with channel ranges on multi-instrument niscope session.
     * #### Removed
 * ### `niswitch` (NI-SWITCH)
     * #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ All notable changes to this project will be documented in this file.
     * #### Added
         * `get_channel_names()`
     * #### Changed
-        * Fix [#1770](https://github.com/ni/nimi-python/issues/1770): fetch(), read(), and friends return wrong data when called with channel ranges on multi-instrument niscope session.
+        * Fix [#1770](https://github.com/ni/nimi-python/issues/1770): fetch(), read(), and friends return wrong data when called with channel ranges on multi-instrument session.
     * #### Removed
 * ### `niswitch` (NI-SWITCH)
     * #### Added

--- a/generated/niscope/niscope/session.py
+++ b/generated/niscope/niscope/session.py
@@ -2123,6 +2123,11 @@ class _SessionBase(object):
             if num_samples is None:
                 num_samples = self.horz_record_length
 
+        channel_names = _converters.expand_channel_string(
+            self._repeated_capability,
+            self._all_channels_in_session
+        )
+
         wfm, wfm_info = self._fetch(num_samples, timeout)
 
         if isinstance(wfm, array.ArrayType):
@@ -2133,11 +2138,11 @@ class _SessionBase(object):
         waveform_info._populate_samples_info(wfm_info, mv, num_samples)
 
         lwfm_i = len(wfm_info)
-        lrcl = len(self._repeated_capability_list)
+        lrcl = len(channel_names)
         # Should this raise instead? If this asserts, is it the users fault?
-        assert lwfm_i % lrcl == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(self._repeated_capability_list) == {1}'.format(lwfm_i, lrcl)
+        assert lwfm_i % lrcl == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(channel_names) == {1}'.format(lwfm_i, lrcl)
         actual_num_records = int(lwfm_i / lrcl)
-        waveform_info._populate_channel_and_record_info(wfm_info, self._repeated_capability_list, range(record_number, record_number + actual_num_records))
+        waveform_info._populate_channel_and_record_info(wfm_info, channel_names, range(record_number, record_number + actual_num_records))
 
         return wfm_info
 
@@ -2425,6 +2430,11 @@ class _SessionBase(object):
             if num_samples is None:
                 num_samples = self.horz_record_length
 
+        channel_names = _converters.expand_channel_string(
+            self._repeated_capability,
+            self._all_channels_in_session
+        )
+
         wfm, wfm_info = self._read(num_samples, timeout)
 
         if isinstance(wfm, array.ArrayType):
@@ -2435,11 +2445,11 @@ class _SessionBase(object):
         waveform_info._populate_samples_info(wfm_info, mv, num_samples)
 
         lwfm_i = len(wfm_info)
-        lrcl = len(self._repeated_capability_list)
+        lrcl = len(channel_names)
         # Should this raise instead? If this asserts, is it the users fault?
-        assert lwfm_i % lrcl == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(self._repeated_capability_list) == {1}'.format(lwfm_i, lrcl)
+        assert lwfm_i % lrcl == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(channel_names) == {1}'.format(lwfm_i, lrcl)
         actual_num_records = int(lwfm_i / lrcl)
-        waveform_info._populate_channel_and_record_info(wfm_info, self._repeated_capability_list, range(record_number, record_number + actual_num_records))
+        waveform_info._populate_channel_and_record_info(wfm_info, channel_names, range(record_number, record_number + actual_num_records))
 
         return wfm_info
 

--- a/generated/niscope/niscope/session.py
+++ b/generated/niscope/niscope/session.py
@@ -3167,11 +3167,16 @@ class _SessionBase(object):
 
         waveform_info._populate_samples_info(wfm_info, mv, num_samples)
 
+        channel_names = _converters.expand_channel_string(
+            self._repeated_capability,
+            self._all_channels_in_session
+        )
+
         lwfm_i = len(wfm_info)
-        lrcl = len(self._repeated_capability_list)
-        assert lwfm_i % lrcl == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(self._repeated_capability_list) == {1}'.format(lwfm_i, lrcl)
+        lrcl = len(channel_names)
+        assert lwfm_i % lrcl == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(channel_names) == {1}'.format(lwfm_i, lrcl)
         actual_num_records = int(lwfm_i / lrcl)
-        waveform_info._populate_channel_and_record_info(wfm_info, self._repeated_capability_list, range(record_number, record_number + actual_num_records))
+        waveform_info._populate_channel_and_record_info(wfm_info, channel_names, range(record_number, record_number + actual_num_records))
 
         return wfm_info
 

--- a/generated/niscope/niscope/session.py
+++ b/generated/niscope/niscope/session.py
@@ -2123,11 +2123,6 @@ class _SessionBase(object):
             if num_samples is None:
                 num_samples = self.horz_record_length
 
-        channel_names = _converters.expand_channel_string(
-            self._repeated_capability,
-            self._all_channels_in_session
-        )
-
         wfm, wfm_info = self._fetch(num_samples, timeout)
 
         if isinstance(wfm, array.ArrayType):
@@ -2137,11 +2132,16 @@ class _SessionBase(object):
 
         waveform_info._populate_samples_info(wfm_info, mv, num_samples)
 
-        lwfm_i = len(wfm_info)
-        lrcl = len(channel_names)
+        channel_names = _converters.expand_channel_string(
+            self._repeated_capability,
+            self._all_channels_in_session
+        )
+
+        wfm_info_count = len(wfm_info)
+        channel_count = len(channel_names)
         # Should this raise instead? If this asserts, is it the users fault?
-        assert lwfm_i % lrcl == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(channel_names) == {1}'.format(lwfm_i, lrcl)
-        actual_num_records = int(lwfm_i / lrcl)
+        assert wfm_info_count % channel_count == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(channel_names) == {1}'.format(wfm_info_count, channel_count)
+        actual_num_records = int(wfm_info_count / channel_count)
         waveform_info._populate_channel_and_record_info(wfm_info, channel_names, range(record_number, record_number + actual_num_records))
 
         return wfm_info
@@ -2231,18 +2231,19 @@ class _SessionBase(object):
             if meas_wfm_size is None:
                 meas_wfm_size = self._actual_meas_wfm_size(array_meas_function)
 
-        channel_names = _converters.expand_channel_string(
-            self._repeated_capability,
-            self._all_channels_in_session
-        )
-
         meas_wfm, wfm_info = self._fetch_array_measurement(array_meas_function, meas_wfm_size, timeout)
 
         record_length = int(len(meas_wfm) / len(wfm_info))
         waveform_info._populate_samples_info(wfm_info, meas_wfm, record_length)
 
+        channel_names = _converters.expand_channel_string(
+            self._repeated_capability,
+            self._all_channels_in_session
+        )
+
         wfm_info_count = len(wfm_info)
         channel_count = len(channel_names)
+        # Should this raise instead? If this asserts, is it the users fault?
         assert wfm_info_count % channel_count == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(channel_names) == {1}'.format(wfm_info_count, channel_count)
         actual_num_records = int(wfm_info_count / channel_count)
         waveform_info._populate_channel_and_record_info(wfm_info, channel_names, range(record_number, record_number + actual_num_records))
@@ -2342,6 +2343,7 @@ class _SessionBase(object):
 
         results_count = len(results)
         channel_count = len(channel_names)
+        # Should this raise instead? If this asserts, is it the users fault?
         assert results_count % channel_count == 0, 'Number of results should be evenly divisible by the number of channels: len(results) == {0}, len(channel_names) == {1}'.format(results_count, channel_count)
         actual_num_records = int(results_count / channel_count)
         waveform_info._populate_channel_and_record_info(output, channel_names, range(record_number, record_number + actual_num_records))
@@ -2440,11 +2442,6 @@ class _SessionBase(object):
             if num_samples is None:
                 num_samples = self.horz_record_length
 
-        channel_names = _converters.expand_channel_string(
-            self._repeated_capability,
-            self._all_channels_in_session
-        )
-
         wfm, wfm_info = self._read(num_samples, timeout)
 
         if isinstance(wfm, array.ArrayType):
@@ -2454,11 +2451,16 @@ class _SessionBase(object):
 
         waveform_info._populate_samples_info(wfm_info, mv, num_samples)
 
-        lwfm_i = len(wfm_info)
-        lrcl = len(channel_names)
+        channel_names = _converters.expand_channel_string(
+            self._repeated_capability,
+            self._all_channels_in_session
+        )
+
+        wfm_info_count = len(wfm_info)
+        channel_count = len(channel_names)
         # Should this raise instead? If this asserts, is it the users fault?
-        assert lwfm_i % lrcl == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(channel_names) == {1}'.format(lwfm_i, lrcl)
-        actual_num_records = int(lwfm_i / lrcl)
+        assert wfm_info_count % channel_count == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(channel_names) == {1}'.format(wfm_info_count, channel_count)
+        actual_num_records = int(wfm_info_count / channel_count)
         waveform_info._populate_channel_and_record_info(wfm_info, channel_names, range(record_number, record_number + actual_num_records))
 
         return wfm_info
@@ -3172,10 +3174,11 @@ class _SessionBase(object):
             self._all_channels_in_session
         )
 
-        lwfm_i = len(wfm_info)
-        lrcl = len(channel_names)
-        assert lwfm_i % lrcl == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(channel_names) == {1}'.format(lwfm_i, lrcl)
-        actual_num_records = int(lwfm_i / lrcl)
+        wfm_info_count = len(wfm_info)
+        channel_count = len(channel_names)
+        # Should this raise instead? If this asserts, is it the users fault?
+        assert wfm_info_count % channel_count == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(channel_names) == {1}'.format(wfm_info_count, channel_count)
+        actual_num_records = int(wfm_info_count / channel_count)
         waveform_info._populate_channel_and_record_info(wfm_info, channel_names, range(record_number, record_number + actual_num_records))
 
         return wfm_info

--- a/generated/niscope/niscope/session.py
+++ b/generated/niscope/niscope/session.py
@@ -2335,11 +2335,16 @@ class _SessionBase(object):
             measurement_stat = measurement_stats.MeasurementStats(result, mean, stdev, min_val, max_val, num_in_stats)
             output.append(measurement_stat)
 
+        channel_names = _converters.expand_channel_string(
+            self._repeated_capability,
+            self._all_channels_in_session
+        )
+
         results_count = len(results)
-        channel_count = len(self._repeated_capability_list)
-        assert results_count % channel_count == 0, 'Number of results should be evenly divisible by the number of channels: len(results) == {0}, len(self._repeated_capability_list) == {1}'.format(results_count, channel_count)
+        channel_count = len(channel_names)
+        assert results_count % channel_count == 0, 'Number of results should be evenly divisible by the number of channels: len(results) == {0}, len(channel_names) == {1}'.format(results_count, channel_count)
         actual_num_records = int(results_count / channel_count)
-        waveform_info._populate_channel_and_record_info(output, self._repeated_capability_list, range(record_number, record_number + actual_num_records))
+        waveform_info._populate_channel_and_record_info(output, channel_names, range(record_number, record_number + actual_num_records))
 
         return output
 

--- a/generated/niscope/niscope/session.py
+++ b/generated/niscope/niscope/session.py
@@ -2231,16 +2231,21 @@ class _SessionBase(object):
             if meas_wfm_size is None:
                 meas_wfm_size = self._actual_meas_wfm_size(array_meas_function)
 
+        channel_names = _converters.expand_channel_string(
+            self._repeated_capability,
+            self._all_channels_in_session
+        )
+
         meas_wfm, wfm_info = self._fetch_array_measurement(array_meas_function, meas_wfm_size, timeout)
 
         record_length = int(len(meas_wfm) / len(wfm_info))
         waveform_info._populate_samples_info(wfm_info, meas_wfm, record_length)
 
         wfm_info_count = len(wfm_info)
-        channel_count = len(self._repeated_capability_list)
-        assert wfm_info_count % channel_count == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(self._repeated_capability_list) == {1}'.format(wfm_info_count, channel_count)
+        channel_count = len(channel_names)
+        assert wfm_info_count % channel_count == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(channel_names) == {1}'.format(wfm_info_count, channel_count)
         actual_num_records = int(wfm_info_count / channel_count)
-        waveform_info._populate_channel_and_record_info(wfm_info, self._repeated_capability_list, range(record_number, record_number + actual_num_records))
+        waveform_info._populate_channel_and_record_info(wfm_info, channel_names, range(record_number, record_number + actual_num_records))
 
         return wfm_info
 

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -18,7 +18,6 @@ import system_test_utilities  # noqa: E402
 
 
 instruments = ['FakeDevice1', 'FakeDevice2']
-# TODO(sbethur): Use `get_channel_names` when #1402 is fixed
 test_channels_1 = 'FakeDevice2/0,FakeDevice1/1'
 test_channels_1_expanded = test_channels_1
 test_channels_2 = 'FakeDevice2/0:1'

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -21,9 +21,8 @@ instruments = ['FakeDevice1', 'FakeDevice2']
 # TODO(sbethur): Use `get_channel_names` when #1402 is fixed
 test_channels_1 = 'FakeDevice2/0,FakeDevice1/1'
 test_channels_1_expanded = test_channels_1
-# TODO(jfitzger): Use the commented values, once #1770 is fixed
-test_channels_2 = 'FakeDevice2/0'  # 'FakeDevice2/0:1'
-test_channels_2_expanded = 'FakeDevice2/0'  # 'FakeDevice2/0,FakeDevice2/1'
+test_channels_2 = 'FakeDevice2/0:1'
+test_channels_2_expanded = 'FakeDevice2/0,FakeDevice2/1'
 
 
 # There are system tests below that need either a PXI-5124 or a PXI-5142 instead of the PXIe-5164 we use everywhere else

--- a/src/niscope/templates/session.py/fancy_fetch.py.mako
+++ b/src/niscope/templates/session.py/fancy_fetch.py.mako
@@ -19,11 +19,6 @@
             if num_samples is None:
                 num_samples = self.horz_record_length
 
-        channel_names = _converters.expand_channel_string(
-            self._repeated_capability,
-            self._all_channels_in_session
-        )
-
         wfm, wfm_info = self._${f['python_name']}(num_samples, timeout)
 
         if isinstance(wfm, array.ArrayType):
@@ -33,11 +28,6 @@
 
         waveform_info._populate_samples_info(wfm_info, mv, num_samples)
 
-        lwfm_i = len(wfm_info)
-        lrcl = len(channel_names)
-        # Should this raise instead? If this asserts, is it the users fault?
-        assert lwfm_i % lrcl == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(channel_names) == {1}'.format(lwfm_i, lrcl)
-        actual_num_records = int(lwfm_i / lrcl)
-        waveform_info._populate_channel_and_record_info(wfm_info, channel_names, range(record_number, record_number + actual_num_records))
+<%include file="./fetch_waveform_info_population.py.mako"/>
 
         return wfm_info

--- a/src/niscope/templates/session.py/fancy_fetch.py.mako
+++ b/src/niscope/templates/session.py/fancy_fetch.py.mako
@@ -19,6 +19,11 @@
             if num_samples is None:
                 num_samples = self.horz_record_length
 
+        channel_names = _converters.expand_channel_string(
+            self._repeated_capability,
+            self._all_channels_in_session
+        )
+
         wfm, wfm_info = self._${f['python_name']}(num_samples, timeout)
 
         if isinstance(wfm, array.ArrayType):
@@ -29,10 +34,10 @@
         waveform_info._populate_samples_info(wfm_info, mv, num_samples)
 
         lwfm_i = len(wfm_info)
-        lrcl = len(self._repeated_capability_list)
+        lrcl = len(channel_names)
         # Should this raise instead? If this asserts, is it the users fault?
-        assert lwfm_i % lrcl == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(self._repeated_capability_list) == {1}'.format(lwfm_i, lrcl)
+        assert lwfm_i % lrcl == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(channel_names) == {1}'.format(lwfm_i, lrcl)
         actual_num_records = int(lwfm_i / lrcl)
-        waveform_info._populate_channel_and_record_info(wfm_info, self._repeated_capability_list, range(record_number, record_number + actual_num_records))
+        waveform_info._populate_channel_and_record_info(wfm_info, channel_names, range(record_number, record_number + actual_num_records))
 
         return wfm_info

--- a/src/niscope/templates/session.py/fancy_fetch_array_measurement.py.mako
+++ b/src/niscope/templates/session.py/fancy_fetch_array_measurement.py.mako
@@ -22,20 +22,11 @@
             if meas_wfm_size is None:
                 meas_wfm_size = self._actual_meas_wfm_size(array_meas_function)
 
-        channel_names = _converters.expand_channel_string(
-            self._repeated_capability,
-            self._all_channels_in_session
-        )
-
         meas_wfm, wfm_info = self._${f['python_name']}(array_meas_function, meas_wfm_size, timeout)
 
         record_length = int(len(meas_wfm) / len(wfm_info))
         waveform_info._populate_samples_info(wfm_info, meas_wfm, record_length)
 
-        wfm_info_count = len(wfm_info)
-        channel_count = len(channel_names)
-        assert wfm_info_count % channel_count == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(channel_names) == {1}'.format(wfm_info_count, channel_count)
-        actual_num_records = int(wfm_info_count / channel_count)
-        waveform_info._populate_channel_and_record_info(wfm_info, channel_names, range(record_number, record_number + actual_num_records))
+<%include file="./fetch_waveform_info_population.py.mako"/>
 
         return wfm_info

--- a/src/niscope/templates/session.py/fancy_fetch_array_measurement.py.mako
+++ b/src/niscope/templates/session.py/fancy_fetch_array_measurement.py.mako
@@ -22,15 +22,20 @@
             if meas_wfm_size is None:
                 meas_wfm_size = self._actual_meas_wfm_size(array_meas_function)
 
+        channel_names = _converters.expand_channel_string(
+            self._repeated_capability,
+            self._all_channels_in_session
+        )
+
         meas_wfm, wfm_info = self._${f['python_name']}(array_meas_function, meas_wfm_size, timeout)
 
         record_length = int(len(meas_wfm) / len(wfm_info))
         waveform_info._populate_samples_info(wfm_info, meas_wfm, record_length)
 
         wfm_info_count = len(wfm_info)
-        channel_count = len(self._repeated_capability_list)
-        assert wfm_info_count % channel_count == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(self._repeated_capability_list) == {1}'.format(wfm_info_count, channel_count)
+        channel_count = len(channel_names)
+        assert wfm_info_count % channel_count == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(channel_names) == {1}'.format(wfm_info_count, channel_count)
         actual_num_records = int(wfm_info_count / channel_count)
-        waveform_info._populate_channel_and_record_info(wfm_info, self._repeated_capability_list, range(record_number, record_number + actual_num_records))
+        waveform_info._populate_channel_and_record_info(wfm_info, channel_names, range(record_number, record_number + actual_num_records))
 
         return wfm_info

--- a/src/niscope/templates/session.py/fancy_fetch_measurement_stats.py.mako
+++ b/src/niscope/templates/session.py/fancy_fetch_measurement_stats.py.mako
@@ -23,10 +23,15 @@
             measurement_stat = measurement_stats.MeasurementStats(result, mean, stdev, min_val, max_val, num_in_stats)
             output.append(measurement_stat)
 
+        channel_names = _converters.expand_channel_string(
+            self._repeated_capability,
+            self._all_channels_in_session
+        )
+
         results_count = len(results)
-        channel_count = len(self._repeated_capability_list)
-        assert results_count % channel_count == 0, 'Number of results should be evenly divisible by the number of channels: len(results) == {0}, len(self._repeated_capability_list) == {1}'.format(results_count, channel_count)
+        channel_count = len(channel_names)
+        assert results_count % channel_count == 0, 'Number of results should be evenly divisible by the number of channels: len(results) == {0}, len(channel_names) == {1}'.format(results_count, channel_count)
         actual_num_records = int(results_count / channel_count)
-        waveform_info._populate_channel_and_record_info(output, self._repeated_capability_list, range(record_number, record_number + actual_num_records))
+        waveform_info._populate_channel_and_record_info(output, channel_names, range(record_number, record_number + actual_num_records))
 
         return output

--- a/src/niscope/templates/session.py/fancy_fetch_measurement_stats.py.mako
+++ b/src/niscope/templates/session.py/fancy_fetch_measurement_stats.py.mako
@@ -23,15 +23,6 @@
             measurement_stat = measurement_stats.MeasurementStats(result, mean, stdev, min_val, max_val, num_in_stats)
             output.append(measurement_stat)
 
-        channel_names = _converters.expand_channel_string(
-            self._repeated_capability,
-            self._all_channels_in_session
-        )
-
-        results_count = len(results)
-        channel_count = len(channel_names)
-        assert results_count % channel_count == 0, 'Number of results should be evenly divisible by the number of channels: len(results) == {0}, len(channel_names) == {1}'.format(results_count, channel_count)
-        actual_num_records = int(results_count / channel_count)
-        waveform_info._populate_channel_and_record_info(output, channel_names, range(record_number, record_number + actual_num_records))
+<%include file="./fetch_waveform_info_population.py.mako" args="results_name='results', results_description='results', output_name='output'"/>
 
         return output

--- a/src/niscope/templates/session.py/fetch_waveform.py.mako
+++ b/src/niscope/templates/session.py/fetch_waveform.py.mako
@@ -36,10 +36,15 @@
 
         waveform_info._populate_samples_info(wfm_info, mv, num_samples)
 
+        channel_names = _converters.expand_channel_string(
+            self._repeated_capability,
+            self._all_channels_in_session
+        )
+
         lwfm_i = len(wfm_info)
-        lrcl = len(self._repeated_capability_list)
-        assert lwfm_i % lrcl == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(self._repeated_capability_list) == {1}'.format(lwfm_i, lrcl)
+        lrcl = len(channel_names)
+        assert lwfm_i % lrcl == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(channel_names) == {1}'.format(lwfm_i, lrcl)
         actual_num_records = int(lwfm_i / lrcl)
-        waveform_info._populate_channel_and_record_info(wfm_info, self._repeated_capability_list, range(record_number, record_number + actual_num_records))
+        waveform_info._populate_channel_and_record_info(wfm_info, channel_names, range(record_number, record_number + actual_num_records))
 
         return wfm_info

--- a/src/niscope/templates/session.py/fetch_waveform.py.mako
+++ b/src/niscope/templates/session.py/fetch_waveform.py.mako
@@ -36,15 +36,6 @@
 
         waveform_info._populate_samples_info(wfm_info, mv, num_samples)
 
-        channel_names = _converters.expand_channel_string(
-            self._repeated_capability,
-            self._all_channels_in_session
-        )
-
-        lwfm_i = len(wfm_info)
-        lrcl = len(channel_names)
-        assert lwfm_i % lrcl == 0, 'Number of waveforms should be evenly divisible by the number of channels: len(wfm_info) == {0}, len(channel_names) == {1}'.format(lwfm_i, lrcl)
-        actual_num_records = int(lwfm_i / lrcl)
-        waveform_info._populate_channel_and_record_info(wfm_info, channel_names, range(record_number, record_number + actual_num_records))
+<%include file="./fetch_waveform_info_population.py.mako"/>
 
         return wfm_info

--- a/src/niscope/templates/session.py/fetch_waveform_info_population.py.mako
+++ b/src/niscope/templates/session.py/fetch_waveform_info_population.py.mako
@@ -1,0 +1,15 @@
+<%page args="results_name='wfm_info', results_description='waveforms', output_name='wfm_info'"/>\
+<%
+    '''Sub-template to populate channel and record info for a waveform in a fetch method.'''
+%>\
+        channel_names = _converters.expand_channel_string(
+            self._repeated_capability,
+            self._all_channels_in_session
+        )
+
+        ${results_name}_count = len(${results_name})
+        channel_count = len(channel_names)
+        # Should this raise instead? If this asserts, is it the users fault?
+        assert ${results_name}_count % channel_count == 0, 'Number of ${results_description} should be evenly divisible by the number of channels: len(${results_name}) == {0}, len(channel_names) == {1}'.format(${results_name}_count, channel_count)
+        actual_num_records = int(${results_name}_count / channel_count)
+        waveform_info._populate_channel_and_record_info(${output_name}, channel_names, range(record_number, record_number + actual_num_records))


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- [X] I've added tests applicable for this pull request

### What does this Pull Request accomplish?
Based on how nidcpower does things for `fetch_multiple`, `measure_multiple`, etc., expand the _repeated_capability (channels) before trying to do anything with it, other than pass it to a driver function.

The driver knows how to handle unexpanded channel strings (or it will error if it can't), but the simple code in 
`_populate_channel_and_record_info` assumes that all channels in the `channels` iterable are individual channels.

### List issues fixed by this Pull Request below, if any.

* Fix #1770

### What testing has been done?
* Locally, I used the tests changes to catch the bug, then ran codegen with the changes in this PR (prior to the latest merge) and #1957 to confirm that the issue would be fixed.
* PR Checks
* I played with the tests to make sure there wasn't some other bad data case to worry about for single-instrument sessions. Passing a qualified name to `fetch()` or `get_channel_names` will error, so no bad data. Passing test_channels: '0:1', test_channels_expanded: `0,1` to `test_fetch`, passed.