### PR TITLE
Drop Python 3.7 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ matrix:
       # We run tests on the latest supported version of Python first.
       # This is where additional tests are run so we give it more time.
       - python: "3.11"
-      - python: "3.7"
       - python: "3.8"
       - python: "3.9"
       - python: "3.10"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
     * #### Added
     * #### Changed
     * #### Removed
+        * Support for Python 3.7
 * ### `nidcpower` (NI-DCPower)
     * #### Added
     * #### Changed

--- a/README.rst
+++ b/README.rst
@@ -60,8 +60,7 @@ called through its public C API using the `ctypes <https://docs.python.org/2/lib
 
 **nimi-python** supports all the Operating Systems supported by the underlying driver.
 
-**nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions. At
-this time this includes Python 3.8 and above using CPython.
+**nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions.
 
 
 NI-DCPower Python API Status

--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ called through its public C API using the `ctypes <https://docs.python.org/2/lib
 **nimi-python** supports all the Operating Systems supported by the underlying driver.
 
 **nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions. At
-this time this includes Python 3.7 and above using CPython.
+this time this includes Python 3.8 and above using CPython.
 
 
 NI-DCPower Python API Status

--- a/build/templates/setup.py.mako
+++ b/build/templates/setup.py.mako
@@ -57,8 +57,7 @@ setup(
     % if grpc_supported:
     extras_require={
         'grpc': [
-            'grpcio>=1.49.1,<1.53;python_version=="3.7"',  # no 32-bit wheel for 1.53.0 and later
-            'grpcio>=1.49.1,<2.0;python_version>"3.7"',
+            'grpcio>=1.49.1,<2.0',
             'protobuf>=4.21,<5.0'
         ],
     },
@@ -75,7 +74,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/build/templates/tox-system_tests.ini.mako
+++ b/build/templates/tox-system_tests.ini.mako
@@ -26,7 +26,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/${module_name})
 [tox]
-envlist = ${wheel_env}py{37,38,39,310,311}-${module_name}-system_tests, py311-${module_name}-coverage
+envlist = ${wheel_env}py{38,39,310,311}-${module_name}-system_tests, py311-${module_name}-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -85,7 +85,7 @@ deps =
     ${module_name}-coverage: coverage
 
 depends =
-    ${module_name}-coverage: py{37,38,39,310,311}-${module_name}-system_tests
+    ${module_name}-coverage: py{38,39,310,311}-${module_name}-system_tests
 % if uses_other_wheel:
     ${module_name}-system_tests: ${wheel_env}
 % endif

--- a/docs/_static/about.inc
+++ b/docs/_static/about.inc
@@ -22,5 +22,5 @@ called through its public C API using the `ctypes <https://docs.python.org/2/lib
 **nimi-python** supports all the Operating Systems supported by the underlying driver.
 
 **nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions. At
-this time this includes Python 3.7 and above using CPython.
+this time this includes Python 3.8 and above using CPython.
 

--- a/docs/_static/about.inc
+++ b/docs/_static/about.inc
@@ -21,6 +21,5 @@ called through its public C API using the `ctypes <https://docs.python.org/2/lib
 
 **nimi-python** supports all the Operating Systems supported by the underlying driver.
 
-**nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions. At
-this time this includes Python 3.8 and above using CPython.
+**nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions.
 

--- a/docs/_static/about_driver.inc
+++ b/docs/_static/about_driver.inc
@@ -9,6 +9,5 @@ Support Policy
 --------------
 This package supports all the Operating Systems supported by the underlying driver.
 
-It follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions. At
-this time this includes Python 3.8 and above using CPython.
+It follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions.
 

--- a/docs/_static/about_driver.inc
+++ b/docs/_static/about_driver.inc
@@ -10,5 +10,5 @@ Support Policy
 This package supports all the Operating Systems supported by the underlying driver.
 
 It follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions. At
-this time this includes Python 3.7 and above using CPython.
+this time this includes Python 3.8 and above using CPython.
 

