### PR TITLE
Do not compare types

### DIFF
--- a/build/unit_tests/test_metadata_add_all.py
+++ b/build/unit_tests/test_metadata_add_all.py
@@ -15,14 +15,14 @@ def _compare_values(actual, expected, k):
 
 
 def _compare_lists(actual, expected):
-    assert type(actual) == type(expected), 'Type mismatch, {0} != {1}'.format(type(actual), type(expected))
+    assert isinstance(actual, type(expected)), 'Type mismatch, {0} != {1}'.format(type(actual), type(expected))
     assert len(actual) == len(expected), 'Length mismatch, {0} != {1}'.format(len(actual), len(expected))
     for k in range(len(actual)):
         _compare_values(actual[k], expected[k], k)
 
 
 def _compare_dicts(actual, expected):
-    assert type(actual) == type(expected), 'Type mismatch, {0} != {1}'.format(type(actual), type(expected))
+    assert isinstance(actual, type(expected)), 'Type mismatch, {0} != {1}'.format(type(actual), type(expected))
     for k in actual:
         assert k in expected, 'Key {0} not in expected'.format(k)
         _compare_values(actual[k], expected[k], k)

--- a/generated/nifake/nifake/unit_tests/test_grpc.py
+++ b/generated/nifake/nifake/unit_tests/test_grpc.py
@@ -881,7 +881,7 @@ class TestGrpcStubInterpreter(object):
         cs = interpreter.get_custom_type()
         assert cs.struct_int == expected_cs.struct_int
         assert cs.struct_double == expected_cs.struct_double
-        assert type(cs) == type(expected_cs)
+        assert isinstance(cs, type(expected_cs))
         self._assert_call(library_func, response_object).assert_called_once_with(vi=GRPC_SESSION_OBJECT_FOR_TEST)
 
     def test_set_custom_type_array(self):
@@ -906,7 +906,7 @@ class TestGrpcStubInterpreter(object):
         for actual, expected in zip(cs_test, cs):
             assert actual.struct_int == expected.struct_int
             assert actual.struct_double == expected.struct_double
-            assert type(actual) == type(expected)
+            assert isinstance(actual, type(expected))
         self._assert_call(library_func, response_object).assert_called_once_with(
             vi=GRPC_SESSION_OBJECT_FOR_TEST, number_of_elements=len(cs)
         )
@@ -928,9 +928,9 @@ class TestGrpcStubInterpreter(object):
         assert csnt_test.struct_custom_struct.struct_double == csnt.struct_custom_struct.struct_double
         assert csnt_test.struct_custom_struct_typedef.struct_int == csnt.struct_custom_struct_typedef.struct_int
         assert csnt_test.struct_custom_struct_typedef.struct_double == csnt.struct_custom_struct_typedef.struct_double
-        assert type(csnt_test.struct_custom_struct) == type(csnt.struct_custom_struct)  # noqa: E721
-        assert type(csnt_test.struct_custom_struct_typedef) == type(csnt.struct_custom_struct_typedef)  # noqa: E721
-        assert type(csnt_test) == type(csnt)
+        assert isinstance(csnt_test.struct_custom_struct, type(csnt.struct_custom_struct))
+        assert isinstance(csnt_test.struct_custom_struct_typedef, type(csnt.struct_custom_struct_typedef))
+        assert isinstance(csnt_test, type(csnt))
         request_object = self._assert_call(library_func, response_object)
         request_object.assert_called_once()
         call = request_object.call_args_list[0]
@@ -943,9 +943,9 @@ class TestGrpcStubInterpreter(object):
         assert sent_csnt.struct_custom_struct.struct_double == grpc_csnt.struct_custom_struct.struct_double
         assert sent_csnt.struct_custom_struct_typedef.struct_int == grpc_csnt.struct_custom_struct_typedef.struct_int
         assert sent_csnt.struct_custom_struct_typedef.struct_double == grpc_csnt.struct_custom_struct_typedef.struct_double
-        assert type(sent_csnt.struct_custom_struct) == type(grpc_csnt.struct_custom_struct)  # noqa: E721
-        assert type(sent_csnt.struct_custom_struct_typedef) == type(grpc_csnt.struct_custom_struct_typedef)  # noqa: E721
-        assert type(sent_csnt) == type(grpc_csnt)
+        assert isinstance(sent_csnt.struct_custom_struct, type(grpc_csnt.struct_custom_struct))
+        assert isinstance(sent_csnt.struct_custom_struct_typedef, type(grpc_csnt.struct_custom_struct_typedef))
+        assert isinstance(sent_csnt, type(grpc_csnt))
 
     def test_get_cal_date_time(self):
         library_func = 'GetCalDateAndTime'

