### PR TITLE
Do not overwrite example testing results

### DIFF
--- a/.github/actions/linux/action.yml
+++ b/.github/actions/linux/action.yml
@@ -13,7 +13,6 @@ runs:
         source /etc/bashrc
         cd generated
         mkdir junit
-        mkdir kibana
         cd ${{ inputs.module_name }}
         python -m tox -c tox-system_tests.ini
       shell: bash

--- a/.github/actions/windows/action.yml
+++ b/.github/actions/windows/action.yml
@@ -12,7 +12,6 @@ runs:
     - run: |
         cd generated        
         mkdir junit
-        mkdir kibana
         cd ${{ inputs.module_name }}
         python -m tox -c tox-system_tests.ini
       shell: powershell

--- a/build/templates/tox-system_tests.ini.mako
+++ b/build/templates/tox-system_tests.ini.mako
@@ -58,8 +58,8 @@ commands =
     ${module_name}-system_tests: python ../../tools/install_local_wheel.py --driver ${other_wheel} --start-path ../..
 % endif
     ${module_name}-system_tests: python -c "import ${module_name}; ${module_name}.print_diagnostic_information()"
-    ${module_name}-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source ${module_name} --parallel-mode -m pytest ../../src/${module_name}/examples --junitxml=../junit/junit-${module_name}-{envname}-{env:BITNESS:64}.xml --json=../kibana/${module_name}_system_test_result.json {posargs}
-    ${module_name}-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source ${module_name} --parallel-mode -m pytest ../../src/${module_name}/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-${module_name}-{envname}-{env:BITNESS:64}.xml --json=../kibana/${module_name}_system_test_result.json --durations=5 {posargs}
+    ${module_name}-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source ${module_name} --parallel-mode -m pytest ../../src/${module_name}/examples --junitxml=../junit/junit-${module_name}-{envname}-{env:BITNESS:64}.xml {posargs}
+    ${module_name}-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source ${module_name} --parallel-mode -m pytest ../../src/${module_name}/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-${module_name}-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
 
     ${module_name}-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./
     # Create the report to upload

--- a/build/templates/tox-system_tests.ini.mako
+++ b/build/templates/tox-system_tests.ini.mako
@@ -58,7 +58,7 @@ commands =
     ${module_name}-system_tests: python ../../tools/install_local_wheel.py --driver ${other_wheel} --start-path ../..
 % endif
     ${module_name}-system_tests: python -c "import ${module_name}; ${module_name}.print_diagnostic_information()"
-    ${module_name}-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source ${module_name} --parallel-mode -m pytest ../../src/${module_name}/examples --junitxml=../junit/junit-${module_name}-{envname}-{env:BITNESS:64}.xml {posargs}
+    ${module_name}-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source ${module_name} --parallel-mode -m pytest ../../src/${module_name}/examples --junitxml=../junit/junit-${module_name}-{envname}-examples-{env:BITNESS:64}.xml {posargs}
     ${module_name}-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source ${module_name} --parallel-mode -m pytest ../../src/${module_name}/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-${module_name}-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
 
     ${module_name}-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./

--- a/generated/nidcpower/tox-system_tests.ini
+++ b/generated/nidcpower/tox-system_tests.ini
@@ -22,7 +22,7 @@ commands =
     # --disable-pip-version-check prevents pip from telling us we need to upgrade pip, since we are doing that now
     nidcpower-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     nidcpower-system_tests: python -c "import nidcpower; nidcpower.print_diagnostic_information()"
-    nidcpower-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidcpower --parallel-mode -m pytest ../../src/nidcpower/examples --junitxml=../junit/junit-nidcpower-{envname}-{env:BITNESS:64}.xml {posargs}
+    nidcpower-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidcpower --parallel-mode -m pytest ../../src/nidcpower/examples --junitxml=../junit/junit-nidcpower-{envname}-examples-{env:BITNESS:64}.xml {posargs}
     nidcpower-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidcpower --parallel-mode -m pytest ../../src/nidcpower/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nidcpower-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
 
     nidcpower-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./

