### PR TITLE
[NI-DCPower] Address timeout issues with nidcpower_advanced_sequence.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to this project will be documented in this file.
 * ### `nidcpower` (NI-DCPower)
     * #### Added
     * #### Changed
+        * Fix [#1664](https://github.com/ni/nimi-python/issues/1970): nidcpower_advanced_sequence.py has several issues preventing it from working out of the box on real hardware.
     * #### Removed
 * ### `nidigital` (NI-Digital Pattern Driver)
     * #### Added

--- a/src/nidcpower/examples/nidcpower_advanced_sequence.py
+++ b/src/nidcpower/examples/nidcpower_advanced_sequence.py
@@ -7,7 +7,7 @@ import sys
 
 
 def example(resource_name, options, voltage_max, current_max, points_per_output_function, delay_in_seconds):
-    timeout = hightime.timedelta(seconds=(delay_in_seconds + 1.0))
+    timeout = hightime.timedelta(seconds=(delay_in_seconds * points_per_output_function + 1.0))
 
     with nidcpower.Session(resource_name=resource_name, options=options) as session:
         # Configure the session.
@@ -31,7 +31,6 @@ def example(resource_name, options, voltage_max, current_max, points_per_output_
             session.current_level = current_per_step * i
 
         with session.initiate():
-            session.wait_for_event(nidcpower.Event.SEQUENCE_ENGINE_DONE)
             channel_indices = '0-{0}'.format(session.channel_count - 1)
             channels = session.get_channel_names(channel_indices)
             measurement_group = [session.channels[name].fetch_multiple(points_per_output_function * 2, timeout=timeout) for name in channels]
@@ -50,7 +49,7 @@ def example(resource_name, options, voltage_max, current_max, points_per_output_
 def _main(argsv):
     parser = argparse.ArgumentParser(description='Output ramping voltage to voltage max, then ramping current to current max.', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('-n', '--resource-name', default='PXI1Slot2/0, PXI1Slot3/0-1', help='Resource names of NI SMUs.')
-    parser.add_argument('-s', '--number-steps', default=256, help='Number of steps per output function')
+    parser.add_argument('-s', '--number-steps', default=256, type=int, help='Number of steps per output function')
     parser.add_argument('-v', '--voltage-max', default=1.0, type=float, help='Maximum voltage (V)')
     parser.add_argument('-i', '--current-max', default=0.001, type=float, help='Maximum Current (I)')
     parser.add_argument('-d', '--delay', default=0.05, type=float, help='Source delay (s)')

--- a/src/nidcpower/examples/nidcpower_advanced_sequence.py
+++ b/src/nidcpower/examples/nidcpower_advanced_sequence.py
@@ -6,15 +6,13 @@ import nidcpower
 import sys
 
 
-def example(resource_name, options, voltage_max, current_max, points_per_output_function, delay_in_seconds):
-    timeout = hightime.timedelta(seconds=(delay_in_seconds * points_per_output_function + 1.0))
-
+def example(resource_name, options, voltage_max, current_max, points_per_output_function, source_delay):
     with nidcpower.Session(resource_name=resource_name, options=options) as session:
         # Configure the session.
         session.source_mode = nidcpower.SourceMode.SEQUENCE
         session.voltage_level_autorange = True
         session.current_limit_autorange = True
-        session.source_delay = hightime.timedelta(seconds=delay_in_seconds)
+        session.source_delay = hightime.timedelta(seconds=source_delay)
         properties_used = ['output_function', 'voltage_level', 'current_level']
         session.create_advanced_sequence(sequence_name='my_sequence', property_names=properties_used, set_as_active_sequence=True)
 
@@ -29,11 +27,16 @@ def example(resource_name, options, voltage_max, current_max, points_per_output_
             session.create_advanced_sequence_step(set_as_active_step=False)
             session.output_function = nidcpower.OutputFunction.DC_CURRENT
             session.current_level = current_per_step * i
-
+        
+        # Calculate the timeout.
+        aperture_time = session.aperture_time
+        total_points = points_per_output_function * 2
+        timeout = hightime.timedelta(seconds=((source_delay + aperture_time) * total_points + 1.0))
+            
         with session.initiate():
             channel_indices = '0-{0}'.format(session.channel_count - 1)
             channels = session.get_channel_names(channel_indices)
-            measurement_group = [session.channels[name].fetch_multiple(points_per_output_function * 2, timeout=timeout) for name in channels]
+            measurement_group = [session.channels[name].fetch_multiple(total_points, timeout=timeout) for name in channels]
 
         session.delete_advanced_sequence(sequence_name='my_sequence')
         line_format = '{:<15} {:<4} {:<10} {:<10} {:<6}'


### PR DESCRIPTION
- [ x ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [ x ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

TODO: Check the above box with an 'x' if considered if there were any and then documented client facing changes in [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md). Strike through if this is not a relevant client facing change.

- [ x ] I've added tests applicable for this pull request

TODO: Check the above box with an 'x' indicating you have considered and added any applicable system or unit tests. Strike through if you considered and decided additional tests were not warranted.

### What does this Pull Request accomplish?

This change addresses the timeout issues that prevent `nidcpower_advanced_sequence.py` from running out of the box. The fix for this was initially detailed in #1664.

More specifically, the timeout is calculated using the source delay, aperture time, and total number of points.

### List issues fixed by this Pull Request below, if any.

* Fix #1664

### What testing has been done?

I verified that the test is working with real hardware.