--- a/generated/nifake/nifake/unit_tests/test_session.py
+++ b/generated/nifake/nifake/unit_tests/test_session.py
@@ -76,7 +76,7 @@ class TestSession(object):
 
     def test_session_context_manager(self):
         with nifake.Session('dev1') as session:
-            assert type(session) == nifake.Session
+            assert isinstance(session, nifake.Session)
             self.patched_library_interpreter.init_with_options.assert_called_once_with('dev1', False, False, '')
             assert session._interpreter._vi == SESSION_NUM_FOR_TEST
         self.patched_library_interpreter.close.assert_called_once_with()
@@ -114,7 +114,7 @@ class TestSession(object):
         self.patched_library_interpreter.init_with_options.side_effect = nifake.errors.DriverError(test_error_code, test_error_desc)
         try:
             with nifake.Session('dev1') as session:
-                assert type(session) == nifake.Session
+                assert isinstance(session, nifake.Session)
                 assert False
         except nifake.Error as e:
             assert e.code == test_error_code
@@ -126,7 +126,7 @@ class TestSession(object):
         self.patched_library_interpreter.close.side_effect = nifake.errors.DriverError(test_error_code, test_error_desc)
         try:
             with nifake.Session('dev1') as session:
-                assert type(session) == nifake.Session
+                assert isinstance(session, nifake.Session)
                 assert False
         except nifake.Error as e:
             assert e.code == test_error_code

--- a/generated/nimodinst/nimodinst/unit_tests/test_modinst.py
+++ b/generated/nimodinst/nimodinst/unit_tests/test_modinst.py
@@ -74,7 +74,7 @@ class TestSession(object):
 
     def test_context_manager(self):
         with nimodinst.Session('') as session:
-            assert type(session) == nimodinst.Session
+            assert isinstance(session, nimodinst.Session)
             self.patched_library.niModInst_OpenInstalledDevicesSession.assert_called_once_with(_matchers.ViStringMatcher(''), _matchers.ViSessionPointerMatcher(), _matchers.ViInt32PointerMatcher())
         self.patched_library.niModInst_CloseInstalledDevicesSession.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST))
 

--- a/src/nifake/unit_tests/test_grpc.py
+++ b/src/nifake/unit_tests/test_grpc.py
@@ -881,7 +881,7 @@ class TestGrpcStubInterpreter(object):
         cs = interpreter.get_custom_type()
         assert cs.struct_int == expected_cs.struct_int
         assert cs.struct_double == expected_cs.struct_double
-        assert type(cs) == type(expected_cs)
+        assert isinstance(cs, type(expected_cs))
         self._assert_call(library_func, response_object).assert_called_once_with(vi=GRPC_SESSION_OBJECT_FOR_TEST)
 
     def test_set_custom_type_array(self):
@@ -906,7 +906,7 @@ class TestGrpcStubInterpreter(object):
         for actual, expected in zip(cs_test, cs):
             assert actual.struct_int == expected.struct_int
             assert actual.struct_double == expected.struct_double
-            assert type(actual) == type(expected)
+            assert isinstance(actual, type(expected))
         self._assert_call(library_func, response_object).assert_called_once_with(
             vi=GRPC_SESSION_OBJECT_FOR_TEST, number_of_elements=len(cs)
         )
@@ -928,9 +928,9 @@ class TestGrpcStubInterpreter(object):
         assert csnt_test.struct_custom_struct.struct_double == csnt.struct_custom_struct.struct_double
         assert csnt_test.struct_custom_struct_typedef.struct_int == csnt.struct_custom_struct_typedef.struct_int
         assert csnt_test.struct_custom_struct_typedef.struct_double == csnt.struct_custom_struct_typedef.struct_double
-        assert type(csnt_test.struct_custom_struct) == type(csnt.struct_custom_struct)  # noqa: E721
-        assert type(csnt_test.struct_custom_struct_typedef) == type(csnt.struct_custom_struct_typedef)  # noqa: E721
-        assert type(csnt_test) == type(csnt)
+        assert isinstance(csnt_test.struct_custom_struct, type(csnt.struct_custom_struct))
+        assert isinstance(csnt_test.struct_custom_struct_typedef, type(csnt.struct_custom_struct_typedef))
+        assert isinstance(csnt_test, type(csnt))
         request_object = self._assert_call(library_func, response_object)
         request_object.assert_called_once()
         call = request_object.call_args_list[0]
