### PR TITLE
Add intersphinx mappings

### DIFF
--- a/build/templates/class.rst.mako
+++ b/build/templates/class.rst.mako
@@ -131,7 +131,7 @@ ${helper.get_rst_header_snippet('NI-TClk Support', '=')}
 
         This is used to get and set NI-TClk attributes on the session.
 
-        .. seealso:: See :py:attr:`nitclk.SessionReference` for a complete list of attributes.
+        .. seealso:: See :py:class:`nitclk.SessionReference` for a complete list of attributes.
 
 
 % endif

--- a/build/templates/conf.py.mako
+++ b/build/templates/conf.py.mako
@@ -9,6 +9,10 @@ version = config['module_version']
 api_name = f"{config['driver_name']} Python API"
 api_name_no_spaces_or_hyphens = api_name.replace(" ", "").replace("-", "")
 api_name_no_spaces_or_hyphens_lower = api_name_no_spaces_or_hyphens.lower()
+
+all_modules = {'nidcpower', 'nidigital', 'nidmm', 'nifgen', 'nimodinst', 'niscope', 'niswitch', 'nise', 'nitclk'}
+module_name   = config['module_name']
+external_modules = all_modules - {module_name}
 %>\
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
@@ -195,6 +199,9 @@ texinfo_documents = [
 ]
 
 # Example configuration for intersphinx: refer to the Python standard library.
-## TODO(ni-jfitzger): Add mappings for nimi-python APIs that reference other nimi-python APIs.
-## We can probably just list all of the mappings (other than maybe the current module, I think)
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+% for module in sorted(external_modules):
+    '${module}': ('https://${module}.readthedocs.io/en/latest/', None),
+% endfor
+}

--- a/docs/nidcpower/conf.py
+++ b/docs/nidcpower/conf.py
@@ -183,4 +183,14 @@ texinfo_documents = [
 ]
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'nidigital': ('https://nidigital.readthedocs.io/en/latest/', None),
+    'nidmm': ('https://nidmm.readthedocs.io/en/latest/', None),
+    'nifgen': ('https://nifgen.readthedocs.io/en/latest/', None),
+    'nimodinst': ('https://nimodinst.readthedocs.io/en/latest/', None),
+    'niscope': ('https://niscope.readthedocs.io/en/latest/', None),
+    'nise': ('https://nise.readthedocs.io/en/latest/', None),
+    'niswitch': ('https://niswitch.readthedocs.io/en/latest/', None),
+    'nitclk': ('https://nitclk.readthedocs.io/en/latest/', None),
+}

--- a/docs/nidigital/class.rst
+++ b/docs/nidigital/class.rst
@@ -5705,7 +5705,7 @@ NI-TClk Support
 
         This is used to get and set NI-TClk attributes on the session.
 
-        .. seealso:: See :py:attr:`nitclk.SessionReference` for a complete list of attributes.
+        .. seealso:: See :py:class:`nitclk.SessionReference` for a complete list of attributes.
 
 
 .. contents:: Session

--- a/docs/nidigital/conf.py
+++ b/docs/nidigital/conf.py
@@ -183,4 +183,14 @@ texinfo_documents = [
 ]
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'nidcpower': ('https://nidcpower.readthedocs.io/en/latest/', None),
+    'nidmm': ('https://nidmm.readthedocs.io/en/latest/', None),
+    'nifgen': ('https://nifgen.readthedocs.io/en/latest/', None),
+    'nimodinst': ('https://nimodinst.readthedocs.io/en/latest/', None),
+    'niscope': ('https://niscope.readthedocs.io/en/latest/', None),
+    'nise': ('https://nise.readthedocs.io/en/latest/', None),
+    'niswitch': ('https://niswitch.readthedocs.io/en/latest/', None),
+    'nitclk': ('https://nitclk.readthedocs.io/en/latest/', None),
+}

--- a/docs/nidmm/conf.py
+++ b/docs/nidmm/conf.py
@@ -183,4 +183,14 @@ texinfo_documents = [
 ]
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'nidcpower': ('https://nidcpower.readthedocs.io/en/latest/', None),
+    'nidigital': ('https://nidigital.readthedocs.io/en/latest/', None),
+    'nifgen': ('https://nifgen.readthedocs.io/en/latest/', None),
+    'nimodinst': ('https://nimodinst.readthedocs.io/en/latest/', None),
+    'niscope': ('https://niscope.readthedocs.io/en/latest/', None),
+    'nise': ('https://nise.readthedocs.io/en/latest/', None),
+    'niswitch': ('https://niswitch.readthedocs.io/en/latest/', None),
+    'nitclk': ('https://nitclk.readthedocs.io/en/latest/', None),
+}

--- a/docs/nifgen/class.rst
+++ b/docs/nifgen/class.rst
@@ -6005,7 +6005,7 @@ NI-TClk Support
 
         This is used to get and set NI-TClk attributes on the session.
 
-        .. seealso:: See :py:attr:`nitclk.SessionReference` for a complete list of attributes.
+        .. seealso:: See :py:class:`nitclk.SessionReference` for a complete list of attributes.
 
 
 .. contents:: Session

