### PR TITLE
Install read_the_docs theme in .readthedocs.yaml

### DIFF
--- a/build/templates/.readthedocs.yaml.mako
+++ b/build/templates/.readthedocs.yaml.mako
@@ -52,12 +52,9 @@ formats:
   - epub
   - pdf
 
-# Optionally declare the Python requirements required to build your docs
+# Declare the Python requirements required to build your docs
 ## TODO(ni-jfitzger): Create requirements file for docs to make builds reproducible. See https://github.com/ni/nimi-python/issues/1968
 ## Note: Our nimi-python readthedocs project used the defaults here: https://docs.readthedocs.io/en/stable/build-default-versions.html#external-dependencies
-# python:
-#   install:
-#   - requirements: docs/requirements.txt
 python:
   install:
-    - sphinx-rtd-theme
+  - requirements: docs/requirements.txt

--- a/build/templates/.readthedocs.yaml.mako
+++ b/build/templates/.readthedocs.yaml.mako
@@ -58,3 +58,6 @@ formats:
 # python:
 #   install:
 #   - requirements: docs/requirements.txt
+python:
+  install:
+    - sphinx-rtd-theme

--- a/docs/nidcpower/.readthedocs.yaml
+++ b/docs/nidcpower/.readthedocs.yaml
@@ -45,10 +45,7 @@ formats:
   - epub
   - pdf
 
-# Optionally declare the Python requirements required to build your docs
-# python:
-#   install:
-#   - requirements: docs/requirements.txt
+# Declare the Python requirements required to build your docs
 python:
   install:
-    - sphinx-rtd-theme
+  - requirements: docs/requirements.txt

--- a/docs/nidcpower/.readthedocs.yaml
+++ b/docs/nidcpower/.readthedocs.yaml
@@ -49,3 +49,6 @@ formats:
 # python:
 #   install:
 #   - requirements: docs/requirements.txt
+python:
+  install:
+    - sphinx-rtd-theme

--- a/docs/nidigital/.readthedocs.yaml
+++ b/docs/nidigital/.readthedocs.yaml
@@ -45,10 +45,7 @@ formats:
   - epub
   - pdf
 
-# Optionally declare the Python requirements required to build your docs
-# python:
-#   install:
-#   - requirements: docs/requirements.txt
+# Declare the Python requirements required to build your docs
 python:
   install:
-    - sphinx-rtd-theme
+  - requirements: docs/requirements.txt

--- a/docs/nidigital/.readthedocs.yaml
+++ b/docs/nidigital/.readthedocs.yaml
@@ -49,3 +49,6 @@ formats:
 # python:
 #   install:
 #   - requirements: docs/requirements.txt
+python:
+  install:
+    - sphinx-rtd-theme

--- a/docs/nidmm/.readthedocs.yaml
+++ b/docs/nidmm/.readthedocs.yaml
@@ -45,10 +45,7 @@ formats:
   - epub
   - pdf
 
-# Optionally declare the Python requirements required to build your docs
-# python:
-#   install:
-#   - requirements: docs/requirements.txt
+# Declare the Python requirements required to build your docs
 python:
   install:
-    - sphinx-rtd-theme
+  - requirements: docs/requirements.txt

--- a/docs/nidmm/.readthedocs.yaml
+++ b/docs/nidmm/.readthedocs.yaml
@@ -49,3 +49,6 @@ formats:
 # python:
 #   install:
 #   - requirements: docs/requirements.txt
+python:
+  install:
+    - sphinx-rtd-theme

--- a/docs/nifgen/.readthedocs.yaml
+++ b/docs/nifgen/.readthedocs.yaml
@@ -45,10 +45,7 @@ formats:
   - epub
   - pdf
 
-# Optionally declare the Python requirements required to build your docs
-# python:
-#   install:
-#   - requirements: docs/requirements.txt
+# Declare the Python requirements required to build your docs
 python:
   install:
-    - sphinx-rtd-theme
+  - requirements: docs/requirements.txt

--- a/docs/nifgen/.readthedocs.yaml
+++ b/docs/nifgen/.readthedocs.yaml
@@ -49,3 +49,6 @@ formats:
 # python:
 #   install:
 #   - requirements: docs/requirements.txt
+python:
+  install:
+    - sphinx-rtd-theme

--- a/docs/nimodinst/.readthedocs.yaml
+++ b/docs/nimodinst/.readthedocs.yaml
@@ -45,10 +45,7 @@ formats:
   - epub
   - pdf
 