--- a/generated/nidcpower/tox-system_tests.ini
+++ b/generated/nidcpower/tox-system_tests.ini
@@ -22,8 +22,8 @@ commands =
     # --disable-pip-version-check prevents pip from telling us we need to upgrade pip, since we are doing that now
     nidcpower-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     nidcpower-system_tests: python -c "import nidcpower; nidcpower.print_diagnostic_information()"
-    nidcpower-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidcpower --parallel-mode -m pytest ../../src/nidcpower/examples --junitxml=../junit/junit-nidcpower-{envname}-{env:BITNESS:64}.xml --json=../kibana/nidcpower_system_test_result.json {posargs}
-    nidcpower-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidcpower --parallel-mode -m pytest ../../src/nidcpower/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nidcpower-{envname}-{env:BITNESS:64}.xml --json=../kibana/nidcpower_system_test_result.json --durations=5 {posargs}
+    nidcpower-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidcpower --parallel-mode -m pytest ../../src/nidcpower/examples --junitxml=../junit/junit-nidcpower-{envname}-{env:BITNESS:64}.xml {posargs}
+    nidcpower-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidcpower --parallel-mode -m pytest ../../src/nidcpower/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nidcpower-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
 
     nidcpower-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./
     # Create the report to upload

--- a/generated/nidigital/tox-system_tests.ini
+++ b/generated/nidigital/tox-system_tests.ini
@@ -27,8 +27,8 @@ commands =
     nidigital-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     nidigital-system_tests: python ../../tools/install_local_wheel.py --driver nitclk --start-path ../..
     nidigital-system_tests: python -c "import nidigital; nidigital.print_diagnostic_information()"
-    nidigital-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidigital --parallel-mode -m pytest ../../src/nidigital/examples --junitxml=../junit/junit-nidigital-{envname}-{env:BITNESS:64}.xml --json=../kibana/nidigital_system_test_result.json {posargs}
-    nidigital-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidigital --parallel-mode -m pytest ../../src/nidigital/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nidigital-{envname}-{env:BITNESS:64}.xml --json=../kibana/nidigital_system_test_result.json --durations=5 {posargs}
+    nidigital-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidigital --parallel-mode -m pytest ../../src/nidigital/examples --junitxml=../junit/junit-nidigital-{envname}-{env:BITNESS:64}.xml {posargs}
+    nidigital-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidigital --parallel-mode -m pytest ../../src/nidigital/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nidigital-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
 
     nidigital-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./
     # Create the report to upload

--- a/generated/nidigital/tox-system_tests.ini
+++ b/generated/nidigital/tox-system_tests.ini
@@ -27,7 +27,7 @@ commands =
     nidigital-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     nidigital-system_tests: python ../../tools/install_local_wheel.py --driver nitclk --start-path ../..
     nidigital-system_tests: python -c "import nidigital; nidigital.print_diagnostic_information()"
-    nidigital-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidigital --parallel-mode -m pytest ../../src/nidigital/examples --junitxml=../junit/junit-nidigital-{envname}-{env:BITNESS:64}.xml {posargs}
+    nidigital-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidigital --parallel-mode -m pytest ../../src/nidigital/examples --junitxml=../junit/junit-nidigital-{envname}-examples-{env:BITNESS:64}.xml {posargs}
     nidigital-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidigital --parallel-mode -m pytest ../../src/nidigital/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nidigital-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
 
     nidigital-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./

--- a/generated/nidmm/tox-system_tests.ini
+++ b/generated/nidmm/tox-system_tests.ini
@@ -22,7 +22,7 @@ commands =
     # --disable-pip-version-check prevents pip from telling us we need to upgrade pip, since we are doing that now
     nidmm-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     nidmm-system_tests: python -c "import nidmm; nidmm.print_diagnostic_information()"
-    nidmm-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidmm --parallel-mode -m pytest ../../src/nidmm/examples --junitxml=../junit/junit-nidmm-{envname}-{env:BITNESS:64}.xml {posargs}
+    nidmm-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidmm --parallel-mode -m pytest ../../src/nidmm/examples --junitxml=../junit/junit-nidmm-{envname}-examples-{env:BITNESS:64}.xml {posargs}
     nidmm-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidmm --parallel-mode -m pytest ../../src/nidmm/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nidmm-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
 
     nidmm-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./

