### PR TITLE
Use simulated 5433 for all nifgen system tests

### DIFF
--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -74,7 +74,7 @@ class SystemTests:
     def test_get_self_cal_last_date_and_time(self, session):
         before = hightime.datetime.now()
         # Returned cal time does not have sub-minute info
-        before = before.replace(second = 0, microsecond = 0)
+        before = before.replace(second=0, microsecond=0)
         last_cal_time = session.get_self_cal_last_date_and_time()
         after = hightime.datetime.now()
         assert before <= last_cal_time <= after

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -228,7 +228,7 @@ class SystemTests:
         assert 1 == session.create_arb_sequence(waveform_handles_array, [10])
 
     def test_create_advanced_arb_sequence(self, session):
-        seq_handle_base = 100000  # This is not necessary on 5433 because handles start at 0.
+        seq_handle_base = 0  # On 5433, handles start at 0.
         waveform_data = [x * (1.0 / 256.0) for x in range(256)]
         waveform_handles_array = [session.create_waveform(waveform_data), session.create_waveform(waveform_data), session.create_waveform(waveform_data)]
         marker_location_array = [0, 16, 32]

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -4,7 +4,6 @@ import sys
 import tempfile
 import warnings
 
-import fasteners
 import grpc
 import hightime
 import numpy
@@ -16,19 +15,8 @@ sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent / 'shared'))
 import system_test_utilities  # noqa: E402
 
 
-# Set up some global information we need
+# Set up global information we need
 test_files_base_dir = os.path.join(os.path.dirname(__file__))
-
-# We need a lock file so multiple tests aren't hitting the db at the same time
-# Trying to create simulated DAQmx devices at the same time (which can happen when running
-# tox with --parallel N, or when two different drivers are being tested at the same time on
-# the same machine, can result in an internal error:
-# -2147220733: MAX:  (Hex 0x80040303) Internal error: The requested object was not found in
-# the configuration database. Please note the steps you performed that led to this error and
-# contact technical support at http://ni.com/support.
-# This is filed as internal bug 255545
-daqmx_sim_db_lock_file = os.path.join(tempfile.gettempdir(), 'daqmx_db.lock')
-daqmx_sim_db_lock = fasteners.InterProcessLock(daqmx_sim_db_lock_file)
 
 
 def get_test_file_path(file_name):
@@ -47,14 +35,6 @@ class SystemTests:
     def session(self, session_creation_kwargs):
         with nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:5433 (2CH);BoardType:PXIe', **session_creation_kwargs) as simulated_session:
             yield simulated_session
-
-    @pytest.fixture(scope='function')
-    def session_5421(self, session_creation_kwargs):
-        with daqmx_sim_db_lock:
-            simulated_session = nifgen.Session('', '0', False, 'Simulate=1, DriverSetup=Model:5421;BoardType:PXI', **session_creation_kwargs)
-        yield simulated_session
-        with daqmx_sim_db_lock:
-            simulated_session.close()
 
     def test_self_test(self, session):
         # We should not get an assert if self_test passes
@@ -91,10 +71,9 @@ class SystemTests:
     def test_method_get_self_cal_supported(self, session):
         assert session.get_self_cal_supported() in [True, False]
 
-    # TODO(sbethur): When internal bug# 999932 is fixed, update the test to use PXIe-5433 (Tracked on GitHub by #1375)
-    def test_get_self_cal_last_date_and_time(self, session_5421):
+    def test_get_self_cal_last_date_and_time(self, session):
         try:
-            session_5421.get_self_cal_last_date_and_time()
+            session.get_self_cal_last_date_and_time()
             assert False
         except nifgen.Error as e:
             assert e.code == -1074118632  # This operation is not supported for simulated device
@@ -247,20 +226,19 @@ class SystemTests:
         assert 0 == session.create_arb_sequence(waveform_handles_array, [10])
         assert 1 == session.create_arb_sequence(waveform_handles_array, [10])
 
-    # TODO(sbethur): When internal bug# 227842 is fixed, update the test to use PXIe-5433 (Tracked on GitHub by #1376)
-    def test_create_advanced_arb_sequence(self, session_5421):
+    def test_create_advanced_arb_sequence(self, session):
         seq_handle_base = 100000  # This is not necessary on 5433 because handles start at 0.
         waveform_data = [x * (1.0 / 256.0) for x in range(256)]
-        waveform_handles_array = [session_5421.create_waveform(waveform_data), session_5421.create_waveform(waveform_data), session_5421.create_waveform(waveform_data)]
+        waveform_handles_array = [session.create_waveform(waveform_data), session.create_waveform(waveform_data), session.create_waveform(waveform_data)]
         marker_location_array = [0, 16, 32]
         sample_counts_array = [256, 128, 64]
         loop_counts_array = [10, 20, 30]