--- a/generated/nidcpower/README.rst
+++ b/generated/nidcpower/README.rst
@@ -60,8 +60,7 @@ called through its public C API using the `ctypes <https://docs.python.org/2/lib
 
 **nimi-python** supports all the Operating Systems supported by the underlying driver.
 
-**nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions. At
-this time this includes Python 3.8 and above using CPython.
+**nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions.
 
 
 NI-DCPower Python API Status

--- a/generated/nidcpower/README.rst
+++ b/generated/nidcpower/README.rst
@@ -61,7 +61,7 @@ called through its public C API using the `ctypes <https://docs.python.org/2/lib
 **nimi-python** supports all the Operating Systems supported by the underlying driver.
 
 **nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions. At
-this time this includes Python 3.7 and above using CPython.
+this time this includes Python 3.8 and above using CPython.
 
 
 NI-DCPower Python API Status

--- a/generated/nidcpower/setup.py
+++ b/generated/nidcpower/setup.py
@@ -47,8 +47,7 @@ setup(
     ],
     extras_require={
         'grpc': [
-            'grpcio>=1.49.1,<1.53;python_version=="3.7"',  # no 32-bit wheel for 1.53.0 and later
-            'grpcio>=1.49.1,<2.0;python_version>"3.7"',
+            'grpcio>=1.49.1,<2.0',
             'protobuf>=4.21,<5.0'
         ],
     },
@@ -64,7 +63,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/generated/nidcpower/tox-system_tests.ini
+++ b/generated/nidcpower/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/nidcpower)
 [tox]
-envlist = py{37,38,39,310,311}-nidcpower-system_tests, py311-nidcpower-coverage
+envlist = py{38,39,310,311}-nidcpower-system_tests, py311-nidcpower-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -43,7 +43,7 @@ deps =
     nidcpower-coverage: coverage
 
 depends =
-    nidcpower-coverage: py{37,38,39,310,311}-nidcpower-system_tests
+    nidcpower-coverage: py{38,39,310,311}-nidcpower-system_tests
 
 passenv =
     GIT_BRANCH

--- a/generated/nidigital/README.rst
+++ b/generated/nidigital/README.rst
@@ -61,7 +61,7 @@ called through its public C API using the `ctypes <https://docs.python.org/2/lib
 **nimi-python** supports all the Operating Systems supported by the underlying driver.
 
 **nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions. At
-this time this includes Python 3.7 and above using CPython.
+this time this includes Python 3.8 and above using CPython.
 
 
 NI-Digital Pattern Driver Python API Status

--- a/generated/nidigital/README.rst
+++ b/generated/nidigital/README.rst
@@ -60,8 +60,7 @@ called through its public C API using the `ctypes <https://docs.python.org/2/lib
 
 **nimi-python** supports all the Operating Systems supported by the underlying driver.
 
-**nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions. At
-this time this includes Python 3.8 and above using CPython.
+**nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions.
 
 
 NI-Digital Pattern Driver Python API Status

--- a/generated/nidigital/setup.py
+++ b/generated/nidigital/setup.py
@@ -48,8 +48,7 @@ setup(
     ],
     extras_require={
         'grpc': [
-            'grpcio>=1.49.1,<1.53;python_version=="3.7"',  # no 32-bit wheel for 1.53.0 and later
-            'grpcio>=1.49.1,<2.0;python_version>"3.7"',
+            'grpcio>=1.49.1,<2.0',
             'protobuf>=4.21,<5.0'
         ],
     },
@@ -65,7 +64,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/generated/nidigital/tox-system_tests.ini
+++ b/generated/nidigital/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/nidigital)
 [tox]
-envlist = py3-nidigital-wheel_dep,py{37,38,39,310,311}-nidigital-system_tests, py311-nidigital-coverage
+envlist = py3-nidigital-wheel_dep,py{38,39,310,311}-nidigital-system_tests, py311-nidigital-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -50,7 +50,7 @@ deps =
     nidigital-coverage: coverage
 
 depends =
-    nidigital-coverage: py{37,38,39,310,311}-nidigital-system_tests
+    nidigital-coverage: py{38,39,310,311}-nidigital-system_tests
     nidigital-system_tests: py3-nidigital-wheel_dep,
 
 passenv =

