### PR TITLE
Add set_runtime_environment functionality to niswitch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ All notable changes to this project will be documented in this file.
     * #### Removed
 * ### `niswitch` (NI-SWITCH)
     * #### Added
+        * Pass Python interpreter information if the driver runtime version supports it. This is used by NI in order to better understand client usage.
     * #### Changed
     * #### Removed
 * ### `nise` (NI Switch Executive)

--- a/generated/niswitch/niswitch/_grpc_stub_interpreter.py
+++ b/generated/niswitch/niswitch/_grpc_stub_interpreter.py
@@ -276,6 +276,9 @@ class GrpcStubInterpreter(object):
             grpc_types.SetPathRequest(vi=self._vi, path_list=path_list),
         )
 
+    def set_runtime_environment(self, environment, environment_version, reserved1, reserved2):  # noqa: N802
+        raise NotImplementedError('set_runtime_environment is not supported over gRPC')
+
     def unlock(self):  # noqa: N802
         self._lock.release()
 

--- a/generated/niswitch/niswitch/_library.py
+++ b/generated/niswitch/niswitch/_library.py
@@ -51,6 +51,7 @@ class Library(object):
         self.niSwitch_SetAttributeViReal64_cfunc = None
         self.niSwitch_SetAttributeViString_cfunc = None
         self.niSwitch_SetPath_cfunc = None
+        self.niSwitch_SetRuntimeEnvironment_cfunc = None
         self.niSwitch_UnlockSession_cfunc = None
         self.niSwitch_WaitForDebounce_cfunc = None
         self.niSwitch_WaitForScanComplete_cfunc = None
@@ -178,13 +179,13 @@ class Library(object):
                 self.niSwitch_GetChannelName_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_GetChannelName_cfunc(vi, index, buffer_size, channel_name_buffer)
 
