### PR TITLE
Run pyupgrade to update Python syntax used

### DIFF
--- a/build/generate_template.py
+++ b/build/generate_template.py
@@ -14,7 +14,7 @@ def generate_template(template_name, template_params, dest_file, in_zip_file=Fal
     try:
         template_params['encoding_tag'] = '# -*- coding: utf-8 -*-'
         module_name = template_params['metadata'].config['module_name']
-        lookup = TemplateLookup(directories=['src/{0}/templates'.format(module_name), 'build/templates'])
+        lookup = TemplateLookup(directories=[f'src/{module_name}/templates', 'build/templates'])
         template = Template(filename=template_name, lookup=lookup)
         rendered_template = template.render(template_parameters=template_params)
 
@@ -28,7 +28,7 @@ def generate_template(template_name, template_params, dest_file, in_zip_file=Fal
         lines = tback.source.split('\n')
 
         # The underlying error.
-        logging.error("\n%s: %s\n" % (str(tback.error.__class__.__name__), str(tback.error)))
+        logging.error("\n{}: {}\n".format(str(tback.error.__class__.__name__), str(tback.error)))
         logging.error("Offending Template: %s\n" % template_name)
 
         # Show a source listing of the template, with offending line marked.

--- a/build/helper/codegen_helper.py
+++ b/build/helper/codegen_helper.py
@@ -112,7 +112,7 @@ def get_params_snippet(function, parameter_usage_options):
 
 
 def _get_interpreter_output_param_return_type(output_parameter, config):
-    assert output_parameter['direction'] == 'out', 'Expected parameter {0} (a.k.a. {1}) to have direction out'.format(output_parameter['name'], output_parameter['python_name'])
+    assert output_parameter['direction'] == 'out', 'Expected parameter {} (a.k.a. {}) to have direction out'.format(output_parameter['name'], output_parameter['python_name'])
 
     custom_type = find_custom_type(output_parameter, config)
     is_custom_type = custom_type is not None
@@ -132,7 +132,7 @@ def _get_library_interpreter_output_param_return_snippet(output_parameter, param
     val_suffix = '' if is_custom_type else '.value'
 
     if output_parameter['use_array']:
-        snippet = '{0}_array'.format(output_parameter['python_name'])
+        snippet = '{}_array'.format(output_parameter['python_name'])
     elif output_parameter['is_buffer']:
         if output_parameter['size']['mechanism'] == 'fixed':
             size = str(output_parameter['size']['value'])
@@ -212,7 +212,7 @@ def get_enum_type_check_snippet(parameter, indent):
     assert parameter['enum'] is not None, pp.pformat(parameter)
     assert parameter['direction'] == 'in', pp.pformat(parameter)
     enum_check = 'if type(' + parameter['python_name'] + ') is not ' + parameter['python_type'] + ':\n'
-    enum_check += (' ' * indent) + 'raise TypeError(\'Parameter {0} must be of type \' + str({1}))'.format(parameter['python_name'], parameter['python_type'])
+    enum_check += (' ' * indent) + 'raise TypeError(\'Parameter {} must be of type \' + str({}))'.format(parameter['python_name'], parameter['python_type'])
     return enum_check
 
 
@@ -284,11 +284,11 @@ def _get_ctype_variable_definition_snippet_for_string(parameter, parameters, ivi
 
     if parameter['direction'] == 'in':
         if parameter['is_repeated_capability'] is True:
-            definition = 'ctypes.create_string_buffer({0}.encode(self._encoding))  # case C010'.format(parameter['python_name'])
+            definition = 'ctypes.create_string_buffer({}.encode(self._encoding))  # case C010'.format(parameter['python_name'])
         elif parameter['enum'] is not None:
-            definition = 'ctypes.create_string_buffer({0}.value.encode(self._encoding))  # case C030'.format(parameter['python_name'])
+            definition = 'ctypes.create_string_buffer({}.value.encode(self._encoding))  # case C030'.format(parameter['python_name'])
         else:
-            definition = 'ctypes.create_string_buffer({0}.encode(self._encoding))  # case C020'.format(parameter['python_name'])
+            definition = 'ctypes.create_string_buffer({}.encode(self._encoding))  # case C020'.format(parameter['python_name'])
     else:
         assert parameter['direction'] == 'out'
         if parameter['size']['mechanism'] == 'ivi-dance':
@@ -296,26 +296,26 @@ def _get_ctype_variable_definition_snippet_for_string(parameter, parameters, ivi
                 definition = 'None  # case C050'
             elif ivi_dance_step == IviDanceStep.GET_DATA:
                 size_parameter = find_size_parameter(parameter, parameters)
-                definition = '({0}.ViChar * {1}.value)()  # case C060'.format(module_name, size_parameter['ctypes_variable_name'])
+                definition = '({}.ViChar * {}.value)()  # case C060'.format(module_name, size_parameter['ctypes_variable_name'])
             else:
-                assert False, "ivi_dance_step {0} not valid for parameter {1} with ['size']['mechanism'] == 'ivi-dance'".format(ivi_dance_step, parameter['name'])
+                assert False, "ivi_dance_step {} not valid for parameter {} with ['size']['mechanism'] == 'ivi-dance'".format(ivi_dance_step, parameter['name'])
 
         elif parameter['size']['mechanism'] == 'ivi-dance-with-a-twist':
             if ivi_dance_step == IviDanceStep.QUERY_SIZE:
                 definition = 'None  # case C090'
             elif ivi_dance_step == IviDanceStep.GET_DATA:
                 size_parameter = find_size_parameter(parameter, parameters, key='value_twist')
-                definition = '({0}.ViChar * {1}.value)()  # case C100'.format(module_name, size_parameter['ctypes_variable_name'])
+                definition = '({}.ViChar * {}.value)()  # case C100'.format(module_name, size_parameter['ctypes_variable_name'])
             else:
-                assert False, "ivi_dance_step {0} not valid for parameter {1} with ['size']['mechanism'] == 'ivi-dance-with-a-twist'".format(ivi_dance_step, parameter['name'])
+                assert False, "ivi_dance_step {} not valid for parameter {} with ['size']['mechanism'] == 'ivi-dance-with-a-twist'".format(ivi_dance_step, parameter['name'])
 
         elif parameter['size']['mechanism'] == 'fixed':
-            assert parameter['size']['value'] != 1, "Parameter {0} has 'direction':'out' and 'size':{1}... seems wrong. Check your metadata, maybe you forgot to specify?".format(parameter['name'], parameter['size'])
-            definition = '({0}.ViChar * {1})()  # case C070'.format(module_name, parameter['size']['value'])
+            assert parameter['size']['value'] != 1, "Parameter {} has 'direction':'out' and 'size':{}... seems wrong. Check your metadata, maybe you forgot to specify?".format(parameter['name'], parameter['size'])
+            definition = '({}.ViChar * {})()  # case C070'.format(module_name, parameter['size']['value'])
 
         elif parameter['size']['mechanism'] == 'python-code':
-            assert parameter['size']['value'] != 1, "Parameter {0} has 'direction':'out' and 'size':{1}... seems wrong. Check your metadata, maybe you forgot to specify?".format(parameter['name'], parameter['size'])
-            definition = '({0}.ViChar * {1})()  # case C080'.format(module_name, parameter['size']['value'])
+            assert parameter['size']['value'] != 1, "Parameter {} has 'direction':'out' and 'size':{}... seems wrong. Check your metadata, maybe you forgot to specify?".format(parameter['name'], parameter['size'])
+            definition = '({}.ViChar * {})()  # case C080'.format(module_name, parameter['size']['value'])
 
         else:
             assert False, "Invalid mechanism for parameters with 'direction':'out': " + str(parameter)
@@ -344,8 +344,8 @@ def _get_ctype_variable_definition_snippet_for_scalar(parameter, parameters, ivi
     Return Value (list): each item in the list will be one line needed for the declaration of that parameter
     '''
 
-    assert parameter['is_buffer'] is False, 'Parameter {}'.format(parameter)
-    assert parameter['numpy'] is False, 'Parameter {}'.format(parameter)
+    assert parameter['is_buffer'] is False, f'Parameter {parameter}'
+    assert parameter['numpy'] is False, f'Parameter {parameter}'
     corresponding_buffer_parameters = _get_buffer_parameters_for_size_parameter(parameter, parameters)
 
     definitions = []
@@ -353,13 +353,13 @@ def _get_ctype_variable_definition_snippet_for_scalar(parameter, parameters, ivi
 
     if parameter['direction'] == 'in':
         if parameter['is_session_handle'] is True:
-            definition = '{0}.{1}(self._{2})  # case S110'.format(module_name, parameter['ctypes_type'], config['session_handle_parameter_name'])
+            definition = '{}.{}(self._{})  # case S110'.format(module_name, parameter['ctypes_type'], config['session_handle_parameter_name'])
         elif parameter['size']['mechanism'] == 'python-code':
-            definition = '{0}.{1}({2})  # case S120'.format(module_name, parameter['ctypes_type'], parameter['size']['value'])
+            definition = '{}.{}({})  # case S120'.format(module_name, parameter['ctypes_type'], parameter['size']['value'])
         elif parameter['enum'] is not None:
-            definition = '{0}.{1}({2}.value)  # case S130'.format(module_name, parameter['ctypes_type'], parameter['python_name'])
+            definition = '{}.{}({}.value)  # case S130'.format(module_name, parameter['ctypes_type'], parameter['python_name'])
         elif not corresponding_buffer_parameters:
-            definition = '{0}.{1}({2})  # case S150'.format(module_name, parameter['ctypes_type'], parameter['python_name'])
+            definition = '{}.{}({})  # case S150'.format(module_name, parameter['ctypes_type'], parameter['python_name'])
         elif corresponding_buffer_parameters and corresponding_buffer_parameters[0]['direction'] == 'in':  # We are only looking at the first one to see if it is 'in'. Assumes all are the same here, assert below if not
             # Parameter denotes the size of another (the "corresponding") parameter.
             definitions.append(parameter['ctypes_variable_name'] + ' = {0}.{1}(0 if {2} is None else len({2}))  # case S160'.format(module_name, parameter['ctypes_type'], corresponding_buffer_parameters[0]['python_name']))
@@ -370,32 +370,32 @@ def _get_ctype_variable_definition_snippet_for_scalar(parameter, parameters, ivi
                     assert p['direction'] == 'out'
                     assert p['size']['mechanism'] == 'ivi-dance'
                 if ivi_dance_step == IviDanceStep.QUERY_SIZE:
-                    definition = '{0}.{1}()  # case S170'.format(module_name, parameter['ctypes_type'])
+                    definition = '{}.{}()  # case S170'.format(module_name, parameter['ctypes_type'])
                 elif ivi_dance_step == IviDanceStep.GET_DATA:
-                    definition = '{0}.{1}(error_code)  # case S180'.format(module_name, parameter['ctypes_type'])
+                    definition = '{}.{}(error_code)  # case S180'.format(module_name, parameter['ctypes_type'])
                 else:
-                    assert False, "ivi_dance_step {0} not valid for parameter {1} with ['size']['mechanism'] == 'ivi-dance'".format(ivi_dance_step, parameter['name'])
+                    assert False, "ivi_dance_step {} not valid for parameter {} with ['size']['mechanism'] == 'ivi-dance'".format(ivi_dance_step, parameter['name'])
             elif corresponding_buffer_parameters[0]['size']['mechanism'] == 'ivi-dance-with-a-twist':  # We are only looking at the first one. Assumes all are the same here, assert below if not
                 # Verify all corresponding_buffer_parameters are 'out' and 'ivi-dance-with-a-twist'
                 for p in corresponding_buffer_parameters:
                     assert p['direction'] == 'out'
                     assert p['size']['mechanism'] == 'ivi-dance-with-a-twist'
                 if ivi_dance_step == IviDanceStep.QUERY_SIZE:
-                    definition = '{0}.{1}(0)  # case S190'.format(module_name, parameter['ctypes_type'])
+                    definition = '{}.{}(0)  # case S190'.format(module_name, parameter['ctypes_type'])
                 elif ivi_dance_step == IviDanceStep.GET_DATA:
                     size_parameter_twist = find_size_parameter(corresponding_buffer_parameters[0], parameters, key='value_twist')
-                    definition = '{0}.{1}({2}.value)  # case S200'.format(module_name, parameter['ctypes_type'], size_parameter_twist['ctypes_variable_name'])
+                    definition = '{}.{}({}.value)  # case S200'.format(module_name, parameter['ctypes_type'], size_parameter_twist['ctypes_variable_name'])
                 else:
-                    assert False, "ivi_dance_step {0} not valid for parameter {1} with ['size']['mechanism'] == 'ivi-dance-with-a-twist'".format(ivi_dance_step, parameter['name'])
+                    assert False, "ivi_dance_step {} not valid for parameter {} with ['size']['mechanism'] == 'ivi-dance-with-a-twist'".format(ivi_dance_step, parameter['name'])
             else:
                 # Verify all corresponding_buffer_parameters are 'out' and not 'fixed-size'
                 for p in corresponding_buffer_parameters:
                     assert p['direction'] == 'out', 'Parameter direction not "out", Parameter: {}'.format(p['name'])
-                    assert p['size']['mechanism'] != 'fixed-size' and p['size']['mechanism'] != 'fixed-size', 'Parameter: {0}, Actual mechanism: {1}'.format(p['name'], p['size']['mechanism'])
-                definition = '{0}.{1}({2})  # case S210'.format(module_name, parameter['ctypes_type'], parameter['python_name'])
+                    assert p['size']['mechanism'] != 'fixed-size' and p['size']['mechanism'] != 'fixed-size', 'Parameter: {}, Actual mechanism: {}'.format(p['name'], p['size']['mechanism'])
+                definition = '{}.{}({})  # case S210'.format(module_name, parameter['ctypes_type'], parameter['python_name'])
     else:
         assert parameter['direction'] == 'out'
-        definition = '{0}.{1}()  # case S220'.format(module_name, parameter['ctypes_type'])
+        definition = '{}.{}()  # case S220'.format(module_name, parameter['ctypes_type'])
 
     if definition is not None:
         definitions.append(parameter['ctypes_variable_name'] + ' = ' + definition)
@@ -426,7 +426,7 @@ def _get_ctype_variable_definition_snippet_for_buffers(parameter, parameters, iv
     definition = None
 
     if parameter['numpy'] is True and use_numpy_array is True:
-        definition = '_get_ctypes_pointer_for_buffer(value={0})  # case B510'.format(parameter['python_name'])
+        definition = '_get_ctypes_pointer_for_buffer(value={})  # case B510'.format(parameter['python_name'])
     elif parameter['direction'] == 'in':
         if custom_type is not None:
             definition = '_get_ctypes_pointer_for_buffer([{0}.{1}(c) for c in {2}], library_type={0}.{1})  # case B540'.format(module_name, parameter['ctypes_type'], parameter['python_name'])
@@ -435,35 +435,35 @@ def _get_ctype_variable_definition_snippet_for_buffers(parameter, parameters, iv
                 # If the incoming type is array.array, we can just use that, otherwise we need to create an array.array that is initialized with the passed in value, which must be iterable
                 array_declaration = '{0}_array = _convert_to_array(value={0}, array_type="{1}")  # case B550'.format(parameter['python_name'], get_array_type_for_api_type(parameter['ctypes_type']))
                 definitions.append(array_declaration)
-                definition = '_get_ctypes_pointer_for_buffer(value={0}_array, library_type={1}.{2})  # case B550'.format(parameter['python_name'], module_name, parameter['ctypes_type'])
+                definition = '_get_ctypes_pointer_for_buffer(value={}_array, library_type={}.{})  # case B550'.format(parameter['python_name'], module_name, parameter['ctypes_type'])
             elif parameter['use_list']:
-                definition = '_get_ctypes_pointer_for_buffer(value={0}, library_type={1}.{2})  # case B550'.format(parameter['python_name'], module_name, parameter['ctypes_type'])
+                definition = '_get_ctypes_pointer_for_buffer(value={}, library_type={}.{})  # case B550'.format(parameter['python_name'], module_name, parameter['ctypes_type'])
             else:
                 assert False, "Expected either 'use_array' or 'use_list' to be True. Both False."
     else:
         assert parameter['direction'] == 'out'
-        assert 'size' in parameter, "Parameter {0} is output buffer but metadata doesn't define its 'size'".format(parameter['name'])
+        assert 'size' in parameter, "Parameter {} is output buffer but metadata doesn't define its 'size'".format(parameter['name'])
         if parameter['size']['mechanism'] == 'python-code':
-            line1 = '{0}_size = {1}  # case B560'.format(parameter['python_name'], parameter['size']['value'])
+            line1 = '{}_size = {}  # case B560'.format(parameter['python_name'], parameter['size']['value'])
             definitions.append(line1)
             if parameter['use_array']:
                 line2 = '{0}_array = array.array("{1}", [0]) * {0}_size  # case B560'.format(parameter['python_name'], get_array_type_for_api_type(parameter['ctypes_type']))
                 definitions.append(line2)
                 definition = '_get_ctypes_pointer_for_buffer(value={1}_array, library_type={0}.{2})  # case B560'.format(module_name, parameter['python_name'], parameter['ctypes_type'])
             elif parameter['use_list']:
-                definition = '_get_ctypes_pointer_for_buffer(library_type={0}.{1}, size={2}_size)  # case B560'.format(module_name, parameter['ctypes_type'], parameter['python_name'])
+                definition = '_get_ctypes_pointer_for_buffer(library_type={}.{}, size={}_size)  # case B560'.format(module_name, parameter['ctypes_type'], parameter['python_name'])
             else:
                 assert False, "Expected either 'use_array' or 'use_list' to be True. Both False."
         elif parameter['size']['mechanism'] == 'fixed':
-            assert parameter['size']['value'] != 1, "Parameter {0} has 'direction':'out' and 'size':{1}... seems wrong. Check your metadata, maybe you forgot to specify?".format(parameter['name'], parameter['size'])
-            line1 = '{0}_size = {1}  # case B570'.format(parameter['python_name'], parameter['size']['value'])
+            assert parameter['size']['value'] != 1, "Parameter {} has 'direction':'out' and 'size':{}... seems wrong. Check your metadata, maybe you forgot to specify?".format(parameter['name'], parameter['size'])
+            line1 = '{}_size = {}  # case B570'.format(parameter['python_name'], parameter['size']['value'])
             definitions.append(line1)
             if parameter['use_array']:
                 line2 = '{0}_array = array.array("{1}", [0]) * {0}_size  # case B570'.format(parameter['python_name'], get_array_type_for_api_type(parameter['ctypes_type']))
                 definitions.append(line2)
                 definition = '_get_ctypes_pointer_for_buffer(value={1}_array, library_type={0}.{2})  # case B570'.format(module_name, parameter['python_name'], parameter['ctypes_type'])
             elif parameter['use_list']:
-                definition = '_get_ctypes_pointer_for_buffer(library_type={0}.{1}, size={2}_size)  # case B570'.format(module_name, parameter['ctypes_type'], parameter['python_name'])
+                definition = '_get_ctypes_pointer_for_buffer(library_type={}.{}, size={}_size)  # case B570'.format(module_name, parameter['ctypes_type'], parameter['python_name'])
             else:
                 assert False, "Expected either 'use_array' or 'use_list' to be True. Both False."
         elif parameter['size']['mechanism'] == 'ivi-dance':
@@ -471,45 +471,45 @@ def _get_ctype_variable_definition_snippet_for_buffers(parameter, parameters, iv
                 definition = 'None  # case B580'
             elif ivi_dance_step == IviDanceStep.GET_DATA:
                 size_parameter = find_size_parameter(parameter, parameters)
-                line1 = '{0}_size = {1}.value  # case B590'.format(parameter['python_name'], size_parameter['ctypes_variable_name'])
+                line1 = '{}_size = {}.value  # case B590'.format(parameter['python_name'], size_parameter['ctypes_variable_name'])
                 definitions.append(line1)
                 if parameter['use_array']:
                     line2 = '{0}_array = array.array("{1}", [0]) * {0}_size  # case B590'.format(parameter['python_name'], get_array_type_for_api_type(parameter['ctypes_type']))
                     definition = '_get_ctypes_pointer_for_buffer(value={1}_array, library_type={0}.{2})  # case B590'.format(module_name, parameter['python_name'], parameter['ctypes_type'])
                     definitions.append(line2)
                 elif parameter['use_list']:
-                    definition = '_get_ctypes_pointer_for_buffer(library_type={0}.{1}, size={2}_size)  # case B590'.format(module_name, parameter['ctypes_type'], parameter['python_name'])
+                    definition = '_get_ctypes_pointer_for_buffer(library_type={}.{}, size={}_size)  # case B590'.format(module_name, parameter['ctypes_type'], parameter['python_name'])
                 else:
                     assert False, "Expected either 'use_array' or 'use_list' to be True. Both False."
             else:
-                assert False, "ivi_dance_step {0} not valid for parameter {1} with ['size']['mechanism'] == 'ivi-dance'".format(ivi_dance_step, parameter['name'])
+                assert False, "ivi_dance_step {} not valid for parameter {} with ['size']['mechanism'] == 'ivi-dance'".format(ivi_dance_step, parameter['name'])
         elif parameter['size']['mechanism'] == 'ivi-dance-with-a-twist':
             if ivi_dance_step == IviDanceStep.QUERY_SIZE:
                 definition = 'None  # case B610'
             elif ivi_dance_step == IviDanceStep.GET_DATA:
                 size_parameter_twist = find_size_parameter(parameter, parameters, key='value_twist')
-                line1 = '{0}_size = {1}.value  # case B620'.format(parameter['python_name'], size_parameter_twist['ctypes_variable_name'])
+                line1 = '{}_size = {}.value  # case B620'.format(parameter['python_name'], size_parameter_twist['ctypes_variable_name'])
                 definitions.append(line1)
                 if parameter['use_array']:
                     line2 = '{0}_array = array.array("{1}", [0]) * {0}_size  # case B620'.format(parameter['python_name'], get_array_type_for_api_type(parameter['ctypes_type']))
                     definitions.append(line2)
                     definition = '_get_ctypes_pointer_for_buffer(value={1}_array, library_type={0}.{2})  # case B620'.format(module_name, parameter['python_name'], parameter['ctypes_type'])
                 elif parameter['use_list']:
-                    definition = '_get_ctypes_pointer_for_buffer(library_type={0}.{1}, size={2}_size)  # case B620'.format(module_name, parameter['ctypes_type'], parameter['python_name'])
+                    definition = '_get_ctypes_pointer_for_buffer(library_type={}.{}, size={}_size)  # case B620'.format(module_name, parameter['ctypes_type'], parameter['python_name'])
                 else:
                     assert False, "Expected either 'use_array' or 'use_list' to be True. Both False."
             else:
-                assert False, "ivi_dance_step {0} not valid for parameter {1} with ['size']['mechanism'] == 'ivi-dance-with-a-twist'".format(ivi_dance_step, parameter['name'])
+                assert False, "ivi_dance_step {} not valid for parameter {} with ['size']['mechanism'] == 'ivi-dance-with-a-twist'".format(ivi_dance_step, parameter['name'])
         elif parameter['size']['mechanism'] == 'passed-in':
             size_parameter = find_size_parameter(parameter, parameters)
-            line1 = '{0}_size = {1}  # case B600'.format(parameter['python_name'], size_parameter['python_name'])
+            line1 = '{}_size = {}  # case B600'.format(parameter['python_name'], size_parameter['python_name'])
             definitions.append(line1)
             if parameter['use_array']:
                 line2 = '{0}_array = array.array("{1}", [0]) * {0}_size  # case B600'.format(parameter['python_name'], get_array_type_for_api_type(parameter['ctypes_type']))
                 definition = '_get_ctypes_pointer_for_buffer(value={1}_array, library_type={0}.{2})  # case B600'.format(module_name, parameter['python_name'], parameter['ctypes_type'])
                 definitions.append(line2)
             elif parameter['use_list']:
-                definition = '_get_ctypes_pointer_for_buffer(library_type={0}.{1}, size={2}_size)  # case B600'.format(module_name, parameter['ctypes_type'], parameter['python_name'])
+                definition = '_get_ctypes_pointer_for_buffer(library_type={}.{}, size={}_size)  # case B600'.format(module_name, parameter['ctypes_type'], parameter['python_name'])
             else:
                 assert False, "Expected either 'use_array' or 'use_list' to be True. Both False."
         else:
@@ -546,7 +546,7 @@ def _get_parameter_size_check_snippets(parameter, parameters):
             # Parameter denotes the size of another (the "corresponding") parameter.
             for i in range(1, len(corresponding_buffer_parameters)):
                 snippets.append('if {0} is not None and len({0}) != len({1}):  # case S160'.format(corresponding_buffer_parameters[i]['python_name'], corresponding_buffer_parameters[0]['python_name']))
-                snippets.append('    raise ValueError("Length of {0} and {1} parameters do not match.")  # case S160'.format(corresponding_buffer_parameters[i]['python_name'], corresponding_buffer_parameters[0]['python_name']))
+                snippets.append('    raise ValueError("Length of {} and {} parameters do not match.")  # case S160'.format(corresponding_buffer_parameters[i]['python_name'], corresponding_buffer_parameters[0]['python_name']))
 
     return snippets
 

--- a/build/helper/documentation_helper.py
+++ b/build/helper/documentation_helper.py
@@ -52,9 +52,9 @@ def get_rst_header_snippet(t, header_level='='):
 
 def get_rst_picture_reference(tag, url, title, link, indent=0):
     '''Get rst formatted snippet that represents a picture'''
-    ret_val = (' ' * indent) + '.. |{0}| image:: {1}\n'.format(tag, url)
-    ret_val += (' ' * (indent + 4)) + ':alt: {0}\n'.format(title)
-    ret_val += (' ' * (indent + 4)) + ':target: {0}\n'.format(link)
+    ret_val = (' ' * indent) + f'.. |{tag}| image:: {url}\n'
+    ret_val += (' ' * (indent + 4)) + f':alt: {title}\n'
+    ret_val += (' ' * (indent + 4)) + f':target: {link}\n'
     return ret_val
 
 
@@ -101,7 +101,7 @@ def get_rst_admonition_snippet(node, admonition, d, config, indent=0):
             admonition_content = [admonition_content]
         a = ''
         for admonition_text in admonition_content:
-            a += '\n\n' + (' ' * indent) + '.. {0}:: '.format(admonition)
+            a += '\n\n' + (' ' * indent) + f'.. {admonition}:: '
             a += get_indented_docstring_snippet(_fix_references(node, admonition_text, config, make_link=True), indent + 4)
         return a
     else:
@@ -173,7 +173,7 @@ def get_docstring_admonition_snippet(node, admonition, d, config, indent=0, extr
             admonition_content = [admonition_content]
         a = ''
         for admonition_text in admonition_content:
-            admonition_text = '{0}: {1}'.format(admonition.title(), admonition_text)
+            admonition_text = f'{admonition.title()}: {admonition_text}'
             admonition_text = _fix_references(node, admonition_text, config, make_link=False)
             a += '\n' + extra_newline + (' ' * indent) + get_indented_docstring_snippet(admonition_text, indent)
             extra_newline = '\n'
@@ -270,15 +270,15 @@ def _replace_enum_python_name(e_match):
     ename = e_match.group(1)
     start_enum = config['start_enum']
     if e_match:
-        ename = '{0}_VAL_{1}'.format(config['module_name'].upper(), ename.replace('\\', ''))
+        ename = '{}_VAL_{}'.format(config['module_name'].upper(), ename.replace('\\', ''))
         enum, value = find_enum_by_value(config['enums'], ename, start_enum)
         if enum and enum['codegen_method'] != 'no':
             ename = enum['python_name'] + '.' + value['python_name']
 
     if config['make_link']:
-        return ':py:data:`~{0}.{1}`'.format(config['module_name'], ename)
+        return ':py:data:`~{}.{}`'.format(config['module_name'], ename)
     else:
-        return '{0}'.format(ename)
+        return f'{ename}'
 
 
 def find_attribute_by_name(attributes, name):
@@ -287,7 +287,7 @@ def find_attribute_by_name(attributes, name):
     There should only be one so return that individual parameter and not a list
     '''
     attr = [attributes[x] for x in attributes if attributes[x]['name'] == name]
-    assert len(attr) <= 1, '{0} attributes with name {1}. No more than one is allowed'.format(len(attr), name)
+    assert len(attr) <= 1, f'{len(attr)} attributes with name {name}. No more than one is allowed'
     if len(attr) == 0:
         return None
     return attr[0]
@@ -311,11 +311,11 @@ def _replace_attribute_python_name(a_match):
 
     if config['make_link']:
         if config['module_name'] == 'nitclk':
-            return ':py:attr:`{0}.SessionReference.{1}`'.format(config['module_name'], aname)
+            return ':py:attr:`{}.SessionReference.{}`'.format(config['module_name'], aname)
         else:
-            return ':py:attr:`{0}.Session.{1}`'.format(config['module_name'], aname)
+            return ':py:attr:`{}.Session.{}`'.format(config['module_name'], aname)
     else:
-        return '{0}'.format(aname)
+        return f'{aname}'
 
 
 def _replace_func_python_name(f_match):
@@ -336,18 +336,18 @@ def _replace_func_python_name(f_match):
             else:
                 fname = config['functions'][fname]['python_name']
         except KeyError:
-            print('Warning: "{0}" not found in function metadata. Typo? Generated code will be funky!'.format(fname))
+            print(f'Warning: "{fname}" not found in function metadata. Typo? Generated code will be funky!')
     else:
-        print('Unknown function name: {0}'.format(f_match.group(1)))
+        print(f'Unknown function name: {f_match.group(1)}')
         print(config['functions'])
 
     if config['make_link']:
         if config['module_name'] == 'nitclk':
-            return ':py:func:`{0}.{1}`'.format(config['module_name'], fname)
+            return ':py:func:`{}.{}`'.format(config['module_name'], fname)
         else:
-            return ':py:meth:`{0}.Session.{1}`'.format(config['module_name'], fname)
+            return ':py:meth:`{}.Session.{}`'.format(config['module_name'], fname)
     else:
-        return '{0}'.format(fname)
+        return f'{fname}'
 
 
 def _replace_urls(u_match):
@@ -393,10 +393,10 @@ def _fix_references(node, doc, cfg, make_link=False):
     if 'enum' in node:
         config['start_enum'] = node['enum']
 
-    attr_search_string = '{0}_ATTR_([A-Z0-9_]+)'.format(config['module_name'].upper())
-    func_search_string = '{0}_([A-Za-z0-9_]+)'.format(config['c_function_prefix'].replace('_', ''))
-    func_search_string_lower = '{0}_([A-Za-z0-9_]+)'.format(config['c_function_prefix'].lower().replace('_', ''))
-    enum_search_string = '{0}_VAL_([A-Z0-9_]+)'.format(config['module_name'].upper())
+    attr_search_string = '{}_ATTR_([A-Z0-9_]+)'.format(config['module_name'].upper())
+    func_search_string = '{}_([A-Za-z0-9_]+)'.format(config['c_function_prefix'].replace('_', ''))
+    func_search_string_lower = '{}_([A-Za-z0-9_]+)'.format(config['c_function_prefix'].lower().replace('_', ''))
+    enum_search_string = '{}_VAL_([A-Z0-9_]+)'.format(config['module_name'].upper())
     attr_re = re.compile(attr_search_string)
     func_re = re.compile(func_search_string)
     func_lower_re = re.compile(func_search_string_lower)
@@ -409,7 +409,7 @@ def _fix_references(node, doc, cfg, make_link=False):
 
     if 'driver_urls' in cfg:
         for url_key in cfg['driver_urls']:
-            url_re = re.compile(r'{0}\((.+?)\)'.format(url_key))
+            url_re = re.compile(fr'{url_key}\((.+?)\)')
             config['url_key'] = url_key
             doc = url_re.sub(_replace_urls, doc)
 
@@ -439,7 +439,7 @@ def format_type_for_rst_documentation(param, numpy, config):
     if numpy and param['numpy']:
         p_type = param['numpy_type']
     elif param['enum'] is not None:
-        p_type = ':py:data:`{0}.{1}`'.format(config['module_name'], param['enum'])
+        p_type = ':py:data:`{}.{}`'.format(config['module_name'], param['enum'])
     else:
         p_type = param['type_in_documentation']
 
@@ -448,11 +448,11 @@ def format_type_for_rst_documentation(param, numpy, config):
         if param['is_string'] is True and param['enum'] is None:
             p_type = 'str'
         elif param['is_buffer'] is True and numpy is True:
-            p_type = 'numpy.array(dtype=numpy.{0})'.format(get_numpy_type_for_api_type(param['type'], config))
+            p_type = 'numpy.array(dtype=numpy.{})'.format(get_numpy_type_for_api_type(param['type'], config))
         elif param['use_list'] is True:
             p_type = 'list of ' + p_type
         elif param['use_array'] is True:
-            p_type = 'array.array("{0}")'.format(get_array_type_for_api_type(param['type']))
+            p_type = 'array.array("{}")'.format(get_array_type_for_api_type(param['type']))
 
     return p_type
 
@@ -482,7 +482,7 @@ def get_function_rst(function, method_template, numpy, config, indent=0, method_
     if function['has_repeated_capability'] is True:
         function['documentation']['tip'] = rep_cap_method_desc.format(config['module_name'], function['repeated_capability_type'], function['python_name'])
 
-    rst = '.. py:{0}:: {1}{2}('.format(method_or_function, function['python_name'], suffix)
+    rst = '.. py:{}:: {}{}('.format(method_or_function, function['python_name'], suffix)
     rst += get_params_snippet(function, session_method) + ')'
     indent += 4
     rst += get_documentation_for_node_rst(function, config, indent)
@@ -491,11 +491,11 @@ def get_function_rst(function, method_template, numpy, config, indent=0, method_
     if len(input_params) > 0:
         rst += '\n'
     for p in input_params:
-        rst += '\n' + (' ' * indent) + ':param {0}:'.format(p['python_name']) + '\n'
+        rst += '\n' + (' ' * indent) + ':param {}:'.format(p['python_name']) + '\n'
         rst += get_documentation_for_node_rst(p, config, indent + 4)
 
         p_type = format_type_for_rst_documentation(p, numpy, config)
-        rst += '\n' + (' ' * indent) + ':type {0}: '.format(p['python_name']) + p_type
+        rst += '\n' + (' ' * indent) + ':type {}: '.format(p['python_name']) + p_type
 
     output_params = filter_parameters(function['parameters'], output_parameters)
     if len(output_params) > 1:
@@ -503,7 +503,7 @@ def get_function_rst(function, method_template, numpy, config, indent=0, method_
         rst += (' ' * (indent + 4)) + 'WHERE\n'
         for p in output_params:
             p_type = format_type_for_rst_documentation(p, numpy, config)
-            rst += '\n' + (' ' * (indent + 4)) + '{0} ({1}): '.format(p['python_name'], p_type) + '\n'
+            rst += '\n' + (' ' * (indent + 4)) + '{} ({}): '.format(p['python_name'], p_type) + '\n'
             rst += get_documentation_for_node_rst(p, config, indent + 8)
     elif len(output_params) == 1:
         p = output_params[0]
@@ -527,11 +527,11 @@ def _format_type_for_docstring(param, numpy, config):
         if param['is_string'] is True and param['enum'] is None:
             p_type = 'str'
         elif param['is_buffer'] is True and numpy is True:
-            p_type = 'numpy.array(dtype=numpy.{0})'.format(get_numpy_type_for_api_type(param['type'], config))
+            p_type = 'numpy.array(dtype=numpy.{})'.format(get_numpy_type_for_api_type(param['type'], config))
         elif param['use_list'] is True:
             p_type = 'list of ' + p_type
         elif param['use_array'] is True:
-            p_type = 'array.array("{0}")'.format(get_array_type_for_api_type(param['type']))
+            p_type = 'array.array("{}")'.format(get_array_type_for_api_type(param['type']))
 
     return p_type
 
@@ -564,7 +564,7 @@ def get_function_docstring(function, numpy, config, indent=0):
     if len(input_params) > 0:
         docstring += '\n\n' + (' ' * indent) + 'Args:'
     for p in input_params:
-        docstring += '\n' + (' ' * (indent + 4)) + '{0} ({1}):'.format(p['python_name'], _format_type_for_docstring(p, numpy, config))
+        docstring += '\n' + (' ' * (indent + 4)) + '{} ({}):'.format(p['python_name'], _format_type_for_docstring(p, numpy, config))
         ds = get_documentation_for_node_docstring(p, config, indent + 8)
         if len(ds) > 0:
             docstring += ' ' + ds
@@ -574,7 +574,7 @@ def get_function_docstring(function, numpy, config, indent=0):
     if len(output_params) > 0:
         docstring += '\n\n' + (' ' * indent) + 'Returns:'
         for p in output_params:
-            docstring += '\n' + (' ' * (indent + 4)) + '{0} ({1}):'.format(p['python_name'], _format_type_for_docstring(p, numpy, config))
+            docstring += '\n' + (' ' * (indent + 4)) + '{} ({}):'.format(p['python_name'], _format_type_for_docstring(p, numpy, config))
             ds = get_documentation_for_node_docstring(p, config, indent + 8)
             if len(ds) > 0:
                 docstring += ' ' + ds
@@ -621,21 +621,21 @@ def as_rest_table(data, header=True):
     line_marker = '-'
 
     meta_template = vertical_separator.join(['{{{{{0}:{{{0}}}}}}}'.format(i) for i in range(num_elts)])
-    template = '{0}{1}{2}'.format(start_of_line, meta_template.format(*sizes), end_of_line)
+    template = f'{start_of_line}{meta_template.format(*sizes)}{end_of_line}'
     # determine top/bottom borders
     to_separator = {ord('|'): '+', ord(' '): '-'}
 
     start_of_line = start_of_line.translate(to_separator)
     vertical_separator = vertical_separator.translate(to_separator)
     end_of_line = end_of_line.translate(to_separator)
-    separator = '{0}{1}{2}'.format(start_of_line, vertical_separator.join([x * line_marker for x in sizes]), end_of_line)
+    separator = f'{start_of_line}{vertical_separator.join([x * line_marker for x in sizes])}{end_of_line}'
     # determine header separator
     th_separator_tr = {ord('-'): '='}
     start_of_line = start_of_line.translate(th_separator_tr)
     line_marker = line_marker.translate(th_separator_tr)
     vertical_separator = vertical_separator.translate(th_separator_tr)
     end_of_line = end_of_line.translate(th_separator_tr)
-    th_separator = '{0}{1}{2}'.format(start_of_line, vertical_separator.join([x * line_marker for x in sizes]), end_of_line)
+    th_separator = f'{start_of_line}{vertical_separator.join([x * line_marker for x in sizes])}{end_of_line}'
     # prepare result
     table.append(separator)
     # set table header
@@ -719,7 +719,7 @@ def square_up_tables(config):
 
 def _need_func_note(nd, config):
     '''Determine if we need the extra note about function names not matching anything in Python'''
-    func_re = re.compile('{0}_([A-Za-z0-9_]+)'.format(config['c_function_prefix'].replace('_', '')))
+    func_re = re.compile('{}_([A-Za-z0-9_]+)'.format(config['c_function_prefix'].replace('_', '')))
     for m in func_re.finditer(nd):
         fname = m.group(1).replace('.', '').replace(',', '').replace('\\', '')
         try:
@@ -732,7 +732,7 @@ def _need_func_note(nd, config):
 
 def _need_attr_note(nd, config):
     '''Determine if we need the extra note about attribute names not matching anything in Python'''
-    attr_re = re.compile('{0}_ATTR_([A-Z0-9_]+)'.format(config['module_name'].upper()))
+    attr_re = re.compile('{}_ATTR_([A-Z0-9_]+)'.format(config['module_name'].upper()))
     for m in attr_re.finditer(nd):
         aname = m.group(1).replace('\\', '')
         attr = find_attribute_by_name(config['attributes'], aname)
@@ -744,9 +744,9 @@ def _need_attr_note(nd, config):
 
 def _need_enum_note(nd, config, start_enum=None):
     '''Determine if we need the extra note about enum names not matching anything in Python'''
-    enum_re = re.compile('{0}_VAL_([A-Z0-9_]+)'.format(config['module_name'].upper()))
+    enum_re = re.compile('{}_VAL_([A-Z0-9_]+)'.format(config['module_name'].upper()))
     for m in enum_re.finditer(nd):
-        ename = '{0}_VAL_{1}'.format(config['module_name'].upper(), m.group(1).replace('\\', ''))
+        ename = '{}_VAL_{}'.format(config['module_name'].upper(), m.group(1).replace('\\', ''))
         enum, _ = find_enum_by_value(config['enums'], ename, start_enum=start_enum)
         if not enum or enum['codegen_method'] == 'no':
             return True

--- a/build/helper/documentation_snippets.py
+++ b/build/helper/documentation_snippets.py
@@ -106,7 +106,7 @@ def close_function_def_for_doc(functions, config):
         function_def['documentation']['note'].append(close_function_note)
         function_def['python_name'] = 'close'
     else:
-        assert False, "No '{}' function defined".format(close_name)
+        assert False, f"No '{close_name}' function defined"
 
     return function_def
 
@@ -138,7 +138,7 @@ def initiate_function_def_for_doc(functions, config):
         function_def['documentation']['note'].append(initiate_function_note)
         function_def['python_name'] = 'initiate'
     else:
-        assert False, "No '{}' function defined".format(session_context_manager_initiate)
+        assert False, f"No '{session_context_manager_initiate}' function defined"
 
     return function_def
 

--- a/build/helper/helper.py
+++ b/build/helper/helper.py
@@ -86,7 +86,7 @@ def get_numpy_type_for_api_type(api_type, config):
             if c['ctypes_type'] == api_type:
                 return c['python_name']
         # We didn't find it so assert
-        assert False, 'Unknown value for api_type: {0}'.format(api_type)
+        assert False, f'Unknown value for api_type: {api_type}'
 
 
 def get_array_type_for_api_type(api_type):
@@ -98,7 +98,7 @@ def get_array_type_for_api_type(api_type):
     if api_type in _type_map and _type_map[api_type]['array_type'] is not None:
         return _type_map[api_type]['array_type']
     else:
-        raise TypeError('Only simple types allowed for arrays: {0}'.format(api_type))
+        raise TypeError(f'Only simple types allowed for arrays: {api_type}')
 
 
 def get_development_status(config):

--- a/build/helper/metadata_add_all.py
+++ b/build/helper/metadata_add_all.py
@@ -63,7 +63,7 @@ def _add_python_method_name(function, name):
             function['python_name'] = '_' + camelcase_to_snakecase(name)
         else:
             function['python_name'] = camelcase_to_snakecase(name)
-            assert function['codegen_method'] == 'no' or 'method_name_for_documentation' not in function, "'method_name_for_documentation' not allowed to be set: function['method_name_for_documentation'] = '{0}', function['python_name'] = '{1}'".format(function['method_name_for_documentation'], function['python_name'])
+            assert function['codegen_method'] == 'no' or 'method_name_for_documentation' not in function, "'method_name_for_documentation' not allowed to be set: function['method_name_for_documentation'] = '{}', function['python_name'] = '{}'".format(function['method_name_for_documentation'], function['python_name'])
 
 
 def _add_interpreter_method_name(function, name):
@@ -264,7 +264,7 @@ def _add_default_value_name(parameter):
             name_with_default = parameter['python_name'] + "=" + str(parameter['default_value'])
 
         if 'python_api_converter_name' in parameter:
-            name_for_init = '_converters.{0}({1}, self._encoding)'.format(parameter['python_api_converter_name'], parameter['python_name'])
+            name_for_init = '_converters.{}({}, self._encoding)'.format(parameter['python_api_converter_name'], parameter['python_name'])
         elif parameter['use_in_python_api']:
             name_for_init = parameter['python_name']
         else:
@@ -525,8 +525,8 @@ def _add_enum_codegen_method(enums, config):
     for e in enums:
         least_restrictive_codegen_method = _get_least_restrictive_codegen_method(
             set.union(
-                set(config['functions'][f]['codegen_method'] for f in enum_to_client_functions[e]),
-                set(config['attributes'][a]['codegen_method'] for a in enum_to_client_attributes[e])
+                {config['functions'][f]['codegen_method'] for f in enum_to_client_functions[e]},
+                {config['attributes'][a]['codegen_method'] for a in enum_to_client_attributes[e]}
             )
         )
         if 'codegen_method' not in enums[e]:
@@ -561,7 +561,7 @@ def _get_functions_that_use_enums(enums, config):
             e = p['enum']
             if e is not None:
                 if e not in enum_to_client_functions:
-                    print('Missing enum {0} referenced by function {1}'.format(e, f))
+                    print(f'Missing enum {e} referenced by function {f}')
                 else:
                     enum_to_client_functions[e].append(f)
     return enum_to_client_functions
@@ -574,7 +574,7 @@ def _get_attributes_that_use_enums(enums, config):
         e = config['attributes'][a]['enum']
         if e is not None:
             if e not in enum_to_client_attributes:
-                print('Missing enum {0} referenced by attribute {1}'.format(e, a))
+                print(f'Missing enum {e} referenced by attribute {a}')
             else:
                 enum_to_client_attributes[e].append(a)
     return enum_to_client_attributes
@@ -610,7 +610,7 @@ def _add_enum_value_python_name(enum_info, config):
     '''Add 'python_name' for all values, removing any common prefixes and suffixes'''
     for v in enum_info['values']:
         if 'python_name' not in v:
-            v['python_name'] = v['name'].replace('{0}_VAL_'.format(config['module_name'].upper()), '')
+            v['python_name'] = v['name'].replace('{}_VAL_'.format(config['module_name'].upper()), '')
 
     # We are using an os.path function do find any common prefix. So that we don't
     # get 'O' in 'ON' and 'OFF' we remove characters at the end until they are '_'
@@ -627,7 +627,7 @@ def _add_enum_value_python_name(enum_info, config):
     # '_' only means the name starts with a number
     if len(prefix) > 0 and prefix != '_':
         for v in enum_info['values']:
-            assert v['python_name'].startswith(prefix), '{0} does not start with {1}'.format(v['name'], prefix)
+            assert v['python_name'].startswith(prefix), '{} does not start with {}'.format(v['name'], prefix)
             v['prefix'] = prefix
             v['python_name'] = v['python_name'].replace(prefix, '')
 
@@ -649,7 +649,7 @@ def _add_enum_value_python_name(enum_info, config):
     # '_' only means the name starts with a number
     if len(suffix) > 0:
         for v in enum_info['values']:
-            assert v['python_name'].endswith(suffix), '{0} does not end with {1}'.format(v['name'], suffix)
+            assert v['python_name'].endswith(suffix), '{} does not end with {}'.format(v['name'], suffix)
             v['suffix'] = suffix
             v['python_name'] = v['python_name'][:-len(suffix)]
 
@@ -759,13 +759,13 @@ def add_all_metadata(functions, attributes, enums, config, persist_output=True):
         os.makedirs(metadata_dir)
 
     with codecs.open(os.path.join(metadata_dir, config['module_name'] + '_functions.py'), "w", "utf-8") as text_file:
-        text_file.write("function =\n{0}".format(pp_persist.pformat(functions)))
+        text_file.write(f"function =\n{pp_persist.pformat(functions)}")
 
     with codecs.open(os.path.join(metadata_dir, config['module_name'] + '_attributes.py'), "w", "utf-8") as text_file:
-        text_file.write("attributes =\n{0}".format(pp_persist.pformat(attributes)))
+        text_file.write(f"attributes =\n{pp_persist.pformat(attributes)}")
 
     with codecs.open(os.path.join(metadata_dir, config['module_name'] + '_enums.py'), "w", "utf-8") as text_file:
-        text_file.write("enums =\n{0}".format(pp_persist.pformat(enums)))
+        text_file.write(f"enums =\n{pp_persist.pformat(enums)}")
 
     # We need to delete modules before we deepcopy, otherwise we get an error
     # These were needed only for merging, which has already happened
@@ -779,7 +779,7 @@ def add_all_metadata(functions, attributes, enums, config, persist_output=True):
     del config_copy['enums']
 
     with codecs.open(os.path.join(metadata_dir, config['module_name'] + '_config.py'), "w", "utf-8") as text_file:
-        text_file.write("enums =\n{0}".format(pp_persist.pformat(config_copy)))
+        text_file.write(f"enums =\n{pp_persist.pformat(config_copy)}")
 
     return config
 

--- a/build/helper/metadata_find.py
+++ b/build/helper/metadata_find.py
@@ -1,7 +1,7 @@
 # Find utilities
 def find_parameter(name, parameters):
     parameter = [x for x in parameters if x['name'] == name]
-    assert len(parameter) == 1, 'Parameter {0} not found in {1}. Check your metadata.'.format(name, parameters)
+    assert len(parameter) == 1, f'Parameter {name} not found in {parameters}. Check your metadata.'
     return parameter[0]
 
 
@@ -11,11 +11,11 @@ def find_session_handle_parameter(parameters):
     Usually it's the one marked as is_session_handle. For Init functions, it's the output parameter.
     '''
     matching = [p for p in parameters if p['is_session_handle']]
-    assert len(matching) <= 1, 'More than one parameter found with is_session_handle=True:\n{0}'.format(parameters)
+    assert len(matching) <= 1, f'More than one parameter found with is_session_handle=True:\n{parameters}'
     if len(matching) == 0:
         matching = [p for p in parameters if p['type'] == 'ViSession']
-        assert len(matching) <= 1, 'More than one ViSession parameter found:\n{0}'.format(parameters)
-        assert len(matching) > 0, 'No ViSession parameter found:\n{0}'.format(parameters)
+        assert len(matching) <= 1, f'More than one ViSession parameter found:\n{parameters}'
+        assert len(matching) > 0, f'No ViSession parameter found:\n{parameters}'
     return matching[0]
 
 
@@ -24,7 +24,7 @@ def find_size_parameter(parameter_list, parameters, key='value'):
 
     Most behaviors will use 'value', but 'ivi-dance-with-a-twist' uses 'value' and 'value_twist'
     '''
-    assert type(parameter_list) is list or type(parameter_list) is dict, 'Wrong type: {}'.format(type(parameter_list))
+    assert type(parameter_list) is list or type(parameter_list) is dict, f'Wrong type: {type(parameter_list)}'
     if len(parameter_list) == 0:
         return None
     # Assumption: all parameters have the same size parameter, so we only need to use the first one

--- a/build/helper/metadata_merge_dicts.py
+++ b/build/helper/metadata_merge_dicts.py
@@ -7,15 +7,15 @@ pp = pprint.PrettyPrinter(indent=4, width=80)
 
 
 def merge_helper(metadata, metadata_type, config, use_re):
-    metadata_module = 'metadata.{0}_addon'.format(metadata_type)
+    metadata_module = f'metadata.{metadata_type}_addon'
     if 'modules' in config and metadata_module in config['modules']:
         for m in dir(config['modules'][metadata_module]):
-            if m.startswith('{0}_additional_'.format(metadata_type)):
+            if m.startswith(f'{metadata_type}_additional_'):
                 # We need to explicitly copy new entries
                 outof = config['modules'][metadata_module].__getattribute__(m)
                 for a in outof:
                     metadata[a] = outof[a]
-            elif m.startswith('{0}_'.format(metadata_type)):
+            elif m.startswith(f'{metadata_type}_'):
                 merge_dicts(metadata, config['modules'][metadata_module].__getattribute__(m), use_re, m)
 
     # Delete any entries that are empty
@@ -41,7 +41,7 @@ def merge_dicts(into, outof, use_re, dict_name):
     for item in sorted(outof):
         # If we're not using regex's then this is an easy check
         if not use_re and item not in into and dict_name is not None:
-            raise KeyError('Key {0} from {1} is not in the destination'.format(item, dict_name))
+            raise KeyError(f'Key {item} from {dict_name} is not in the destination')
         # If we are using regex's we need to seach all keys to see if any match
         if use_re and dict_name is not None:
             key_exists = False
@@ -49,7 +49,7 @@ def merge_dicts(into, outof, use_re, dict_name):
                 if re.search(item, item2):
                     key_exists = True
             if not key_exists:
-                raise KeyError('Key {0} from {1} is not in the destination'.format(item, dict_name))
+                raise KeyError(f'Key {item} from {dict_name} is not in the destination')
 
         if type(outof[item]) is dict:
             if item in into:

--- a/build/templates/_matchers.py.mako
+++ b/build/templates/_matchers.py.mako
@@ -21,15 +21,15 @@ class _ScalarMatcher(object):
 
     def __eq__(self, other):
         if not isinstance(other, self.expected_type):
-            print("{0}: Unexpected type. Expected: {1}. Received: {2}".format(self.__class__.__name__, self.expected_type, type(other)))
+            print("{}: Unexpected type. Expected: {}. Received: {}".format(self.__class__.__name__, self.expected_type, type(other)))
             return False
         if other.value != self.expected_value:
-            print("{0}: Unexpected value. Expected: {1}. Received: {2}".format(self.__class__.__name__, self.expected_value, other.value))
+            print("{}: Unexpected value. Expected: {}. Received: {}".format(self.__class__.__name__, self.expected_value, other.value))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
 
 
 class _PointerMatcher(object):
@@ -38,12 +38,12 @@ class _PointerMatcher(object):
 
     def __eq__(self, other):
         if not isinstance(other, ctypes.POINTER(self.expected_type)):
-            print("Unexpected type. Expected: {0}. Received: {1}".format(ctypes.POINTER(self.expected_type), type(other)))
+            print("Unexpected type. Expected: {}. Received: {}".format(ctypes.POINTER(self.expected_type), type(other)))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1})'.format(self.__class__.__name__, pp.pformat(self.expected_type))
+        return '{}({})'.format(self.__class__.__name__, pp.pformat(self.expected_type))
 
 
 class _BufferMatcher(object):
@@ -71,22 +71,22 @@ class _BufferMatcher(object):
 
             # Because of object lifetimes, we may need to mock the other instance and provide lists instead of the actual array
             if not isinstance(other, self.expected_type) and not isinstance(other, list):
-                print("Unexpected type. Expected: {0} or {1}. Received: {2}".format(self.expected_type, list, type(other)))
+                print("Unexpected type. Expected: {} or {}. Received: {}".format(self.expected_type, list, type(other)))
                 return False
         if self.expected_size != len(other):
-            print("Unexpected length. Expected: {0}. Received: {1}".format(self.expected_size, len(other)))
+            print("Unexpected length. Expected: {}. Received: {}".format(self.expected_size, len(other)))
             return False
         if self.expected_value is not None:
             # Can't compare the objects directly because they're different types (one is list, another is ctypes array).
             # Go element by element, which allows for reporting the first index where different values were found.
             for i in range(0, len(self.expected_value)):
                 if self.expected_value[i] != other[i]:
-                    print("Unexpected value at index {0}. Expected: {1}. Received: {2}".format(i, self.expected_value[i], other[i]))
+                    print("Unexpected value at index {}. Expected: {}. Received: {}".format(i, self.expected_value[i], other[i]))
                     return False
         return True
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self._expected_element_type), pp.pformat(self._expected_size_or_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self._expected_element_type), pp.pformat(self._expected_size_or_value))
 
     def __str__(self):
         ret_str = self.__repr__() + '\n'
@@ -112,21 +112,21 @@ class ViStringMatcher(object):
                 pass
 
             if not isinstance(other, ctypes.Array):
-                print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_type, type(other)))
+                print("Unexpected type. Expected: {}. Received: {}".format(self.expected_type, type(other)))
                 return False
         if len(other) < len(self.expected_string_value) + 1:  # +1 for NULL terminating character
-            print("Unexpected length in C string. Expected at least: {0}. Received {1}".format(len(other), len(self.expected_string_value) + 1))
+            print("Unexpected length in C string. Expected at least: {}. Received {}".format(len(other), len(self.expected_string_value) + 1))
             return False
         if not isinstance(other[0], bytes):
-            print("Unexpected type. Not a string. Received: {0}".format(type(other[0])))
+            print("Unexpected type. Not a string. Received: {}".format(type(other[0])))
             return False
         if other.value.decode("ascii") != self.expected_string_value:
-            print("Unexpected value. Expected {0}. Received: {1}".format(self.expected_string_value, other.value.decode))
+            print("Unexpected value. Expected {}. Received: {}".format(self.expected_string_value, other.value.decode))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1})'.format(self.__class__.__name__, pp.pformat(self.expected_string_value))
+        return '{}({})'.format(self.__class__.__name__, pp.pformat(self.expected_string_value))
 
 
 # Custom Type
@@ -139,7 +139,7 @@ def _compare_ctype_structs(expected, actual):
         expected_val = getattr(expected, field_name)
         actual_val = getattr(actual, field_name)
         if expected_val != actual_val:
-            print("Unexpected value field {0}. Expected: {1}. Received: {2}".format(field_name, expected_val, actual_val))
+            print("Unexpected value field {}. Expected: {}. Received: {}".format(field_name, expected_val, actual_val))
             return False
     return True
 
@@ -151,12 +151,12 @@ class CustomTypeMatcher(object):
 
     def __eq__(self, actual):
         if not isinstance(actual, self.expected_type):
-            print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_type, type(actual)))
+            print("Unexpected type. Expected: {}. Received: {}".format(self.expected_type, type(actual)))
             return False
         return _compare_ctype_structs(self.expected_value, actual)
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
 
 
 class CustomTypeBufferMatcher(object):
