### PR TITLE
Use instrument_model property in nidmm system test test_vi_string_attribute

### DIFF
--- a/src/nidmm/system_tests/test_system_nidmm.py
+++ b/src/nidmm/system_tests/test_system_nidmm.py
@@ -42,9 +42,9 @@ class SystemTests:
 
     # Attribute tests
     def test_vi_string_attribute(self, session):
-        assert session.serial_number == 'FFFFFFFF'
+        assert session.instrument_model == 'NI PXIe-4082'
         try:
-            session.serial_number = 'FFFFFFFA'
+            session.instrument_model = 'NI PXIe-4081'
         except nidmm.Error as e:
             assert e.code == -1074135027  # Attribute is read-only
 


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [ ] ~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- [ ] ~I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
In a recent version of the NI-DMM, the reported serial of a simulated DMM was intentionally changed. This causes the nidmm system test `test_vi_string_attribute` to fail in our internal test suite and will cause failures in PR Checks when we update the version we test against.

This change updates the test to rely on `instrument_model`, instead of `serial_number`. They are both read-only properties and we do not expect the reported value for `instrument_model` to change in the future.

### List issues fixed by this Pull Request below, if any.
* Fix #2012

### What testing has been done?
* Ran the nidmm system tests on a local machine with a dev version NI-DMM 2023Q4 installed and confirmed that the test failed.
* Updated the test and ran again, confirming that the test passed.
* PR Checks will confirm that the updated test passes with the driver runtime that we currently test against