-    def niSwitch_GetError(self, vi, code, buffer_size, description):  # noqa: N802
+    def niSwitch_GetError(self, vi, error_code, buffer_size, description):  # noqa: N802
         with self._func_lock:
             if self.niSwitch_GetError_cfunc is None:
                 self.niSwitch_GetError_cfunc = self._get_library_function('niSwitch_GetError')
                 self.niSwitch_GetError_cfunc.argtypes = [ViSession, ctypes.POINTER(ViStatus), ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_GetError_cfunc.restype = ViStatus  # noqa: F405
-        return self.niSwitch_GetError_cfunc(vi, code, buffer_size, description)
+        return self.niSwitch_GetError_cfunc(vi, error_code, buffer_size, description)
 
     def niSwitch_GetPath(self, vi, channel1, channel2, buffer_size, path):  # noqa: N802
         with self._func_lock:
@@ -321,6 +322,14 @@ class Library(object):
                 self.niSwitch_SetPath_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niSwitch_SetPath_cfunc.restype = ViStatus  # noqa: F405
         return self.niSwitch_SetPath_cfunc(vi, path_list)
+
+    def niSwitch_SetRuntimeEnvironment(self, environment, environment_version, reserved1, reserved2):  # noqa: N802
+        with self._func_lock:
+            if self.niSwitch_SetRuntimeEnvironment_cfunc is None:
+                self.niSwitch_SetRuntimeEnvironment_cfunc = self._get_library_function('niSwitch_SetRuntimeEnvironment')
+                self.niSwitch_SetRuntimeEnvironment_cfunc.argtypes = [ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
+                self.niSwitch_SetRuntimeEnvironment_cfunc.restype = ViStatus  # noqa: F405
+        return self.niSwitch_SetRuntimeEnvironment_cfunc(environment, environment_version, reserved1, reserved2)
 
     def niSwitch_UnlockSession(self, vi, caller_has_lock):  # noqa: N802
         with self._func_lock:

--- a/generated/niswitch/niswitch/unit_tests/_mock_helper.py
+++ b/generated/niswitch/niswitch/unit_tests/_mock_helper.py
@@ -52,7 +52,7 @@ class SideEffectsHelper(object):
         self._defaults['GetChannelName']['channelNameBuffer'] = None
         self._defaults['GetError'] = {}
         self._defaults['GetError']['return'] = 0
-        self._defaults['GetError']['code'] = None
+        self._defaults['GetError']['errorCode'] = None
         self._defaults['GetError']['description'] = None
         self._defaults['GetPath'] = {}
         self._defaults['GetPath']['return'] = 0
@@ -94,6 +94,8 @@ class SideEffectsHelper(object):
         self._defaults['SetAttributeViString']['return'] = 0
         self._defaults['SetPath'] = {}
         self._defaults['SetPath']['return'] = 0
+        self._defaults['SetRuntimeEnvironment'] = {}
+        self._defaults['SetRuntimeEnvironment']['return'] = 0
         self._defaults['UnlockSession'] = {}
         self._defaults['UnlockSession']['return'] = 0
         self._defaults['UnlockSession']['callerHasLock'] = None
@@ -221,14 +223,14 @@ class SideEffectsHelper(object):
         channel_name_buffer.value = self._defaults['GetChannelName']['channelNameBuffer'].encode('ascii')
         return self._defaults['GetChannelName']['return']
 
-    def niSwitch_GetError(self, vi, code, buffer_size, description):  # noqa: N802
+    def niSwitch_GetError(self, vi, error_code, buffer_size, description):  # noqa: N802
         if self._defaults['GetError']['return'] != 0:
             return self._defaults['GetError']['return']
-        # code
-        if self._defaults['GetError']['code'] is None:
-            raise MockFunctionCallError("niSwitch_GetError", param='code')
-        if code is not None:
-            code.contents.value = self._defaults['GetError']['code']
+        # error_code
+        if self._defaults['GetError']['errorCode'] is None:
+            raise MockFunctionCallError("niSwitch_GetError", param='errorCode')
+        if error_code is not None:
+            error_code.contents.value = self._defaults['GetError']['errorCode']
         # description
         if self._defaults['GetError']['description'] is None:
             raise MockFunctionCallError("niSwitch_GetError", param='description')
@@ -353,6 +355,11 @@ class SideEffectsHelper(object):
         if self._defaults['SetPath']['return'] != 0:
             return self._defaults['SetPath']['return']
         return self._defaults['SetPath']['return']
+
+    def niSwitch_SetRuntimeEnvironment(self, environment, environment_version, reserved1, reserved2):  # noqa: N802
+        if self._defaults['SetRuntimeEnvironment']['return'] != 0:
+            return self._defaults['SetRuntimeEnvironment']['return']
+        return self._defaults['SetRuntimeEnvironment']['return']
 
     def niSwitch_UnlockSession(self, vi, caller_has_lock):  # noqa: N802
         if self._defaults['UnlockSession']['return'] != 0:
@@ -483,6 +490,8 @@ class SideEffectsHelper(object):
         mock_library.niSwitch_SetAttributeViString.return_value = 0
         mock_library.niSwitch_SetPath.side_effect = MockFunctionCallError("niSwitch_SetPath")
         mock_library.niSwitch_SetPath.return_value = 0
+        mock_library.niSwitch_SetRuntimeEnvironment.side_effect = MockFunctionCallError("niSwitch_SetRuntimeEnvironment")
+        mock_library.niSwitch_SetRuntimeEnvironment.return_value = 0
         mock_library.niSwitch_UnlockSession.side_effect = MockFunctionCallError("niSwitch_UnlockSession")
         mock_library.niSwitch_UnlockSession.return_value = 0
         mock_library.niSwitch_WaitForDebounce.side_effect = MockFunctionCallError("niSwitch_WaitForDebounce")

--- a/src/niswitch/metadata/attributes.py
+++ b/src/niswitch/metadata/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SWITCH API metadata version 23.0.0f167
+# This file is generated from NI-SWITCH API metadata version 23.5.0d149
 attributes = {
     1050005: {
         'access': 'read-write',

--- a/src/niswitch/metadata/config.py
+++ b/src/niswitch/metadata/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SWITCH API metadata version 23.0.0f167
+# This file is generated from NI-SWITCH API metadata version 23.5.0d149
 config = {
-    'api_version': '23.0.0f167',
+    'api_version': '23.5.0d149',
     'c_function_prefix': 'niSwitch_',
     'close_function': 'close',
     'context_manager_name': {

--- a/src/niswitch/metadata/enums.py
+++ b/src/niswitch/metadata/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SWITCH API metadata version 23.0.0f167
+# This file is generated from NI-SWITCH API metadata version 23.5.0d149
 enums = {
     'CabledModuleScanAdvancedBus': {
         'values': [

--- a/src/niswitch/metadata/functions.py
+++ b/src/niswitch/metadata/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SWITCH API metadata version 23.0.0f167
+# This file is generated from NI-SWITCH API metadata version 23.5.0d149
 functions = {
     'AbortScan': {
         'documentation': {
@@ -482,7 +482,8 @@ functions = {
                 'documentation': {
                     'description': '\nReturns the error code for the session or execution thread. If you pass\n0 for the Buffer Size, you can pass VI_NULL for this parameter.\n'
                 },
-                'name': 'code',
+                'grpc_name': 'code',
+                'name': 'errorCode',
                 'type': 'ViStatus'
             },
             {
@@ -1115,7 +1116,7 @@ functions = {
                 },
                 'grpc_name': 'attribute_value_raw',
                 'name': 'attributeValue',
-                'type': 'ViString'
+                'type': 'ViConstString'
             }
         ],
         'returns': 'ViStatus'
@@ -1140,6 +1141,44 @@ functions = {
                     'description': '\nA string composed of comma-separated paths between channel 1 and channel\n2. The first and last names in the path are the endpoints of the path.\nEvery other channel in the path are configuration channels. Example of a\nvalid path list string: ch0->com0, com0->ab0. In this example, com0 is a\nconfiguration channel. Default value: None Obtain the path list for a\npreviously created path with niSwitch_GetPath.\n'
                 },
                 'name': 'pathList',
+                'type': 'ViConstString'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'SetRuntimeEnvironment': {
+        'codegen_method': 'private',
+        'documentation': {
+            'description': 'TBD'
+        },
+        'included_in_proto': False,
+        'method_templates': [
+            {
+                'documentation_filename': 'none',
+                'library_interpreter_filename': 'default_method',
+                'method_python_name_suffix': '',
+                'session_filename': 'none'
+            }
+        ],
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'environment',
+                'type': 'ViConstString'
+            },
+            {
+                'direction': 'in',
+                'name': 'environmentVersion',
+                'type': 'ViConstString'
+            },
+            {
+                'direction': 'in',
+                'name': 'reserved1',
+                'type': 'ViConstString'
+            },
+            {
+                'direction': 'in',
+                'name': 'reserved2',
                 'type': 'ViConstString'
             }
         ],


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- ~[] I've added tests applicable for this pull request~

This feature is tested through nifake unit tests.

### What does this Pull Request accomplish?
* niswitch metadata is updated from the latest internal export.
* `set_runtime_environment` call is added to niswitch/_library_interpreter.py

### List issues fixed by this Pull Request below, if any.
None

### What testing has been done?
None