### PR TITLE
Accept multiple error codes, descriptions in nifgen system test test_error_message

### DIFF
--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -70,8 +70,15 @@ class SystemTests:
             with nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:invalid_model (2CH);BoardType:PXIe', **session_creation_kwargs):
                 assert False
         except nifgen.Error as e:
-            assert e.code == -1074134944
-            assert e.description.find('Insufficient location information or resource not present in the system.') != -1
+            # The returned error has changed over time, so accept multiple error codes, descriptions.
+            # Users should generally not look for specific error codes and should instead correct their code if they hit an error.
+            assert e.code in [-1074134944, -1074134964]
+            assert any(
+                [
+                    e.description.find('Insufficient location information or resource not present in the system.') != -1,
+                    e.description.find('The option string parameter contains an entry with an unknown option value.') != -1,
+                ]
+            )
 
     def test_get_error(self, session):
         try:


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [ ] ~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- [ ] ~I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
Beginning with NI-FGEN 2023Q3, the error returned in the nifgen system test "test_error_message" has changed, causing the test to fail in our internal test suite. When we update the version of NI-FGEN installed to nimi-bot, the failure will occur in nimi-python PR checks as well.

This updates the test to accept both the new error code and descrption and the old ones.

### List issues fixed by this Pull Request below, if any.

* Fix #1987

### What testing has been done?

Ran the nifgen system tests with NI-FGEN 2023Q4 (in-dev version).