--- a/generated/nidmm/tox-system_tests.ini
+++ b/generated/nidmm/tox-system_tests.ini
@@ -22,8 +22,8 @@ commands =
     # --disable-pip-version-check prevents pip from telling us we need to upgrade pip, since we are doing that now
     nidmm-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     nidmm-system_tests: python -c "import nidmm; nidmm.print_diagnostic_information()"
-    nidmm-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidmm --parallel-mode -m pytest ../../src/nidmm/examples --junitxml=../junit/junit-nidmm-{envname}-{env:BITNESS:64}.xml --json=../kibana/nidmm_system_test_result.json {posargs}
-    nidmm-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidmm --parallel-mode -m pytest ../../src/nidmm/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nidmm-{envname}-{env:BITNESS:64}.xml --json=../kibana/nidmm_system_test_result.json --durations=5 {posargs}
+    nidmm-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidmm --parallel-mode -m pytest ../../src/nidmm/examples --junitxml=../junit/junit-nidmm-{envname}-{env:BITNESS:64}.xml {posargs}
+    nidmm-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidmm --parallel-mode -m pytest ../../src/nidmm/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nidmm-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
 
     nidmm-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./
     # Create the report to upload

--- a/generated/nifake/tox-system_tests.ini
+++ b/generated/nifake/tox-system_tests.ini
@@ -27,7 +27,7 @@ commands =
     nifake-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     nifake-system_tests: python ../../tools/install_local_wheel.py --driver nitclk --start-path ../..
     nifake-system_tests: python -c "import nifake; nifake.print_diagnostic_information()"
-    nifake-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nifake --parallel-mode -m pytest ../../src/nifake/examples --junitxml=../junit/junit-nifake-{envname}-{env:BITNESS:64}.xml {posargs}
+    nifake-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nifake --parallel-mode -m pytest ../../src/nifake/examples --junitxml=../junit/junit-nifake-{envname}-examples-{env:BITNESS:64}.xml {posargs}
     nifake-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nifake --parallel-mode -m pytest ../../src/nifake/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nifake-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
 
     nifake-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./

--- a/generated/nifake/tox-system_tests.ini
+++ b/generated/nifake/tox-system_tests.ini
@@ -27,8 +27,8 @@ commands =
     nifake-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     nifake-system_tests: python ../../tools/install_local_wheel.py --driver nitclk --start-path ../..
     nifake-system_tests: python -c "import nifake; nifake.print_diagnostic_information()"
-    nifake-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nifake --parallel-mode -m pytest ../../src/nifake/examples --junitxml=../junit/junit-nifake-{envname}-{env:BITNESS:64}.xml --json=../kibana/nifake_system_test_result.json {posargs}
-    nifake-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nifake --parallel-mode -m pytest ../../src/nifake/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nifake-{envname}-{env:BITNESS:64}.xml --json=../kibana/nifake_system_test_result.json --durations=5 {posargs}
+    nifake-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nifake --parallel-mode -m pytest ../../src/nifake/examples --junitxml=../junit/junit-nifake-{envname}-{env:BITNESS:64}.xml {posargs}
+    nifake-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nifake --parallel-mode -m pytest ../../src/nifake/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nifake-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
 
     nifake-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./
     # Create the report to upload

--- a/generated/nifgen/tox-system_tests.ini
+++ b/generated/nifgen/tox-system_tests.ini
@@ -27,8 +27,8 @@ commands =
     nifgen-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     nifgen-system_tests: python ../../tools/install_local_wheel.py --driver nitclk --start-path ../..
     nifgen-system_tests: python -c "import nifgen; nifgen.print_diagnostic_information()"