-# Optionally declare the Python requirements required to build your docs
-# python:
-#   install:
-#   - requirements: docs/requirements.txt
+# Declare the Python requirements required to build your docs
 python:
   install:
-    - sphinx-rtd-theme
+  - requirements: docs/requirements.txt

--- a/docs/nimodinst/.readthedocs.yaml
+++ b/docs/nimodinst/.readthedocs.yaml
@@ -49,3 +49,6 @@ formats:
 # python:
 #   install:
 #   - requirements: docs/requirements.txt
+python:
+  install:
+    - sphinx-rtd-theme

--- a/docs/niscope/.readthedocs.yaml
+++ b/docs/niscope/.readthedocs.yaml
@@ -45,10 +45,7 @@ formats:
   - epub
   - pdf
 
-# Optionally declare the Python requirements required to build your docs
-# python:
-#   install:
-#   - requirements: docs/requirements.txt
+# Declare the Python requirements required to build your docs
 python:
   install:
-    - sphinx-rtd-theme
+  - requirements: docs/requirements.txt

--- a/docs/niscope/.readthedocs.yaml
+++ b/docs/niscope/.readthedocs.yaml
@@ -49,3 +49,6 @@ formats:
 # python:
 #   install:
 #   - requirements: docs/requirements.txt
+python:
+  install:
+    - sphinx-rtd-theme

--- a/docs/nise/.readthedocs.yaml
+++ b/docs/nise/.readthedocs.yaml
@@ -45,10 +45,7 @@ formats:
   - epub
   - pdf
 
-# Optionally declare the Python requirements required to build your docs
-# python:
-#   install:
-#   - requirements: docs/requirements.txt
+# Declare the Python requirements required to build your docs
 python:
   install:
-    - sphinx-rtd-theme
+  - requirements: docs/requirements.txt

--- a/docs/nise/.readthedocs.yaml
+++ b/docs/nise/.readthedocs.yaml
@@ -49,3 +49,6 @@ formats:
 # python:
 #   install:
 #   - requirements: docs/requirements.txt
+python:
+  install:
+    - sphinx-rtd-theme

--- a/docs/niswitch/.readthedocs.yaml
+++ b/docs/niswitch/.readthedocs.yaml
@@ -45,10 +45,7 @@ formats:
   - epub
   - pdf
 
-# Optionally declare the Python requirements required to build your docs
-# python:
-#   install:
-#   - requirements: docs/requirements.txt
+# Declare the Python requirements required to build your docs
 python:
   install:
-    - sphinx-rtd-theme
+  - requirements: docs/requirements.txt

--- a/docs/niswitch/.readthedocs.yaml
+++ b/docs/niswitch/.readthedocs.yaml
@@ -49,3 +49,6 @@ formats:
 # python:
 #   install:
 #   - requirements: docs/requirements.txt
+python:
+  install:
+    - sphinx-rtd-theme

--- a/docs/nitclk/.readthedocs.yaml
+++ b/docs/nitclk/.readthedocs.yaml
@@ -45,10 +45,7 @@ formats:
   - epub
   - pdf
 
-# Optionally declare the Python requirements required to build your docs
-# python:
-#   install:
-#   - requirements: docs/requirements.txt
+# Declare the Python requirements required to build your docs
 python:
   install:
-    - sphinx-rtd-theme
+  - requirements: docs/requirements.txt

--- a/docs/nitclk/.readthedocs.yaml
+++ b/docs/nitclk/.readthedocs.yaml
@@ -49,3 +49,6 @@ formats:
 # python:
 #   install:
 #   - requirements: docs/requirements.txt
+python:
+  install:
+    - sphinx-rtd-theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+# This isn't a full-fledged requirements file, yet. It's just a single unpinned dependency that we needed to fix our documentation builds.
+# TODO(ni-jfitzger): Create requirements file for docs to make builds reproducible. See https://github.com/ni/nimi-python/issues/1968
+# Note: Our nimi-python readthedocs project used the defaults here: https://docs.readthedocs.io/en/stable/build-default-versions.html#external-dependencies
+sphinx_rtd_theme


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
Documentation is failing to build due to the theme not being found. Most likely, Read the Docs changed something so that their theme is no longer installed by default.

This change updates  the .readthedocs.yamls to install the theme.

I don't have time to properly add a requirements file, right now, so this is just a band-aid: a sort-of requirements file to get the dependency installed. We still have an open issue to properly add a requirements file for the sphinx build.

### List issues fixed by this Pull Request below, if any.
* Fix #2028

### What testing has been done?
None. If the PR checks pass, it should fix the issue.