--- a/generated/nidmm/README.rst
+++ b/generated/nidmm/README.rst
@@ -60,8 +60,7 @@ called through its public C API using the `ctypes <https://docs.python.org/2/lib
 
 **nimi-python** supports all the Operating Systems supported by the underlying driver.
 
-**nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions. At
-this time this includes Python 3.8 and above using CPython.
+**nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions.
 
 
 NI-DMM Python API Status

--- a/generated/nidmm/README.rst
+++ b/generated/nidmm/README.rst
@@ -61,7 +61,7 @@ called through its public C API using the `ctypes <https://docs.python.org/2/lib
 **nimi-python** supports all the Operating Systems supported by the underlying driver.
 
 **nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions. At
-this time this includes Python 3.7 and above using CPython.
+this time this includes Python 3.8 and above using CPython.
 
 
 NI-DMM Python API Status

--- a/generated/nidmm/setup.py
+++ b/generated/nidmm/setup.py
@@ -47,8 +47,7 @@ setup(
     ],
     extras_require={
         'grpc': [
-            'grpcio>=1.49.1,<1.53;python_version=="3.7"',  # no 32-bit wheel for 1.53.0 and later
-            'grpcio>=1.49.1,<2.0;python_version>"3.7"',
+            'grpcio>=1.49.1,<2.0',
             'protobuf>=4.21,<5.0'
         ],
     },
@@ -64,7 +63,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/generated/nidmm/tox-system_tests.ini
+++ b/generated/nidmm/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/nidmm)
 [tox]
-envlist = py{37,38,39,310,311}-nidmm-system_tests, py311-nidmm-coverage
+envlist = py{38,39,310,311}-nidmm-system_tests, py311-nidmm-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -43,7 +43,7 @@ deps =
     nidmm-coverage: coverage
 
 depends =
-    nidmm-coverage: py{37,38,39,310,311}-nidmm-system_tests
+    nidmm-coverage: py{38,39,310,311}-nidmm-system_tests
 
 passenv =
     GIT_BRANCH

--- a/generated/nifake/setup.py
+++ b/generated/nifake/setup.py
@@ -48,8 +48,7 @@ setup(
     ],
     extras_require={
         'grpc': [
-            'grpcio>=1.49.1,<1.53;python_version=="3.7"',  # no 32-bit wheel for 1.53.0 and later
-            'grpcio>=1.49.1,<2.0;python_version>"3.7"',
+            'grpcio>=1.49.1,<2.0',
             'protobuf>=4.21,<5.0'
         ],
     },
@@ -65,7 +64,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/generated/nifake/tox-system_tests.ini
+++ b/generated/nifake/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/nifake)
 [tox]
-envlist = py3-nifake-wheel_dep,py{37,38,39,310,311}-nifake-system_tests, py311-nifake-coverage
+envlist = py3-nifake-wheel_dep,py{38,39,310,311}-nifake-system_tests, py311-nifake-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -50,7 +50,7 @@ deps =
     nifake-coverage: coverage
 
 depends =
-    nifake-coverage: py{37,38,39,310,311}-nifake-system_tests
+    nifake-coverage: py{38,39,310,311}-nifake-system_tests
     nifake-system_tests: py3-nifake-wheel_dep,
 
 passenv =

--- a/generated/nifgen/README.rst
+++ b/generated/nifgen/README.rst
@@ -60,8 +60,7 @@ called through its public C API using the `ctypes <https://docs.python.org/2/lib
 
 **nimi-python** supports all the Operating Systems supported by the underlying driver.
 
-**nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions. At
-this time this includes Python 3.8 and above using CPython.
+**nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions.
 
 
 NI-FGEN Python API Status

--- a/generated/nifgen/README.rst
+++ b/generated/nifgen/README.rst
@@ -61,7 +61,7 @@ called through its public C API using the `ctypes <https://docs.python.org/2/lib
 **nimi-python** supports all the Operating Systems supported by the underlying driver.
 
 **nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions. At
-this time this includes Python 3.7 and above using CPython.
+this time this includes Python 3.8 and above using CPython.
 
 
 NI-FGEN Python API Status

