### PR TITLE
Fix nidmm usage example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -445,7 +445,7 @@ The following is a basic example of using the **nidmm** module to open a session
 
     import nidmm
     with nidmm.Session("Dev1") as session:
-        session.configureMeasurementDigits(nidmm.Function.DC_VOLTS, 10, 5.5)
+        session.configure_measurement_digits(nidmm.Function.DC_VOLTS, 10.0, 5.5)
         print("Measurement: " + str(session.read()))
 
 `Other usage examples can be found on GitHub. <https://github.com/ni/nimi-python/tree/master/src/nidmm/examples>`_

--- a/docs/_static/nidmm_usage.inc
+++ b/docs/_static/nidmm_usage.inc
@@ -7,7 +7,7 @@ The following is a basic example of using the **nidmm** module to open a session
 
     import nidmm
     with nidmm.Session("Dev1") as session:
-        session.configureMeasurementDigits(nidmm.Function.DC_VOLTS, 10, 5.5)
+        session.configure_measurement_digits(nidmm.Function.DC_VOLTS, 10.0, 5.5)
         print("Measurement: " + str(session.read()))
 
 `Other usage examples can be found on GitHub. <https://github.com/ni/nimi-python/tree/master/src/nidmm/examples>`_

--- a/generated/nidmm/README.rst
+++ b/generated/nidmm/README.rst
@@ -116,7 +116,7 @@ The following is a basic example of using the **nidmm** module to open a session
 
     import nidmm
     with nidmm.Session("Dev1") as session:
-        session.configureMeasurementDigits(nidmm.Function.DC_VOLTS, 10, 5.5)
+        session.configure_measurement_digits(nidmm.Function.DC_VOLTS, 10.0, 5.5)
         print("Measurement: " + str(session.read()))
 
 `Other usage examples can be found on GitHub. <https://github.com/ni/nimi-python/tree/master/src/nidmm/examples>`_


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

This change fixes the nidmm example shown in nidmm.readthedocs.io, and the NI-DMM and general READMEs. Right now, if you attempt to run this code, you get:

```
AttributeError: 'Session' object has no attribute 'configureMeasurementDigits'
```

(Based upon #2003)

### List issues fixed by this Pull Request below, if any.

* #1476 

### What testing has been done?
Tested in original PR: #2003