### PR TITLE
Faster Array Allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
     * #### Added
     * #### Changed
         * Fix [#1970](https://github.com/ni/nimi-python/issues/1970): Incorrect error when driver runtime not installed.
+        * Fix [#1998](https://github.com/ni/nimi-python/issues/1998): nimi-python APIs inefficiently allocate Python arrays.
     * #### Removed
         * Support for Python 3.7
 * ### `nidcpower` (NI-DCPower)

--- a/build/helper/codegen_helper.py
+++ b/build/helper/codegen_helper.py
@@ -411,10 +411,10 @@ def _get_ctype_variable_definition_snippet_for_buffers(parameter, parameters, iv
         B560. Output buffer with mechanism python-code:                            _get_ctypes_pointer_for_buffer(value=array.array('d'), library_type=ViInt32)
         B570. Output buffer with mechanism fixed-size:                             _get_ctypes_pointer_for_buffer(library_type=ViInt32, size=256)
         B580. Output buffer with mechanism ivi-dance, QUERY_SIZE:                  None
-        B590. Output buffer with mechanism ivi-dance, GET_DATA:                    _get_ctypes_pointer_for_buffer(value=array.array('d', [0] * buffer_size_ctype.value, library_type=ViInt32)
-        B600. Output buffer with mechanism passed-in:                              _get_ctypes_pointer_for_buffer(value-array.array('d', [0] * buffer_size, library_type=ViInt32)
+        B590. Output buffer with mechanism ivi-dance, GET_DATA:                    _get_ctypes_pointer_for_buffer(value=array.array('d', [0]) * buffer_size_ctype.value, library_type=ViInt32)
+        B600. Output buffer with mechanism passed-in:                              _get_ctypes_pointer_for_buffer(value-array.array('d', [0]) * buffer_size, library_type=ViInt32)
         B610. Output buffer with mechanism ivi-dance-with-a-twist, QUERY_SIZE:     None
-        B620. Output buffer with mechanism ivi-dance-with-a-twist, GET_DATA:       _get_ctypes_pointer_for_buffer(value=array.array('d', [0] * buffer_size_ctype.value, library_type=ViInt32)
+        B620. Output buffer with mechanism ivi-dance-with-a-twist, GET_DATA:       _get_ctypes_pointer_for_buffer(value=array.array('d', [0]) * buffer_size_ctype.value, library_type=ViInt32)
 
     Return Value (list): each item in the list will be one line needed for the declaration of that parameter
 
@@ -447,7 +447,7 @@ def _get_ctype_variable_definition_snippet_for_buffers(parameter, parameters, iv
             line1 = '{0}_size = {1}  # case B560'.format(parameter['python_name'], parameter['size']['value'])
             definitions.append(line1)
             if parameter['use_array']:
-                line2 = '{0}_array = array.array("{1}", [0] * {0}_size)  # case B560'.format(parameter['python_name'], get_array_type_for_api_type(parameter['ctypes_type']))
+                line2 = '{0}_array = array.array("{1}", [0]) * {0}_size  # case B560'.format(parameter['python_name'], get_array_type_for_api_type(parameter['ctypes_type']))
                 definitions.append(line2)
                 definition = '_get_ctypes_pointer_for_buffer(value={1}_array, library_type={0}.{2})  # case B560'.format(module_name, parameter['python_name'], parameter['ctypes_type'])
             elif parameter['use_list']:
@@ -459,7 +459,7 @@ def _get_ctype_variable_definition_snippet_for_buffers(parameter, parameters, iv
             line1 = '{0}_size = {1}  # case B570'.format(parameter['python_name'], parameter['size']['value'])
             definitions.append(line1)
             if parameter['use_array']:
-                line2 = '{0}_array = array.array("{1}", [0] * {0}_size)  # case B570'.format(parameter['python_name'], get_array_type_for_api_type(parameter['ctypes_type']))
+                line2 = '{0}_array = array.array("{1}", [0]) * {0}_size  # case B570'.format(parameter['python_name'], get_array_type_for_api_type(parameter['ctypes_type']))
                 definitions.append(line2)
                 definition = '_get_ctypes_pointer_for_buffer(value={1}_array, library_type={0}.{2})  # case B570'.format(module_name, parameter['python_name'], parameter['ctypes_type'])
             elif parameter['use_list']:
@@ -474,7 +474,7 @@ def _get_ctype_variable_definition_snippet_for_buffers(parameter, parameters, iv
                 line1 = '{0}_size = {1}.value  # case B590'.format(parameter['python_name'], size_parameter['ctypes_variable_name'])
                 definitions.append(line1)
                 if parameter['use_array']:
-                    line2 = '{0}_array = array.array("{1}", [0] * {0}_size)  # case B590'.format(parameter['python_name'], get_array_type_for_api_type(parameter['ctypes_type']))
+                    line2 = '{0}_array = array.array("{1}", [0]) * {0}_size  # case B590'.format(parameter['python_name'], get_array_type_for_api_type(parameter['ctypes_type']))
                     definition = '_get_ctypes_pointer_for_buffer(value={1}_array, library_type={0}.{2})  # case B590'.format(module_name, parameter['python_name'], parameter['ctypes_type'])
                     definitions.append(line2)
                 elif parameter['use_list']:
@@ -491,7 +491,7 @@ def _get_ctype_variable_definition_snippet_for_buffers(parameter, parameters, iv
                 line1 = '{0}_size = {1}.value  # case B620'.format(parameter['python_name'], size_parameter_twist['ctypes_variable_name'])
                 definitions.append(line1)
                 if parameter['use_array']:
-                    line2 = '{0}_array = array.array("{1}", [0] * {0}_size)  # case B620'.format(parameter['python_name'], get_array_type_for_api_type(parameter['ctypes_type']))
+                    line2 = '{0}_array = array.array("{1}", [0]) * {0}_size  # case B620'.format(parameter['python_name'], get_array_type_for_api_type(parameter['ctypes_type']))
                     definitions.append(line2)
                     definition = '_get_ctypes_pointer_for_buffer(value={1}_array, library_type={0}.{2})  # case B620'.format(module_name, parameter['python_name'], parameter['ctypes_type'])
                 elif parameter['use_list']:
@@ -505,7 +505,7 @@ def _get_ctype_variable_definition_snippet_for_buffers(parameter, parameters, iv
             line1 = '{0}_size = {1}  # case B600'.format(parameter['python_name'], size_parameter['python_name'])
             definitions.append(line1)
             if parameter['use_array']:
-                line2 = '{0}_array = array.array("{1}", [0] * {0}_size)  # case B600'.format(parameter['python_name'], get_array_type_for_api_type(parameter['ctypes_type']))
+                line2 = '{0}_array = array.array("{1}", [0]) * {0}_size  # case B600'.format(parameter['python_name'], get_array_type_for_api_type(parameter['ctypes_type']))
                 definition = '_get_ctypes_pointer_for_buffer(value={1}_array, library_type={0}.{2})  # case B600'.format(module_name, parameter['python_name'], parameter['ctypes_type'])
                 definitions.append(line2)
             elif parameter['use_list']:

--- a/build/unit_tests/test_codegen_helper.py
+++ b/build/unit_tests/test_codegen_helper.py
@@ -1220,7 +1220,7 @@ def test_get_ctype_variable_declaration_snippet_case_b570():
     actual = get_ctype_variable_declaration_snippet(parameters_for_testing[18], parameters_for_testing, IviDanceStep.NOT_APPLICABLE, config_for_testing, use_numpy_array=False)
     expected = [
         'an_int_size = 256  # case B570',
-        'an_int_array = array.array("h", [0] * an_int_size)  # case B570',
+        'an_int_array = array.array("h", [0]) * an_int_size  # case B570',
         'an_int_ctype = _get_ctypes_pointer_for_buffer(value=an_int_array, library_type=_visatype.ViInt16)  # case B570',
     ]
     assert len(actual) == len(expected)
@@ -1237,7 +1237,7 @@ def test_get_ctype_variable_declaration_snippet_case_b590_array():
     actual = get_ctype_variable_declaration_snippet(parameters_for_testing[24], parameters_for_testing, IviDanceStep.GET_DATA, config_for_testing, use_numpy_array=False)
     expected = [
         'a_buffer_array_size = string_size_ctype.value  # case B590',
-        'a_buffer_array_array = array.array("l", [0] * a_buffer_array_size)  # case B590',
+        'a_buffer_array_array = array.array("l", [0]) * a_buffer_array_size  # case B590',
         'a_buffer_array_ctype = _get_ctypes_pointer_for_buffer(value=a_buffer_array_array, library_type=_visatype.ViInt32)  # case B590',
     ]
     assert len(actual) == len(expected)
@@ -1265,7 +1265,7 @@ def test_get_ctype_variable_declaration_snippet_case_b600():
     actual = get_ctype_variable_declaration_snippet(parameters_for_testing[7], parameters_for_testing, IviDanceStep.NOT_APPLICABLE, config_for_testing, use_numpy_array=False)
     expected = [
         'output_size = number_of_elements  # case B600',
-        'output_array = array.array("q", [0] * output_size)  # case B600',
+        'output_array = array.array("q", [0]) * output_size  # case B600',
         'output_ctype = _get_ctypes_pointer_for_buffer(value=output_array, library_type=_visatype.ViInt64)  # case B600',
     ]
     assert len(actual) == len(expected)
@@ -1282,7 +1282,7 @@ def test_get_ctype_variable_declaration_snippet_case_b620_array():
     actual = get_ctype_variable_declaration_snippet(parameters_for_testing[26], parameters_for_testing, IviDanceStep.GET_DATA, config_for_testing, use_numpy_array=False)
     expected = [
         'a_buffer_twist_array_size = output_twist_ctype.value  # case B620',
-        'a_buffer_twist_array_array = array.array("l", [0] * a_buffer_twist_array_size)  # case B620',
+        'a_buffer_twist_array_array = array.array("l", [0]) * a_buffer_twist_array_size  # case B620',
         'a_buffer_twist_array_ctype = _get_ctypes_pointer_for_buffer(value=a_buffer_twist_array_array, library_type=_visatype.ViInt32)  # case B620',
     ]
     assert len(actual) == len(expected)

--- a/generated/nidcpower/nidcpower/_library_interpreter.py
+++ b/generated/nidcpower/nidcpower/_library_interpreter.py
@@ -220,7 +220,7 @@ class LibraryInterpreter(object):
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         size_ctype = _visatype.ViInt32(error_code)  # case S180
         configuration_size = size_ctype.value  # case B590
-        configuration_array = array.array("b", [0] * configuration_size)  # case B590
+        configuration_array = array.array("b", [0]) * configuration_size  # case B590
         configuration_ctype = _get_ctypes_pointer_for_buffer(value=configuration_array, library_type=_visatype.ViInt8)  # case B590
         error_code = self._library.niDCPower_ExportAttributeConfigurationBuffer(vi_ctype, size_ctype, configuration_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
@@ -250,10 +250,10 @@ class LibraryInterpreter(object):
         timeout_ctype = _visatype.ViReal64(timeout)  # case S150
         count_ctype = _visatype.ViInt32(count)  # case S210
         voltage_measurements_size = count  # case B600
-        voltage_measurements_array = array.array("d", [0] * voltage_measurements_size)  # case B600
+        voltage_measurements_array = array.array("d", [0]) * voltage_measurements_size  # case B600
         voltage_measurements_ctype = _get_ctypes_pointer_for_buffer(value=voltage_measurements_array, library_type=_visatype.ViReal64)  # case B600
         current_measurements_size = count  # case B600
-        current_measurements_array = array.array("d", [0] * current_measurements_size)  # case B600
+        current_measurements_array = array.array("d", [0]) * current_measurements_size  # case B600
         current_measurements_ctype = _get_ctypes_pointer_for_buffer(value=current_measurements_array, library_type=_visatype.ViReal64)  # case B600
         in_compliance_size = count  # case B600
         in_compliance_ctype = _get_ctypes_pointer_for_buffer(library_type=_visatype.ViBoolean, size=in_compliance_size)  # case B600
@@ -397,7 +397,7 @@ class LibraryInterpreter(object):
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         compensation_data_size_ctype = _visatype.ViInt32(error_code)  # case S180
         compensation_data_size = compensation_data_size_ctype.value  # case B590
-        compensation_data_array = array.array("b", [0] * compensation_data_size)  # case B590
+        compensation_data_array = array.array("b", [0]) * compensation_data_size  # case B590
         compensation_data_ctype = _get_ctypes_pointer_for_buffer(value=compensation_data_array, library_type=_visatype.ViInt8)  # case B590
         error_code = self._library.niDCPower_GetLCRCompensationData(vi_ctype, channel_name_ctype, compensation_data_size_ctype, compensation_data_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
@@ -425,7 +425,7 @@ class LibraryInterpreter(object):
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         custom_cable_compensation_data_size_ctype = _visatype.ViInt32(error_code)  # case S180
         custom_cable_compensation_data_size = custom_cable_compensation_data_size_ctype.value  # case B590
-        custom_cable_compensation_data_array = array.array("b", [0] * custom_cable_compensation_data_size)  # case B590
+        custom_cable_compensation_data_array = array.array("b", [0]) * custom_cable_compensation_data_size  # case B590
         custom_cable_compensation_data_ctype = _get_ctypes_pointer_for_buffer(value=custom_cable_compensation_data_array, library_type=_visatype.ViInt8)  # case B590
         error_code = self._library.niDCPower_GetLCRCustomCableCompensationData(vi_ctype, channel_name_ctype, custom_cable_compensation_data_size_ctype, custom_cable_compensation_data_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
@@ -511,10 +511,10 @@ class LibraryInterpreter(object):
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         channel_name_ctype = ctypes.create_string_buffer(channel_name.encode(self._encoding))  # case C010
         voltage_measurements_size = self.parse_channel_count(channel_name)  # case B560
-        voltage_measurements_array = array.array("d", [0] * voltage_measurements_size)  # case B560
+        voltage_measurements_array = array.array("d", [0]) * voltage_measurements_size  # case B560
         voltage_measurements_ctype = _get_ctypes_pointer_for_buffer(value=voltage_measurements_array, library_type=_visatype.ViReal64)  # case B560
         current_measurements_size = self.parse_channel_count(channel_name)  # case B560
-        current_measurements_array = array.array("d", [0] * current_measurements_size)  # case B560
+        current_measurements_array = array.array("d", [0]) * current_measurements_size  # case B560
         current_measurements_ctype = _get_ctypes_pointer_for_buffer(value=current_measurements_array, library_type=_visatype.ViReal64)  # case B560
         error_code = self._library.niDCPower_MeasureMultiple(vi_ctype, channel_name_ctype, voltage_measurements_ctype, current_measurements_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)

--- a/generated/nidigital/nidigital/_library_interpreter.py
+++ b/generated/nidigital/nidigital/_library_interpreter.py
@@ -392,7 +392,7 @@ class LibraryInterpreter(object):
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         data_buffer_size_ctype = _visatype.ViInt32(actual_num_waveforms_ctype.value * actual_samples_per_waveform_ctype.value)  # case S200 (modified)
         data_size = actual_num_waveforms_ctype.value * actual_samples_per_waveform_ctype.value  # case B620 (modified)
-        data_array = array.array("L", [0] * data_size)  # case B620
+        data_array = array.array("L", [0]) * data_size  # case B620
         data_ctype = _get_ctypes_pointer_for_buffer(value=data_array, library_type=_visatype.ViUInt32)  # case B620
         error_code = self._library.niDigital_FetchCaptureWaveformU32(vi_ctype, site_list_ctype, waveform_name_ctype, samples_to_read_ctype, timeout_ctype, data_buffer_size_ctype, data_ctype, None if actual_num_waveforms_ctype is None else (ctypes.pointer(actual_num_waveforms_ctype)), None if actual_samples_per_waveform_ctype is None else (ctypes.pointer(actual_samples_per_waveform_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -3523,7 +3523,7 @@ class Session(_SessionBase):
             actual_samples_per_waveform = 0
         else:
             actual_samples_per_waveform = len(waveform_data[next(iter(waveform_data))])
-        data = array.array('L', [0] * (len(waveform_data) * actual_samples_per_waveform))
+        data = array.array('L', [0]) * (len(waveform_data) * actual_samples_per_waveform)
         mv = memoryview(data)
 
         i = 0

--- a/generated/nidmm/nidmm/_library_interpreter.py
+++ b/generated/nidmm/nidmm/_library_interpreter.py
@@ -211,7 +211,7 @@ class LibraryInterpreter(object):
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         size_ctype = _visatype.ViInt32(error_code)  # case S180
         configuration_size = size_ctype.value  # case B590
-        configuration_array = array.array("b", [0] * configuration_size)  # case B590
+        configuration_array = array.array("b", [0]) * configuration_size  # case B590
         configuration_ctype = _get_ctypes_pointer_for_buffer(value=configuration_array, library_type=_visatype.ViInt8)  # case B590
         error_code = self._library.niDMM_ExportAttributeConfigurationBuffer(vi_ctype, size_ctype, configuration_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
@@ -237,7 +237,7 @@ class LibraryInterpreter(object):
         maximum_time_ctype = _visatype.ViInt32(maximum_time)  # case S150
         array_size_ctype = _visatype.ViInt32(array_size)  # case S210
         reading_array_size = array_size  # case B600
-        reading_array_array = array.array("d", [0] * reading_array_size)  # case B600
+        reading_array_array = array.array("d", [0]) * reading_array_size  # case B600
         reading_array_ctype = _get_ctypes_pointer_for_buffer(value=reading_array_array, library_type=_visatype.ViReal64)  # case B600
         actual_number_of_points_ctype = _visatype.ViInt32()  # case S220
         error_code = self._library.niDMM_FetchMultiPoint(vi_ctype, maximum_time_ctype, array_size_ctype, reading_array_ctype, None if actual_number_of_points_ctype is None else (ctypes.pointer(actual_number_of_points_ctype)))
@@ -249,7 +249,7 @@ class LibraryInterpreter(object):
         maximum_time_ctype = _visatype.ViInt32(maximum_time)  # case S150
         array_size_ctype = _visatype.ViInt32(array_size)  # case S210
         waveform_array_size = array_size  # case B600
-        waveform_array_array = array.array("d", [0] * waveform_array_size)  # case B600
+        waveform_array_array = array.array("d", [0]) * waveform_array_size  # case B600
         waveform_array_ctype = _get_ctypes_pointer_for_buffer(value=waveform_array_array, library_type=_visatype.ViReal64)  # case B600
         actual_number_of_points_ctype = _visatype.ViInt32()  # case S220
         error_code = self._library.niDMM_FetchWaveform(vi_ctype, maximum_time_ctype, array_size_ctype, waveform_array_ctype, None if actual_number_of_points_ctype is None else (ctypes.pointer(actual_number_of_points_ctype)))
@@ -430,7 +430,7 @@ class LibraryInterpreter(object):
         maximum_time_ctype = _visatype.ViInt32(maximum_time)  # case S150
         array_size_ctype = _visatype.ViInt32(array_size)  # case S210
         reading_array_size = array_size  # case B600
-        reading_array_array = array.array("d", [0] * reading_array_size)  # case B600
+        reading_array_array = array.array("d", [0]) * reading_array_size  # case B600
         reading_array_ctype = _get_ctypes_pointer_for_buffer(value=reading_array_array, library_type=_visatype.ViReal64)  # case B600
         actual_number_of_points_ctype = _visatype.ViInt32()  # case S220
         error_code = self._library.niDMM_ReadMultiPoint(vi_ctype, maximum_time_ctype, array_size_ctype, reading_array_ctype, None if actual_number_of_points_ctype is None else (ctypes.pointer(actual_number_of_points_ctype)))
@@ -450,7 +450,7 @@ class LibraryInterpreter(object):
         maximum_time_ctype = _visatype.ViInt32(maximum_time)  # case S150
         array_size_ctype = _visatype.ViInt32(array_size)  # case S210
         waveform_array_size = array_size  # case B600
-        waveform_array_array = array.array("d", [0] * waveform_array_size)  # case B600
+        waveform_array_array = array.array("d", [0]) * waveform_array_size  # case B600
         waveform_array_ctype = _get_ctypes_pointer_for_buffer(value=waveform_array_array, library_type=_visatype.ViReal64)  # case B600
         actual_number_of_points_ctype = _visatype.ViInt32()  # case S220
         error_code = self._library.niDMM_ReadWaveform(vi_ctype, maximum_time_ctype, array_size_ctype, waveform_array_ctype, None if actual_number_of_points_ctype is None else (ctypes.pointer(actual_number_of_points_ctype)))

--- a/generated/nifake/nifake/_library_interpreter.py
+++ b/generated/nifake/nifake/_library_interpreter.py
@@ -185,7 +185,7 @@ class LibraryInterpreter(object):
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         size_in_bytes_ctype = _visatype.ViInt32(error_code)  # case S180
         configuration_size = size_in_bytes_ctype.value  # case B590
-        configuration_array = array.array("b", [0] * configuration_size)  # case B590
+        configuration_array = array.array("b", [0]) * configuration_size  # case B590
         configuration_ctype = _get_ctypes_pointer_for_buffer(value=configuration_array, library_type=_visatype.ViInt8)  # case B590
         error_code = self._library.niFake_ExportAttributeConfigurationBuffer(vi_ctype, size_in_bytes_ctype, configuration_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
@@ -195,7 +195,7 @@ class LibraryInterpreter(object):
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         number_of_samples_ctype = _visatype.ViInt32(number_of_samples)  # case S210
         waveform_data_size = number_of_samples  # case B600
-        waveform_data_array = array.array("d", [0] * waveform_data_size)  # case B600
+        waveform_data_array = array.array("d", [0]) * waveform_data_size  # case B600
         waveform_data_ctype = _get_ctypes_pointer_for_buffer(value=waveform_data_array, library_type=_visatype.ViReal64)  # case B600
         actual_number_of_samples_ctype = _visatype.ViInt32()  # case S220
         error_code = self._library.niFake_FetchWaveform(vi_ctype, number_of_samples_ctype, waveform_data_ctype, None if actual_number_of_samples_ctype is None else (ctypes.pointer(actual_number_of_samples_ctype)))

--- a/generated/nifake/nifake/unit_tests/test_library_interpreter.py
+++ b/generated/nifake/nifake/unit_tests/test_library_interpreter.py
@@ -161,7 +161,7 @@ class TestLibraryInterpreter(object):
 
         # Because we are mocking _get_ctypes_pointer_for_buffer() we don't end up using the array allocated in the function call. Instead, we will allocate the arrays here
         # and have the mock return them. These are the ones that are actually filled in by the function.
-        expected_waveform = array.array('d', [0] * len(expected_waveform_list))
+        expected_waveform = array.array('d', [0]) * len(expected_waveform_list)
         expected_waveform_ctypes = ctypes.cast(expected_waveform.buffer_info()[0], ctypes.POINTER(nifake._visatype.ViReal64 * len(expected_waveform_list)))
 
         interpreter = self.get_initialized_library_interpreter()

--- a/generated/nifgen/nifgen/_library_interpreter.py
+++ b/generated/nifgen/nifgen/_library_interpreter.py
@@ -343,7 +343,7 @@ class LibraryInterpreter(object):
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         size_in_bytes_ctype = _visatype.ViInt32(error_code)  # case S180
         configuration_size = size_in_bytes_ctype.value  # case B590
-        configuration_array = array.array("b", [0] * configuration_size)  # case B590
+        configuration_array = array.array("b", [0]) * configuration_size  # case B590
         configuration_ctype = _get_ctypes_pointer_for_buffer(value=configuration_array, library_type=_visatype.ViInt8)  # case B590
         error_code = self._library.niFgen_ExportAttributeConfigurationBuffer(vi_ctype, size_in_bytes_ctype, configuration_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)

--- a/generated/niscope/niscope/_library_interpreter.py
+++ b/generated/niscope/niscope/_library_interpreter.py
@@ -346,7 +346,7 @@ class LibraryInterpreter(object):
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         size_in_bytes_ctype = _visatype.ViInt32(error_code)  # case S180
         configuration_size = size_in_bytes_ctype.value  # case B590
-        configuration_array = array.array("b", [0] * configuration_size)  # case B590
+        configuration_array = array.array("b", [0]) * configuration_size  # case B590
         configuration_ctype = _get_ctypes_pointer_for_buffer(value=configuration_array, library_type=_visatype.ViInt8)  # case B590
         error_code = self._library.niScope_ExportAttributeConfigurationBuffer(vi_ctype, size_in_bytes_ctype, configuration_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
@@ -365,7 +365,7 @@ class LibraryInterpreter(object):
         timeout_ctype = _visatype.ViReal64(timeout)  # case S150
         num_samples_ctype = _visatype.ViInt32(num_samples)  # case S150
         waveform_size = (num_samples * self.actual_num_wfms(channel_list))  # case B560
-        waveform_array = array.array("d", [0] * waveform_size)  # case B560
+        waveform_array = array.array("d", [0]) * waveform_size  # case B560
         waveform_ctype = _get_ctypes_pointer_for_buffer(value=waveform_array, library_type=_visatype.ViReal64)  # case B560
         wfm_info_size = self.actual_num_wfms(channel_list)  # case B560
         wfm_info_ctype = _get_ctypes_pointer_for_buffer(library_type=waveform_info.struct_niScope_wfmInfo, size=wfm_info_size)  # case B560
@@ -598,7 +598,7 @@ class LibraryInterpreter(object):
         timeout_ctype = _visatype.ViReal64(timeout)  # case S150
         num_samples_ctype = _visatype.ViInt32(num_samples)  # case S150
         waveform_size = (num_samples * self.actual_num_wfms(channel_list))  # case B560
-        waveform_array = array.array("d", [0] * waveform_size)  # case B560
+        waveform_array = array.array("d", [0]) * waveform_size  # case B560
         waveform_ctype = _get_ctypes_pointer_for_buffer(value=waveform_array, library_type=_visatype.ViReal64)  # case B560
         wfm_info_size = self.actual_num_wfms(channel_list)  # case B560
         wfm_info_ctype = _get_ctypes_pointer_for_buffer(library_type=waveform_info.struct_niScope_wfmInfo, size=wfm_info_size)  # case B560

--- a/src/nidigital/templates/_library_interpreter.py/fancy_fetch_capture_waveform.py.mako
+++ b/src/nidigital/templates/_library_interpreter.py/fancy_fetch_capture_waveform.py.mako
@@ -18,7 +18,7 @@
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
         data_buffer_size_ctype = _visatype.ViInt32(actual_num_waveforms_ctype.value * actual_samples_per_waveform_ctype.value)  # case S200 (modified)
         data_size = actual_num_waveforms_ctype.value * actual_samples_per_waveform_ctype.value  # case B620 (modified)
-        data_array = array.array("L", [0] * data_size)  # case B620
+        data_array = array.array("L", [0]) * data_size  # case B620
         data_ctype = _get_ctypes_pointer_for_buffer(value=data_array, library_type=_visatype.ViUInt32)  # case B620
         error_code = self._library.niDigital_FetchCaptureWaveformU32(vi_ctype, site_list_ctype, waveform_name_ctype, samples_to_read_ctype, timeout_ctype, data_buffer_size_ctype, data_ctype, None if actual_num_waveforms_ctype is None else (ctypes.pointer(actual_num_waveforms_ctype)), None if actual_samples_per_waveform_ctype is None else (ctypes.pointer(actual_samples_per_waveform_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)

--- a/src/nidigital/templates/session.py/fancy_write_source_waveform_site_unique.py.mako
+++ b/src/nidigital/templates/session.py/fancy_write_source_waveform_site_unique.py.mako
@@ -18,7 +18,7 @@
             actual_samples_per_waveform = 0
         else:
             actual_samples_per_waveform = len(waveform_data[next(iter(waveform_data))])
-        data = array.array('L', [0] * (len(waveform_data) * actual_samples_per_waveform))
+        data = array.array('L', [0]) * (len(waveform_data) * actual_samples_per_waveform)
         mv = memoryview(data)
 
         i = 0

--- a/src/nifake/unit_tests/test_library_interpreter.py
+++ b/src/nifake/unit_tests/test_library_interpreter.py
@@ -161,7 +161,7 @@ class TestLibraryInterpreter(object):
 
         # Because we are mocking _get_ctypes_pointer_for_buffer() we don't end up using the array allocated in the function call. Instead, we will allocate the arrays here
         # and have the mock return them. These are the ones that are actually filled in by the function.
-        expected_waveform = array.array('d', [0] * len(expected_waveform_list))
+        expected_waveform = array.array('d', [0]) * len(expected_waveform_list)
         expected_waveform_ctypes = ctypes.cast(expected_waveform.buffer_info()[0], ctypes.POINTER(nifake._visatype.ViReal64 * len(expected_waveform_list)))
 
         interpreter = self.get_initialized_library_interpreter()


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
When allocating a buffer, nimi-python APIs create a list of 0s then copy them into an array.array that is being initialized, causing allocation of the array to take much longer than necessary. For large buffers, the extra time spent allocating and copying the list is significant.

This change updates the allocation process to instead create a single element list `[0]` that is copied into the array, then use the `*` operator to extend the array to a specified number of elements.

### List issues fixed by this Pull Request below, if any.

* Fix #1998

### What testing has been done?

Functional: System and Unit tests
Performance: 
1. Tested allocation time of arrays of various sizes with both methods. When allocation time was not negligible (0 s measured), the new method consistently allocated faster, typically with a reduction in execution time of %90 or more.
3. With a real 5164 and NI-SCOPE 23.8.0 (in-dev version), tested `niscope.Session.fetch()` performance of single channel fetches of various record lengths and numbers of records.

100 Samples
niscope 1.4.5 fetch time: 0.002000
PR                  fetch time: 0.000999

10k Samples
niscope 1.4.5 fetch time: 0.001999
PR                  fetch time: 0.001987

1M Samples
niscope 1.4.5 fetch time: 0.051974
PR                  fetch time: 0.006997

100M Samples
niscope 1.4.5 fetch time: 5.340731
PR                  fetch time: 0.582741

10k Samples, 1k Records
niscope 1.4.5 fetch time: 0.589767
PR                  fetch time: 0.139914

1M Samples, 100 Records
niscope 1.4.5 fetch time: 5.240911
PR                  fetch time: 0.526281

100M Samples, 10 Records
niscope 1.4.5 fetch time: 5.177619
PR                  fetch time: 0.493325