--- a/generated/nifgen/setup.py
+++ b/generated/nifgen/setup.py
@@ -48,8 +48,7 @@ setup(
     ],
     extras_require={
         'grpc': [
-            'grpcio>=1.49.1,<1.53;python_version=="3.7"',  # no 32-bit wheel for 1.53.0 and later
-            'grpcio>=1.49.1,<2.0;python_version>"3.7"',
+            'grpcio>=1.49.1,<2.0',
             'protobuf>=4.21,<5.0'
         ],
     },
@@ -65,7 +64,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/generated/nifgen/tox-system_tests.ini
+++ b/generated/nifgen/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/nifgen)
 [tox]
-envlist = py3-nifgen-wheel_dep,py{37,38,39,310,311}-nifgen-system_tests, py311-nifgen-coverage
+envlist = py3-nifgen-wheel_dep,py{38,39,310,311}-nifgen-system_tests, py311-nifgen-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -50,7 +50,7 @@ deps =
     nifgen-coverage: coverage
 
 depends =
-    nifgen-coverage: py{37,38,39,310,311}-nifgen-system_tests
+    nifgen-coverage: py{38,39,310,311}-nifgen-system_tests
     nifgen-system_tests: py3-nifgen-wheel_dep,
 
 passenv =

--- a/generated/nimodinst/README.rst
+++ b/generated/nimodinst/README.rst
@@ -61,7 +61,7 @@ called through its public C API using the `ctypes <https://docs.python.org/2/lib
 **nimi-python** supports all the Operating Systems supported by the underlying driver.
 
 **nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions. At
-this time this includes Python 3.7 and above using CPython.
+this time this includes Python 3.8 and above using CPython.
 
 
 NI-ModInst Python API Status

--- a/generated/nimodinst/README.rst
+++ b/generated/nimodinst/README.rst
@@ -60,8 +60,7 @@ called through its public C API using the `ctypes <https://docs.python.org/2/lib
 
 **nimi-python** supports all the Operating Systems supported by the underlying driver.
 
-**nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions. At
-this time this includes Python 3.8 and above using CPython.
+**nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions.
 
 
 NI-ModInst Python API Status

--- a/generated/nimodinst/setup.py
+++ b/generated/nimodinst/setup.py
@@ -57,7 +57,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/generated/nimodinst/tox-system_tests.ini
+++ b/generated/nimodinst/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/nimodinst)
 [tox]
-envlist = py{37,38,39,310,311}-nimodinst-system_tests, py311-nimodinst-coverage
+envlist = py{38,39,310,311}-nimodinst-system_tests, py311-nimodinst-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -42,7 +42,7 @@ deps =
     nimodinst-coverage: coverage
 
 depends =
-    nimodinst-coverage: py{37,38,39,310,311}-nimodinst-system_tests
+    nimodinst-coverage: py{38,39,310,311}-nimodinst-system_tests
 
 passenv =
     GIT_BRANCH

--- a/generated/niscope/README.rst
+++ b/generated/niscope/README.rst
@@ -61,7 +61,7 @@ called through its public C API using the `ctypes <https://docs.python.org/2/lib
 **nimi-python** supports all the Operating Systems supported by the underlying driver.
 
 **nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions. At
-this time this includes Python 3.7 and above using CPython.
+this time this includes Python 3.8 and above using CPython.
 
 
 NI-SCOPE Python API Status

--- a/generated/niscope/README.rst
+++ b/generated/niscope/README.rst
@@ -60,8 +60,7 @@ called through its public C API using the `ctypes <https://docs.python.org/2/lib
 
 **nimi-python** supports all the Operating Systems supported by the underlying driver.
 
-**nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions. At
-this time this includes Python 3.8 and above using CPython.
+**nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions.
 
 
 NI-SCOPE Python API Status

--- a/generated/niscope/setup.py
+++ b/generated/niscope/setup.py
@@ -48,8 +48,7 @@ setup(
     ],
     extras_require={
         'grpc': [
-            'grpcio>=1.49.1,<1.53;python_version=="3.7"',  # no 32-bit wheel for 1.53.0 and later
-            'grpcio>=1.49.1,<2.0;python_version>"3.7"',
+            'grpcio>=1.49.1,<2.0',
             'protobuf>=4.21,<5.0'
         ],
     },
@@ -65,7 +64,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/generated/niscope/tox-system_tests.ini
+++ b/generated/niscope/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/niscope)
 [tox]