-    nifgen-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nifgen --parallel-mode -m pytest ../../src/nifgen/examples --junitxml=../junit/junit-nifgen-{envname}-{env:BITNESS:64}.xml --json=../kibana/nifgen_system_test_result.json {posargs}
-    nifgen-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nifgen --parallel-mode -m pytest ../../src/nifgen/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nifgen-{envname}-{env:BITNESS:64}.xml --json=../kibana/nifgen_system_test_result.json --durations=5 {posargs}
+    nifgen-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nifgen --parallel-mode -m pytest ../../src/nifgen/examples --junitxml=../junit/junit-nifgen-{envname}-{env:BITNESS:64}.xml {posargs}
+    nifgen-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nifgen --parallel-mode -m pytest ../../src/nifgen/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nifgen-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
 
     nifgen-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./
     # Create the report to upload

--- a/generated/nifgen/tox-system_tests.ini
+++ b/generated/nifgen/tox-system_tests.ini
@@ -27,7 +27,7 @@ commands =
     nifgen-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     nifgen-system_tests: python ../../tools/install_local_wheel.py --driver nitclk --start-path ../..
     nifgen-system_tests: python -c "import nifgen; nifgen.print_diagnostic_information()"
-    nifgen-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nifgen --parallel-mode -m pytest ../../src/nifgen/examples --junitxml=../junit/junit-nifgen-{envname}-{env:BITNESS:64}.xml {posargs}
+    nifgen-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nifgen --parallel-mode -m pytest ../../src/nifgen/examples --junitxml=../junit/junit-nifgen-{envname}-examples-{env:BITNESS:64}.xml {posargs}
     nifgen-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nifgen --parallel-mode -m pytest ../../src/nifgen/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nifgen-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
 
     nifgen-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./

--- a/generated/nimodinst/tox-system_tests.ini
+++ b/generated/nimodinst/tox-system_tests.ini
@@ -22,8 +22,8 @@ commands =
     # --disable-pip-version-check prevents pip from telling us we need to upgrade pip, since we are doing that now
     nimodinst-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     nimodinst-system_tests: python -c "import nimodinst; nimodinst.print_diagnostic_information()"
-    nimodinst-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nimodinst --parallel-mode -m pytest ../../src/nimodinst/examples --junitxml=../junit/junit-nimodinst-{envname}-{env:BITNESS:64}.xml --json=../kibana/nimodinst_system_test_result.json {posargs}
-    nimodinst-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nimodinst --parallel-mode -m pytest ../../src/nimodinst/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nimodinst-{envname}-{env:BITNESS:64}.xml --json=../kibana/nimodinst_system_test_result.json --durations=5 {posargs}
+    nimodinst-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nimodinst --parallel-mode -m pytest ../../src/nimodinst/examples --junitxml=../junit/junit-nimodinst-{envname}-{env:BITNESS:64}.xml {posargs}
+    nimodinst-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nimodinst --parallel-mode -m pytest ../../src/nimodinst/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nimodinst-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
 
     nimodinst-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./
     # Create the report to upload

--- a/generated/nimodinst/tox-system_tests.ini
+++ b/generated/nimodinst/tox-system_tests.ini
@@ -22,7 +22,7 @@ commands =
     # --disable-pip-version-check prevents pip from telling us we need to upgrade pip, since we are doing that now
     nimodinst-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     nimodinst-system_tests: python -c "import nimodinst; nimodinst.print_diagnostic_information()"
-    nimodinst-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nimodinst --parallel-mode -m pytest ../../src/nimodinst/examples --junitxml=../junit/junit-nimodinst-{envname}-{env:BITNESS:64}.xml {posargs}
+    nimodinst-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nimodinst --parallel-mode -m pytest ../../src/nimodinst/examples --junitxml=../junit/junit-nimodinst-{envname}-examples-{env:BITNESS:64}.xml {posargs}
     nimodinst-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nimodinst --parallel-mode -m pytest ../../src/nimodinst/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nimodinst-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
 
     nimodinst-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./

--- a/generated/niscope/tox-system_tests.ini
+++ b/generated/niscope/tox-system_tests.ini
@@ -27,8 +27,8 @@ commands =
     niscope-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     niscope-system_tests: python ../../tools/install_local_wheel.py --driver nitclk --start-path ../..
     niscope-system_tests: python -c "import niscope; niscope.print_diagnostic_information()"