@@ -943,9 +943,9 @@ class TestGrpcStubInterpreter(object):
         assert sent_csnt.struct_custom_struct.struct_double == grpc_csnt.struct_custom_struct.struct_double
         assert sent_csnt.struct_custom_struct_typedef.struct_int == grpc_csnt.struct_custom_struct_typedef.struct_int
         assert sent_csnt.struct_custom_struct_typedef.struct_double == grpc_csnt.struct_custom_struct_typedef.struct_double
-        assert type(sent_csnt.struct_custom_struct) == type(grpc_csnt.struct_custom_struct)  # noqa: E721
-        assert type(sent_csnt.struct_custom_struct_typedef) == type(grpc_csnt.struct_custom_struct_typedef)  # noqa: E721
-        assert type(sent_csnt) == type(grpc_csnt)
+        assert isinstance(sent_csnt.struct_custom_struct, type(grpc_csnt.struct_custom_struct))
+        assert isinstance(sent_csnt.struct_custom_struct_typedef, type(grpc_csnt.struct_custom_struct_typedef))
+        assert isinstance(sent_csnt, type(grpc_csnt))
 
     def test_get_cal_date_time(self):
         library_func = 'GetCalDateAndTime'

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -76,7 +76,7 @@ class TestSession(object):
 
     def test_session_context_manager(self):
         with nifake.Session('dev1') as session:
-            assert type(session) == nifake.Session
+            assert isinstance(session, nifake.Session)
             self.patched_library_interpreter.init_with_options.assert_called_once_with('dev1', False, False, '')
             assert session._interpreter._vi == SESSION_NUM_FOR_TEST
         self.patched_library_interpreter.close.assert_called_once_with()
@@ -114,7 +114,7 @@ class TestSession(object):
         self.patched_library_interpreter.init_with_options.side_effect = nifake.errors.DriverError(test_error_code, test_error_desc)
         try:
             with nifake.Session('dev1') as session:
-                assert type(session) == nifake.Session
+                assert isinstance(session, nifake.Session)
                 assert False
         except nifake.Error as e:
             assert e.code == test_error_code
@@ -126,7 +126,7 @@ class TestSession(object):
         self.patched_library_interpreter.close.side_effect = nifake.errors.DriverError(test_error_code, test_error_desc)
         try:
             with nifake.Session('dev1') as session:
-                assert type(session) == nifake.Session
+                assert isinstance(session, nifake.Session)
                 assert False
         except nifake.Error as e:
             assert e.code == test_error_code

--- a/src/nimodinst/unit_tests/test_modinst.py
+++ b/src/nimodinst/unit_tests/test_modinst.py
@@ -74,7 +74,7 @@ class TestSession(object):
 
     def test_context_manager(self):
         with nimodinst.Session('') as session:
-            assert type(session) == nimodinst.Session
+            assert isinstance(session, nimodinst.Session)
             self.patched_library.niModInst_OpenInstalledDevicesSession.assert_called_once_with(_matchers.ViStringMatcher(''), _matchers.ViSessionPointerMatcher(), _matchers.ViInt32PointerMatcher())
         self.patched_library.niModInst_CloseInstalledDevicesSession.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST))
 

--- a/src/nitclk/system_tests/test_system_nitclk.py
+++ b/src/nitclk/system_tests/test_system_nitclk.py
@@ -18,7 +18,7 @@ def multiple_niscope_sessions():
 
 
 def test_nitclk_integration(single_niscope_session):
-    assert type(single_niscope_session.tclk) == nitclk.SessionReference
+    assert isinstance(single_niscope_session.tclk, nitclk.SessionReference)
 
 
 def test_nitclk_vi_string(single_niscope_session):


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
`build_test` and `flake8` started failing with the latest dependencies.

Example:
```
build/unit_tests/test_metadata_add_all.py:18:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
    assert type(actual) == type(expected), 'Type mismatch, {0} != {1}'.format(type(actual), type(expected))
           ^
build/unit_tests/test_metadata_add_all.py:25:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
    assert type(actual) == type(expected), 'Type mismatch, {0} != {1}'.format(type(actual), type(expected))
```

This change fixes those flake8 failures, by using `isinstance()`.
For consistency, It also changes some type comparisons in test_grpc.py, where we were ignoring the flake8 error.

### List issues fixed by this Pull Request below, if any.
None

### What testing has been done?
PR Checks