-envlist = py3-niscope-wheel_dep,py{37,38,39,310,311}-niscope-system_tests, py311-niscope-coverage
+envlist = py3-niscope-wheel_dep,py{38,39,310,311}-niscope-system_tests, py311-niscope-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -50,7 +50,7 @@ deps =
     niscope-coverage: coverage
 
 depends =
-    niscope-coverage: py{37,38,39,310,311}-niscope-system_tests
+    niscope-coverage: py{38,39,310,311}-niscope-system_tests
     niscope-system_tests: py3-niscope-wheel_dep,
 
 passenv =

--- a/generated/nise/README.rst
+++ b/generated/nise/README.rst
@@ -60,8 +60,7 @@ called through its public C API using the `ctypes <https://docs.python.org/2/lib
 
 **nimi-python** supports all the Operating Systems supported by the underlying driver.
 
-**nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions. At
-this time this includes Python 3.8 and above using CPython.
+**nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions.
 
 
 NI Switch Executive Python API Status

--- a/generated/nise/README.rst
+++ b/generated/nise/README.rst
@@ -61,7 +61,7 @@ called through its public C API using the `ctypes <https://docs.python.org/2/lib
 **nimi-python** supports all the Operating Systems supported by the underlying driver.
 
 **nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions. At
-this time this includes Python 3.7 and above using CPython.
+this time this includes Python 3.8 and above using CPython.
 
 
 NI Switch Executive Python API Status

--- a/generated/nise/setup.py
+++ b/generated/nise/setup.py
@@ -57,7 +57,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/generated/nise/tox-system_tests.ini
+++ b/generated/nise/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/nise)
 [tox]
-envlist = py{37,38,39,310,311}-nise-system_tests, py311-nise-coverage
+envlist = py{38,39,310,311}-nise-system_tests, py311-nise-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -42,7 +42,7 @@ deps =
     nise-coverage: coverage
 
 depends =
-    nise-coverage: py{37,38,39,310,311}-nise-system_tests
+    nise-coverage: py{38,39,310,311}-nise-system_tests
 
 passenv =
     GIT_BRANCH

--- a/generated/niswitch/README.rst
+++ b/generated/niswitch/README.rst
@@ -61,7 +61,7 @@ called through its public C API using the `ctypes <https://docs.python.org/2/lib
 **nimi-python** supports all the Operating Systems supported by the underlying driver.
 
 **nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions. At
-this time this includes Python 3.7 and above using CPython.
+this time this includes Python 3.8 and above using CPython.
 
 
 NI-SWITCH Python API Status

--- a/generated/niswitch/README.rst
+++ b/generated/niswitch/README.rst
@@ -60,8 +60,7 @@ called through its public C API using the `ctypes <https://docs.python.org/2/lib
 
 **nimi-python** supports all the Operating Systems supported by the underlying driver.
 
-**nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions. At
-this time this includes Python 3.8 and above using CPython.
+**nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions.
 
 
 NI-SWITCH Python API Status

--- a/generated/niswitch/setup.py
+++ b/generated/niswitch/setup.py
@@ -47,8 +47,7 @@ setup(
     ],
     extras_require={
         'grpc': [
-            'grpcio>=1.49.1,<1.53;python_version=="3.7"',  # no 32-bit wheel for 1.53.0 and later
-            'grpcio>=1.49.1,<2.0;python_version>"3.7"',
+            'grpcio>=1.49.1,<2.0',
             'protobuf>=4.21,<5.0'
         ],
     },
@@ -64,7 +63,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/generated/niswitch/tox-system_tests.ini
+++ b/generated/niswitch/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/niswitch)
 [tox]
-envlist = py{37,38,39,310,311}-niswitch-system_tests, py311-niswitch-coverage
+envlist = py{38,39,310,311}-niswitch-system_tests, py311-niswitch-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -43,7 +43,7 @@ deps =
     niswitch-coverage: coverage
 
 depends =
-    niswitch-coverage: py{37,38,39,310,311}-niswitch-system_tests
+    niswitch-coverage: py{38,39,310,311}-niswitch-system_tests
 
 passenv =
     GIT_BRANCH

