### PR TITLE
Raise error if library not found, before attempting to load it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file.
 * ### ALL
     * #### Added
     * #### Changed
+        * Fix [#1970](https://github.com/ni/nimi-python/issues/1970): Incorrect error when driver runtime not installed.
     * #### Removed
 * ### `nidcpower` (NI-DCPower)
     * #### Added

--- a/build/templates/_library_singleton.py.mako
+++ b/build/templates/_library_singleton.py.mako
@@ -23,7 +23,10 @@ _library_info = ${helper.get_dictionary_snippet(config['library_info'], indent=1
 
 def _get_library_name():
     try:
-        return ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
+        lib_name = ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
+        if lib_name is None:
+            raise errors.DriverNotInstalledError()
+        return lib_name
     except KeyError:
         raise errors.UnsupportedConfigurationError
 

--- a/generated/nidcpower/nidcpower/_library_singleton.py
+++ b/generated/nidcpower/nidcpower/_library_singleton.py
@@ -19,7 +19,10 @@ _library_info = {'Linux': {'64bit': {'name': 'nidcpower', 'type': 'cdll'}},
 
 def _get_library_name():
     try:
-        return ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
+        lib_name = ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
+        if lib_name is None:
+            raise errors.DriverNotInstalledError()
+        return lib_name
     except KeyError:
         raise errors.UnsupportedConfigurationError
 

--- a/generated/nidigital/nidigital/_library_singleton.py
+++ b/generated/nidigital/nidigital/_library_singleton.py
@@ -19,7 +19,10 @@ _library_info = {'Linux': {'64bit': {'name': 'nidigital', 'type': 'cdll'}},
 
 def _get_library_name():
     try:
-        return ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
+        lib_name = ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
+        if lib_name is None:
+            raise errors.DriverNotInstalledError()
+        return lib_name
     except KeyError:
         raise errors.UnsupportedConfigurationError
 

--- a/generated/nidmm/nidmm/_library_singleton.py
+++ b/generated/nidmm/nidmm/_library_singleton.py
@@ -19,7 +19,10 @@ _library_info = {'Linux': {'64bit': {'name': 'nidmm', 'type': 'cdll'}},
 
 def _get_library_name():
     try:
-        return ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
+        lib_name = ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
+        if lib_name is None:
+            raise errors.DriverNotInstalledError()
+        return lib_name
     except KeyError:
         raise errors.UnsupportedConfigurationError
 

--- a/generated/nifake/nifake/_library_singleton.py
+++ b/generated/nifake/nifake/_library_singleton.py
@@ -19,7 +19,10 @@ _library_info = {'Linux': {'64bit': {'name': 'nifake', 'type': 'cdll'}},
 
 def _get_library_name():
     try:
-        return ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
+        lib_name = ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
+        if lib_name is None:
+            raise errors.DriverNotInstalledError()
+        return lib_name
     except KeyError:
         raise errors.UnsupportedConfigurationError
 

--- a/generated/nifake/nifake/unit_tests/test_library_singleton.py
+++ b/generated/nifake/nifake/unit_tests/test_library_singleton.py
@@ -2,6 +2,6 @@ import nifake
 import pytest
 
 
-def test_get_uninstalled_driver_library_raises_driver_not_installed_error():
+def test_driver_runtime_not_installed_raises_driver_not_installed_error():
     with pytest.raises(nifake.errors.DriverNotInstalledError):
         nifake._library_singleton.get()

--- a/generated/nifake/nifake/unit_tests/test_library_singleton.py
+++ b/generated/nifake/nifake/unit_tests/test_library_singleton.py
@@ -1,0 +1,7 @@
+import nifake
+import pytest
+
+
+def test_get_uninstalled_driver_library_raises_driver_not_installed_error():
+    with pytest.raises(nifake.errors.DriverNotInstalledError):
+        nifake._library_singleton.get()

--- a/generated/nifgen/nifgen/_library_singleton.py
+++ b/generated/nifgen/nifgen/_library_singleton.py
@@ -19,7 +19,10 @@ _library_info = {'Linux': {'64bit': {'name': 'nifgen', 'type': 'cdll'}},
 
 def _get_library_name():
     try:
-        return ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
+        lib_name = ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
+        if lib_name is None:
+            raise errors.DriverNotInstalledError()
+        return lib_name
     except KeyError:
         raise errors.UnsupportedConfigurationError
 

--- a/generated/nimodinst/nimodinst/_library_singleton.py
+++ b/generated/nimodinst/nimodinst/_library_singleton.py
@@ -19,7 +19,10 @@ _library_info = {'Linux': {'64bit': {'name': 'nimodinst', 'type': 'cdll'}},
 
 def _get_library_name():
     try:
-        return ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
+        lib_name = ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
+        if lib_name is None:
+            raise errors.DriverNotInstalledError()
+        return lib_name
     except KeyError:
         raise errors.UnsupportedConfigurationError
 

--- a/generated/niscope/niscope/_library_singleton.py
+++ b/generated/niscope/niscope/_library_singleton.py
@@ -19,7 +19,10 @@ _library_info = {'Linux': {'64bit': {'name': 'niscope', 'type': 'cdll'}},
 
 def _get_library_name():
     try:
-        return ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
+        lib_name = ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
+        if lib_name is None:
+            raise errors.DriverNotInstalledError()
+        return lib_name
     except KeyError:
         raise errors.UnsupportedConfigurationError
 

--- a/generated/nise/nise/_library_singleton.py
+++ b/generated/nise/nise/_library_singleton.py
@@ -19,7 +19,10 @@ _library_info = {'Linux': {'64bit': {'name': 'nise', 'type': 'cdll'}},
 
 def _get_library_name():
     try:
-        return ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
+        lib_name = ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
+        if lib_name is None:
+            raise errors.DriverNotInstalledError()
+        return lib_name
     except KeyError:
         raise errors.UnsupportedConfigurationError
 

--- a/generated/niswitch/niswitch/_library_singleton.py
+++ b/generated/niswitch/niswitch/_library_singleton.py
@@ -19,7 +19,10 @@ _library_info = {'Linux': {'64bit': {'name': 'niswitch', 'type': 'cdll'}},
 
 def _get_library_name():
     try:
-        return ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
+        lib_name = ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
+        if lib_name is None:
+            raise errors.DriverNotInstalledError()
+        return lib_name
     except KeyError:
         raise errors.UnsupportedConfigurationError
 

--- a/generated/nitclk/nitclk/_library_singleton.py
+++ b/generated/nitclk/nitclk/_library_singleton.py
@@ -19,7 +19,10 @@ _library_info = {'Linux': {'64bit': {'name': 'nitclk', 'type': 'cdll'}},
 
 def _get_library_name():
     try:
-        return ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
+        lib_name = ctypes.util.find_library(_library_info[platform.system()][platform.architecture()[0]]['name'])  # We find and return full path to the DLL
+        if lib_name is None:
+            raise errors.DriverNotInstalledError()
+        return lib_name
     except KeyError:
         raise errors.UnsupportedConfigurationError
 

--- a/src/nifake/unit_tests/test_library_singleton.py
+++ b/src/nifake/unit_tests/test_library_singleton.py
@@ -2,6 +2,6 @@ import nifake
 import pytest
 
 
-def test_get_uninstalled_driver_library_raises_driver_not_installed_error():
+def test_driver_runtime_not_installed_raises_driver_not_installed_error():
     with pytest.raises(nifake.errors.DriverNotInstalledError):
         nifake._library_singleton.get()

--- a/src/nifake/unit_tests/test_library_singleton.py
+++ b/src/nifake/unit_tests/test_library_singleton.py
@@ -1,0 +1,7 @@
+import nifake
+import pytest
+
+
+def test_get_uninstalled_driver_library_raises_driver_not_installed_error():
+    with pytest.raises(nifake.errors.DriverNotInstalledError):
+        nifake._library_singleton.get()


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- [X] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

The code to load a DLL may change over time, leading to it returning different errors. This led to us returning a poor error when the driver runtime is not installed.

To improve our error behavior, raise a DriverNotInstalledError at the step where we look for the library, if it's not found. This happens before we attempt to load the library and since determining that the library wasn't found doesn't rely on getting a specific error, our behavior will be less likely to change.

Also add a test to cover this behavior.

### List issues fixed by this Pull Request below, if any.

* Fix #1970

### What testing has been done?

* Added a unit test.
  * Ran it without the fix: it failed
  * Ran it with the fix: it passed

There's nothing OS-specific about `_get_library_name()`, so it should be okay that the unit tests only run on Linux.