@@ -168,17 +168,17 @@ class CustomTypeBufferMatcher(object):
 
     def __eq__(self, actual):
         if not isinstance(actual, self.expected_type):
-            print("Unexpected array type. Expected: {0}. Received: {1}".format(self.expected_type, type(actual)))
+            print("Unexpected array type. Expected: {}. Received: {}".format(self.expected_type, type(actual)))
             return False
         if self.expected_size != len(actual):
-            print("Unexpected length. Expected: {0}. Received: {1}".format(self.expected_size, len(actual)))
+            print("Unexpected length. Expected: {}. Received: {}".format(self.expected_size, len(actual)))
             return False
         if self.expected_value is not None:
             # Can't compare the objects directly because they're different types (one is list, another is ctypes array).
             # Go element by element, which allows for reporting the first index where different values were found.
             for a, e in zip(actual, self.expected_value):
                 if not isinstance(a, self.expected_element_type):
-                    print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_element_type, type(a)))
+                    print("Unexpected type. Expected: {}. Received: {}".format(self.expected_element_type, type(a)))
                     return False
                 if not _compare_ctype_structs(e, a):
                     return False
@@ -186,7 +186,7 @@ class CustomTypeBufferMatcher(object):
 
     def __repr__(self):
         expected_val_repr = '[' + ', '.join([x.__repr__() for x in self.expected_value]) + ']'
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_element_type), expected_val_repr)
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_element_type), expected_val_repr)
 
     def __str__(self):
         ret_str = self.__repr__() + '\n'