--- a/docs/nifgen/conf.py
+++ b/docs/nifgen/conf.py
@@ -183,4 +183,14 @@ texinfo_documents = [
 ]
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'nidcpower': ('https://nidcpower.readthedocs.io/en/latest/', None),
+    'nidigital': ('https://nidigital.readthedocs.io/en/latest/', None),
+    'nidmm': ('https://nidmm.readthedocs.io/en/latest/', None),
+    'nimodinst': ('https://nimodinst.readthedocs.io/en/latest/', None),
+    'niscope': ('https://niscope.readthedocs.io/en/latest/', None),
+    'nise': ('https://nise.readthedocs.io/en/latest/', None),
+    'niswitch': ('https://niswitch.readthedocs.io/en/latest/', None),
+    'nitclk': ('https://nitclk.readthedocs.io/en/latest/', None),
+}

--- a/docs/nimodinst/conf.py
+++ b/docs/nimodinst/conf.py
@@ -183,4 +183,14 @@ texinfo_documents = [
 ]
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'nidcpower': ('https://nidcpower.readthedocs.io/en/latest/', None),
+    'nidigital': ('https://nidigital.readthedocs.io/en/latest/', None),
+    'nidmm': ('https://nidmm.readthedocs.io/en/latest/', None),
+    'nifgen': ('https://nifgen.readthedocs.io/en/latest/', None),
+    'niscope': ('https://niscope.readthedocs.io/en/latest/', None),
+    'nise': ('https://nise.readthedocs.io/en/latest/', None),
+    'niswitch': ('https://niswitch.readthedocs.io/en/latest/', None),
+    'nitclk': ('https://nitclk.readthedocs.io/en/latest/', None),
+}

--- a/docs/niscope/class.rst
+++ b/docs/niscope/class.rst
@@ -7477,7 +7477,7 @@ NI-TClk Support
 
         This is used to get and set NI-TClk attributes on the session.
 
-        .. seealso:: See :py:attr:`nitclk.SessionReference` for a complete list of attributes.
+        .. seealso:: See :py:class:`nitclk.SessionReference` for a complete list of attributes.
 
 
 .. contents:: Session

--- a/docs/niscope/conf.py
+++ b/docs/niscope/conf.py
@@ -183,4 +183,14 @@ texinfo_documents = [
 ]
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'nidcpower': ('https://nidcpower.readthedocs.io/en/latest/', None),
+    'nidigital': ('https://nidigital.readthedocs.io/en/latest/', None),
+    'nidmm': ('https://nidmm.readthedocs.io/en/latest/', None),
+    'nifgen': ('https://nifgen.readthedocs.io/en/latest/', None),
+    'nimodinst': ('https://nimodinst.readthedocs.io/en/latest/', None),
+    'nise': ('https://nise.readthedocs.io/en/latest/', None),
+    'niswitch': ('https://niswitch.readthedocs.io/en/latest/', None),
+    'nitclk': ('https://nitclk.readthedocs.io/en/latest/', None),
+}

--- a/docs/nise/conf.py
+++ b/docs/nise/conf.py
@@ -183,4 +183,14 @@ texinfo_documents = [
 ]
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'nidcpower': ('https://nidcpower.readthedocs.io/en/latest/', None),
+    'nidigital': ('https://nidigital.readthedocs.io/en/latest/', None),
+    'nidmm': ('https://nidmm.readthedocs.io/en/latest/', None),
+    'nifgen': ('https://nifgen.readthedocs.io/en/latest/', None),
+    'nimodinst': ('https://nimodinst.readthedocs.io/en/latest/', None),
+    'niscope': ('https://niscope.readthedocs.io/en/latest/', None),
+    'niswitch': ('https://niswitch.readthedocs.io/en/latest/', None),
+    'nitclk': ('https://nitclk.readthedocs.io/en/latest/', None),
+}

--- a/docs/niswitch/conf.py
+++ b/docs/niswitch/conf.py
@@ -183,4 +183,14 @@ texinfo_documents = [
 ]
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'nidcpower': ('https://nidcpower.readthedocs.io/en/latest/', None),
+    'nidigital': ('https://nidigital.readthedocs.io/en/latest/', None),
+    'nidmm': ('https://nidmm.readthedocs.io/en/latest/', None),
+    'nifgen': ('https://nifgen.readthedocs.io/en/latest/', None),
+    'nimodinst': ('https://nimodinst.readthedocs.io/en/latest/', None),
+    'niscope': ('https://niscope.readthedocs.io/en/latest/', None),
+    'nise': ('https://nise.readthedocs.io/en/latest/', None),
+    'nitclk': ('https://nitclk.readthedocs.io/en/latest/', None),
+}

--- a/docs/nitclk/conf.py
+++ b/docs/nitclk/conf.py
@@ -183,4 +183,14 @@ texinfo_documents = [
 ]
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'nidcpower': ('https://nidcpower.readthedocs.io/en/latest/', None),
+    'nidigital': ('https://nidigital.readthedocs.io/en/latest/', None),
+    'nidmm': ('https://nidmm.readthedocs.io/en/latest/', None),
+    'nifgen': ('https://nifgen.readthedocs.io/en/latest/', None),
+    'nimodinst': ('https://nimodinst.readthedocs.io/en/latest/', None),
+    'niscope': ('https://niscope.readthedocs.io/en/latest/', None),
+    'nise': ('https://nise.readthedocs.io/en/latest/', None),
+    'niswitch': ('https://niswitch.readthedocs.io/en/latest/', None),
+}


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
Links between our new separate Read the Docs projects have not been setup. This change creates them by:

* Adding intersphinx mappings for each of the other projects to every project
* Fixing the way we reference the class nitclk.SessionReference
  * This was the only link found in the docs

### List issues fixed by this Pull Request below, if any.
None

### What testing has been done?
Generated docs locally and was able to click on the link to nitclk.SessionReference from nidigital documentation