--- a/generated/nitclk/README.rst
+++ b/generated/nitclk/README.rst
@@ -60,8 +60,7 @@ called through its public C API using the `ctypes <https://docs.python.org/2/lib
 
 **nimi-python** supports all the Operating Systems supported by the underlying driver.
 
-**nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions. At
-this time this includes Python 3.8 and above using CPython.
+**nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions.
 
 
 NI-TClk Python API Status

--- a/generated/nitclk/README.rst
+++ b/generated/nitclk/README.rst
@@ -61,7 +61,7 @@ called through its public C API using the `ctypes <https://docs.python.org/2/lib
 **nimi-python** supports all the Operating Systems supported by the underlying driver.
 
 **nimi-python** follows `Python Software Foundation <https://devguide.python.org/#status-of-python-branches>`_ support policy for different versions. At
-this time this includes Python 3.7 and above using CPython.
+this time this includes Python 3.8 and above using CPython.
 
 
 NI-TClk Python API Status

--- a/generated/nitclk/setup.py
+++ b/generated/nitclk/setup.py
@@ -57,7 +57,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/generated/nitclk/tox-system_tests.ini
+++ b/generated/nitclk/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/nitclk)
 [tox]
-envlist = py3-nitclk-wheel_dep,py{37,38,39,310,311}-nitclk-system_tests, py311-nitclk-coverage
+envlist = py3-nitclk-wheel_dep,py{38,39,310,311}-nitclk-system_tests, py311-nitclk-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -49,7 +49,7 @@ deps =
     nitclk-coverage: coverage
 
 depends =
-    nitclk-coverage: py{37,38,39,310,311}-nitclk-system_tests
+    nitclk-coverage: py{38,39,310,311}-nitclk-system_tests
     nitclk-system_tests: py3-nitclk-wheel_dep,
 
 passenv =

--- a/tox-travis.ini
+++ b/tox-travis.ini
@@ -7,9 +7,9 @@
 # tox-travis.ini will have pyXX-clean and all pyXX-installers in the default envlist, while the developer tox.ini
 # does not have clean and only has one pyXX-installers
 # Uncomment this line for tox.ini
-# envlist = py311-build_test,py311-codegen,py311-installers,py{37,38,39,310,311}-test,py311-flake8,py311-docs,py311-pkg
+# envlist = py311-build_test,py311-codegen,py311-installers,py{38,39,310,311}-test,py311-flake8,py311-docs,py311-pkg
 # Uncomment this line for tox-travis.ini
-envlist = py311-clean,py311-build_test,py311-codegen,py{37,38,39,310,311}-installers,py{37,38,39,310,311}-test,py311-flake8,py311-docs,py311-pkg
+envlist = py311-clean,py311-build_test,py311-codegen,py{38,39,310,311}-installers,py{38,39,310,311}-test,py311-flake8,py311-docs,py311-pkg
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 skipsdist = true

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,9 @@
 # tox-travis.ini will have pyXX-clean and all pyXX-installers in the default envlist, while the developer tox.ini
 # does not have clean and only has one pyXX-installers
 # Uncomment this line for tox.ini
-envlist = py311-build_test,py311-codegen,py311-installers,py{37,38,39,310,311}-test,py311-flake8,py311-docs,py311-pkg
+envlist = py311-build_test,py311-codegen,py311-installers,py{38,39,310,311}-test,py311-flake8,py311-docs,py311-pkg
 # Uncomment this line for tox-travis.ini
-# envlist = py311-clean,py311-build_test,py311-codegen,py{37,38,39,310,311}-installers,py{37,38,39,310,311}-test,py311-flake8,py311-docs,py311-pkg
+# envlist = py311-clean,py311-build_test,py311-codegen,py{38,39,310,311}-installers,py{38,39,310,311}-test,py311-flake8,py311-docs,py311-pkg
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 skipsdist = true


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

* Drop Python 3.7 support, by removing it from our testing and list of offociailly supported versions.
* Drop Python 3.7-specific workarounds

Similar past PRs for comparsion:
* https://github.com/ni/nimi-python/pull/1810
* https://github.com/ni/nimi-python/pull/1903

### List issues fixed by this Pull Request below, if any.

* Fix #1953
* Fix #1952

### What testing has been done?

PR Checks