-    niscope-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source niscope --parallel-mode -m pytest ../../src/niscope/examples --junitxml=../junit/junit-niscope-{envname}-{env:BITNESS:64}.xml --json=../kibana/niscope_system_test_result.json {posargs}
-    niscope-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source niscope --parallel-mode -m pytest ../../src/niscope/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-niscope-{envname}-{env:BITNESS:64}.xml --json=../kibana/niscope_system_test_result.json --durations=5 {posargs}
+    niscope-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source niscope --parallel-mode -m pytest ../../src/niscope/examples --junitxml=../junit/junit-niscope-{envname}-{env:BITNESS:64}.xml {posargs}
+    niscope-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source niscope --parallel-mode -m pytest ../../src/niscope/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-niscope-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
 
     niscope-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./
     # Create the report to upload

--- a/generated/niscope/tox-system_tests.ini
+++ b/generated/niscope/tox-system_tests.ini
@@ -27,7 +27,7 @@ commands =
     niscope-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     niscope-system_tests: python ../../tools/install_local_wheel.py --driver nitclk --start-path ../..
     niscope-system_tests: python -c "import niscope; niscope.print_diagnostic_information()"
-    niscope-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source niscope --parallel-mode -m pytest ../../src/niscope/examples --junitxml=../junit/junit-niscope-{envname}-{env:BITNESS:64}.xml {posargs}
+    niscope-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source niscope --parallel-mode -m pytest ../../src/niscope/examples --junitxml=../junit/junit-niscope-{envname}-examples-{env:BITNESS:64}.xml {posargs}
     niscope-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source niscope --parallel-mode -m pytest ../../src/niscope/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-niscope-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
 
     niscope-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./

--- a/generated/nise/tox-system_tests.ini
+++ b/generated/nise/tox-system_tests.ini
@@ -22,7 +22,7 @@ commands =
     # --disable-pip-version-check prevents pip from telling us we need to upgrade pip, since we are doing that now
     nise-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     nise-system_tests: python -c "import nise; nise.print_diagnostic_information()"
-    nise-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nise --parallel-mode -m pytest ../../src/nise/examples --junitxml=../junit/junit-nise-{envname}-{env:BITNESS:64}.xml {posargs}
+    nise-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nise --parallel-mode -m pytest ../../src/nise/examples --junitxml=../junit/junit-nise-{envname}-examples-{env:BITNESS:64}.xml {posargs}
     nise-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nise --parallel-mode -m pytest ../../src/nise/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nise-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
 
     nise-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./

--- a/generated/nise/tox-system_tests.ini
+++ b/generated/nise/tox-system_tests.ini
@@ -22,8 +22,8 @@ commands =
     # --disable-pip-version-check prevents pip from telling us we need to upgrade pip, since we are doing that now
     nise-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     nise-system_tests: python -c "import nise; nise.print_diagnostic_information()"
-    nise-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nise --parallel-mode -m pytest ../../src/nise/examples --junitxml=../junit/junit-nise-{envname}-{env:BITNESS:64}.xml --json=../kibana/nise_system_test_result.json {posargs}
-    nise-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nise --parallel-mode -m pytest ../../src/nise/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nise-{envname}-{env:BITNESS:64}.xml --json=../kibana/nise_system_test_result.json --durations=5 {posargs}
+    nise-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nise --parallel-mode -m pytest ../../src/nise/examples --junitxml=../junit/junit-nise-{envname}-{env:BITNESS:64}.xml {posargs}
+    nise-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nise --parallel-mode -m pytest ../../src/nise/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nise-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
 
     nise-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./
     # Create the report to upload

--- a/generated/niswitch/tox-system_tests.ini
+++ b/generated/niswitch/tox-system_tests.ini
@@ -22,7 +22,7 @@ commands =
     # --disable-pip-version-check prevents pip from telling us we need to upgrade pip, since we are doing that now
     niswitch-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     niswitch-system_tests: python -c "import niswitch; niswitch.print_diagnostic_information()"
