### PR TITLE
Update copyright date to 2024 so that travis-ci passes

### DIFF
--- a/docs/nidcpower/conf.py
+++ b/docs/nidcpower/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI-DCPower Python API'
-copyright = '2017-2023, National Instruments Corporation'
+copyright = '2017-2024, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/nidigital/conf.py
+++ b/docs/nidigital/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI-Digital Pattern Driver Python API'
-copyright = '2019-2023, National Instruments Corporation'
+copyright = '2019-2024, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/nidmm/conf.py
+++ b/docs/nidmm/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI-DMM Python API'
-copyright = '2017-2023, National Instruments Corporation'
+copyright = '2017-2024, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/nifgen/conf.py
+++ b/docs/nifgen/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI-FGEN Python API'
-copyright = '2017-2023, National Instruments Corporation'
+copyright = '2017-2024, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/nimodinst/conf.py
+++ b/docs/nimodinst/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI-ModInst Python API'
-copyright = '2017-2023, National Instruments Corporation'
+copyright = '2017-2024, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/niscope/conf.py
+++ b/docs/niscope/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI-SCOPE Python API'
-copyright = '2017-2023, National Instruments Corporation'
+copyright = '2017-2024, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/nise/conf.py
+++ b/docs/nise/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI Switch Executive Python API'
-copyright = '2018-2023, National Instruments Corporation'
+copyright = '2018-2024, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/niswitch/conf.py
+++ b/docs/niswitch/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI-SWITCH Python API'
-copyright = '2017-2023, National Instruments Corporation'
+copyright = '2017-2024, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/nitclk/conf.py
+++ b/docs/nitclk/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI-TClk Python API'
-copyright = '2019-2023, National Instruments Corporation'
+copyright = '2019-2024, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [ ] ~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- [ ] ~I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
The time between when the last PR was posted and when it was merged was so long that the year changed, leading the merged code to not mach `tox -e codegen` and [causing the `travis-ci` build of the commit to fail](https://github.com/ni/nimi-python/runs/20597088068).

### List issues fixed by this Pull Request below, if any.
None

### What testing has been done?
PR Checks