--- a/build/templates/_visatype.py
+++ b/build/templates/_visatype.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import ctypes
 
 

--- a/build/templates/errors.py.mako
+++ b/build/templates/errors.py.mako
@@ -53,7 +53,7 @@ class DriverWarning(Warning):
 
     def __init__(self, code, description):
         assert _is_warning(code), "Should not create Warning if code is not positive."
-        super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(DriverWarning, self).__init__('Warning {} occurred.\n\n{}'.format(code, description))
 
 
 % if grpc_supported:
@@ -105,7 +105,7 @@ class InvalidRepeatedCapabilityError(Error):
     '''An error due to an invalid character in a repeated capability'''
 
     def __init__(self, invalid_character, invalid_string):
-        super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({0}) was found in repeated capability string ({1})'.format(invalid_character, invalid_string))
+        super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({}) was found in repeated capability string ({})'.format(invalid_character, invalid_string))
 
 
 % endif
@@ -116,7 +116,7 @@ class SelfTestError(Error):
     def __init__(self, code, msg):
         self.code = code
         self.message = msg
-        super(SelfTestError, self).__init__('Self-test failed with code {0}: {1}'.format(code, msg))
+        super(SelfTestError, self).__init__('Self-test failed with code {}: {}'.format(code, msg))
 
 
 % endif

--- a/build/templates/examples.rst.mako
+++ b/build/templates/examples.rst.mako
@@ -27,7 +27,7 @@
 
     with open(f'./src/{module_name}/LATEST_RELEASE') as vf:
         latest_release_version = vf.read().strip()
-    released_zip_url = 'https://github.com/ni/nimi-python/releases/download/{0}/{1}_examples.zip'.format(latest_release_version, module_name)
+    released_zip_url = 'https://github.com/ni/nimi-python/releases/download/{}/{}_examples.zip'.format(latest_release_version, module_name)
 
     example_url_base = 'https://github.com/ni/nimi-python/blob/'
 
@@ -35,10 +35,10 @@
     v = Version(module_version)
 
     if v.dev is None and v.pre is None:
-        examples_zip_url_text = '`You can download all {0} examples here <{1}>`_'.format(module_name, released_zip_url)
+        examples_zip_url_text = '`You can download all {} examples here <{}>`_'.format(module_name, released_zip_url)
         example_url_base += latest_release_version
     else:
-        examples_zip_url_text = '`You can download all {0} examples for latest version here <{1}>`_'.format(module_name, released_zip_url)
+        examples_zip_url_text = '`You can download all {} examples for latest version here <{}>`_'.format(module_name, released_zip_url)
         example_url_base += 'master'
 %>\
 ${helper.get_rst_header_snippet('Examples', '=')}

--- a/build/templates/setup.py.mako
+++ b/build/templates/setup.py.mako
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 # This file was generated
 <%
 import build.helper as helper

--- a/build/templates/status.inc.mako
+++ b/build/templates/status.inc.mako
@@ -10,13 +10,13 @@
 %>\
 <%
 table_contents = []
-table_contents.append(['{0} ({1})'.format(driver_name, module_name), '', ])
+table_contents.append(['{} ({})'.format(driver_name, module_name), '', ])
 table_contents.append(['Driver Version Tested Against', config['latest_runtime_version_tested_against']])
-table_contents.append(['PyPI Version', '|{0}LatestVersion|'.format(module_name)])
-table_contents.append(['Supported Python Version', '|{0}PythonVersion|'.format(module_name)])
-table_contents.append(['Documentation', '|{0}Docs|'.format(module_name)])
-table_contents.append(['Open Issues', '|{0}OpenIssues|'.format(module_name)])
-table_contents.append(['Open Pull Requests', '|{0}OpenPRs|'.format(module_name)])
+table_contents.append(['PyPI Version', '|{}LatestVersion|'.format(module_name)])
+table_contents.append(['Supported Python Version', '|{}PythonVersion|'.format(module_name)])
+table_contents.append(['Documentation', '|{}Docs|'.format(module_name)])
+table_contents.append(['Open Issues', '|{}OpenIssues|'.format(module_name)])
+table_contents.append(['Open Pull Requests', '|{}OpenPRs|'.format(module_name)])
 
 driver_status_table = helper.as_rest_table(table_contents, header=True)
 
@@ -26,13 +26,13 @@ ${helper.get_rst_header_snippet(driver_name + ' Python API Status', '-')}
 ${helper.get_indented_docstring_snippet(driver_status_table, indent=0)}
 
 
-${helper.get_rst_picture_reference('{0}LatestVersion'.format(module_name), 'http://img.shields.io/pypi/v/{0}.svg'.format(module_name), 'Latest {0} Version'.format(driver_name), 'http://pypi.python.org/pypi/{0}'.format(module_name), indent=0)}
+${helper.get_rst_picture_reference('{}LatestVersion'.format(module_name), 'http://img.shields.io/pypi/v/{}.svg'.format(module_name), 'Latest {} Version'.format(driver_name), 'http://pypi.python.org/pypi/{}'.format(module_name), indent=0)}
 
-${helper.get_rst_picture_reference('{0}PythonVersion'.format(module_name), 'http://img.shields.io/pypi/pyversions/{0}.svg'.format(module_name), '{0} supported Python versions'.format(driver_name), 'http://pypi.python.org/pypi/{0}'.format(module_name), indent=0)}
+${helper.get_rst_picture_reference('{}PythonVersion'.format(module_name), 'http://img.shields.io/pypi/pyversions/{}.svg'.format(module_name), '{} supported Python versions'.format(driver_name), 'http://pypi.python.org/pypi/{}'.format(module_name), indent=0)}
 
-${helper.get_rst_picture_reference('{0}Docs'.format(module_name), 'https://readthedocs.org/projects/{0}/badge/?version=latest'.format(module_name), '{0} Python API Documentation Status'.format(driver_name), 'https://{0}.readthedocs.io/en/latest'.format(module_name), indent=0)}
+${helper.get_rst_picture_reference('{}Docs'.format(module_name), 'https://readthedocs.org/projects/{}/badge/?version=latest'.format(module_name), '{} Python API Documentation Status'.format(driver_name), 'https://{}.readthedocs.io/en/latest'.format(module_name), indent=0)}
 
-${helper.get_rst_picture_reference('{0}OpenIssues'.format(module_name), 'https://img.shields.io/github/issues/ni/nimi-python/{0}.svg'.format(module_name), 'Open Issues + Pull Requests for {0}'.format(driver_name), 'https://github.com/ni/nimi-python/issues?q=is%3Aopen+is%3Aissue+label%3A{0}'.format(module_name), indent=0)}
+${helper.get_rst_picture_reference('{}OpenIssues'.format(module_name), 'https://img.shields.io/github/issues/ni/nimi-python/{}.svg'.format(module_name), 'Open Issues + Pull Requests for {}'.format(driver_name), 'https://github.com/ni/nimi-python/issues?q=is%3Aopen+is%3Aissue+label%3A{}'.format(module_name), indent=0)}
 
-${helper.get_rst_picture_reference('{0}OpenPRs'.format(module_name), 'https://img.shields.io/github/issues-pr/ni/nimi-python/{0}.svg'.format(module_name), 'Pull Requests for {0}'.format(driver_name), 'https://github.com/ni/nimi-python/pulls?q=is%3Aopen+is%3Aissue+label%3A{0}'.format(module_name), indent=0)}
+${helper.get_rst_picture_reference('{}OpenPRs'.format(module_name), 'https://img.shields.io/github/issues-pr/ni/nimi-python/{}.svg'.format(module_name), 'Pull Requests for {}'.format(driver_name), 'https://github.com/ni/nimi-python/pulls?q=is%3Aopen+is%3Aissue+label%3A{}'.format(module_name), indent=0)}
 

--- a/build/unit_tests/test_documentation_helper.py
+++ b/build/unit_tests/test_documentation_helper.py
@@ -23,7 +23,7 @@ def assert_rst_strings_are_equal(expected, actual):
     expected = _remove_trailing_whitespace(expected)
     actual = _remove_trailing_whitespace(actual)
     for expected_line, actual_line in zip(expected, actual):