-    niswitch-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source niswitch --parallel-mode -m pytest ../../src/niswitch/examples --junitxml=../junit/junit-niswitch-{envname}-{env:BITNESS:64}.xml {posargs}
+    niswitch-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source niswitch --parallel-mode -m pytest ../../src/niswitch/examples --junitxml=../junit/junit-niswitch-{envname}-examples-{env:BITNESS:64}.xml {posargs}
     niswitch-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source niswitch --parallel-mode -m pytest ../../src/niswitch/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-niswitch-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
 
     niswitch-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./

--- a/generated/niswitch/tox-system_tests.ini
+++ b/generated/niswitch/tox-system_tests.ini
@@ -22,8 +22,8 @@ commands =
     # --disable-pip-version-check prevents pip from telling us we need to upgrade pip, since we are doing that now
     niswitch-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     niswitch-system_tests: python -c "import niswitch; niswitch.print_diagnostic_information()"
-    niswitch-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source niswitch --parallel-mode -m pytest ../../src/niswitch/examples --junitxml=../junit/junit-niswitch-{envname}-{env:BITNESS:64}.xml --json=../kibana/niswitch_system_test_result.json {posargs}
-    niswitch-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source niswitch --parallel-mode -m pytest ../../src/niswitch/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-niswitch-{envname}-{env:BITNESS:64}.xml --json=../kibana/niswitch_system_test_result.json --durations=5 {posargs}
+    niswitch-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source niswitch --parallel-mode -m pytest ../../src/niswitch/examples --junitxml=../junit/junit-niswitch-{envname}-{env:BITNESS:64}.xml {posargs}
+    niswitch-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source niswitch --parallel-mode -m pytest ../../src/niswitch/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-niswitch-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
 
     niswitch-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./
     # Create the report to upload

--- a/generated/nitclk/tox-system_tests.ini
+++ b/generated/nitclk/tox-system_tests.ini
@@ -27,7 +27,7 @@ commands =
     nitclk-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     nitclk-system_tests: python ../../tools/install_local_wheel.py --driver niscope --start-path ../..
     nitclk-system_tests: python -c "import nitclk; nitclk.print_diagnostic_information()"
-    nitclk-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nitclk --parallel-mode -m pytest ../../src/nitclk/examples --junitxml=../junit/junit-nitclk-{envname}-{env:BITNESS:64}.xml {posargs}
+    nitclk-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nitclk --parallel-mode -m pytest ../../src/nitclk/examples --junitxml=../junit/junit-nitclk-{envname}-examples-{env:BITNESS:64}.xml {posargs}
     nitclk-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nitclk --parallel-mode -m pytest ../../src/nitclk/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nitclk-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
 
     nitclk-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./

--- a/generated/nitclk/tox-system_tests.ini
+++ b/generated/nitclk/tox-system_tests.ini
@@ -27,8 +27,8 @@ commands =
     nitclk-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     nitclk-system_tests: python ../../tools/install_local_wheel.py --driver niscope --start-path ../..
     nitclk-system_tests: python -c "import nitclk; nitclk.print_diagnostic_information()"
-    nitclk-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nitclk --parallel-mode -m pytest ../../src/nitclk/examples --junitxml=../junit/junit-nitclk-{envname}-{env:BITNESS:64}.xml --json=../kibana/nitclk_system_test_result.json {posargs}
-    nitclk-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nitclk --parallel-mode -m pytest ../../src/nitclk/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nitclk-{envname}-{env:BITNESS:64}.xml --json=../kibana/nitclk_system_test_result.json --durations=5 {posargs}
+    nitclk-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nitclk --parallel-mode -m pytest ../../src/nitclk/examples --junitxml=../junit/junit-nitclk-{envname}-{env:BITNESS:64}.xml {posargs}
+    nitclk-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nitclk --parallel-mode -m pytest ../../src/nitclk/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nitclk-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
 
     nitclk-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./
     # Create the report to upload


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
* Stop creating the unused kibana jsons 
* Assign a different junitxml name to example test results, so they are not overwrriten by system test results
  * junitxmls are only used by our internal test suites

### List issues fixed by this Pull Request below, if any.

* Fix #2041

### What testing has been done?

* Ran the system tests on a local machine for niswitch.
  * Confirmed that results were being overwritten
  * Confirmed that the changes produce 2 seprate test result files, so nothing is overwritten
