### PR TITLE
Upload niscope unit test coverage in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,5 @@ after_success:
   - travis_retry ./codecov --flags nidcpowerunittests --file nidcpowerunittest.xml
   - travis_retry ./codecov --flags nidigitalunittests --file nidigitalunittest.xml
   - travis_retry ./codecov --flags nimodinstunittests --file nimodinstunittest.xml
+  - travis_retry ./codecov --flags niscopeunittests --file niscopeunittest.xml
   - travis_retry ./codecov --flags nitclkunittests --file nitclkunittest.xml


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [ ] ~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- [ ] ~I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
We're not uploading our niscope unit test coverage when we run travis-ci. This change fixes that.

### List issues fixed by this Pull Request below, if any.
None

### What testing has been done?
Confirmed that niscopeunittest coverage was uploaded for this PR.
https://app.codecov.io/github/ni/nimi-python/commit/f3a6309343c5b58ce732149b4d8d16d88e90a61b

![image](https://github.com/ni/nimi-python/assets/34140133/52ceb327-691d-4b02-8c5b-256952051ae6)