### PR TITLE
Use actions/checkout@v3

### DIFF
--- a/.github/workflows/github_actions_aws_rhel_python64.yml
+++ b/.github/workflows/github_actions_aws_rhel_python64.yml
@@ -29,7 +29,7 @@ jobs:
         module_name: ["nidcpower", "nidmm", "nifgen", "niscope", "niswitch", "nitclk"]
     steps:
       - name: checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: execute system tests
         uses: ./.github/actions/linux
         with:

--- a/.github/workflows/github_actions_aws_windows_python32.yml
+++ b/.github/workflows/github_actions_aws_windows_python32.yml
@@ -41,7 +41,7 @@ jobs:
             ]
       steps:
         - name: checkout repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
         - name: execute system tests
           uses: ./.github/actions/windows
           with:

--- a/.github/workflows/github_actions_aws_windows_python64.yml
+++ b/.github/workflows/github_actions_aws_windows_python64.yml
@@ -41,7 +41,7 @@ jobs:
             ]
       steps:
         - name: checkout repository
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
         - name: execute system tests
           uses: ./.github/actions/windows
           with:


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

The nimibot GitHub actions workflows are updated to use v3 of the GitHub checkout action. v2 used Node.js 12 and this was causing annotations about it being deprecated to appear in the nimibot run summaries.

[With v3, node16  runtime is used by default](https://github.com/actions/checkout/tree/8e5e7e5ab8b370d6c329ec480221332ada57f0ab#whats-new).

### List issues fixed by this Pull Request below, if any.

* Fix #1909 

### What testing has been done?
PR Checks.

The annotations are gone. See

* https://github.com/ni/nimi-python/actions/runs/5027414297?pr=1969
* https://github.com/ni/nimi-python/actions/runs/5027414296?pr=1969
* https://github.com/ni/nimi-python/actions/runs/5027414299?pr=1969

Ignore the failing readthedocs PR Checks. Those checks were added for #1963 and expect .readthedocs.yaml files that are added by that PR.