-        assert expected_line == actual_line, 'Difference found:\n{0}\n{1}'.format(expected_line, actual_line)
+        assert expected_line == actual_line, f'Difference found:\n{expected_line}\n{actual_line}'
 
 
 config = {

--- a/build/unit_tests/test_metadata_add_all.py
+++ b/build/unit_tests/test_metadata_add_all.py
@@ -11,23 +11,23 @@ def _compare_values(actual, expected, k):
     elif type(actual) is list:
         _compare_lists(actual, expected)
     else:
-        assert actual == expected, "Value mismatch with key/index '{0}', {1} != {2}".format(k, actual, expected)
+        assert actual == expected, f"Value mismatch with key/index '{k}', {actual} != {expected}"
 
 
 def _compare_lists(actual, expected):
-    assert isinstance(actual, type(expected)), 'Type mismatch, {0} != {1}'.format(type(actual), type(expected))
-    assert len(actual) == len(expected), 'Length mismatch, {0} != {1}'.format(len(actual), len(expected))
+    assert isinstance(actual, type(expected)), f'Type mismatch, {type(actual)} != {type(expected)}'
+    assert len(actual) == len(expected), f'Length mismatch, {len(actual)} != {len(expected)}'
     for k in range(len(actual)):
         _compare_values(actual[k], expected[k], k)
 
 
 def _compare_dicts(actual, expected):
-    assert isinstance(actual, type(expected)), 'Type mismatch, {0} != {1}'.format(type(actual), type(expected))
+    assert isinstance(actual, type(expected)), f'Type mismatch, {type(actual)} != {type(expected)}'
     for k in actual:
-        assert k in expected, 'Key {0} not in expected'.format(k)
+        assert k in expected, f'Key {k} not in expected'
         _compare_values(actual[k], expected[k], k)
     for k in expected:
-        assert k in actual, 'Key {0} not in actual'.format(k)
+        assert k in actual, f'Key {k} not in actual'
 
 
 functions_input = {

--- a/build/unit_tests/test_metadata_merge_dicts.py
+++ b/build/unit_tests/test_metadata_merge_dicts.py
@@ -4,7 +4,7 @@ from build.helper.metadata_merge_dicts import *
 def _do_the_test_merge_dicts(a, b, expected, use_re):
     actual = a.copy()
     merge_dicts(actual, b, use_re, 'test')
-    assert expected == actual, "\na = {0}\nb = {1}\nexpected = {2}\nactual = {3}".format(a, b, expected, actual)
+    assert expected == actual, f"\na = {a}\nb = {b}\nexpected = {expected}\nactual = {actual}"
 
 
 def test_merge_dict_second_is_empty():

--- a/docs/_static/nidcpower_usage.inc
+++ b/docs/_static/nidcpower_usage.inc
@@ -15,13 +15,13 @@ The following is a basic example of using the **nidcpower** module to open a ses
         session.voltage_level = 5.0
 
         session.commit()
-        print('Effective measurement rate: {0} S/s'.format(session.measure_record_delta_time / 1))
+        print('Effective measurement rate: {} S/s'.format(session.measure_record_delta_time / 1))
 
         samples_acquired = 0
         print('Channel           Num  Voltage    Current    In Compliance')
         row_format = '{0:15} {1:3d}    {2:8.6f}   {3:8.6f}   {4}'
         with session.initiate():
-            channel_indices = '0-{0}'.format(session.channel_count - 1)
+            channel_indices = '0-{}'.format(session.channel_count - 1)
             channels = session.get_channel_names(channel_indices)
             for i, channel_name in enumerate(channels):
                 samples_acquired = 0

--- a/docs/_static/niscope_usage.inc
+++ b/docs/_static/niscope_usage.inc
@@ -13,7 +13,7 @@ The following is a basic example of using the **niscope** module to open a sessi
         with session.initiate():
             waveforms = session.channels[0,1].fetch(num_records=5)
         for wfm in waveforms:
-            print('Channel {0}, record {1} samples acquired: {2:,}\n'.format(wfm.channel, wfm.record, len(wfm.samples)))
+            print('Channel {}, record {} samples acquired: {:,}\n'.format(wfm.channel, wfm.record, len(wfm.samples)))
 
         # Find all channel 1 records (Note channel name is always a string even if integers used in channel[])
         chan1 = [wfm for wfm in waveforms if wfm.channel == '0']

--- a/docs/nidcpower/conf.py
+++ b/docs/nidcpower/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI-DCPower Python API'
-copyright = '2017-2023, National Instruments Corporation'
+copyright = '2017-2024, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/nidigital/conf.py
+++ b/docs/nidigital/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI-Digital Pattern Driver Python API'
-copyright = '2019-2023, National Instruments Corporation'
+copyright = '2019-2024, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/nidmm/conf.py
+++ b/docs/nidmm/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI-DMM Python API'
-copyright = '2017-2023, National Instruments Corporation'
+copyright = '2017-2024, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/nifgen/conf.py
+++ b/docs/nifgen/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI-FGEN Python API'
-copyright = '2017-2023, National Instruments Corporation'
+copyright = '2017-2024, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/nimodinst/conf.py
+++ b/docs/nimodinst/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI-ModInst Python API'
-copyright = '2017-2023, National Instruments Corporation'
+copyright = '2017-2024, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/niscope/conf.py
+++ b/docs/niscope/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI-SCOPE Python API'
-copyright = '2017-2023, National Instruments Corporation'
+copyright = '2017-2024, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/nise/conf.py
+++ b/docs/nise/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI Switch Executive Python API'
-copyright = '2018-2023, National Instruments Corporation'
+copyright = '2018-2024, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/niswitch/conf.py
+++ b/docs/niswitch/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI-SWITCH Python API'
-copyright = '2017-2023, National Instruments Corporation'
+copyright = '2017-2024, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/nitclk/conf.py
+++ b/docs/nitclk/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI-TClk Python API'
-copyright = '2019-2023, National Instruments Corporation'
+copyright = '2019-2024, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/generated/nidcpower/README.rst
+++ b/generated/nidcpower/README.rst
@@ -127,13 +127,13 @@ The following is a basic example of using the **nidcpower** module to open a ses
         session.voltage_level = 5.0
 
         session.commit()
-        print('Effective measurement rate: {0} S/s'.format(session.measure_record_delta_time / 1))
+        print('Effective measurement rate: {} S/s'.format(session.measure_record_delta_time / 1))
 
         samples_acquired = 0
         print('Channel           Num  Voltage    Current    In Compliance')
         row_format = '{0:15} {1:3d}    {2:8.6f}   {3:8.6f}   {4}'
         with session.initiate():
-            channel_indices = '0-{0}'.format(session.channel_count - 1)
+            channel_indices = '0-{}'.format(session.channel_count - 1)
             channels = session.get_channel_names(channel_indices)
             for i, channel_name in enumerate(channels):
                 samples_acquired = 0

--- a/generated/nidcpower/nidcpower/_visatype.py
+++ b/generated/nidcpower/nidcpower/_visatype.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import ctypes
 
 

--- a/generated/nidcpower/nidcpower/errors.py
+++ b/generated/nidcpower/nidcpower/errors.py
@@ -40,7 +40,7 @@ class DriverWarning(Warning):
 
     def __init__(self, code, description):
         assert _is_warning(code), "Should not create Warning if code is not positive."
-        super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(DriverWarning, self).__init__('Warning {} occurred.\n\n{}'.format(code, description))
 
 
 class RpcError(Error):
@@ -89,7 +89,7 @@ class InvalidRepeatedCapabilityError(Error):
     '''An error due to an invalid character in a repeated capability'''
 
     def __init__(self, invalid_character, invalid_string):
-        super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({0}) was found in repeated capability string ({1})'.format(invalid_character, invalid_string))
+        super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({}) was found in repeated capability string ({})'.format(invalid_character, invalid_string))
 
 
 class SelfTestError(Error):
@@ -98,7 +98,7 @@ class SelfTestError(Error):
     def __init__(self, code, msg):
         self.code = code
         self.message = msg
-        super(SelfTestError, self).__init__('Self-test failed with code {0}: {1}'.format(code, msg))
+        super(SelfTestError, self).__init__('Self-test failed with code {}: {}'.format(code, msg))
 
 
 def handle_error(library_interpreter, code, ignore_warnings, is_error_handling):

--- a/generated/nidcpower/nidcpower/lcr_load_compensation_spot.py
+++ b/generated/nidcpower/nidcpower/lcr_load_compensation_spot.py
@@ -32,7 +32,7 @@ class struct_NILCRLoadCompensationSpot(ctypes.Structure):  # noqa N801
             self.reference_value_b = 0.0
 
 
-class LCRLoadCompensationSpot(object):
+class LCRLoadCompensationSpot:
     """Specifies a DUT specification for a given frequency to use in LCR load compensation."""
 
     _lcr_reference_value_type_to_label_and_units = {
@@ -79,7 +79,7 @@ class LCRLoadCompensationSpot(object):
             return target_class(frequency=self.frequency, reference_value_type=self.reference_value_type.value, reference_value_a=self.reference_value.real, reference_value_b=self.reference_value.imag)
 
     def __repr__(self):
-        return "{0}.{1}(frequency={2}, reference_value_type={3}.{4}.{5}, reference_value={6})".format(
+        return "{}.{}(frequency={}, reference_value_type={}.{}.{}, reference_value={})".format(
             self.__class__.__module__,
             self.__class__.__qualname__,
             self.frequency,

--- a/generated/nidcpower/nidcpower/lcr_measurement.py
+++ b/generated/nidcpower/nidcpower/lcr_measurement.py
@@ -48,7 +48,7 @@ class struct_NILCRMeasurement(ctypes.Structure):  # noqa N801
     ]
 
 
-class LCRMeasurement(object):
+class LCRMeasurement:
     """Specifies an LCR measurement.
 
     Data attributes:
@@ -182,9 +182,9 @@ class LCRMeasurement(object):
                 "ac_in_compliance",
                 "unbalanced"
             ):
-                row_format = "{{:<{}}}: {{:}}{{}}\n".format(max_field_label_len)
+                row_format = f"{{:<{max_field_label_len}}}: {{:}}{{}}\n"
             else:
-                row_format = "{{:<{}}}: {{:,.6g}}{{}}\n".format(max_field_label_len)
+                row_format = f"{{:<{max_field_label_len}}}: {{:,.6g}}{{}}\n"
             # Process namedtuple fields
             if isinstance(field_label, tuple) and isinstance(field_unit, tuple):
                 for label, unit, value in zip(field_label, field_unit, getattr(self, field_name)):

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -5316,9 +5316,9 @@ class _SessionBase(object):
         attribute_ids_used = set()
         for prop in property_names:
             if prop not in Session.__base__.__dict__:
-                raise KeyError('{0} is not an property on the nidcpower.Session'.format(prop))
+                raise KeyError('{} is not an property on the nidcpower.Session'.format(prop))
             if not isinstance(Session.__base__.__dict__[prop], _attributes.Attribute):
-                raise TypeError('{0} is not a valid property: {1}'.format(prop, type(Session.__base__.__dict__[prop])))
+                raise TypeError('{} is not a valid property: {}'.format(prop, type(Session.__base__.__dict__[prop])))
             attribute_ids_used.add(Session.__base__.__dict__[prop]._attribute_id)
 
         self._create_advanced_sequence_with_channels(sequence_name, list(attribute_ids_used), set_as_active_sequence)

--- a/generated/nidcpower/nidcpower/unit_tests/_matchers.py
+++ b/generated/nidcpower/nidcpower/unit_tests/_matchers.py
@@ -21,15 +21,15 @@ class _ScalarMatcher(object):
 
     def __eq__(self, other):
         if not isinstance(other, self.expected_type):
-            print("{0}: Unexpected type. Expected: {1}. Received: {2}".format(self.__class__.__name__, self.expected_type, type(other)))
+            print("{}: Unexpected type. Expected: {}. Received: {}".format(self.__class__.__name__, self.expected_type, type(other)))
             return False
         if other.value != self.expected_value:
-            print("{0}: Unexpected value. Expected: {1}. Received: {2}".format(self.__class__.__name__, self.expected_value, other.value))
+            print("{}: Unexpected value. Expected: {}. Received: {}".format(self.__class__.__name__, self.expected_value, other.value))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
 
 
 class _PointerMatcher(object):
@@ -38,12 +38,12 @@ class _PointerMatcher(object):
 
     def __eq__(self, other):
         if not isinstance(other, ctypes.POINTER(self.expected_type)):
-            print("Unexpected type. Expected: {0}. Received: {1}".format(ctypes.POINTER(self.expected_type), type(other)))
+            print("Unexpected type. Expected: {}. Received: {}".format(ctypes.POINTER(self.expected_type), type(other)))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1})'.format(self.__class__.__name__, pp.pformat(self.expected_type))
+        return '{}({})'.format(self.__class__.__name__, pp.pformat(self.expected_type))
 
 
 class _BufferMatcher(object):
@@ -71,22 +71,22 @@ class _BufferMatcher(object):
 
             # Because of object lifetimes, we may need to mock the other instance and provide lists instead of the actual array
             if not isinstance(other, self.expected_type) and not isinstance(other, list):
-                print("Unexpected type. Expected: {0} or {1}. Received: {2}".format(self.expected_type, list, type(other)))
+                print("Unexpected type. Expected: {} or {}. Received: {}".format(self.expected_type, list, type(other)))
                 return False
         if self.expected_size != len(other):
-            print("Unexpected length. Expected: {0}. Received: {1}".format(self.expected_size, len(other)))
+            print("Unexpected length. Expected: {}. Received: {}".format(self.expected_size, len(other)))
             return False
         if self.expected_value is not None:
             # Can't compare the objects directly because they're different types (one is list, another is ctypes array).
             # Go element by element, which allows for reporting the first index where different values were found.
             for i in range(0, len(self.expected_value)):
                 if self.expected_value[i] != other[i]:
-                    print("Unexpected value at index {0}. Expected: {1}. Received: {2}".format(i, self.expected_value[i], other[i]))
+                    print("Unexpected value at index {}. Expected: {}. Received: {}".format(i, self.expected_value[i], other[i]))
                     return False
         return True
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self._expected_element_type), pp.pformat(self._expected_size_or_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self._expected_element_type), pp.pformat(self._expected_size_or_value))
 
     def __str__(self):
         ret_str = self.__repr__() + '\n'
@@ -112,21 +112,21 @@ class ViStringMatcher(object):
                 pass
 
             if not isinstance(other, ctypes.Array):
-                print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_type, type(other)))
+                print("Unexpected type. Expected: {}. Received: {}".format(self.expected_type, type(other)))
                 return False
         if len(other) < len(self.expected_string_value) + 1:  # +1 for NULL terminating character
-            print("Unexpected length in C string. Expected at least: {0}. Received {1}".format(len(other), len(self.expected_string_value) + 1))
+            print("Unexpected length in C string. Expected at least: {}. Received {}".format(len(other), len(self.expected_string_value) + 1))
             return False
         if not isinstance(other[0], bytes):
-            print("Unexpected type. Not a string. Received: {0}".format(type(other[0])))
+            print("Unexpected type. Not a string. Received: {}".format(type(other[0])))
             return False
         if other.value.decode("ascii") != self.expected_string_value:
-            print("Unexpected value. Expected {0}. Received: {1}".format(self.expected_string_value, other.value.decode))
+            print("Unexpected value. Expected {}. Received: {}".format(self.expected_string_value, other.value.decode))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1})'.format(self.__class__.__name__, pp.pformat(self.expected_string_value))
+        return '{}({})'.format(self.__class__.__name__, pp.pformat(self.expected_string_value))
 
 
 # Custom Type
@@ -139,7 +139,7 @@ def _compare_ctype_structs(expected, actual):
         expected_val = getattr(expected, field_name)
         actual_val = getattr(actual, field_name)
         if expected_val != actual_val:
-            print("Unexpected value field {0}. Expected: {1}. Received: {2}".format(field_name, expected_val, actual_val))
+            print("Unexpected value field {}. Expected: {}. Received: {}".format(field_name, expected_val, actual_val))
             return False
     return True
 
@@ -151,12 +151,12 @@ class CustomTypeMatcher(object):
 
     def __eq__(self, actual):
         if not isinstance(actual, self.expected_type):
-            print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_type, type(actual)))
+            print("Unexpected type. Expected: {}. Received: {}".format(self.expected_type, type(actual)))
             return False
         return _compare_ctype_structs(self.expected_value, actual)
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
 
 
 class CustomTypeBufferMatcher(object):
@@ -168,17 +168,17 @@ class CustomTypeBufferMatcher(object):
 
     def __eq__(self, actual):
         if not isinstance(actual, self.expected_type):
-            print("Unexpected array type. Expected: {0}. Received: {1}".format(self.expected_type, type(actual)))
+            print("Unexpected array type. Expected: {}. Received: {}".format(self.expected_type, type(actual)))
             return False
         if self.expected_size != len(actual):
-            print("Unexpected length. Expected: {0}. Received: {1}".format(self.expected_size, len(actual)))
+            print("Unexpected length. Expected: {}. Received: {}".format(self.expected_size, len(actual)))
             return False
         if self.expected_value is not None:
             # Can't compare the objects directly because they're different types (one is list, another is ctypes array).
             # Go element by element, which allows for reporting the first index where different values were found.
             for a, e in zip(actual, self.expected_value):
                 if not isinstance(a, self.expected_element_type):
-                    print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_element_type, type(a)))
+                    print("Unexpected type. Expected: {}. Received: {}".format(self.expected_element_type, type(a)))
                     return False
                 if not _compare_ctype_structs(e, a):
                     return False
@@ -186,7 +186,7 @@ class CustomTypeBufferMatcher(object):
 
     def __repr__(self):
         expected_val_repr = '[' + ', '.join([x.__repr__() for x in self.expected_value]) + ']'
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_element_type), expected_val_repr)
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_element_type), expected_val_repr)
 
     def __str__(self):
         ret_str = self.__repr__() + '\n'

--- a/generated/nidcpower/setup.py
+++ b/generated/nidcpower/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 # This file was generated
 
 

--- a/generated/nidigital/nidigital/_visatype.py
+++ b/generated/nidigital/nidigital/_visatype.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import ctypes
 
 

--- a/generated/nidigital/nidigital/errors.py
+++ b/generated/nidigital/nidigital/errors.py
@@ -40,7 +40,7 @@ class DriverWarning(Warning):
 
     def __init__(self, code, description):
         assert _is_warning(code), "Should not create Warning if code is not positive."
-        super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(DriverWarning, self).__init__('Warning {} occurred.\n\n{}'.format(code, description))
 
 
 class RpcError(Error):
@@ -89,7 +89,7 @@ class InvalidRepeatedCapabilityError(Error):
     '''An error due to an invalid character in a repeated capability'''
 
     def __init__(self, invalid_character, invalid_string):
-        super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({0}) was found in repeated capability string ({1})'.format(invalid_character, invalid_string))
+        super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({}) was found in repeated capability string ({})'.format(invalid_character, invalid_string))
 
 
 class SelfTestError(Error):
@@ -98,7 +98,7 @@ class SelfTestError(Error):
     def __init__(self, code, msg):
         self.code = code
         self.message = msg
-        super(SelfTestError, self).__init__('Self-test failed with code {0}: {1}'.format(code, msg))
+        super(SelfTestError, self).__init__('Self-test failed with code {}: {}'.format(code, msg))
 
 
 def handle_error(library_interpreter, code, ignore_warnings, is_error_handling):

--- a/generated/nidigital/nidigital/history_ram_cycle_information.py
+++ b/generated/nidigital/nidigital/history_ram_cycle_information.py
@@ -1,4 +1,4 @@
-class HistoryRAMCycleInformation(object):
+class HistoryRAMCycleInformation:
     def __init__(self, pattern_name, time_set_name, vector_number, cycle_number, scan_cycle_number, expected_pin_states, actual_pin_states, per_pin_pass_fail):
         self.pattern_name = pattern_name
         self.time_set_name = time_set_name
@@ -11,17 +11,17 @@ class HistoryRAMCycleInformation(object):
 
     def __repr__(self):
         parameter_list = [
-            'pattern_name="{}"'.format(self.pattern_name),
-            'time_set_name="{}"'.format(self.time_set_name),
-            'vector_number={}'.format(self.vector_number),
-            'cycle_number={}'.format(self.cycle_number),
-            'scan_cycle_number={}'.format(self.scan_cycle_number),
-            'expected_pin_states={}'.format(self._digital_states_representation(self.expected_pin_states)),
-            'actual_pin_states={}'.format(self._digital_states_representation(self.actual_pin_states)),
-            'per_pin_pass_fail={}'.format(self.per_pin_pass_fail),
+            f'pattern_name="{self.pattern_name}"',
+            f'time_set_name="{self.time_set_name}"',
+            f'vector_number={self.vector_number}',
+            f'cycle_number={self.cycle_number}',
+            f'scan_cycle_number={self.scan_cycle_number}',
+            f'expected_pin_states={self._digital_states_representation(self.expected_pin_states)}',
+            f'actual_pin_states={self._digital_states_representation(self.actual_pin_states)}',
+            f'per_pin_pass_fail={self.per_pin_pass_fail}',
         ]
 
-        return '{0}.{1}({2})'.format(self.__class__.__module__, self.__class__.__qualname__, ', '.join(parameter_list))
+        return '{}.{}({})'.format(self.__class__.__module__, self.__class__.__qualname__, ', '.join(parameter_list))
 
     def __str__(self):
         # different format lines
@@ -42,7 +42,7 @@ class HistoryRAMCycleInformation(object):
 
     @staticmethod
     def _digital_states_representation(states):
-        states_representation = [['{0}.{1}.{2}'.format(i.__class__.__module__, i.__class__.__qualname__, i.name) for i in j] for j in states]
+        states_representation = [[f'{i.__class__.__module__}.{i.__class__.__qualname__}.{i.name}' for i in j] for j in states]
         return '[{}]'.format(', '.join(['[{}]'.format(', '.join(i)) for i in states_representation]))
 
     @staticmethod

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -2087,7 +2087,7 @@ class _SessionBase(object):
         # site is passed as repeated capability
         samples_available = self.get_history_ram_sample_count()
         if position > samples_available:
-            raise ValueError('position: Specified value = {0}, Maximum value = {1}.'.format(position, samples_available - 1))
+            raise ValueError('position: Specified value = {}, Maximum value = {}.'.format(position, samples_available - 1))
 
         if samples_to_read == -1:
             with _NoChannel(session=self):
@@ -2099,7 +2099,7 @@ class _SessionBase(object):
 
         if position + samples_to_read > samples_available:
             raise ValueError(
-                'position: Specified value = {0}, samples_to_read: Specified value = {1}; Samples available = {2}.'
+                'position: Specified value = {}, samples_to_read: Specified value = {}; Samples available = {}.'
                 .format(position, samples_to_read, samples_available - position))
 
         pattern_names = {}
@@ -3536,7 +3536,7 @@ class Session(_SessionBase):
                 if waveform_data[site].dtype == numpy.uint32:
                     wfm = array.array('L', waveform_data[site])
                 else:
-                    raise TypeError("Unsupported dtype for waveform_data array element type. Is {0}, expected {1}".format(waveform_data[site].dtype, numpy.int32))
+                    raise TypeError("Unsupported dtype for waveform_data array element type. Is {}, expected {}".format(waveform_data[site].dtype, numpy.int32))
 
             elif isinstance(waveform_data[site], array.array):
                 if waveform_data[site].typecode == 'L':

--- a/generated/nidigital/nidigital/unit_tests/_matchers.py
+++ b/generated/nidigital/nidigital/unit_tests/_matchers.py
@@ -21,15 +21,15 @@ class _ScalarMatcher(object):
 
     def __eq__(self, other):
         if not isinstance(other, self.expected_type):
-            print("{0}: Unexpected type. Expected: {1}. Received: {2}".format(self.__class__.__name__, self.expected_type, type(other)))
+            print("{}: Unexpected type. Expected: {}. Received: {}".format(self.__class__.__name__, self.expected_type, type(other)))
             return False
         if other.value != self.expected_value:
-            print("{0}: Unexpected value. Expected: {1}. Received: {2}".format(self.__class__.__name__, self.expected_value, other.value))
+            print("{}: Unexpected value. Expected: {}. Received: {}".format(self.__class__.__name__, self.expected_value, other.value))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
 
 
 class _PointerMatcher(object):
@@ -38,12 +38,12 @@ class _PointerMatcher(object):
 
     def __eq__(self, other):
         if not isinstance(other, ctypes.POINTER(self.expected_type)):
-            print("Unexpected type. Expected: {0}. Received: {1}".format(ctypes.POINTER(self.expected_type), type(other)))
+            print("Unexpected type. Expected: {}. Received: {}".format(ctypes.POINTER(self.expected_type), type(other)))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1})'.format(self.__class__.__name__, pp.pformat(self.expected_type))
+        return '{}({})'.format(self.__class__.__name__, pp.pformat(self.expected_type))
 
 
 class _BufferMatcher(object):
@@ -71,22 +71,22 @@ class _BufferMatcher(object):
 
             # Because of object lifetimes, we may need to mock the other instance and provide lists instead of the actual array
             if not isinstance(other, self.expected_type) and not isinstance(other, list):
-                print("Unexpected type. Expected: {0} or {1}. Received: {2}".format(self.expected_type, list, type(other)))
+                print("Unexpected type. Expected: {} or {}. Received: {}".format(self.expected_type, list, type(other)))
                 return False
         if self.expected_size != len(other):
-            print("Unexpected length. Expected: {0}. Received: {1}".format(self.expected_size, len(other)))
+            print("Unexpected length. Expected: {}. Received: {}".format(self.expected_size, len(other)))
             return False
         if self.expected_value is not None:
             # Can't compare the objects directly because they're different types (one is list, another is ctypes array).
             # Go element by element, which allows for reporting the first index where different values were found.
             for i in range(0, len(self.expected_value)):
                 if self.expected_value[i] != other[i]:
-                    print("Unexpected value at index {0}. Expected: {1}. Received: {2}".format(i, self.expected_value[i], other[i]))
+                    print("Unexpected value at index {}. Expected: {}. Received: {}".format(i, self.expected_value[i], other[i]))
                     return False
         return True
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self._expected_element_type), pp.pformat(self._expected_size_or_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self._expected_element_type), pp.pformat(self._expected_size_or_value))
 
     def __str__(self):
         ret_str = self.__repr__() + '\n'
@@ -112,21 +112,21 @@ class ViStringMatcher(object):
                 pass
 
             if not isinstance(other, ctypes.Array):
-                print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_type, type(other)))
+                print("Unexpected type. Expected: {}. Received: {}".format(self.expected_type, type(other)))
                 return False
         if len(other) < len(self.expected_string_value) + 1:  # +1 for NULL terminating character
-            print("Unexpected length in C string. Expected at least: {0}. Received {1}".format(len(other), len(self.expected_string_value) + 1))
+            print("Unexpected length in C string. Expected at least: {}. Received {}".format(len(other), len(self.expected_string_value) + 1))
             return False
         if not isinstance(other[0], bytes):
-            print("Unexpected type. Not a string. Received: {0}".format(type(other[0])))
+            print("Unexpected type. Not a string. Received: {}".format(type(other[0])))
             return False
         if other.value.decode("ascii") != self.expected_string_value:
-            print("Unexpected value. Expected {0}. Received: {1}".format(self.expected_string_value, other.value.decode))
+            print("Unexpected value. Expected {}. Received: {}".format(self.expected_string_value, other.value.decode))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1})'.format(self.__class__.__name__, pp.pformat(self.expected_string_value))
+        return '{}({})'.format(self.__class__.__name__, pp.pformat(self.expected_string_value))
 
 
 # Custom Type
@@ -139,7 +139,7 @@ def _compare_ctype_structs(expected, actual):
         expected_val = getattr(expected, field_name)
         actual_val = getattr(actual, field_name)
         if expected_val != actual_val:
-            print("Unexpected value field {0}. Expected: {1}. Received: {2}".format(field_name, expected_val, actual_val))
+            print("Unexpected value field {}. Expected: {}. Received: {}".format(field_name, expected_val, actual_val))
             return False
     return True
 
@@ -151,12 +151,12 @@ class CustomTypeMatcher(object):
 
     def __eq__(self, actual):
         if not isinstance(actual, self.expected_type):
-            print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_type, type(actual)))
+            print("Unexpected type. Expected: {}. Received: {}".format(self.expected_type, type(actual)))
             return False
         return _compare_ctype_structs(self.expected_value, actual)
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
 
 
 class CustomTypeBufferMatcher(object):
@@ -168,17 +168,17 @@ class CustomTypeBufferMatcher(object):
 
     def __eq__(self, actual):
         if not isinstance(actual, self.expected_type):
-            print("Unexpected array type. Expected: {0}. Received: {1}".format(self.expected_type, type(actual)))
+            print("Unexpected array type. Expected: {}. Received: {}".format(self.expected_type, type(actual)))
             return False
         if self.expected_size != len(actual):
-            print("Unexpected length. Expected: {0}. Received: {1}".format(self.expected_size, len(actual)))
+            print("Unexpected length. Expected: {}. Received: {}".format(self.expected_size, len(actual)))
             return False
         if self.expected_value is not None:
             # Can't compare the objects directly because they're different types (one is list, another is ctypes array).
             # Go element by element, which allows for reporting the first index where different values were found.
             for a, e in zip(actual, self.expected_value):
                 if not isinstance(a, self.expected_element_type):
-                    print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_element_type, type(a)))
+                    print("Unexpected type. Expected: {}. Received: {}".format(self.expected_element_type, type(a)))
                     return False
                 if not _compare_ctype_structs(e, a):
                     return False
@@ -186,7 +186,7 @@ class CustomTypeBufferMatcher(object):
 
     def __repr__(self):
         expected_val_repr = '[' + ', '.join([x.__repr__() for x in self.expected_value]) + ']'
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_element_type), expected_val_repr)
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_element_type), expected_val_repr)
 
     def __str__(self):
         ret_str = self.__repr__() + '\n'

--- a/generated/nidigital/nidigital/unit_tests/test_nidigital.py
+++ b/generated/nidigital/nidigital/unit_tests/test_nidigital.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 session_id_for_test = 42
 
 
-class TestSession(object):
+class TestSession:
     class PatchedLibrary(nidigital._library.Library):
         def __init__(self, ctypes_library):
             super().__init__(ctypes_library)
@@ -335,7 +335,7 @@ class TestSession(object):
 
     # Helper function for validating site behavior in fetch_history_ram_cycle_information.
     def niDigital_GetHistoryRAMSampleCount_check_site_looping(self, vi, site, sample_count):  # noqa: N802
-        assert site.value.decode('ascii') == 'site{}'.format(self.site_numbers_looping[self.iteration_check_site_looping])
+        assert site.value.decode('ascii') == f'site{self.site_numbers_looping[self.iteration_check_site_looping]}'
         sample_count.contents.value = 0  # we don't care if this is right as long as the fetch does not error
         self.iteration_check_site_looping += 1
         return 0

--- a/generated/nidigital/setup.py
+++ b/generated/nidigital/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 # This file was generated
 
 

--- a/generated/nidmm/nidmm/_visatype.py
+++ b/generated/nidmm/nidmm/_visatype.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import ctypes
 
 

--- a/generated/nidmm/nidmm/errors.py
+++ b/generated/nidmm/nidmm/errors.py
@@ -40,7 +40,7 @@ class DriverWarning(Warning):
 
     def __init__(self, code, description):
         assert _is_warning(code), "Should not create Warning if code is not positive."
-        super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(DriverWarning, self).__init__('Warning {} occurred.\n\n{}'.format(code, description))
 
 
 class RpcError(Error):
@@ -89,7 +89,7 @@ class InvalidRepeatedCapabilityError(Error):
     '''An error due to an invalid character in a repeated capability'''
 
     def __init__(self, invalid_character, invalid_string):
-        super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({0}) was found in repeated capability string ({1})'.format(invalid_character, invalid_string))
+        super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({}) was found in repeated capability string ({})'.format(invalid_character, invalid_string))
 
 
 class SelfTestError(Error):
@@ -98,7 +98,7 @@ class SelfTestError(Error):
     def __init__(self, code, msg):
         self.code = code
         self.message = msg
-        super(SelfTestError, self).__init__('Self-test failed with code {0}: {1}'.format(code, msg))
+        super(SelfTestError, self).__init__('Self-test failed with code {}: {}'.format(code, msg))
 
 
 def handle_error(library_interpreter, code, ignore_warnings, is_error_handling):

--- a/generated/nidmm/nidmm/unit_tests/_matchers.py
+++ b/generated/nidmm/nidmm/unit_tests/_matchers.py
@@ -21,15 +21,15 @@ class _ScalarMatcher(object):
 
     def __eq__(self, other):
         if not isinstance(other, self.expected_type):
-            print("{0}: Unexpected type. Expected: {1}. Received: {2}".format(self.__class__.__name__, self.expected_type, type(other)))
+            print("{}: Unexpected type. Expected: {}. Received: {}".format(self.__class__.__name__, self.expected_type, type(other)))
             return False
         if other.value != self.expected_value:
-            print("{0}: Unexpected value. Expected: {1}. Received: {2}".format(self.__class__.__name__, self.expected_value, other.value))
+            print("{}: Unexpected value. Expected: {}. Received: {}".format(self.__class__.__name__, self.expected_value, other.value))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
 
 
 class _PointerMatcher(object):
@@ -38,12 +38,12 @@ class _PointerMatcher(object):
 
     def __eq__(self, other):
         if not isinstance(other, ctypes.POINTER(self.expected_type)):
-            print("Unexpected type. Expected: {0}. Received: {1}".format(ctypes.POINTER(self.expected_type), type(other)))
+            print("Unexpected type. Expected: {}. Received: {}".format(ctypes.POINTER(self.expected_type), type(other)))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1})'.format(self.__class__.__name__, pp.pformat(self.expected_type))
+        return '{}({})'.format(self.__class__.__name__, pp.pformat(self.expected_type))
 
 
 class _BufferMatcher(object):
@@ -71,22 +71,22 @@ class _BufferMatcher(object):
 
             # Because of object lifetimes, we may need to mock the other instance and provide lists instead of the actual array
             if not isinstance(other, self.expected_type) and not isinstance(other, list):
-                print("Unexpected type. Expected: {0} or {1}. Received: {2}".format(self.expected_type, list, type(other)))
+                print("Unexpected type. Expected: {} or {}. Received: {}".format(self.expected_type, list, type(other)))
                 return False
         if self.expected_size != len(other):
-            print("Unexpected length. Expected: {0}. Received: {1}".format(self.expected_size, len(other)))
+            print("Unexpected length. Expected: {}. Received: {}".format(self.expected_size, len(other)))
             return False
         if self.expected_value is not None:
             # Can't compare the objects directly because they're different types (one is list, another is ctypes array).
             # Go element by element, which allows for reporting the first index where different values were found.
             for i in range(0, len(self.expected_value)):
                 if self.expected_value[i] != other[i]:
-                    print("Unexpected value at index {0}. Expected: {1}. Received: {2}".format(i, self.expected_value[i], other[i]))
+                    print("Unexpected value at index {}. Expected: {}. Received: {}".format(i, self.expected_value[i], other[i]))
                     return False
         return True
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self._expected_element_type), pp.pformat(self._expected_size_or_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self._expected_element_type), pp.pformat(self._expected_size_or_value))
 
     def __str__(self):
         ret_str = self.__repr__() + '\n'
@@ -112,21 +112,21 @@ class ViStringMatcher(object):
                 pass
 
             if not isinstance(other, ctypes.Array):
-                print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_type, type(other)))
+                print("Unexpected type. Expected: {}. Received: {}".format(self.expected_type, type(other)))
                 return False
         if len(other) < len(self.expected_string_value) + 1:  # +1 for NULL terminating character
-            print("Unexpected length in C string. Expected at least: {0}. Received {1}".format(len(other), len(self.expected_string_value) + 1))
+            print("Unexpected length in C string. Expected at least: {}. Received {}".format(len(other), len(self.expected_string_value) + 1))
             return False
         if not isinstance(other[0], bytes):
-            print("Unexpected type. Not a string. Received: {0}".format(type(other[0])))
+            print("Unexpected type. Not a string. Received: {}".format(type(other[0])))
             return False
         if other.value.decode("ascii") != self.expected_string_value:
-            print("Unexpected value. Expected {0}. Received: {1}".format(self.expected_string_value, other.value.decode))
+            print("Unexpected value. Expected {}. Received: {}".format(self.expected_string_value, other.value.decode))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1})'.format(self.__class__.__name__, pp.pformat(self.expected_string_value))
+        return '{}({})'.format(self.__class__.__name__, pp.pformat(self.expected_string_value))
 
 
 # Custom Type
@@ -139,7 +139,7 @@ def _compare_ctype_structs(expected, actual):
         expected_val = getattr(expected, field_name)
         actual_val = getattr(actual, field_name)
         if expected_val != actual_val:
-            print("Unexpected value field {0}. Expected: {1}. Received: {2}".format(field_name, expected_val, actual_val))
+            print("Unexpected value field {}. Expected: {}. Received: {}".format(field_name, expected_val, actual_val))
             return False
     return True
 
@@ -151,12 +151,12 @@ class CustomTypeMatcher(object):
 
     def __eq__(self, actual):
         if not isinstance(actual, self.expected_type):
-            print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_type, type(actual)))
+            print("Unexpected type. Expected: {}. Received: {}".format(self.expected_type, type(actual)))
             return False
         return _compare_ctype_structs(self.expected_value, actual)
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
 
 
 class CustomTypeBufferMatcher(object):
@@ -168,17 +168,17 @@ class CustomTypeBufferMatcher(object):
 
     def __eq__(self, actual):
         if not isinstance(actual, self.expected_type):
-            print("Unexpected array type. Expected: {0}. Received: {1}".format(self.expected_type, type(actual)))
+            print("Unexpected array type. Expected: {}. Received: {}".format(self.expected_type, type(actual)))
             return False
         if self.expected_size != len(actual):
-            print("Unexpected length. Expected: {0}. Received: {1}".format(self.expected_size, len(actual)))
+            print("Unexpected length. Expected: {}. Received: {}".format(self.expected_size, len(actual)))
             return False
         if self.expected_value is not None:
             # Can't compare the objects directly because they're different types (one is list, another is ctypes array).
             # Go element by element, which allows for reporting the first index where different values were found.
             for a, e in zip(actual, self.expected_value):
                 if not isinstance(a, self.expected_element_type):
-                    print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_element_type, type(a)))
+                    print("Unexpected type. Expected: {}. Received: {}".format(self.expected_element_type, type(a)))
                     return False
                 if not _compare_ctype_structs(e, a):
                     return False
@@ -186,7 +186,7 @@ class CustomTypeBufferMatcher(object):
 
     def __repr__(self):
         expected_val_repr = '[' + ', '.join([x.__repr__() for x in self.expected_value]) + ']'
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_element_type), expected_val_repr)
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_element_type), expected_val_repr)
 
     def __str__(self):
         ret_str = self.__repr__() + '\n'

--- a/generated/nidmm/setup.py
+++ b/generated/nidmm/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 # This file was generated
 
 

--- a/generated/nifake/nifake/_visatype.py
+++ b/generated/nifake/nifake/_visatype.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import ctypes
 
 

--- a/generated/nifake/nifake/custom_struct.py
+++ b/generated/nifake/nifake/custom_struct.py
@@ -22,13 +22,13 @@ class struct_CustomStruct(ctypes.Structure):  # noqa N801
             self.struct_double = struct_double
 
     def __repr__(self):
-        return '{0}(data=None, struct_int={1}, struct_double={2})'.format(self.__class__.__name__, self.struct_int, self.struct_double)
+        return f'{self.__class__.__name__}(data=None, struct_int={self.struct_int}, struct_double={self.struct_double})'
 
     def __str__(self):
         return self.__repr__()
 
 
-class CustomStruct(object):
+class CustomStruct:
     def __init__(self, data=None, struct_int=0, struct_double=0.0):
         if data is not None:
             self.struct_int = data.struct_int
@@ -41,7 +41,7 @@ class CustomStruct(object):
         return target_class(struct_int=self.struct_int, struct_double=self.struct_double)
 
     def __repr__(self):
-        return '{0}(data=None, struct_int={1}, struct_double={2})'.format(self.__class__.__name__, self.struct_int, self.struct_double)
+        return f'{self.__class__.__name__}(data=None, struct_int={self.struct_int}, struct_double={self.struct_double})'
 
     def __str__(self):
         return self.__repr__()

--- a/generated/nifake/nifake/custom_struct_nested_typedef.py
+++ b/generated/nifake/nifake/custom_struct_nested_typedef.py
@@ -22,7 +22,7 @@ class struct_CustomStructNestedTypedef(ctypes.Structure):  # noqa N801
             self.struct_custom_struct_typedef = custom_struct_typedef.struct_CustomStructTypedef()
 
 
-class CustomStructNestedTypedef(object):
+class CustomStructNestedTypedef:
     def __init__(
         self,
         data=None,
@@ -50,7 +50,7 @@ class CustomStructNestedTypedef(object):
         )
 
     def __repr__(self):
-        return '{0}(data=None, struct_custom_struct={1}, struct_custom_struct_typedef={2})'.format(
+        return '{}(data=None, struct_custom_struct={}, struct_custom_struct_typedef={})'.format(
             self.__class__.__name__,
             repr(self.struct_custom_struct),
             repr(self.struct_custom_struct_typedef)

--- a/generated/nifake/nifake/custom_struct_typedef.py
+++ b/generated/nifake/nifake/custom_struct_typedef.py
@@ -19,7 +19,7 @@ class struct_CustomStructTypedef(ctypes.Structure):  # noqa N801
             self.struct_double = 0.0
 
 
-class CustomStructTypedef(object):
+class CustomStructTypedef:
     def __init__(self, data=None, struct_int=0, struct_double=0.0):
         if data is not None:
             self.struct_int = data.struct_int
@@ -32,7 +32,7 @@ class CustomStructTypedef(object):
         return target_class(struct_int=self.struct_int, struct_double=self.struct_double)
 
     def __repr__(self):
-        return '{0}(data=None, struct_int={1}, struct_double={2})'.format(
+        return '{}(data=None, struct_int={}, struct_double={})'.format(
             self.__class__.__name__,
             self.struct_int,
             self.struct_double

--- a/generated/nifake/nifake/errors.py
+++ b/generated/nifake/nifake/errors.py
@@ -40,7 +40,7 @@ class DriverWarning(Warning):
 
     def __init__(self, code, description):
         assert _is_warning(code), "Should not create Warning if code is not positive."
-        super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(DriverWarning, self).__init__('Warning {} occurred.\n\n{}'.format(code, description))
 
 
 class RpcError(Error):
@@ -89,7 +89,7 @@ class InvalidRepeatedCapabilityError(Error):
     '''An error due to an invalid character in a repeated capability'''
 
     def __init__(self, invalid_character, invalid_string):
-        super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({0}) was found in repeated capability string ({1})'.format(invalid_character, invalid_string))
+        super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({}) was found in repeated capability string ({})'.format(invalid_character, invalid_string))
 
 
 class SelfTestError(Error):
@@ -98,7 +98,7 @@ class SelfTestError(Error):
     def __init__(self, code, msg):
         self.code = code
         self.message = msg
-        super(SelfTestError, self).__init__('Self-test failed with code {0}: {1}'.format(code, msg))
+        super(SelfTestError, self).__init__('Self-test failed with code {}: {}'.format(code, msg))
 
 
 def handle_error(library_interpreter, code, ignore_warnings, is_error_handling):

--- a/generated/nifake/nifake/unit_tests/_matchers.py
+++ b/generated/nifake/nifake/unit_tests/_matchers.py
@@ -21,15 +21,15 @@ class _ScalarMatcher(object):
 
     def __eq__(self, other):
         if not isinstance(other, self.expected_type):
-            print("{0}: Unexpected type. Expected: {1}. Received: {2}".format(self.__class__.__name__, self.expected_type, type(other)))
+            print("{}: Unexpected type. Expected: {}. Received: {}".format(self.__class__.__name__, self.expected_type, type(other)))
             return False
         if other.value != self.expected_value:
-            print("{0}: Unexpected value. Expected: {1}. Received: {2}".format(self.__class__.__name__, self.expected_value, other.value))
+            print("{}: Unexpected value. Expected: {}. Received: {}".format(self.__class__.__name__, self.expected_value, other.value))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
 
 
 class _PointerMatcher(object):
@@ -38,12 +38,12 @@ class _PointerMatcher(object):
 
     def __eq__(self, other):
         if not isinstance(other, ctypes.POINTER(self.expected_type)):
-            print("Unexpected type. Expected: {0}. Received: {1}".format(ctypes.POINTER(self.expected_type), type(other)))
+            print("Unexpected type. Expected: {}. Received: {}".format(ctypes.POINTER(self.expected_type), type(other)))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1})'.format(self.__class__.__name__, pp.pformat(self.expected_type))
+        return '{}({})'.format(self.__class__.__name__, pp.pformat(self.expected_type))
 
 
 class _BufferMatcher(object):
@@ -71,22 +71,22 @@ class _BufferMatcher(object):
 
             # Because of object lifetimes, we may need to mock the other instance and provide lists instead of the actual array
             if not isinstance(other, self.expected_type) and not isinstance(other, list):
-                print("Unexpected type. Expected: {0} or {1}. Received: {2}".format(self.expected_type, list, type(other)))
+                print("Unexpected type. Expected: {} or {}. Received: {}".format(self.expected_type, list, type(other)))
                 return False
         if self.expected_size != len(other):
-            print("Unexpected length. Expected: {0}. Received: {1}".format(self.expected_size, len(other)))
+            print("Unexpected length. Expected: {}. Received: {}".format(self.expected_size, len(other)))
             return False
         if self.expected_value is not None:
             # Can't compare the objects directly because they're different types (one is list, another is ctypes array).
             # Go element by element, which allows for reporting the first index where different values were found.
             for i in range(0, len(self.expected_value)):
                 if self.expected_value[i] != other[i]:
-                    print("Unexpected value at index {0}. Expected: {1}. Received: {2}".format(i, self.expected_value[i], other[i]))
+                    print("Unexpected value at index {}. Expected: {}. Received: {}".format(i, self.expected_value[i], other[i]))
                     return False
         return True
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self._expected_element_type), pp.pformat(self._expected_size_or_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self._expected_element_type), pp.pformat(self._expected_size_or_value))
 
     def __str__(self):
         ret_str = self.__repr__() + '\n'
@@ -112,21 +112,21 @@ class ViStringMatcher(object):
                 pass
 
             if not isinstance(other, ctypes.Array):
-                print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_type, type(other)))
+                print("Unexpected type. Expected: {}. Received: {}".format(self.expected_type, type(other)))
                 return False
         if len(other) < len(self.expected_string_value) + 1:  # +1 for NULL terminating character
-            print("Unexpected length in C string. Expected at least: {0}. Received {1}".format(len(other), len(self.expected_string_value) + 1))
+            print("Unexpected length in C string. Expected at least: {}. Received {}".format(len(other), len(self.expected_string_value) + 1))
             return False
         if not isinstance(other[0], bytes):
-            print("Unexpected type. Not a string. Received: {0}".format(type(other[0])))
+            print("Unexpected type. Not a string. Received: {}".format(type(other[0])))
             return False
         if other.value.decode("ascii") != self.expected_string_value:
-            print("Unexpected value. Expected {0}. Received: {1}".format(self.expected_string_value, other.value.decode))
+            print("Unexpected value. Expected {}. Received: {}".format(self.expected_string_value, other.value.decode))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1})'.format(self.__class__.__name__, pp.pformat(self.expected_string_value))
+        return '{}({})'.format(self.__class__.__name__, pp.pformat(self.expected_string_value))
 
 
 # Custom Type
@@ -139,7 +139,7 @@ def _compare_ctype_structs(expected, actual):
         expected_val = getattr(expected, field_name)
         actual_val = getattr(actual, field_name)
         if expected_val != actual_val:
-            print("Unexpected value field {0}. Expected: {1}. Received: {2}".format(field_name, expected_val, actual_val))
+            print("Unexpected value field {}. Expected: {}. Received: {}".format(field_name, expected_val, actual_val))
             return False
     return True
 
@@ -151,12 +151,12 @@ class CustomTypeMatcher(object):
 
     def __eq__(self, actual):
         if not isinstance(actual, self.expected_type):
-            print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_type, type(actual)))
+            print("Unexpected type. Expected: {}. Received: {}".format(self.expected_type, type(actual)))
             return False
         return _compare_ctype_structs(self.expected_value, actual)
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
 
 
 class CustomTypeBufferMatcher(object):
@@ -168,17 +168,17 @@ class CustomTypeBufferMatcher(object):
 
     def __eq__(self, actual):
         if not isinstance(actual, self.expected_type):
-            print("Unexpected array type. Expected: {0}. Received: {1}".format(self.expected_type, type(actual)))
+            print("Unexpected array type. Expected: {}. Received: {}".format(self.expected_type, type(actual)))
             return False
         if self.expected_size != len(actual):
-            print("Unexpected length. Expected: {0}. Received: {1}".format(self.expected_size, len(actual)))
+            print("Unexpected length. Expected: {}. Received: {}".format(self.expected_size, len(actual)))
             return False
         if self.expected_value is not None:
             # Can't compare the objects directly because they're different types (one is list, another is ctypes array).
             # Go element by element, which allows for reporting the first index where different values were found.
             for a, e in zip(actual, self.expected_value):
                 if not isinstance(a, self.expected_element_type):
-                    print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_element_type, type(a)))
+                    print("Unexpected type. Expected: {}. Received: {}".format(self.expected_element_type, type(a)))
                     return False
                 if not _compare_ctype_structs(e, a):
                     return False
@@ -186,7 +186,7 @@ class CustomTypeBufferMatcher(object):
 
     def __repr__(self):
         expected_val_repr = '[' + ', '.join([x.__repr__() for x in self.expected_value]) + ']'
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_element_type), expected_val_repr)
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_element_type), expected_val_repr)
 
     def __str__(self):
         ret_str = self.__repr__() + '\n'

--- a/generated/nifake/nifake/unit_tests/test_grpc.py
+++ b/generated/nifake/nifake/unit_tests/test_grpc.py
@@ -39,7 +39,7 @@ class MyRpcError(grpc.RpcError):
             return [Metadatum('ni-error', str(self._error_code))]
 
 
-class TestGrpcStubInterpreter(object):
+class TestGrpcStubInterpreter:
 
     class PatchedGrpcTypes:
         def __init__(self):
@@ -93,7 +93,7 @@ class TestGrpcStubInterpreter(object):
 
     def _check_fields(self, response_class, **kwargs):
         fields = dict(kwargs)
-        response_fields = dict((x.name, x) for x in response_class.DESCRIPTOR.fields)
+        response_fields = {x.name: x for x in response_class.DESCRIPTOR.fields}
 
         unexpected_fields = set(fields) - set(response_fields)
         assert not unexpected_fields, 'Unexpected fields: ' + str(list(sorted(unexpected_fields)))

--- a/generated/nifake/nifake/unit_tests/test_library_interpreter.py
+++ b/generated/nifake/nifake/unit_tests/test_library_interpreter.py
@@ -17,7 +17,7 @@ import _mock_helper
 SESSION_NUM_FOR_TEST = 42
 
 
-class TestLibraryInterpreter(object):
+class TestLibraryInterpreter:
 
     class PatchedLibrary(nifake._library.Library):
         def __init__(self, ctypes_library):

--- a/generated/nifake/nifake/unit_tests/test_session.py
+++ b/generated/nifake/nifake/unit_tests/test_session.py
@@ -14,7 +14,7 @@ SESSION_NUM_FOR_TEST = 42
 GRPC_SESSION_OBJECT_FOR_TEST = object()
 
 
-class TestSession(object):
+class TestSession:
 
     class PatchedLibraryInterpreter(nifake._library_interpreter.LibraryInterpreter):
         def __init__(self, encoding):
@@ -838,7 +838,7 @@ class TestSession(object):
             self.patched_library_interpreter.return_list_of_durations_in_seconds.assert_called_once_with(len(time_values))
 
 
-class TestGrpcSession(object):
+class TestGrpcSession:
 
     class PatchedGrpcInterpreter(nifake._grpc_stub_interpreter.GrpcStubInterpreter):
         def __init__(self, grpc_options):
@@ -944,5 +944,5 @@ def test_diagnostic_information():
 
 
 def test_dunder_version():
-    print('Version = {}'.format(nifake.__version__))
+    print(f'Version = {nifake.__version__}')
     assert type(nifake.__version__) is str

--- a/generated/nifake/setup.py
+++ b/generated/nifake/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 # This file was generated
 
 

--- a/generated/nifgen/nifgen/_visatype.py
+++ b/generated/nifgen/nifgen/_visatype.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import ctypes
 
 

--- a/generated/nifgen/nifgen/errors.py
+++ b/generated/nifgen/nifgen/errors.py
@@ -40,7 +40,7 @@ class DriverWarning(Warning):
 
     def __init__(self, code, description):
         assert _is_warning(code), "Should not create Warning if code is not positive."
-        super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(DriverWarning, self).__init__('Warning {} occurred.\n\n{}'.format(code, description))
 
 
 class RpcError(Error):
@@ -89,7 +89,7 @@ class InvalidRepeatedCapabilityError(Error):
     '''An error due to an invalid character in a repeated capability'''
 
     def __init__(self, invalid_character, invalid_string):
-        super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({0}) was found in repeated capability string ({1})'.format(invalid_character, invalid_string))
+        super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({}) was found in repeated capability string ({})'.format(invalid_character, invalid_string))
 
 
 class SelfTestError(Error):
@@ -98,7 +98,7 @@ class SelfTestError(Error):
     def __init__(self, code, msg):
         self.code = code
         self.message = msg
-        super(SelfTestError, self).__init__('Self-test failed with code {0}: {1}'.format(code, msg))
+        super(SelfTestError, self).__init__('Self-test failed with code {}: {}'.format(code, msg))
 
 
 def handle_error(library_interpreter, code, ignore_warnings, is_error_handling):

--- a/generated/nifgen/nifgen/session.py
+++ b/generated/nifgen/nifgen/session.py
@@ -1547,14 +1547,14 @@ class _SessionBase(object):
             elif waveform_data_array.dtype == numpy.int16:
                 return self._create_waveform_i16_numpy(waveform_data_array)
             else:
-                raise TypeError("Unsupported dtype. Is {0}, expected {1} or {2}".format(waveform_data_array.dtype, numpy.float64, numpy.int16))
+                raise TypeError("Unsupported dtype. Is {}, expected {} or {}".format(waveform_data_array.dtype, numpy.float64, numpy.int16))
         elif isinstance(waveform_data_array, array.array):
             if waveform_data_array.typecode == 'd':
                 return self._create_waveform_f64(waveform_data_array)
             elif waveform_data_array.typecode == 'h':
                 return self._create_waveform_i16(waveform_data_array)
             else:
-                raise TypeError("Unsupported dtype. Is {0}, expected {1} or {2}".format(waveform_data_array.typecode, 'd (double)', 'h (16 bit int)'))
+                raise TypeError("Unsupported dtype. Is {}, expected {} or {}".format(waveform_data_array.typecode, 'd (double)', 'h (16 bit int)'))
 
         return self._create_waveform_f64(waveform_data_array)
 
@@ -2212,7 +2212,7 @@ class _SessionBase(object):
             pass  # This is how the function should be called
 
         else:
-            raise ValueError('Both trigger ({0}) and trigger_id ({1}) should be passed in to the method'.format(str(trigger), str(trigger_id)))
+            raise ValueError('Both trigger ({}) and trigger_id ({}) should be passed in to the method'.format(str(trigger), str(trigger_id)))
 
         if type(trigger) is not enums.Trigger:
             raise TypeError('Parameter trigger must be of type ' + str(enums.Trigger))
@@ -2936,14 +2936,14 @@ class _SessionBase(object):
             elif data.dtype == numpy.int16:
                 return self._write_named_waveform_i16_numpy(waveform_name_or_handle, data) if use_named else self._write_binary16_waveform_numpy(waveform_name_or_handle, data)
             else:
-                raise TypeError("Unsupported dtype. Is {0}, expected {1} or {2}".format(data.dtype, numpy.float64, numpy.int16))
+                raise TypeError("Unsupported dtype. Is {}, expected {} or {}".format(data.dtype, numpy.float64, numpy.int16))
         elif isinstance(data, array.array):
             if data.typecode == 'd':
                 return self._write_named_waveform_f64(waveform_name_or_handle, data) if use_named else self._write_waveform(waveform_name_or_handle, data)
             elif data.typecode == 'h':
                 return self._write_named_waveform_i16(waveform_name_or_handle, data) if use_named else self._write_binary16_waveform(waveform_name_or_handle, data)
             else:
-                raise TypeError("Unsupported dtype. Is {0}, expected {1} or {2}".format(data.typecode, 'd (double)', 'h (16 bit int)'))
+                raise TypeError("Unsupported dtype. Is {}, expected {} or {}".format(data.typecode, 'd (double)', 'h (16 bit int)'))
 
         return self._write_named_waveform_f64(waveform_name_or_handle, data) if use_named else self._write_waveform(waveform_name_or_handle, data)
 

--- a/generated/nifgen/nifgen/unit_tests/_matchers.py
+++ b/generated/nifgen/nifgen/unit_tests/_matchers.py
@@ -21,15 +21,15 @@ class _ScalarMatcher(object):
 
     def __eq__(self, other):
         if not isinstance(other, self.expected_type):
-            print("{0}: Unexpected type. Expected: {1}. Received: {2}".format(self.__class__.__name__, self.expected_type, type(other)))
+            print("{}: Unexpected type. Expected: {}. Received: {}".format(self.__class__.__name__, self.expected_type, type(other)))
             return False
         if other.value != self.expected_value:
-            print("{0}: Unexpected value. Expected: {1}. Received: {2}".format(self.__class__.__name__, self.expected_value, other.value))
+            print("{}: Unexpected value. Expected: {}. Received: {}".format(self.__class__.__name__, self.expected_value, other.value))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
 
 
 class _PointerMatcher(object):
@@ -38,12 +38,12 @@ class _PointerMatcher(object):
 
     def __eq__(self, other):
         if not isinstance(other, ctypes.POINTER(self.expected_type)):
-            print("Unexpected type. Expected: {0}. Received: {1}".format(ctypes.POINTER(self.expected_type), type(other)))
+            print("Unexpected type. Expected: {}. Received: {}".format(ctypes.POINTER(self.expected_type), type(other)))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1})'.format(self.__class__.__name__, pp.pformat(self.expected_type))
+        return '{}({})'.format(self.__class__.__name__, pp.pformat(self.expected_type))
 
 
 class _BufferMatcher(object):
@@ -71,22 +71,22 @@ class _BufferMatcher(object):
 
             # Because of object lifetimes, we may need to mock the other instance and provide lists instead of the actual array
             if not isinstance(other, self.expected_type) and not isinstance(other, list):
-                print("Unexpected type. Expected: {0} or {1}. Received: {2}".format(self.expected_type, list, type(other)))
+                print("Unexpected type. Expected: {} or {}. Received: {}".format(self.expected_type, list, type(other)))
                 return False
         if self.expected_size != len(other):
-            print("Unexpected length. Expected: {0}. Received: {1}".format(self.expected_size, len(other)))
+            print("Unexpected length. Expected: {}. Received: {}".format(self.expected_size, len(other)))
             return False
         if self.expected_value is not None:
             # Can't compare the objects directly because they're different types (one is list, another is ctypes array).
             # Go element by element, which allows for reporting the first index where different values were found.
             for i in range(0, len(self.expected_value)):
                 if self.expected_value[i] != other[i]:
-                    print("Unexpected value at index {0}. Expected: {1}. Received: {2}".format(i, self.expected_value[i], other[i]))
+                    print("Unexpected value at index {}. Expected: {}. Received: {}".format(i, self.expected_value[i], other[i]))
                     return False
         return True
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self._expected_element_type), pp.pformat(self._expected_size_or_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self._expected_element_type), pp.pformat(self._expected_size_or_value))
 
     def __str__(self):
         ret_str = self.__repr__() + '\n'
@@ -112,21 +112,21 @@ class ViStringMatcher(object):
                 pass
 
             if not isinstance(other, ctypes.Array):
-                print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_type, type(other)))
+                print("Unexpected type. Expected: {}. Received: {}".format(self.expected_type, type(other)))
                 return False
         if len(other) < len(self.expected_string_value) + 1:  # +1 for NULL terminating character
-            print("Unexpected length in C string. Expected at least: {0}. Received {1}".format(len(other), len(self.expected_string_value) + 1))
+            print("Unexpected length in C string. Expected at least: {}. Received {}".format(len(other), len(self.expected_string_value) + 1))
             return False
         if not isinstance(other[0], bytes):
-            print("Unexpected type. Not a string. Received: {0}".format(type(other[0])))
+            print("Unexpected type. Not a string. Received: {}".format(type(other[0])))
             return False
         if other.value.decode("ascii") != self.expected_string_value:
-            print("Unexpected value. Expected {0}. Received: {1}".format(self.expected_string_value, other.value.decode))
+            print("Unexpected value. Expected {}. Received: {}".format(self.expected_string_value, other.value.decode))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1})'.format(self.__class__.__name__, pp.pformat(self.expected_string_value))
+        return '{}({})'.format(self.__class__.__name__, pp.pformat(self.expected_string_value))
 
 
 # Custom Type
@@ -139,7 +139,7 @@ def _compare_ctype_structs(expected, actual):
         expected_val = getattr(expected, field_name)
         actual_val = getattr(actual, field_name)
         if expected_val != actual_val:
-            print("Unexpected value field {0}. Expected: {1}. Received: {2}".format(field_name, expected_val, actual_val))
+            print("Unexpected value field {}. Expected: {}. Received: {}".format(field_name, expected_val, actual_val))
             return False
     return True
 
@@ -151,12 +151,12 @@ class CustomTypeMatcher(object):
 
     def __eq__(self, actual):
         if not isinstance(actual, self.expected_type):
-            print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_type, type(actual)))
+            print("Unexpected type. Expected: {}. Received: {}".format(self.expected_type, type(actual)))
             return False
         return _compare_ctype_structs(self.expected_value, actual)
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
 
 
 class CustomTypeBufferMatcher(object):
@@ -168,17 +168,17 @@ class CustomTypeBufferMatcher(object):
 
     def __eq__(self, actual):
         if not isinstance(actual, self.expected_type):
-            print("Unexpected array type. Expected: {0}. Received: {1}".format(self.expected_type, type(actual)))
+            print("Unexpected array type. Expected: {}. Received: {}".format(self.expected_type, type(actual)))
             return False
         if self.expected_size != len(actual):
-            print("Unexpected length. Expected: {0}. Received: {1}".format(self.expected_size, len(actual)))
+            print("Unexpected length. Expected: {}. Received: {}".format(self.expected_size, len(actual)))
             return False
         if self.expected_value is not None:
             # Can't compare the objects directly because they're different types (one is list, another is ctypes array).
             # Go element by element, which allows for reporting the first index where different values were found.
             for a, e in zip(actual, self.expected_value):
                 if not isinstance(a, self.expected_element_type):
-                    print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_element_type, type(a)))
+                    print("Unexpected type. Expected: {}. Received: {}".format(self.expected_element_type, type(a)))
                     return False
                 if not _compare_ctype_structs(e, a):
                     return False
@@ -186,7 +186,7 @@ class CustomTypeBufferMatcher(object):
 
     def __repr__(self):
         expected_val_repr = '[' + ', '.join([x.__repr__() for x in self.expected_value]) + ']'
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_element_type), expected_val_repr)
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_element_type), expected_val_repr)
 
     def __str__(self):
         ret_str = self.__repr__() + '\n'

--- a/generated/nifgen/setup.py
+++ b/generated/nifgen/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 # This file was generated
 
 

--- a/generated/nimodinst/nimodinst/_visatype.py
+++ b/generated/nimodinst/nimodinst/_visatype.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import ctypes
 
 

--- a/generated/nimodinst/nimodinst/errors.py
+++ b/generated/nimodinst/nimodinst/errors.py
@@ -40,7 +40,7 @@ class DriverWarning(Warning):
 
     def __init__(self, code, description):
         assert _is_warning(code), "Should not create Warning if code is not positive."
-        super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(DriverWarning, self).__init__('Warning {} occurred.\n\n{}'.format(code, description))
 
 
 class UnsupportedConfigurationError(Error):

--- a/generated/nimodinst/nimodinst/unit_tests/_matchers.py
+++ b/generated/nimodinst/nimodinst/unit_tests/_matchers.py
@@ -21,15 +21,15 @@ class _ScalarMatcher(object):
 
     def __eq__(self, other):
         if not isinstance(other, self.expected_type):
-            print("{0}: Unexpected type. Expected: {1}. Received: {2}".format(self.__class__.__name__, self.expected_type, type(other)))
+            print("{}: Unexpected type. Expected: {}. Received: {}".format(self.__class__.__name__, self.expected_type, type(other)))
             return False
         if other.value != self.expected_value:
-            print("{0}: Unexpected value. Expected: {1}. Received: {2}".format(self.__class__.__name__, self.expected_value, other.value))
+            print("{}: Unexpected value. Expected: {}. Received: {}".format(self.__class__.__name__, self.expected_value, other.value))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
 
 
 class _PointerMatcher(object):
@@ -38,12 +38,12 @@ class _PointerMatcher(object):
 
     def __eq__(self, other):
         if not isinstance(other, ctypes.POINTER(self.expected_type)):
-            print("Unexpected type. Expected: {0}. Received: {1}".format(ctypes.POINTER(self.expected_type), type(other)))
+            print("Unexpected type. Expected: {}. Received: {}".format(ctypes.POINTER(self.expected_type), type(other)))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1})'.format(self.__class__.__name__, pp.pformat(self.expected_type))
+        return '{}({})'.format(self.__class__.__name__, pp.pformat(self.expected_type))
 
 
 class _BufferMatcher(object):
@@ -71,22 +71,22 @@ class _BufferMatcher(object):
 
             # Because of object lifetimes, we may need to mock the other instance and provide lists instead of the actual array
             if not isinstance(other, self.expected_type) and not isinstance(other, list):
-                print("Unexpected type. Expected: {0} or {1}. Received: {2}".format(self.expected_type, list, type(other)))
+                print("Unexpected type. Expected: {} or {}. Received: {}".format(self.expected_type, list, type(other)))
                 return False
         if self.expected_size != len(other):
-            print("Unexpected length. Expected: {0}. Received: {1}".format(self.expected_size, len(other)))
+            print("Unexpected length. Expected: {}. Received: {}".format(self.expected_size, len(other)))
             return False
         if self.expected_value is not None:
             # Can't compare the objects directly because they're different types (one is list, another is ctypes array).
             # Go element by element, which allows for reporting the first index where different values were found.
             for i in range(0, len(self.expected_value)):
                 if self.expected_value[i] != other[i]:
-                    print("Unexpected value at index {0}. Expected: {1}. Received: {2}".format(i, self.expected_value[i], other[i]))
+                    print("Unexpected value at index {}. Expected: {}. Received: {}".format(i, self.expected_value[i], other[i]))
                     return False
         return True
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self._expected_element_type), pp.pformat(self._expected_size_or_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self._expected_element_type), pp.pformat(self._expected_size_or_value))
 
     def __str__(self):
         ret_str = self.__repr__() + '\n'
@@ -112,21 +112,21 @@ class ViStringMatcher(object):
                 pass
 
             if not isinstance(other, ctypes.Array):
-                print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_type, type(other)))
+                print("Unexpected type. Expected: {}. Received: {}".format(self.expected_type, type(other)))
                 return False
         if len(other) < len(self.expected_string_value) + 1:  # +1 for NULL terminating character
-            print("Unexpected length in C string. Expected at least: {0}. Received {1}".format(len(other), len(self.expected_string_value) + 1))
+            print("Unexpected length in C string. Expected at least: {}. Received {}".format(len(other), len(self.expected_string_value) + 1))
             return False
         if not isinstance(other[0], bytes):
-            print("Unexpected type. Not a string. Received: {0}".format(type(other[0])))
+            print("Unexpected type. Not a string. Received: {}".format(type(other[0])))
             return False
         if other.value.decode("ascii") != self.expected_string_value:
-            print("Unexpected value. Expected {0}. Received: {1}".format(self.expected_string_value, other.value.decode))
+            print("Unexpected value. Expected {}. Received: {}".format(self.expected_string_value, other.value.decode))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1})'.format(self.__class__.__name__, pp.pformat(self.expected_string_value))
+        return '{}({})'.format(self.__class__.__name__, pp.pformat(self.expected_string_value))
 
 
 # Custom Type
@@ -139,7 +139,7 @@ def _compare_ctype_structs(expected, actual):
         expected_val = getattr(expected, field_name)
         actual_val = getattr(actual, field_name)
         if expected_val != actual_val:
-            print("Unexpected value field {0}. Expected: {1}. Received: {2}".format(field_name, expected_val, actual_val))
+            print("Unexpected value field {}. Expected: {}. Received: {}".format(field_name, expected_val, actual_val))
             return False
     return True
 
@@ -151,12 +151,12 @@ class CustomTypeMatcher(object):
 
     def __eq__(self, actual):
         if not isinstance(actual, self.expected_type):
-            print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_type, type(actual)))
+            print("Unexpected type. Expected: {}. Received: {}".format(self.expected_type, type(actual)))
             return False
         return _compare_ctype_structs(self.expected_value, actual)
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
 
 
 class CustomTypeBufferMatcher(object):
@@ -168,17 +168,17 @@ class CustomTypeBufferMatcher(object):
 
     def __eq__(self, actual):
         if not isinstance(actual, self.expected_type):
-            print("Unexpected array type. Expected: {0}. Received: {1}".format(self.expected_type, type(actual)))
+            print("Unexpected array type. Expected: {}. Received: {}".format(self.expected_type, type(actual)))
             return False
         if self.expected_size != len(actual):
-            print("Unexpected length. Expected: {0}. Received: {1}".format(self.expected_size, len(actual)))
+            print("Unexpected length. Expected: {}. Received: {}".format(self.expected_size, len(actual)))
             return False
         if self.expected_value is not None:
             # Can't compare the objects directly because they're different types (one is list, another is ctypes array).
             # Go element by element, which allows for reporting the first index where different values were found.
             for a, e in zip(actual, self.expected_value):
                 if not isinstance(a, self.expected_element_type):
-                    print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_element_type, type(a)))
+                    print("Unexpected type. Expected: {}. Received: {}".format(self.expected_element_type, type(a)))
                     return False
                 if not _compare_ctype_structs(e, a):
                     return False
@@ -186,7 +186,7 @@ class CustomTypeBufferMatcher(object):
 
     def __repr__(self):
         expected_val_repr = '[' + ', '.join([x.__repr__() for x in self.expected_value]) + ']'
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_element_type), expected_val_repr)
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_element_type), expected_val_repr)
 
     def __str__(self):
         ret_str = self.__repr__() + '\n'

--- a/generated/nimodinst/nimodinst/unit_tests/test_modinst.py
+++ b/generated/nimodinst/nimodinst/unit_tests/test_modinst.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 SESSION_NUM_FOR_TEST = 42
 
 
-class TestSession(object):
+class TestSession:
     class PatchedLibrary(nimodinst._library.Library):
         def __init__(self, ctypes_library):
             super().__init__(ctypes_library)

--- a/generated/nimodinst/setup.py
+++ b/generated/nimodinst/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 # This file was generated
 
 

--- a/generated/niscope/README.rst
+++ b/generated/niscope/README.rst
@@ -125,7 +125,7 @@ The following is a basic example of using the **niscope** module to open a sessi
         with session.initiate():
             waveforms = session.channels[0,1].fetch(num_records=5)
         for wfm in waveforms:
-            print('Channel {0}, record {1} samples acquired: {2:,}\n'.format(wfm.channel, wfm.record, len(wfm.samples)))
+            print('Channel {}, record {} samples acquired: {:,}\n'.format(wfm.channel, wfm.record, len(wfm.samples)))
 
         # Find all channel 1 records (Note channel name is always a string even if integers used in channel[])
         chan1 = [wfm for wfm in waveforms if wfm.channel == '0']

--- a/generated/niscope/niscope/_visatype.py
+++ b/generated/niscope/niscope/_visatype.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import ctypes
 
 

--- a/generated/niscope/niscope/errors.py
+++ b/generated/niscope/niscope/errors.py
@@ -40,7 +40,7 @@ class DriverWarning(Warning):
 
     def __init__(self, code, description):
         assert _is_warning(code), "Should not create Warning if code is not positive."
-        super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(DriverWarning, self).__init__('Warning {} occurred.\n\n{}'.format(code, description))
 
 
 class RpcError(Error):
@@ -89,7 +89,7 @@ class InvalidRepeatedCapabilityError(Error):
     '''An error due to an invalid character in a repeated capability'''
 
     def __init__(self, invalid_character, invalid_string):
-        super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({0}) was found in repeated capability string ({1})'.format(invalid_character, invalid_string))
+        super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({}) was found in repeated capability string ({})'.format(invalid_character, invalid_string))
 
 
 class SelfTestError(Error):
@@ -98,7 +98,7 @@ class SelfTestError(Error):
     def __init__(self, code, msg):
         self.code = code
         self.message = msg
-        super(SelfTestError, self).__init__('Self-test failed with code {0}: {1}'.format(code, msg))
+        super(SelfTestError, self).__init__('Self-test failed with code {}: {}'.format(code, msg))
 
 
 def handle_error(library_interpreter, code, ignore_warnings, is_error_handling):

--- a/generated/niscope/niscope/measurement_stats.py
+++ b/generated/niscope/niscope/measurement_stats.py
@@ -1,4 +1,4 @@
-class MeasurementStats(object):
+class MeasurementStats:
     def __init__(self, result=0.0, mean=0.0, stdev=0.0, min_val=0.0, max_val=0.0, num_in_stats=0):
         self.result = result
         self.mean = mean
@@ -12,15 +12,15 @@ class MeasurementStats(object):
 
     def __repr__(self):
         parameter_list = [
-            'result={}'.format(self.result),
-            'mean={}'.format(self.mean),
-            'stdev={}'.format(self.stdev),
-            'min_val={}'.format(self.min_val),
-            'max_val={}'.format(self.max_val),
-            'num_in_stats={}'.format(self.num_in_stats)
+            f'result={self.result}',
+            f'mean={self.mean}',
+            f'stdev={self.stdev}',
+            f'min_val={self.min_val}',
+            f'max_val={self.max_val}',
+            f'num_in_stats={self.num_in_stats}'
         ]
 
-        return '{0}({1})'.format(self.__class__.__name__, ', '.join(parameter_list))
+        return '{}({})'.format(self.__class__.__name__, ', '.join(parameter_list))
 
     def __str__(self):
         row_format_g = '{:<20}: {:,.6g}\n'

--- a/generated/niscope/niscope/session.py
+++ b/generated/niscope/niscope/session.py
@@ -3163,7 +3163,7 @@ class _SessionBase(object):
         elif waveform.dtype == numpy.int32:
             wfm_info = self._fetch_binary32_into_numpy(num_samples=num_samples, waveform=waveform, timeout=timeout)
         else:
-            raise TypeError("Unsupported dtype. Is {0}, expected {1}, {2}, {3}, or {4}".format(waveform.dtype, numpy.float64, numpy.int8, numpy.int16, numpy.int32))
+            raise TypeError("Unsupported dtype. Is {}, expected {}, {}, {}, or {}".format(waveform.dtype, numpy.float64, numpy.int8, numpy.int16, numpy.int32))
 
         mv = memoryview(waveform)
 

--- a/generated/niscope/niscope/unit_tests/_matchers.py
+++ b/generated/niscope/niscope/unit_tests/_matchers.py
@@ -21,15 +21,15 @@ class _ScalarMatcher(object):
 
     def __eq__(self, other):
         if not isinstance(other, self.expected_type):
-            print("{0}: Unexpected type. Expected: {1}. Received: {2}".format(self.__class__.__name__, self.expected_type, type(other)))
+            print("{}: Unexpected type. Expected: {}. Received: {}".format(self.__class__.__name__, self.expected_type, type(other)))
             return False
         if other.value != self.expected_value:
-            print("{0}: Unexpected value. Expected: {1}. Received: {2}".format(self.__class__.__name__, self.expected_value, other.value))
+            print("{}: Unexpected value. Expected: {}. Received: {}".format(self.__class__.__name__, self.expected_value, other.value))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
 
 
 class _PointerMatcher(object):
@@ -38,12 +38,12 @@ class _PointerMatcher(object):
 
     def __eq__(self, other):
         if not isinstance(other, ctypes.POINTER(self.expected_type)):
-            print("Unexpected type. Expected: {0}. Received: {1}".format(ctypes.POINTER(self.expected_type), type(other)))
+            print("Unexpected type. Expected: {}. Received: {}".format(ctypes.POINTER(self.expected_type), type(other)))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1})'.format(self.__class__.__name__, pp.pformat(self.expected_type))
+        return '{}({})'.format(self.__class__.__name__, pp.pformat(self.expected_type))
 
 
 class _BufferMatcher(object):
@@ -71,22 +71,22 @@ class _BufferMatcher(object):
 
             # Because of object lifetimes, we may need to mock the other instance and provide lists instead of the actual array
             if not isinstance(other, self.expected_type) and not isinstance(other, list):
-                print("Unexpected type. Expected: {0} or {1}. Received: {2}".format(self.expected_type, list, type(other)))
+                print("Unexpected type. Expected: {} or {}. Received: {}".format(self.expected_type, list, type(other)))
                 return False
         if self.expected_size != len(other):
-            print("Unexpected length. Expected: {0}. Received: {1}".format(self.expected_size, len(other)))
+            print("Unexpected length. Expected: {}. Received: {}".format(self.expected_size, len(other)))
             return False
         if self.expected_value is not None:
             # Can't compare the objects directly because they're different types (one is list, another is ctypes array).
             # Go element by element, which allows for reporting the first index where different values were found.
             for i in range(0, len(self.expected_value)):
                 if self.expected_value[i] != other[i]:
-                    print("Unexpected value at index {0}. Expected: {1}. Received: {2}".format(i, self.expected_value[i], other[i]))
+                    print("Unexpected value at index {}. Expected: {}. Received: {}".format(i, self.expected_value[i], other[i]))
                     return False
         return True
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self._expected_element_type), pp.pformat(self._expected_size_or_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self._expected_element_type), pp.pformat(self._expected_size_or_value))
 
     def __str__(self):
         ret_str = self.__repr__() + '\n'
@@ -112,21 +112,21 @@ class ViStringMatcher(object):
                 pass
 
             if not isinstance(other, ctypes.Array):
-                print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_type, type(other)))
+                print("Unexpected type. Expected: {}. Received: {}".format(self.expected_type, type(other)))
                 return False
         if len(other) < len(self.expected_string_value) + 1:  # +1 for NULL terminating character
-            print("Unexpected length in C string. Expected at least: {0}. Received {1}".format(len(other), len(self.expected_string_value) + 1))
+            print("Unexpected length in C string. Expected at least: {}. Received {}".format(len(other), len(self.expected_string_value) + 1))
             return False
         if not isinstance(other[0], bytes):
-            print("Unexpected type. Not a string. Received: {0}".format(type(other[0])))
+            print("Unexpected type. Not a string. Received: {}".format(type(other[0])))
             return False
         if other.value.decode("ascii") != self.expected_string_value:
-            print("Unexpected value. Expected {0}. Received: {1}".format(self.expected_string_value, other.value.decode))
+            print("Unexpected value. Expected {}. Received: {}".format(self.expected_string_value, other.value.decode))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1})'.format(self.__class__.__name__, pp.pformat(self.expected_string_value))
+        return '{}({})'.format(self.__class__.__name__, pp.pformat(self.expected_string_value))
 
 
 # Custom Type
@@ -139,7 +139,7 @@ def _compare_ctype_structs(expected, actual):
         expected_val = getattr(expected, field_name)
         actual_val = getattr(actual, field_name)
         if expected_val != actual_val:
-            print("Unexpected value field {0}. Expected: {1}. Received: {2}".format(field_name, expected_val, actual_val))
+            print("Unexpected value field {}. Expected: {}. Received: {}".format(field_name, expected_val, actual_val))
             return False
     return True
 
@@ -151,12 +151,12 @@ class CustomTypeMatcher(object):
 
     def __eq__(self, actual):
         if not isinstance(actual, self.expected_type):
-            print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_type, type(actual)))
+            print("Unexpected type. Expected: {}. Received: {}".format(self.expected_type, type(actual)))
             return False
         return _compare_ctype_structs(self.expected_value, actual)
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
 
 
 class CustomTypeBufferMatcher(object):
@@ -168,17 +168,17 @@ class CustomTypeBufferMatcher(object):
 
     def __eq__(self, actual):
         if not isinstance(actual, self.expected_type):
-            print("Unexpected array type. Expected: {0}. Received: {1}".format(self.expected_type, type(actual)))
+            print("Unexpected array type. Expected: {}. Received: {}".format(self.expected_type, type(actual)))
             return False
         if self.expected_size != len(actual):
-            print("Unexpected length. Expected: {0}. Received: {1}".format(self.expected_size, len(actual)))
+            print("Unexpected length. Expected: {}. Received: {}".format(self.expected_size, len(actual)))
             return False
         if self.expected_value is not None:
             # Can't compare the objects directly because they're different types (one is list, another is ctypes array).
             # Go element by element, which allows for reporting the first index where different values were found.
             for a, e in zip(actual, self.expected_value):
                 if not isinstance(a, self.expected_element_type):
-                    print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_element_type, type(a)))
+                    print("Unexpected type. Expected: {}. Received: {}".format(self.expected_element_type, type(a)))
                     return False
                 if not _compare_ctype_structs(e, a):
                     return False
@@ -186,7 +186,7 @@ class CustomTypeBufferMatcher(object):
 
     def __repr__(self):
         expected_val_repr = '[' + ', '.join([x.__repr__() for x in self.expected_value]) + ']'
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_element_type), expected_val_repr)
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_element_type), expected_val_repr)
 
     def __str__(self):
         ret_str = self.__repr__() + '\n'

--- a/generated/niscope/niscope/waveform_info.py
+++ b/generated/niscope/niscope/waveform_info.py
@@ -43,7 +43,7 @@ class struct_niScope_wfmInfo(ctypes.Structure):  # noqa N801
             self.reserved2 = reserved2
 
 
-class WaveformInfo(object):
+class WaveformInfo:
     def __init__(self, data=None, absolute_initial_x=0.0, relative_initial_x=0.0,
                  x_increment=0.0, offset=0.0, gain=0.0,
                  reserved1=0.0, reserved2=0.0):
@@ -75,14 +75,14 @@ class WaveformInfo(object):
 
     def __repr__(self):
         parameter_list = [
-            'absolute_initial_x={}'.format(self.absolute_initial_x),
-            'relative_initial_x={}'.format(self.relative_initial_x),
-            'x_increment={}'.format(self.x_increment),
-            'offset={}'.format(self.offset),
-            'gain={}'.format(self.gain)
+            f'absolute_initial_x={self.absolute_initial_x}',
+            f'relative_initial_x={self.relative_initial_x}',
+            f'x_increment={self.x_increment}',
+            f'offset={self.offset}',
+            f'gain={self.gain}'
         ]
 
-        return '{0}({1})'.format(self.__class__.__name__, ', '.join(parameter_list))
+        return '{}({})'.format(self.__class__.__name__, ', '.join(parameter_list))
 
     def __str__(self):
         # different format lines

--- a/generated/niscope/setup.py
+++ b/generated/niscope/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 # This file was generated
 
 

--- a/generated/nise/nise/_visatype.py
+++ b/generated/nise/nise/_visatype.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import ctypes
 
 

--- a/generated/nise/nise/errors.py
+++ b/generated/nise/nise/errors.py
@@ -40,7 +40,7 @@ class DriverWarning(Warning):
 
     def __init__(self, code, description):
         assert _is_warning(code), "Should not create Warning if code is not positive."
-        super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(DriverWarning, self).__init__('Warning {} occurred.\n\n{}'.format(code, description))
 
 
 class UnsupportedConfigurationError(Error):
@@ -75,7 +75,7 @@ class InvalidRepeatedCapabilityError(Error):
     '''An error due to an invalid character in a repeated capability'''
 
     def __init__(self, invalid_character, invalid_string):
-        super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({0}) was found in repeated capability string ({1})'.format(invalid_character, invalid_string))
+        super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({}) was found in repeated capability string ({})'.format(invalid_character, invalid_string))
 
 
 def handle_error(library_interpreter, code, ignore_warnings, is_error_handling):

--- a/generated/nise/nise/unit_tests/_matchers.py
+++ b/generated/nise/nise/unit_tests/_matchers.py
@@ -21,15 +21,15 @@ class _ScalarMatcher(object):
 
     def __eq__(self, other):
         if not isinstance(other, self.expected_type):
-            print("{0}: Unexpected type. Expected: {1}. Received: {2}".format(self.__class__.__name__, self.expected_type, type(other)))
+            print("{}: Unexpected type. Expected: {}. Received: {}".format(self.__class__.__name__, self.expected_type, type(other)))
             return False
         if other.value != self.expected_value:
-            print("{0}: Unexpected value. Expected: {1}. Received: {2}".format(self.__class__.__name__, self.expected_value, other.value))
+            print("{}: Unexpected value. Expected: {}. Received: {}".format(self.__class__.__name__, self.expected_value, other.value))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
 
 
 class _PointerMatcher(object):
@@ -38,12 +38,12 @@ class _PointerMatcher(object):
 
     def __eq__(self, other):
         if not isinstance(other, ctypes.POINTER(self.expected_type)):
-            print("Unexpected type. Expected: {0}. Received: {1}".format(ctypes.POINTER(self.expected_type), type(other)))
+            print("Unexpected type. Expected: {}. Received: {}".format(ctypes.POINTER(self.expected_type), type(other)))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1})'.format(self.__class__.__name__, pp.pformat(self.expected_type))
+        return '{}({})'.format(self.__class__.__name__, pp.pformat(self.expected_type))
 
 
 class _BufferMatcher(object):
@@ -71,22 +71,22 @@ class _BufferMatcher(object):
 
             # Because of object lifetimes, we may need to mock the other instance and provide lists instead of the actual array
             if not isinstance(other, self.expected_type) and not isinstance(other, list):
-                print("Unexpected type. Expected: {0} or {1}. Received: {2}".format(self.expected_type, list, type(other)))
+                print("Unexpected type. Expected: {} or {}. Received: {}".format(self.expected_type, list, type(other)))
                 return False
         if self.expected_size != len(other):
-            print("Unexpected length. Expected: {0}. Received: {1}".format(self.expected_size, len(other)))
+            print("Unexpected length. Expected: {}. Received: {}".format(self.expected_size, len(other)))
             return False
         if self.expected_value is not None:
             # Can't compare the objects directly because they're different types (one is list, another is ctypes array).
             # Go element by element, which allows for reporting the first index where different values were found.
             for i in range(0, len(self.expected_value)):
                 if self.expected_value[i] != other[i]:
-                    print("Unexpected value at index {0}. Expected: {1}. Received: {2}".format(i, self.expected_value[i], other[i]))
+                    print("Unexpected value at index {}. Expected: {}. Received: {}".format(i, self.expected_value[i], other[i]))
                     return False
         return True
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self._expected_element_type), pp.pformat(self._expected_size_or_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self._expected_element_type), pp.pformat(self._expected_size_or_value))
 
     def __str__(self):
         ret_str = self.__repr__() + '\n'
@@ -112,21 +112,21 @@ class ViStringMatcher(object):
                 pass
 
             if not isinstance(other, ctypes.Array):
-                print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_type, type(other)))
+                print("Unexpected type. Expected: {}. Received: {}".format(self.expected_type, type(other)))
                 return False
         if len(other) < len(self.expected_string_value) + 1:  # +1 for NULL terminating character
-            print("Unexpected length in C string. Expected at least: {0}. Received {1}".format(len(other), len(self.expected_string_value) + 1))
+            print("Unexpected length in C string. Expected at least: {}. Received {}".format(len(other), len(self.expected_string_value) + 1))
             return False
         if not isinstance(other[0], bytes):
-            print("Unexpected type. Not a string. Received: {0}".format(type(other[0])))
+            print("Unexpected type. Not a string. Received: {}".format(type(other[0])))
             return False
         if other.value.decode("ascii") != self.expected_string_value:
-            print("Unexpected value. Expected {0}. Received: {1}".format(self.expected_string_value, other.value.decode))
+            print("Unexpected value. Expected {}. Received: {}".format(self.expected_string_value, other.value.decode))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1})'.format(self.__class__.__name__, pp.pformat(self.expected_string_value))
+        return '{}({})'.format(self.__class__.__name__, pp.pformat(self.expected_string_value))
 
 
 # Custom Type
@@ -139,7 +139,7 @@ def _compare_ctype_structs(expected, actual):
         expected_val = getattr(expected, field_name)
         actual_val = getattr(actual, field_name)
         if expected_val != actual_val:
-            print("Unexpected value field {0}. Expected: {1}. Received: {2}".format(field_name, expected_val, actual_val))
+            print("Unexpected value field {}. Expected: {}. Received: {}".format(field_name, expected_val, actual_val))
             return False
     return True
 
@@ -151,12 +151,12 @@ class CustomTypeMatcher(object):
 
     def __eq__(self, actual):
         if not isinstance(actual, self.expected_type):
-            print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_type, type(actual)))
+            print("Unexpected type. Expected: {}. Received: {}".format(self.expected_type, type(actual)))
             return False
         return _compare_ctype_structs(self.expected_value, actual)
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
 
 
 class CustomTypeBufferMatcher(object):
@@ -168,17 +168,17 @@ class CustomTypeBufferMatcher(object):
 
     def __eq__(self, actual):
         if not isinstance(actual, self.expected_type):
-            print("Unexpected array type. Expected: {0}. Received: {1}".format(self.expected_type, type(actual)))
+            print("Unexpected array type. Expected: {}. Received: {}".format(self.expected_type, type(actual)))
             return False
         if self.expected_size != len(actual):
-            print("Unexpected length. Expected: {0}. Received: {1}".format(self.expected_size, len(actual)))
+            print("Unexpected length. Expected: {}. Received: {}".format(self.expected_size, len(actual)))
             return False
         if self.expected_value is not None:
             # Can't compare the objects directly because they're different types (one is list, another is ctypes array).
             # Go element by element, which allows for reporting the first index where different values were found.
             for a, e in zip(actual, self.expected_value):
                 if not isinstance(a, self.expected_element_type):
-                    print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_element_type, type(a)))
+                    print("Unexpected type. Expected: {}. Received: {}".format(self.expected_element_type, type(a)))
                     return False
                 if not _compare_ctype_structs(e, a):
                     return False
@@ -186,7 +186,7 @@ class CustomTypeBufferMatcher(object):
 
     def __repr__(self):
         expected_val_repr = '[' + ', '.join([x.__repr__() for x in self.expected_value]) + ']'
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_element_type), expected_val_repr)
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_element_type), expected_val_repr)
 
     def __str__(self):
         ret_str = self.__repr__() + '\n'

--- a/generated/nise/setup.py
+++ b/generated/nise/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 # This file was generated
 
 

--- a/generated/niswitch/niswitch/_visatype.py
+++ b/generated/niswitch/niswitch/_visatype.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import ctypes
 
 

--- a/generated/niswitch/niswitch/errors.py
+++ b/generated/niswitch/niswitch/errors.py
@@ -40,7 +40,7 @@ class DriverWarning(Warning):
 
     def __init__(self, code, description):
         assert _is_warning(code), "Should not create Warning if code is not positive."
-        super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(DriverWarning, self).__init__('Warning {} occurred.\n\n{}'.format(code, description))
 
 
 class RpcError(Error):
@@ -89,7 +89,7 @@ class InvalidRepeatedCapabilityError(Error):
     '''An error due to an invalid character in a repeated capability'''
 
     def __init__(self, invalid_character, invalid_string):
-        super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({0}) was found in repeated capability string ({1})'.format(invalid_character, invalid_string))
+        super(InvalidRepeatedCapabilityError, self).__init__('An invalid character ({}) was found in repeated capability string ({})'.format(invalid_character, invalid_string))
 
 
 class SelfTestError(Error):
@@ -98,7 +98,7 @@ class SelfTestError(Error):
     def __init__(self, code, msg):
         self.code = code
         self.message = msg
-        super(SelfTestError, self).__init__('Self-test failed with code {0}: {1}'.format(code, msg))
+        super(SelfTestError, self).__init__('Self-test failed with code {}: {}'.format(code, msg))
 
 
 def handle_error(library_interpreter, code, ignore_warnings, is_error_handling):

--- a/generated/niswitch/niswitch/unit_tests/_matchers.py
+++ b/generated/niswitch/niswitch/unit_tests/_matchers.py
@@ -21,15 +21,15 @@ class _ScalarMatcher(object):
 
     def __eq__(self, other):
         if not isinstance(other, self.expected_type):
-            print("{0}: Unexpected type. Expected: {1}. Received: {2}".format(self.__class__.__name__, self.expected_type, type(other)))
+            print("{}: Unexpected type. Expected: {}. Received: {}".format(self.__class__.__name__, self.expected_type, type(other)))
             return False
         if other.value != self.expected_value:
-            print("{0}: Unexpected value. Expected: {1}. Received: {2}".format(self.__class__.__name__, self.expected_value, other.value))
+            print("{}: Unexpected value. Expected: {}. Received: {}".format(self.__class__.__name__, self.expected_value, other.value))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
 
 
 class _PointerMatcher(object):
@@ -38,12 +38,12 @@ class _PointerMatcher(object):
 
     def __eq__(self, other):
         if not isinstance(other, ctypes.POINTER(self.expected_type)):
-            print("Unexpected type. Expected: {0}. Received: {1}".format(ctypes.POINTER(self.expected_type), type(other)))
+            print("Unexpected type. Expected: {}. Received: {}".format(ctypes.POINTER(self.expected_type), type(other)))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1})'.format(self.__class__.__name__, pp.pformat(self.expected_type))
+        return '{}({})'.format(self.__class__.__name__, pp.pformat(self.expected_type))
 
 
 class _BufferMatcher(object):
@@ -71,22 +71,22 @@ class _BufferMatcher(object):
 
             # Because of object lifetimes, we may need to mock the other instance and provide lists instead of the actual array
             if not isinstance(other, self.expected_type) and not isinstance(other, list):
-                print("Unexpected type. Expected: {0} or {1}. Received: {2}".format(self.expected_type, list, type(other)))
+                print("Unexpected type. Expected: {} or {}. Received: {}".format(self.expected_type, list, type(other)))
                 return False
         if self.expected_size != len(other):
-            print("Unexpected length. Expected: {0}. Received: {1}".format(self.expected_size, len(other)))
+            print("Unexpected length. Expected: {}. Received: {}".format(self.expected_size, len(other)))
             return False
         if self.expected_value is not None:
             # Can't compare the objects directly because they're different types (one is list, another is ctypes array).
             # Go element by element, which allows for reporting the first index where different values were found.
             for i in range(0, len(self.expected_value)):
                 if self.expected_value[i] != other[i]:
-                    print("Unexpected value at index {0}. Expected: {1}. Received: {2}".format(i, self.expected_value[i], other[i]))
+                    print("Unexpected value at index {}. Expected: {}. Received: {}".format(i, self.expected_value[i], other[i]))
                     return False
         return True
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self._expected_element_type), pp.pformat(self._expected_size_or_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self._expected_element_type), pp.pformat(self._expected_size_or_value))
 
     def __str__(self):
         ret_str = self.__repr__() + '\n'
@@ -112,21 +112,21 @@ class ViStringMatcher(object):
                 pass
 
             if not isinstance(other, ctypes.Array):
-                print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_type, type(other)))
+                print("Unexpected type. Expected: {}. Received: {}".format(self.expected_type, type(other)))
                 return False
         if len(other) < len(self.expected_string_value) + 1:  # +1 for NULL terminating character
-            print("Unexpected length in C string. Expected at least: {0}. Received {1}".format(len(other), len(self.expected_string_value) + 1))
+            print("Unexpected length in C string. Expected at least: {}. Received {}".format(len(other), len(self.expected_string_value) + 1))
             return False
         if not isinstance(other[0], bytes):
-            print("Unexpected type. Not a string. Received: {0}".format(type(other[0])))
+            print("Unexpected type. Not a string. Received: {}".format(type(other[0])))
             return False
         if other.value.decode("ascii") != self.expected_string_value:
-            print("Unexpected value. Expected {0}. Received: {1}".format(self.expected_string_value, other.value.decode))
+            print("Unexpected value. Expected {}. Received: {}".format(self.expected_string_value, other.value.decode))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1})'.format(self.__class__.__name__, pp.pformat(self.expected_string_value))
+        return '{}({})'.format(self.__class__.__name__, pp.pformat(self.expected_string_value))
 
 
 # Custom Type
@@ -139,7 +139,7 @@ def _compare_ctype_structs(expected, actual):
         expected_val = getattr(expected, field_name)
         actual_val = getattr(actual, field_name)
         if expected_val != actual_val:
-            print("Unexpected value field {0}. Expected: {1}. Received: {2}".format(field_name, expected_val, actual_val))
+            print("Unexpected value field {}. Expected: {}. Received: {}".format(field_name, expected_val, actual_val))
             return False
     return True
 
@@ -151,12 +151,12 @@ class CustomTypeMatcher(object):
 
     def __eq__(self, actual):
         if not isinstance(actual, self.expected_type):
-            print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_type, type(actual)))
+            print("Unexpected type. Expected: {}. Received: {}".format(self.expected_type, type(actual)))
             return False
         return _compare_ctype_structs(self.expected_value, actual)
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
 
 
 class CustomTypeBufferMatcher(object):
@@ -168,17 +168,17 @@ class CustomTypeBufferMatcher(object):
 
     def __eq__(self, actual):
         if not isinstance(actual, self.expected_type):
-            print("Unexpected array type. Expected: {0}. Received: {1}".format(self.expected_type, type(actual)))
+            print("Unexpected array type. Expected: {}. Received: {}".format(self.expected_type, type(actual)))
             return False
         if self.expected_size != len(actual):
-            print("Unexpected length. Expected: {0}. Received: {1}".format(self.expected_size, len(actual)))
+            print("Unexpected length. Expected: {}. Received: {}".format(self.expected_size, len(actual)))
             return False
         if self.expected_value is not None:
             # Can't compare the objects directly because they're different types (one is list, another is ctypes array).
             # Go element by element, which allows for reporting the first index where different values were found.
             for a, e in zip(actual, self.expected_value):
                 if not isinstance(a, self.expected_element_type):
-                    print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_element_type, type(a)))
+                    print("Unexpected type. Expected: {}. Received: {}".format(self.expected_element_type, type(a)))
                     return False
                 if not _compare_ctype_structs(e, a):
                     return False
@@ -186,7 +186,7 @@ class CustomTypeBufferMatcher(object):
 
     def __repr__(self):
         expected_val_repr = '[' + ', '.join([x.__repr__() for x in self.expected_value]) + ']'
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_element_type), expected_val_repr)
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_element_type), expected_val_repr)
 
     def __str__(self):
         ret_str = self.__repr__() + '\n'

--- a/generated/niswitch/setup.py
+++ b/generated/niswitch/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 # This file was generated
 
 

--- a/generated/nitclk/nitclk/_visatype.py
+++ b/generated/nitclk/nitclk/_visatype.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import ctypes
 
 

--- a/generated/nitclk/nitclk/errors.py
+++ b/generated/nitclk/nitclk/errors.py
@@ -40,7 +40,7 @@ class DriverWarning(Warning):
 
     def __init__(self, code, description):
         assert _is_warning(code), "Should not create Warning if code is not positive."
-        super(DriverWarning, self).__init__('Warning {0} occurred.\n\n{1}'.format(code, description))
+        super(DriverWarning, self).__init__('Warning {} occurred.\n\n{}'.format(code, description))
 
 
 class UnsupportedConfigurationError(Error):

--- a/generated/nitclk/nitclk/unit_tests/_matchers.py
+++ b/generated/nitclk/nitclk/unit_tests/_matchers.py
@@ -21,15 +21,15 @@ class _ScalarMatcher(object):
 
     def __eq__(self, other):
         if not isinstance(other, self.expected_type):
-            print("{0}: Unexpected type. Expected: {1}. Received: {2}".format(self.__class__.__name__, self.expected_type, type(other)))
+            print("{}: Unexpected type. Expected: {}. Received: {}".format(self.__class__.__name__, self.expected_type, type(other)))
             return False
         if other.value != self.expected_value:
-            print("{0}: Unexpected value. Expected: {1}. Received: {2}".format(self.__class__.__name__, self.expected_value, other.value))
+            print("{}: Unexpected value. Expected: {}. Received: {}".format(self.__class__.__name__, self.expected_value, other.value))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
 
 
 class _PointerMatcher(object):
@@ -38,12 +38,12 @@ class _PointerMatcher(object):
 
     def __eq__(self, other):
         if not isinstance(other, ctypes.POINTER(self.expected_type)):
-            print("Unexpected type. Expected: {0}. Received: {1}".format(ctypes.POINTER(self.expected_type), type(other)))
+            print("Unexpected type. Expected: {}. Received: {}".format(ctypes.POINTER(self.expected_type), type(other)))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1})'.format(self.__class__.__name__, pp.pformat(self.expected_type))
+        return '{}({})'.format(self.__class__.__name__, pp.pformat(self.expected_type))
 
 
 class _BufferMatcher(object):
@@ -71,22 +71,22 @@ class _BufferMatcher(object):
 
             # Because of object lifetimes, we may need to mock the other instance and provide lists instead of the actual array
             if not isinstance(other, self.expected_type) and not isinstance(other, list):
-                print("Unexpected type. Expected: {0} or {1}. Received: {2}".format(self.expected_type, list, type(other)))
+                print("Unexpected type. Expected: {} or {}. Received: {}".format(self.expected_type, list, type(other)))
                 return False
         if self.expected_size != len(other):
-            print("Unexpected length. Expected: {0}. Received: {1}".format(self.expected_size, len(other)))
+            print("Unexpected length. Expected: {}. Received: {}".format(self.expected_size, len(other)))
             return False
         if self.expected_value is not None:
             # Can't compare the objects directly because they're different types (one is list, another is ctypes array).
             # Go element by element, which allows for reporting the first index where different values were found.
             for i in range(0, len(self.expected_value)):
                 if self.expected_value[i] != other[i]:
-                    print("Unexpected value at index {0}. Expected: {1}. Received: {2}".format(i, self.expected_value[i], other[i]))
+                    print("Unexpected value at index {}. Expected: {}. Received: {}".format(i, self.expected_value[i], other[i]))
                     return False
         return True
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self._expected_element_type), pp.pformat(self._expected_size_or_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self._expected_element_type), pp.pformat(self._expected_size_or_value))
 
     def __str__(self):
         ret_str = self.__repr__() + '\n'
@@ -112,21 +112,21 @@ class ViStringMatcher(object):
                 pass
 
             if not isinstance(other, ctypes.Array):
-                print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_type, type(other)))
+                print("Unexpected type. Expected: {}. Received: {}".format(self.expected_type, type(other)))
                 return False
         if len(other) < len(self.expected_string_value) + 1:  # +1 for NULL terminating character
-            print("Unexpected length in C string. Expected at least: {0}. Received {1}".format(len(other), len(self.expected_string_value) + 1))
+            print("Unexpected length in C string. Expected at least: {}. Received {}".format(len(other), len(self.expected_string_value) + 1))
             return False
         if not isinstance(other[0], bytes):
-            print("Unexpected type. Not a string. Received: {0}".format(type(other[0])))
+            print("Unexpected type. Not a string. Received: {}".format(type(other[0])))
             return False
         if other.value.decode("ascii") != self.expected_string_value:
-            print("Unexpected value. Expected {0}. Received: {1}".format(self.expected_string_value, other.value.decode))
+            print("Unexpected value. Expected {}. Received: {}".format(self.expected_string_value, other.value.decode))
             return False
         return True
 
     def __repr__(self):
-        return '{0}({1})'.format(self.__class__.__name__, pp.pformat(self.expected_string_value))
+        return '{}({})'.format(self.__class__.__name__, pp.pformat(self.expected_string_value))
 
 
 # Custom Type
@@ -139,7 +139,7 @@ def _compare_ctype_structs(expected, actual):
         expected_val = getattr(expected, field_name)
         actual_val = getattr(actual, field_name)
         if expected_val != actual_val:
-            print("Unexpected value field {0}. Expected: {1}. Received: {2}".format(field_name, expected_val, actual_val))
+            print("Unexpected value field {}. Expected: {}. Received: {}".format(field_name, expected_val, actual_val))
             return False
     return True
 
@@ -151,12 +151,12 @@ class CustomTypeMatcher(object):
 
     def __eq__(self, actual):
         if not isinstance(actual, self.expected_type):
-            print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_type, type(actual)))
+            print("Unexpected type. Expected: {}. Received: {}".format(self.expected_type, type(actual)))
             return False
         return _compare_ctype_structs(self.expected_value, actual)
 
     def __repr__(self):
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_type), pp.pformat(self.expected_value))
 
 
 class CustomTypeBufferMatcher(object):
@@ -168,17 +168,17 @@ class CustomTypeBufferMatcher(object):
 
     def __eq__(self, actual):
         if not isinstance(actual, self.expected_type):
-            print("Unexpected array type. Expected: {0}. Received: {1}".format(self.expected_type, type(actual)))
+            print("Unexpected array type. Expected: {}. Received: {}".format(self.expected_type, type(actual)))
             return False
         if self.expected_size != len(actual):
-            print("Unexpected length. Expected: {0}. Received: {1}".format(self.expected_size, len(actual)))
+            print("Unexpected length. Expected: {}. Received: {}".format(self.expected_size, len(actual)))
             return False
         if self.expected_value is not None:
             # Can't compare the objects directly because they're different types (one is list, another is ctypes array).
             # Go element by element, which allows for reporting the first index where different values were found.
             for a, e in zip(actual, self.expected_value):
                 if not isinstance(a, self.expected_element_type):
-                    print("Unexpected type. Expected: {0}. Received: {1}".format(self.expected_element_type, type(a)))
+                    print("Unexpected type. Expected: {}. Received: {}".format(self.expected_element_type, type(a)))
                     return False
                 if not _compare_ctype_structs(e, a):
                     return False
@@ -186,7 +186,7 @@ class CustomTypeBufferMatcher(object):
 
     def __repr__(self):
         expected_val_repr = '[' + ', '.join([x.__repr__() for x in self.expected_value]) + ']'
-        return '{0}({1}, {2})'.format(self.__class__.__name__, pp.pformat(self.expected_element_type), expected_val_repr)
+        return '{}({}, {})'.format(self.__class__.__name__, pp.pformat(self.expected_element_type), expected_val_repr)
 
     def __str__(self):
         ret_str = self.__repr__() + '\n'

--- a/generated/nitclk/nitclk/unit_tests/test_nitclk.py
+++ b/generated/nitclk/nitclk/unit_tests/test_nitclk.py
@@ -12,7 +12,7 @@ single_session = [SESSION_NUM_FOR_TEST]
 multiple_sessions = [SESSION_NUM_FOR_TEST, SESSION_NUM_FOR_TEST * 10, SESSION_NUM_FOR_TEST * 100, SESSION_NUM_FOR_TEST + 1]
 
 
-class NitclkSupportingDriverSession(object):
+class NitclkSupportingDriverSession:
     '''Session objects for drivers that support NI-TClk are expected to have a property of type nitclk.SessionReference called tclk
 
     This is why we're creating this fake driver class and adding the tclk property.
@@ -21,7 +21,7 @@ class NitclkSupportingDriverSession(object):
         self.tclk = nitclk.SessionReference(session_number)
 
 
-class TestNitclkApi(object):
+class TestNitclkApi:
     class PatchedLibrary(nitclk._library.Library):
         def __init__(self, ctypes_library):
             super().__init__(ctypes_library)

--- a/generated/nitclk/setup.py
+++ b/generated/nitclk/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 # This file was generated
 
 

--- a/src/nidcpower/custom_types/lcr_load_compensation_spot.py
+++ b/src/nidcpower/custom_types/lcr_load_compensation_spot.py
@@ -32,7 +32,7 @@ class struct_NILCRLoadCompensationSpot(ctypes.Structure):  # noqa N801
             self.reference_value_b = 0.0
 
 
-class LCRLoadCompensationSpot(object):
+class LCRLoadCompensationSpot:
     """Specifies a DUT specification for a given frequency to use in LCR load compensation."""
 
     _lcr_reference_value_type_to_label_and_units = {
@@ -79,7 +79,7 @@ class LCRLoadCompensationSpot(object):
             return target_class(frequency=self.frequency, reference_value_type=self.reference_value_type.value, reference_value_a=self.reference_value.real, reference_value_b=self.reference_value.imag)
 
     def __repr__(self):
-        return "{0}.{1}(frequency={2}, reference_value_type={3}.{4}.{5}, reference_value={6})".format(
+        return "{}.{}(frequency={}, reference_value_type={}.{}.{}, reference_value={})".format(
             self.__class__.__module__,
             self.__class__.__qualname__,
             self.frequency,

--- a/src/nidcpower/custom_types/lcr_measurement.py
+++ b/src/nidcpower/custom_types/lcr_measurement.py
@@ -48,7 +48,7 @@ class struct_NILCRMeasurement(ctypes.Structure):  # noqa N801
     ]
 
 
-class LCRMeasurement(object):
+class LCRMeasurement:
     """Specifies an LCR measurement.
 
     Data attributes:
@@ -182,9 +182,9 @@ class LCRMeasurement(object):
                 "ac_in_compliance",
                 "unbalanced"
             ):
-                row_format = "{{:<{}}}: {{:}}{{}}\n".format(max_field_label_len)
+                row_format = f"{{:<{max_field_label_len}}}: {{:}}{{}}\n"
             else:
-                row_format = "{{:<{}}}: {{:,.6g}}{{}}\n".format(max_field_label_len)
+                row_format = f"{{:<{max_field_label_len}}}: {{:,.6g}}{{}}\n"
             # Process namedtuple fields
             if isinstance(field_label, tuple) and isinstance(field_unit, tuple):
                 for label, unit, value in zip(field_label, field_unit, getattr(self, field_name)):

--- a/src/nidcpower/examples/nidcpower_advanced_sequence.py
+++ b/src/nidcpower/examples/nidcpower_advanced_sequence.py
@@ -32,7 +32,7 @@ def example(resource_name, options, voltage_max, current_max, points_per_output_
 
         with session.initiate():
             session.wait_for_event(nidcpower.Event.SEQUENCE_ENGINE_DONE)
-            channel_indices = '0-{0}'.format(session.channel_count - 1)
+            channel_indices = f'0-{session.channel_count - 1}'
             channels = session.get_channel_names(channel_indices)
             measurement_group = [session.channels[name].fetch_multiple(points_per_output_function * 2, timeout=timeout) for name in channels]
 

--- a/src/nidcpower/examples/nidcpower_measure_record.py
+++ b/src/nidcpower/examples/nidcpower_measure_record.py
@@ -15,12 +15,12 @@ def example(resource_name, options, voltage, length):
         session.voltage_level = voltage
 
         session.commit()
-        print('Effective measurement rate: {0} S/s'.format(session.measure_record_delta_time / 1))
+        print(f'Effective measurement rate: {session.measure_record_delta_time / 1} S/s')
 
         print('Channel           Num  Voltage    Current    In Compliance')
         row_format = '{0:15} {1:3d}    {2:8.6f}   {3:8.6f}   {4}'
         with session.initiate():
-            channel_indices = '0-{0}'.format(session.channel_count - 1)
+            channel_indices = f'0-{session.channel_count - 1}'
             channels = session.get_channel_names(channel_indices)
             for i, channel_name in enumerate(channels):
                 samples_acquired = 0

--- a/src/nidcpower/examples/nidcpower_source_delay_measure.py
+++ b/src/nidcpower/examples/nidcpower_source_delay_measure.py
@@ -7,9 +7,9 @@ import sys
 
 
 def print_fetched_measurements(measurements):
-    print('             Voltage : {:f} V'.format(measurements[0].voltage))
-    print('              Current: {:f} A'.format(measurements[0].current))
-    print('        In compliance: {0}'.format(measurements[0].in_compliance))
+    print(f'             Voltage : {measurements[0].voltage:f} V')
+    print(f'              Current: {measurements[0].current:f} A')
+    print(f'        In compliance: {measurements[0].in_compliance}')
 
 
 def example(resource_name, options, voltage1, voltage2, delay):
@@ -27,10 +27,10 @@ def example(resource_name, options, voltage1, voltage2, delay):
         session.voltage_level = voltage1
 
         with session.initiate():
-            channel_indices = '0-{0}'.format(session.channel_count - 1)
+            channel_indices = f'0-{session.channel_count - 1}'
             channels = session.get_channel_names(channel_indices)
             for channel_name in channels:
-                print('Channel: {0}'.format(channel_name))
+                print(f'Channel: {channel_name}')
                 print('---------------------------------')
                 print('Voltage 1:')
                 print_fetched_measurements(session.channels[channel_name].fetch_multiple(count=1, timeout=timeout))

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -88,13 +88,13 @@ class SystemTests:
         assert name == '4162/0'
 
     def test_get_channel_names(self, session):
-        expected_string = ['4162/{0}'.format(x) for x in range(12)]
+        expected_string = [f'4162/{x}' for x in range(12)]
         channel_indices = ['0-1, 2, 3:4', 5, (6, 7), range(8, 10), slice(10, 12)]
         assert session.get_channel_names(channel_indices) == expected_string
 
     @pytest.mark.resource_name('Dev1/0-5,Dev2/0-5')
     def test_get_channel_names_multiple_instruments(self, session):
-        expected_string = ['{0}/{1}'.format(name, channel) for name in ['Dev1', 'Dev2'] for channel in range(6)]
+        expected_string = [f'{name}/{channel}' for name in ['Dev1', 'Dev2'] for channel in range(6)]
         channel_indices = ['0-1, 2, 3:4', 5, (6, 7), range(8, 10), slice(10, 12)]
         assert session.get_channel_names(channel_indices) == expected_string
 

--- a/src/nidcpower/templates/session.py/fancy_advanced_sequence.py.mako
+++ b/src/nidcpower/templates/session.py/fancy_advanced_sequence.py.mako
@@ -19,9 +19,9 @@
         attribute_ids_used = set()
         for prop in property_names:
             if prop not in Session.__base__.__dict__:
-                raise KeyError('{0} is not an property on the nidcpower.Session'.format(prop))
+                raise KeyError('{} is not an property on the nidcpower.Session'.format(prop))
             if not isinstance(Session.__base__.__dict__[prop], _attributes.Attribute):
-                raise TypeError('{0} is not a valid property: {1}'.format(prop, type(Session.__base__.__dict__[prop])))
+                raise TypeError('{} is not a valid property: {}'.format(prop, type(Session.__base__.__dict__[prop])))
             attribute_ids_used.add(Session.__base__.__dict__[prop]._attribute_id)
 
         self._create_advanced_sequence_with_channels(sequence_name, list(attribute_ids_used), set_as_active_sequence)

--- a/src/nidcpower/templates/session.py/fancy_fetch_measure.py.mako
+++ b/src/nidcpower/templates/session.py/fancy_fetch_measure.py.mako
@@ -23,7 +23,7 @@
         channel_name_unpack = ', channel_name'
         channel_name_value = 'channel_name'
     else:
-        raise ValueError('Only fetch_multiple and measure_multiple are supported. Got {0}'.format(f['python_name']))
+        raise ValueError('Only fetch_multiple and measure_multiple are supported. Got {}'.format(f['python_name']))
 %>\
     def ${f['python_name']}${suffix}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
         '''${f['python_name']}

--- a/src/nidigital/custom_types/history_ram_cycle_information.py
+++ b/src/nidigital/custom_types/history_ram_cycle_information.py
@@ -1,4 +1,4 @@
-class HistoryRAMCycleInformation(object):
+class HistoryRAMCycleInformation:
     def __init__(self, pattern_name, time_set_name, vector_number, cycle_number, scan_cycle_number, expected_pin_states, actual_pin_states, per_pin_pass_fail):
         self.pattern_name = pattern_name
         self.time_set_name = time_set_name
@@ -11,17 +11,17 @@ class HistoryRAMCycleInformation(object):
 
     def __repr__(self):
         parameter_list = [
-            'pattern_name="{}"'.format(self.pattern_name),
-            'time_set_name="{}"'.format(self.time_set_name),
-            'vector_number={}'.format(self.vector_number),
-            'cycle_number={}'.format(self.cycle_number),
-            'scan_cycle_number={}'.format(self.scan_cycle_number),
-            'expected_pin_states={}'.format(self._digital_states_representation(self.expected_pin_states)),
-            'actual_pin_states={}'.format(self._digital_states_representation(self.actual_pin_states)),
-            'per_pin_pass_fail={}'.format(self.per_pin_pass_fail),
+            f'pattern_name="{self.pattern_name}"',
+            f'time_set_name="{self.time_set_name}"',
+            f'vector_number={self.vector_number}',
+            f'cycle_number={self.cycle_number}',
+            f'scan_cycle_number={self.scan_cycle_number}',
+            f'expected_pin_states={self._digital_states_representation(self.expected_pin_states)}',
+            f'actual_pin_states={self._digital_states_representation(self.actual_pin_states)}',
+            f'per_pin_pass_fail={self.per_pin_pass_fail}',
         ]
 
-        return '{0}.{1}({2})'.format(self.__class__.__module__, self.__class__.__qualname__, ', '.join(parameter_list))
+        return '{}.{}({})'.format(self.__class__.__module__, self.__class__.__qualname__, ', '.join(parameter_list))
 
     def __str__(self):
         # different format lines
@@ -42,7 +42,7 @@ class HistoryRAMCycleInformation(object):
 
     @staticmethod
     def _digital_states_representation(states):
-        states_representation = [['{0}.{1}.{2}'.format(i.__class__.__module__, i.__class__.__qualname__, i.name) for i in j] for j in states]
+        states_representation = [[f'{i.__class__.__module__}.{i.__class__.__qualname__}.{i.name}' for i in j] for j in states]
         return '[{}]'.format(', '.join(['[{}]'.format(', '.join(i)) for i in states_representation]))
 
     @staticmethod

--- a/src/nidigital/examples/ppmu_source_and_measure/nidigital_ppmu_source_and_measure.py
+++ b/src/nidigital/examples/ppmu_source_and_measure/nidigital_ppmu_source_and_measure.py
@@ -58,14 +58,14 @@ def example(resource_name, options, channels, measure, aperture_time,
             print('{:<6} {:<20} {:<10}'.format('Site', 'Pin Name', 'Current'))
 
             for pin, current in zip(pin_info, current_measurements):
-                print('{:<6d} {:<20} {:<10f}'.format(pin.site_number, pin.pin_name, current))
+                print(f'{pin.site_number:<6d} {pin.pin_name:<20} {current:<10f}')
         else:
             voltage_measurements = session.channels[channels].ppmu_measure(nidigital.PPMUMeasurementType.VOLTAGE)
 
             print('{:<6} {:<20} {:<10}'.format('Site', 'Pin Name', 'Voltage'))
 
             for pin, voltage in zip(pin_info, voltage_measurements):
-                print('{:<6d} {:<20} {:<10f}'.format(pin.site_number, pin.pin_name, voltage))
+                print(f'{pin.site_number:<6d} {pin.pin_name:<20} {voltage:<10f}')
 
         # Disconnect all channels using programmable onboard switching
         session.channels[channels].selected_function = nidigital.SelectedFunction.DISCONNECT

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -181,7 +181,7 @@ class SystemTests:
         assert multi_instrument_session.start_label == 'foo'
 
     def test_get_channel_names(self, multi_instrument_session):
-        expected_string = ['{0}/{1}'.format(instruments[0], x) for x in range(12)]
+        expected_string = [f'{instruments[0]}/{x}' for x in range(12)]
         # Sanity test few different types of input. No need for test to be exhaustive
         # since all the various types are covered by converter unit tests.
         channel_indices = ['0-1, 2, 3:4', 5, (6, 7), range(8, 10), slice(10, 12)]
@@ -294,7 +294,7 @@ class SystemTests:
                 1: [i for i in range(num_samples)],
                 0: [i for i in reversed(range(num_samples))]}
         else:
-            assert False, "Invalid source waveform data type: {}".format(source_waveform_type)
+            assert False, f"Invalid source waveform data type: {source_waveform_type}"
 
         multi_instrument_session.write_source_waveform_site_unique(
             waveform_name='src_wfm',
@@ -343,7 +343,7 @@ class SystemTests:
                 str(1): [str(i) for i in range(num_samples)],
                 str(0): [str(i) for i in reversed(range(num_samples))]}
         else:
-            assert False, "Invalid source waveform data type: {}".format(source_waveform_wrong_type)
+            assert False, f"Invalid source waveform data type: {source_waveform_wrong_type}"
 
         with pytest.raises(TypeError):
             multi_instrument_session.write_source_waveform_site_unique(

--- a/src/nidigital/templates/session.py/fancy_fetch_history_ram_cycle_information.py.mako
+++ b/src/nidigital/templates/session.py/fancy_fetch_history_ram_cycle_information.py.mako
@@ -28,7 +28,7 @@
         # site is passed as repeated capability
         samples_available = self.get_history_ram_sample_count()
         if position > samples_available:
-            raise ValueError('position: Specified value = {0}, Maximum value = {1}.'.format(position, samples_available - 1))
+            raise ValueError('position: Specified value = {}, Maximum value = {}.'.format(position, samples_available - 1))
 
         if samples_to_read == -1:
             with _NoChannel(session=self):
@@ -40,7 +40,7 @@
 
         if position + samples_to_read > samples_available:
             raise ValueError(
-                'position: Specified value = {0}, samples_to_read: Specified value = {1}; Samples available = {2}.'
+                'position: Specified value = {}, samples_to_read: Specified value = {}; Samples available = {}.'
                 .format(position, samples_to_read, samples_available - position))
 
         pattern_names = {}

--- a/src/nidigital/templates/session.py/fancy_write_source_waveform_site_unique.py.mako
+++ b/src/nidigital/templates/session.py/fancy_write_source_waveform_site_unique.py.mako
@@ -31,7 +31,7 @@
                 if waveform_data[site].dtype == numpy.uint32:
                     wfm = array.array('L', waveform_data[site])
                 else:
-                    raise TypeError("Unsupported dtype for waveform_data array element type. Is {0}, expected {1}".format(waveform_data[site].dtype, numpy.int32))
+                    raise TypeError("Unsupported dtype for waveform_data array element type. Is {}, expected {}".format(waveform_data[site].dtype, numpy.int32))
 
             elif isinstance(waveform_data[site], array.array):
                 if waveform_data[site].typecode == 'L':

--- a/src/nidigital/unit_tests/test_nidigital.py
+++ b/src/nidigital/unit_tests/test_nidigital.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 session_id_for_test = 42
 
 
-class TestSession(object):
+class TestSession:
     class PatchedLibrary(nidigital._library.Library):
         def __init__(self, ctypes_library):
             super().__init__(ctypes_library)
@@ -335,7 +335,7 @@ class TestSession(object):
 
     # Helper function for validating site behavior in fetch_history_ram_cycle_information.
     def niDigital_GetHistoryRAMSampleCount_check_site_looping(self, vi, site, sample_count):  # noqa: N802
-        assert site.value.decode('ascii') == 'site{}'.format(self.site_numbers_looping[self.iteration_check_site_looping])
+        assert site.value.decode('ascii') == f'site{self.site_numbers_looping[self.iteration_check_site_looping]}'
         sample_count.contents.value = 0  # we don't care if this is right as long as the fetch does not error
         self.iteration_check_site_looping += 1
         return 0

--- a/src/nifake/custom_types/custom_struct.py
+++ b/src/nifake/custom_types/custom_struct.py
@@ -22,13 +22,13 @@ class struct_CustomStruct(ctypes.Structure):  # noqa N801
             self.struct_double = struct_double
 
     def __repr__(self):
-        return '{0}(data=None, struct_int={1}, struct_double={2})'.format(self.__class__.__name__, self.struct_int, self.struct_double)
+        return f'{self.__class__.__name__}(data=None, struct_int={self.struct_int}, struct_double={self.struct_double})'
 
     def __str__(self):
         return self.__repr__()
 
 
-class CustomStruct(object):
+class CustomStruct:
     def __init__(self, data=None, struct_int=0, struct_double=0.0):
         if data is not None:
             self.struct_int = data.struct_int
@@ -41,7 +41,7 @@ class CustomStruct(object):
         return target_class(struct_int=self.struct_int, struct_double=self.struct_double)
 
     def __repr__(self):
-        return '{0}(data=None, struct_int={1}, struct_double={2})'.format(self.__class__.__name__, self.struct_int, self.struct_double)
+        return f'{self.__class__.__name__}(data=None, struct_int={self.struct_int}, struct_double={self.struct_double})'
 
     def __str__(self):
         return self.__repr__()

--- a/src/nifake/custom_types/custom_struct_nested_typedef.py
+++ b/src/nifake/custom_types/custom_struct_nested_typedef.py
@@ -22,7 +22,7 @@ class struct_CustomStructNestedTypedef(ctypes.Structure):  # noqa N801
             self.struct_custom_struct_typedef = custom_struct_typedef.struct_CustomStructTypedef()
 
 
-class CustomStructNestedTypedef(object):
+class CustomStructNestedTypedef:
     def __init__(
         self,
         data=None,
@@ -50,7 +50,7 @@ class CustomStructNestedTypedef(object):
         )
 
     def __repr__(self):
-        return '{0}(data=None, struct_custom_struct={1}, struct_custom_struct_typedef={2})'.format(
+        return '{}(data=None, struct_custom_struct={}, struct_custom_struct_typedef={})'.format(
             self.__class__.__name__,
             repr(self.struct_custom_struct),
             repr(self.struct_custom_struct_typedef)

--- a/src/nifake/custom_types/custom_struct_typedef.py
+++ b/src/nifake/custom_types/custom_struct_typedef.py
@@ -19,7 +19,7 @@ class struct_CustomStructTypedef(ctypes.Structure):  # noqa N801
             self.struct_double = 0.0
 
 
-class CustomStructTypedef(object):
+class CustomStructTypedef:
     def __init__(self, data=None, struct_int=0, struct_double=0.0):
         if data is not None:
             self.struct_int = data.struct_int
@@ -32,7 +32,7 @@ class CustomStructTypedef(object):
         return target_class(struct_int=self.struct_int, struct_double=self.struct_double)
 
     def __repr__(self):
-        return '{0}(data=None, struct_int={1}, struct_double={2})'.format(
+        return '{}(data=None, struct_int={}, struct_double={})'.format(
             self.__class__.__name__,
             self.struct_int,
             self.struct_double

--- a/src/nifake/unit_tests/test_grpc.py
+++ b/src/nifake/unit_tests/test_grpc.py
@@ -39,7 +39,7 @@ class MyRpcError(grpc.RpcError):
             return [Metadatum('ni-error', str(self._error_code))]
 
 
-class TestGrpcStubInterpreter(object):
+class TestGrpcStubInterpreter:
 
     class PatchedGrpcTypes:
         def __init__(self):
@@ -93,7 +93,7 @@ class TestGrpcStubInterpreter(object):
 
     def _check_fields(self, response_class, **kwargs):
         fields = dict(kwargs)
-        response_fields = dict((x.name, x) for x in response_class.DESCRIPTOR.fields)
+        response_fields = {x.name: x for x in response_class.DESCRIPTOR.fields}
 
         unexpected_fields = set(fields) - set(response_fields)
         assert not unexpected_fields, 'Unexpected fields: ' + str(list(sorted(unexpected_fields)))

--- a/src/nifake/unit_tests/test_library_interpreter.py
+++ b/src/nifake/unit_tests/test_library_interpreter.py
@@ -17,7 +17,7 @@ import _mock_helper
 SESSION_NUM_FOR_TEST = 42
 
 
-class TestLibraryInterpreter(object):
+class TestLibraryInterpreter:
 
     class PatchedLibrary(nifake._library.Library):
         def __init__(self, ctypes_library):

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -14,7 +14,7 @@ SESSION_NUM_FOR_TEST = 42
 GRPC_SESSION_OBJECT_FOR_TEST = object()
 
 
-class TestSession(object):
+class TestSession:
 
     class PatchedLibraryInterpreter(nifake._library_interpreter.LibraryInterpreter):
         def __init__(self, encoding):
@@ -838,7 +838,7 @@ class TestSession(object):
             self.patched_library_interpreter.return_list_of_durations_in_seconds.assert_called_once_with(len(time_values))
 
 
-class TestGrpcSession(object):
+class TestGrpcSession:
 
     class PatchedGrpcInterpreter(nifake._grpc_stub_interpreter.GrpcStubInterpreter):
         def __init__(self, grpc_options):
@@ -944,5 +944,5 @@ def test_diagnostic_information():
 
 
 def test_dunder_version():
-    print('Version = {}'.format(nifake.__version__))
+    print(f'Version = {nifake.__version__}')
     assert type(nifake.__version__) is str

--- a/src/nifgen/examples/nifgen_script.py
+++ b/src/nifgen/examples/nifgen_script.py
@@ -102,7 +102,7 @@ def example(resource_name, options, shape, channel):
 
         # 4 - Script to generate
         # supported shapes: SINE / SQUARE / SAWTOOTH / RAMPUP / RAMPDOWN / MULTI
-        script_name = 'script{}'.format(shape.lower())
+        script_name = f'script{shape.lower()}'
         num_triggers = 6 if shape.upper() == 'MULTI' else 1  # Only multi needs multiple triggers, all others need one
 
         session.channels[channel].write_script(SCRIPT_ALL)

--- a/src/nifgen/templates/session.py/create_waveform.py.mako
+++ b/src/nifgen/templates/session.py/create_waveform.py.mako
@@ -16,13 +16,13 @@
             elif waveform_data_array.dtype == numpy.int16:
                 return self._create_waveform_i16_numpy(waveform_data_array)
             else:
-                raise TypeError("Unsupported dtype. Is {0}, expected {1} or {2}".format(waveform_data_array.dtype, numpy.float64, numpy.int16))
+                raise TypeError("Unsupported dtype. Is {}, expected {} or {}".format(waveform_data_array.dtype, numpy.float64, numpy.int16))
         elif isinstance(waveform_data_array, array.array):
             if waveform_data_array.typecode == 'd':
                 return self._create_waveform_f64(waveform_data_array)
             elif waveform_data_array.typecode == 'h':
                 return self._create_waveform_i16(waveform_data_array)
             else:
-                raise TypeError("Unsupported dtype. Is {0}, expected {1} or {2}".format(waveform_data_array.typecode, 'd (double)', 'h (16 bit int)'))
+                raise TypeError("Unsupported dtype. Is {}, expected {} or {}".format(waveform_data_array.typecode, 'd (double)', 'h (16 bit int)'))
 
         return self._create_waveform_f64(waveform_data_array)

--- a/src/nifgen/templates/session.py/send_software_edge_trigger.py.mako
+++ b/src/nifgen/templates/session.py/send_software_edge_trigger.py.mako
@@ -24,7 +24,7 @@
             pass  # This is how the function should be called
 
         else:
-            raise ValueError('Both trigger ({0}) and trigger_id ({1}) should be passed in to the method'.format(str(trigger), str(trigger_id)))
+            raise ValueError('Both trigger ({}) and trigger_id ({}) should be passed in to the method'.format(str(trigger), str(trigger_id)))
 
         if type(trigger) is not enums.Trigger:
             raise TypeError('Parameter trigger must be of type ' + str(enums.Trigger))

--- a/src/nifgen/templates/session.py/write_waveform.py.mako
+++ b/src/nifgen/templates/session.py/write_waveform.py.mako
@@ -17,13 +17,13 @@
             elif data.dtype == numpy.int16:
                 return self._write_named_waveform_i16_numpy(waveform_name_or_handle, data) if use_named else self._write_binary16_waveform_numpy(waveform_name_or_handle, data)
             else:
-                raise TypeError("Unsupported dtype. Is {0}, expected {1} or {2}".format(data.dtype, numpy.float64, numpy.int16))
+                raise TypeError("Unsupported dtype. Is {}, expected {} or {}".format(data.dtype, numpy.float64, numpy.int16))
         elif isinstance(data, array.array):
             if data.typecode == 'd':
                 return self._write_named_waveform_f64(waveform_name_or_handle, data) if use_named else self._write_waveform(waveform_name_or_handle, data)
             elif data.typecode == 'h':
                 return self._write_named_waveform_i16(waveform_name_or_handle, data) if use_named else self._write_binary16_waveform(waveform_name_or_handle, data)
             else:
-                raise TypeError("Unsupported dtype. Is {0}, expected {1} or {2}".format(data.typecode, 'd (double)', 'h (16 bit int)'))
+                raise TypeError("Unsupported dtype. Is {}, expected {} or {}".format(data.typecode, 'd (double)', 'h (16 bit int)'))
 
         return self._write_named_waveform_f64(waveform_name_or_handle, data) if use_named else self._write_waveform(waveform_name_or_handle, data)

--- a/src/nimodinst/examples/nimodinst_all_devices.py
+++ b/src/nimodinst/examples/nimodinst_all_devices.py
@@ -9,7 +9,7 @@ def example():
             print("%d items" % len(session))
             print("{: >20} {: >15} {: >10}".format('Name', 'Model', 'S/N'))
         for d in session:
-            print("{: >20} {: >15} {: >10}".format(d.device_name, d.device_model, d.serial_number))
+            print(f"{d.device_name: >20} {d.device_model: >15} {d.serial_number: >10}")
 
 
 def _main():

--- a/src/nimodinst/unit_tests/test_modinst.py
+++ b/src/nimodinst/unit_tests/test_modinst.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 SESSION_NUM_FOR_TEST = 42
 
 
-class TestSession(object):
+class TestSession:
     class PatchedLibrary(nimodinst._library.Library):
         def __init__(self, ctypes_library):
             super().__init__(ctypes_library)

--- a/src/niscope/custom_types/measurement_stats.py
+++ b/src/niscope/custom_types/measurement_stats.py
@@ -1,4 +1,4 @@
-class MeasurementStats(object):
+class MeasurementStats:
     def __init__(self, result=0.0, mean=0.0, stdev=0.0, min_val=0.0, max_val=0.0, num_in_stats=0):
         self.result = result
         self.mean = mean
@@ -12,15 +12,15 @@ class MeasurementStats(object):
 
     def __repr__(self):
         parameter_list = [
-            'result={}'.format(self.result),
-            'mean={}'.format(self.mean),
-            'stdev={}'.format(self.stdev),
-            'min_val={}'.format(self.min_val),
-            'max_val={}'.format(self.max_val),
-            'num_in_stats={}'.format(self.num_in_stats)
+            f'result={self.result}',
+            f'mean={self.mean}',
+            f'stdev={self.stdev}',
+            f'min_val={self.min_val}',
+            f'max_val={self.max_val}',
+            f'num_in_stats={self.num_in_stats}'
         ]
 
-        return '{0}({1})'.format(self.__class__.__name__, ', '.join(parameter_list))
+        return '{}({})'.format(self.__class__.__name__, ', '.join(parameter_list))
 
     def __str__(self):
         row_format_g = '{:<20}: {:,.6g}\n'

--- a/src/niscope/custom_types/waveform_info.py
+++ b/src/niscope/custom_types/waveform_info.py
@@ -43,7 +43,7 @@ class struct_niScope_wfmInfo(ctypes.Structure):  # noqa N801
             self.reserved2 = reserved2
 
 
-class WaveformInfo(object):
+class WaveformInfo:
     def __init__(self, data=None, absolute_initial_x=0.0, relative_initial_x=0.0,
                  x_increment=0.0, offset=0.0, gain=0.0,
                  reserved1=0.0, reserved2=0.0):
@@ -75,14 +75,14 @@ class WaveformInfo(object):
 
     def __repr__(self):
         parameter_list = [
-            'absolute_initial_x={}'.format(self.absolute_initial_x),
-            'relative_initial_x={}'.format(self.relative_initial_x),
-            'x_increment={}'.format(self.x_increment),
-            'offset={}'.format(self.offset),
-            'gain={}'.format(self.gain)
+            f'absolute_initial_x={self.absolute_initial_x}',
+            f'relative_initial_x={self.relative_initial_x}',
+            f'x_increment={self.x_increment}',
+            f'offset={self.offset}',
+            f'gain={self.gain}'
         ]
 
-        return '{0}({1})'.format(self.__class__.__name__, ', '.join(parameter_list))
+        return '{}({})'.format(self.__class__.__name__, ', '.join(parameter_list))
 
     def __str__(self):
         # different format lines

--- a/src/niscope/examples/niscope_fetch.py
+++ b/src/niscope/examples/niscope_fetch.py
@@ -15,7 +15,7 @@ def example(resource_name, channels, options, length, voltage):
         with session.initiate():
             waveforms = session.channels[channels].fetch(num_samples=length)
         for i in range(len(waveforms)):
-            print('Waveform {0} information:'.format(i))
+            print(f'Waveform {i} information:')
             print(str(waveforms[i]) + '\n\n')
 
 

--- a/src/niscope/examples/niscope_read.py
+++ b/src/niscope/examples/niscope_read.py
@@ -14,7 +14,7 @@ def example(resource_name, channels, options, length, voltage):
         session.configure_horizontal_timing(min_sample_rate=50000000, min_num_pts=length, ref_position=50.0, num_records=1, enforce_realtime=True)
         waveforms = session.channels[channels].read(num_samples=length)
         for i in range(len(waveforms)):
-            print('Waveform {0} information:'.format(i))
+            print(f'Waveform {i} information:')
             print(str(waveforms[i]) + '\n\n')
 
 

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -106,7 +106,7 @@ class SystemTests:
         assert default_option is False
 
     def test_vi_string_attribute(self, multi_instrument_session):
-        trigger_source = '/{0}/NISCOPE_VAL_IMMEDIATE'.format(instruments[1])
+        trigger_source = f'/{instruments[1]}/NISCOPE_VAL_IMMEDIATE'
         multi_instrument_session.acq_arm_source = trigger_source
         assert trigger_source == multi_instrument_session.acq_arm_source
 
@@ -464,21 +464,21 @@ class SystemTests:
 
     # Basic configuration tests
     def test_configure_trigger_digital(self, multi_instrument_session):
-        trigger_source = '/{0}/VAL_RTSI_0'.format(instruments[1])
+        trigger_source = f'/{instruments[1]}/VAL_RTSI_0'
         multi_instrument_session.configure_trigger_digital(trigger_source)
         multi_instrument_session.vertical_range = 5
         assert trigger_source == multi_instrument_session.trigger_source
 
     def test_configure_trigger_edge(self, multi_instrument_session):
         assert niscope.TriggerSlope.POSITIVE == multi_instrument_session.trigger_slope
-        trigger_source = '{0}/0'.format(instruments[1])
+        trigger_source = f'{instruments[1]}/0'
         multi_instrument_session.configure_trigger_edge(trigger_source, 0.0, niscope.TriggerCoupling.DC)
         multi_instrument_session.commit()
         assert trigger_source == multi_instrument_session.trigger_source
         assert niscope.TriggerCoupling.DC == multi_instrument_session.trigger_coupling
 
     def test_configure_trigger_hysteresis(self, multi_instrument_session):
-        trigger_source = '{0}/1'.format(instruments[1])
+        trigger_source = f'{instruments[1]}/1'
         multi_instrument_session.configure_trigger_hysteresis(trigger_source, 0.0, 0.05, niscope.TriggerCoupling.DC)
         assert trigger_source == multi_instrument_session.trigger_source
         assert niscope.TriggerCoupling.DC == multi_instrument_session.trigger_coupling
@@ -521,7 +521,7 @@ class SystemTests:
         assert niscope.TriggerCoupling.DC == session_5124.trigger_coupling
 
     def test_configure_trigger_window(self, multi_instrument_session):
-        trigger_source = '{0}/1'.format(instruments[1])
+        trigger_source = f'{instruments[1]}/1'
         multi_instrument_session.configure_trigger_window(trigger_source, 0, 5, niscope.TriggerWindowMode.ENTERING, niscope.TriggerCoupling.DC)
         assert trigger_source == multi_instrument_session.trigger_source
         assert niscope.TriggerWindowMode.ENTERING == multi_instrument_session.trigger_window_mode

--- a/src/niscope/templates/session.py/fetch_waveform.py.mako
+++ b/src/niscope/templates/session.py/fetch_waveform.py.mako
@@ -30,7 +30,7 @@
         elif waveform.dtype == numpy.int32:
             wfm_info = self._fetch_binary32_into_numpy(num_samples=num_samples, waveform=waveform, timeout=timeout)
         else:
-            raise TypeError("Unsupported dtype. Is {0}, expected {1}, {2}, {3}, or {4}".format(waveform.dtype, numpy.float64, numpy.int8, numpy.int16, numpy.int32))
+            raise TypeError("Unsupported dtype. Is {}, expected {}, {}, {}, or {}".format(waveform.dtype, numpy.float64, numpy.int8, numpy.int16, numpy.int32))
 
         mv = memoryview(waveform)
 

--- a/src/nitclk/examples/nitclk_niscope_synchronize_with_trigger.py
+++ b/src/nitclk/examples/nitclk_niscope_synchronize_with_trigger.py
@@ -19,7 +19,7 @@ def example(resource_name1, resource_name2, options):
         session1.send_software_trigger_edge(niscope.WhichTrigger.START)
         waveforms = session2.channels[0].fetch(num_samples=1000)
         for i in range(len(waveforms)):
-            print('Waveform {0} information:'.format(i))
+            print(f'Waveform {i} information:')
             print(str(waveforms[i]) + '\n\n')
 
 

--- a/src/nitclk/unit_tests/test_nitclk.py
+++ b/src/nitclk/unit_tests/test_nitclk.py
@@ -12,7 +12,7 @@ single_session = [SESSION_NUM_FOR_TEST]
 multiple_sessions = [SESSION_NUM_FOR_TEST, SESSION_NUM_FOR_TEST * 10, SESSION_NUM_FOR_TEST * 100, SESSION_NUM_FOR_TEST + 1]
 
 
-class NitclkSupportingDriverSession(object):
+class NitclkSupportingDriverSession:
     '''Session objects for drivers that support NI-TClk are expected to have a property of type nitclk.SessionReference called tclk
 
     This is why we're creating this fake driver class and adding the tclk property.
@@ -21,7 +21,7 @@ class NitclkSupportingDriverSession(object):
         self.tclk = nitclk.SessionReference(session_number)
 
 
-class TestNitclkApi(object):
+class TestNitclkApi:
     class PatchedLibrary(nitclk._library.Library):
         def __init__(self, ctypes_library):
             super().__init__(ctypes_library)

--- a/tools/build_release.py
+++ b/tools/build_release.py
@@ -73,7 +73,7 @@ Steps
     build_group.add_argument("--upload", action="store_true", default=False, help="Upload build distributions to PyPI")
     build_group.add_argument("--update", action="store_true", default=False, help="Update version in config.py files")
     build_group.add_argument("--build", action="store_true", default=False, help="Clean and build")
-    build_group.add_argument("--python-cmd", action="store", default=None, help="Command to use for invoking python. Default: {}".format(default_python_cmd))
+    build_group.add_argument("--python-cmd", action="store", default=None, help=f"Command to use for invoking python. Default: {default_python_cmd}")
 
     verbosity_group = parser.add_argument_group("Verbosity, Logging & Debugging")
     verbosity_group.add_argument("-v", "--verbose", action="count", default=0, help="Verbose output")
@@ -107,8 +107,8 @@ Steps
         logging.info('Updating versions')
 
         for d in drivers_to_update:
-            logging.info(pp.pformat(python_cmd + ['tools/updateReleaseInfo.py', '--src-file', 'src/{}/metadata/config_addon.py'.format(d), ] + passthrough_params))
-            check_call(python_cmd + ['tools/updateReleaseInfo.py', '--src-file', 'src/{}/metadata/config_addon.py'.format(d), ] + passthrough_params)
+            logging.info(pp.pformat(python_cmd + ['tools/updateReleaseInfo.py', '--src-file', f'src/{d}/metadata/config_addon.py', ] + passthrough_params))
+            check_call(python_cmd + ['tools/updateReleaseInfo.py', '--src-file', f'src/{d}/metadata/config_addon.py', ] + passthrough_params)
 
     if args.build:
         logging.info('Clean and build')
@@ -123,7 +123,7 @@ Steps
         logging.info('Uploading to PyPI')
         complete_twine_cmd = twine_cmd + ['upload']
         for d in drivers_to_upload:
-            complete_twine_cmd += ['generated/{}/dist/*'.format(d)]
+            complete_twine_cmd += [f'generated/{d}/dist/*']
 
         logging.info(pp.pformat(complete_twine_cmd))
         if not args.preview:

--- a/tools/install_local_wheel.py
+++ b/tools/install_local_wheel.py
@@ -43,7 +43,7 @@ Install the wheel found in generated/<driver>/dist
     for file in os.listdir(rel_path):
         if file.endswith(".whl"):
             if wheel is not None:
-                logging.error('More than one wheel has been found: {0} and {1}'.format(wheel, os.path.join(rel_path, file)))
+                logging.error(f'More than one wheel has been found: {wheel} and {os.path.join(rel_path, file)}')
                 sys.exit(1)
             wheel = os.path.join(rel_path, file)
 

--- a/tools/simple_mako.py
+++ b/tools/simple_mako.py
@@ -30,7 +30,7 @@ def generate_template(template_name, template_params, dest_file):
         lines = tback.source.split('\n')
 
         # The underlying error.
-        logging.error("\n%s: %s\n" % (str(tback.error.__class__.__name__), str(tback.error)))
+        logging.error("\n{}: {}\n".format(str(tback.error.__class__.__name__), str(tback.error)))
         logging.error("Offending Template: %s\n" % template_name)
 
         # Show a source listing of the template, with offending line marked.

--- a/tools/updateReleaseInfo.py
+++ b/tools/updateReleaseInfo.py
@@ -34,7 +34,7 @@ Update version when it is a dev version. I.e. X.Y.Z.devN to X.Y.Z.dev(N+1)
 
     logging.info(pp.pformat(args))
 
-    with open(args.src_file, 'r') as content_file:
+    with open(args.src_file) as content_file:
         contents = content_file.read()
 
     module_dev_version_re = re.compile(r"'module_version': '(\d+\.\d+\.\d+)\.dev(\d+)'")
@@ -42,16 +42,16 @@ Update version when it is a dev version. I.e. X.Y.Z.devN to X.Y.Z.dev(N+1)
     if m:
         if args.release:
             logging.info('Dev version found, updating {0}.dev{1} to {0}'.format(m.group(1), int(m.group(2))))
-            contents = module_dev_version_re.sub("'module_version': '{0}'".format(m.group(1)), contents)
+            contents = module_dev_version_re.sub(f"'module_version': '{m.group(1)}'", contents)
         else:
             logging.info('Dev version found, updating {0}.dev{1} to {0}.dev{2}'.format(m.group(1), int(m.group(2)), int(m.group(2)) + 1))
-            contents = module_dev_version_re.sub("'module_version': '{0}.dev{1}'".format(m.group(1), int(m.group(2)) + 1), contents)
+            contents = module_dev_version_re.sub(f"'module_version': '{m.group(1)}.dev{int(m.group(2)) + 1}'", contents)
 
     module_version_re = re.compile(r"'module_version': '(\d+\.\d+\.)(\d+)'")
     m = module_version_re.search(contents)
     if m and not args.release:
         logging.info('Release version found, updating {0}{1} to {0}{2}.dev0'.format(m.group(1), int(m.group(2)), int(m.group(2)) + 1))
-        contents = module_version_re.sub("'module_version': '{0}{1}.dev0'".format(m.group(1), int(m.group(2)) + 1), contents)
+        contents = module_version_re.sub(f"'module_version': '{m.group(1)}{int(m.group(2)) + 1}.dev0'", contents)
 
     if not args.preview:
         with open(args.src_file, 'w') as content_file:


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~

- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
Note: No hand-coded changes are included.

Using a script, I ran `pyupgrade --py38-plus` on files in nimi-python. [pyupgrade](https://pypi.org/project/pyupgrade/) is a tool used to automatically update the syntax used in Python code to syntaxes available in newer versions.

The script ran on the following folders:
- build
- docs
- source
- tools

The script ignored folder paths containing:
- .tox
- `__pycache__`

The script ignored files with the extensions:
- ..digiproj
- .mak
- .proto

The script ignored imported metadata files (the ones that say they were generated) as well as "fancy_fetch_capture_waveform.py.mako" (pyupgrade messed up the indentation) and "_get_error_description.py.mako" (pyupgrade messed up the indentation).

List of automatic changes that I noticed:
- String formatting (most of the changes were this)
  - Use fstrings where reasonable
  - delete unnecessary index arguments to {} for strings where we continue to use .format
    - pyupgrade is timid about f-string usage in order to maintain short and readable code
  - replace use of really old % format specifier with .format
- removal of coding: utf-8 comment (it's the default encoding)
- drop unnecessary Object argument from base class declarations
- Use dict comprehension rather than whatever we were doing in nifake/unit_tests/test_grpc.py
- Use set comprehension in metadata_add_all.py
- delete unnecessary arguments from open() calls

I discarded changes to test_converters.py. I believe we're not passing the right arguments for some tuple tests, so I want to handle that separately.

### List issues fixed by this Pull Request below, if any.
None

### What testing has been done?
- I reviewed every line that was changed.
- PR Checks
