### PR TITLE
NI-DCPower: Ensure examples specify Output Function when necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ All notable changes to this project will be documented in this file.
 * ### `nidcpower` (NI-DCPower)
     * #### Added
     * #### Changed
-        * Updated the nidcpower_measure_record example to ensure Output Function DC Voltage is correctly selected.
     * #### Removed
 * ### `nidigital` (NI-Digital Pattern Driver)
     * #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 * ### `nidcpower` (NI-DCPower)
     * #### Added
     * #### Changed
+        * Updated the nidcpower_measure_record example to ensure Output Function DC Voltage is correctly selected.
     * #### Removed
 * ### `nidigital` (NI-Digital Pattern Driver)
     * #### Added

--- a/src/nidcpower/examples/nidcpower_measure_record.py
+++ b/src/nidcpower/examples/nidcpower_measure_record.py
@@ -11,6 +11,7 @@ def example(resource_name, options, voltage, length):
         session.measure_record_length = length
         session.measure_record_length_is_finite = True
         session.measure_when = nidcpower.MeasureWhen.AUTOMATICALLY_AFTER_SOURCE_COMPLETE
+        session.output_function = nidcpower.OutputFunction.DC_VOLTAGE
         session.voltage_level = voltage
 
         session.commit()
@@ -56,5 +57,3 @@ def test_main():
 
 if __name__ == '__main__':
     main()
-
-


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- [ ] ~~I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?
I've been auditing our NI-DCPower examples for all of our supported ADEs to ensure that they specify Output Function rather than assuming a default value.  The nidcpower_measure_record python example expects the Output Function to be DC Voltage but does not explicitly set it, so I've updated this example to explicitly set the Output Function.

### What testing has been done?
I've run the example manually on several NI-DCPower devices to ensure that it functions as expected.