-        session_5421.output_mode = nifgen.OutputMode.SEQ
+        session.output_mode = nifgen.OutputMode.SEQ
         # Test relies on value of sequence handles starting at a known value and incrementing sequentially. Hardly ideal.
-        assert ([], seq_handle_base + 0) == session_5421.create_advanced_arb_sequence(waveform_handles_array, loop_counts_array=loop_counts_array)
-        assert ([], seq_handle_base + 1) == session_5421.create_advanced_arb_sequence(waveform_handles_array, loop_counts_array=loop_counts_array, sample_counts_array=sample_counts_array)
-        assert (marker_location_array, seq_handle_base + 2) == session_5421.create_advanced_arb_sequence(waveform_handles_array, loop_counts_array=loop_counts_array, marker_location_array=marker_location_array)
-        assert (marker_location_array, seq_handle_base + 3) == session_5421.create_advanced_arb_sequence(waveform_handles_array, loop_counts_array=loop_counts_array, sample_counts_array=sample_counts_array, marker_location_array=marker_location_array)
+        assert ([], seq_handle_base + 0) == session.create_advanced_arb_sequence(waveform_handles_array, loop_counts_array=loop_counts_array)
+        assert ([], seq_handle_base + 1) == session.create_advanced_arb_sequence(waveform_handles_array, loop_counts_array=loop_counts_array, sample_counts_array=sample_counts_array)
+        assert (marker_location_array, seq_handle_base + 2) == session.create_advanced_arb_sequence(waveform_handles_array, loop_counts_array=loop_counts_array, marker_location_array=marker_location_array)
+        assert (marker_location_array, seq_handle_base + 3) == session.create_advanced_arb_sequence(waveform_handles_array, loop_counts_array=loop_counts_array, sample_counts_array=sample_counts_array, marker_location_array=marker_location_array)
 
     def test_arb_script(self, session):
         waveform_data = [x * (1.0 / 256.0) for x in range(256)]
@@ -469,16 +447,15 @@ class SystemTests:
             except (TypeError, ValueError):
                 pass
 
-    # TODO(sbethur): When internal bug# 227842 is fixed, update the test to use PXIe-5433 (Tracked on GitHub by #1376)
-    def test_create_advanced_arb_sequence_wrong_size(self, session_5421):
+    def test_create_advanced_arb_sequence_wrong_size(self, session):
         waveform_data = [x * (1.0 / 256.0) for x in range(256)]
-        waveform_handles_array = [session_5421.create_waveform(waveform_data), session_5421.create_waveform(waveform_data), session_5421.create_waveform(waveform_data)]
+        waveform_handles_array = [session.create_waveform(waveform_data), session.create_waveform(waveform_data), session.create_waveform(waveform_data)]
         marker_location_array = [0, 16]
         loop_counts_array = [10, 20, 30]
-        session_5421.output_mode = nifgen.OutputMode.SEQ
+        session.output_mode = nifgen.OutputMode.SEQ
         # Test relies on value of sequence handles starting at a known value and incrementing sequentially. Hardly ideal.
         with pytest.raises(ValueError) as exc_info:
-            session_5421.create_advanced_arb_sequence(waveform_handles_array, loop_counts_array=loop_counts_array, marker_location_array=marker_location_array)
+            session.create_advanced_arb_sequence(waveform_handles_array, loop_counts_array=loop_counts_array, marker_location_array=marker_location_array)
         assert exc_info.value.args[0] == 'Length of marker_location_array and waveform_handles_array parameters do not match.'
         assert str(exc_info.value) == 'Length of marker_location_array and waveform_handles_array parameters do not match.'
 

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -72,11 +72,12 @@ class SystemTests:
         assert session.get_self_cal_supported() in [True, False]
 
     def test_get_self_cal_last_date_and_time(self, session):
-        try:
-            session.get_self_cal_last_date_and_time()
-            assert False
-        except nifgen.Error as e:
-            assert e.code == -1074118632  # This operation is not supported for simulated device
+        before = hightime.datetime.now()
+        # Returned cal time does not have sub-minute info
+        before = before.replace(second = 0, microsecond = 0)
+        last_cal_time = session.get_self_cal_last_date_and_time()
+        after = hightime.datetime.now()
+        assert before <= last_cal_time <= after
 
     def test_self_cal(self, session):
         session.self_cal()


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [ ] ~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- [ ] ~I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
Stop using DAQmx-based simulated device in nifgen system tests, now that the internal issues [AB#227842](https://dev.azure.com/ni/DevCentral/_workitems/edit/227842) and [AB#999932](https://dev.azure.com/ni/DevCentral/_workitems/edit/999932) are fixed.

This is a reimplementation of #1598 against master with minor fixes.

### List issues fixed by this Pull Request below, if any.

* Fix #1375
* Fix #1376

### What testing has been done?

Ran nifgen system tests on a local machine with NI-FGEN 2023Q4 (in-dev version) installed.
Unfortunately, this change only seems to cut test time by a second or two.

PR Checks
