### PR TITLE
[DO NOT MERGE] Do not trigger system testing on PRs that don't need it

### DIFF
--- a/.github/workflows/github_actions_aws_rhel_python64.yml
+++ b/.github/workflows/github_actions_aws_rhel_python64.yml
@@ -5,12 +5,12 @@ on:
     branches:
       - master
       - releases/*
-    paths-ignore:
-      - CHANGELOG.md
-      - CONTRIBUTING.md
-      - .gitattributes
-      - LICENSE
-      - VERSION
+    paths:
+      - .github/workflows/github_actions_aws_rhel_python64.yml
+      - .github/actions/linux
+      - src
+      - generated
+      - tools
     types:
       - opened
       - synchronize

--- a/.github/workflows/github_actions_aws_windows_python32.yml
+++ b/.github/workflows/github_actions_aws_windows_python32.yml
@@ -5,12 +5,12 @@ on:
     branches:
       - master
       - releases/*
-    paths-ignore:
-      - CHANGELOG.md
-      - CONTRIBUTING.md
-      - .gitattributes
-      - LICENSE
-      - VERSION
+    paths:
+      - .github/workflows/github_actions_aws_windows_python32.yml
+      - .github/actions/windows
+      - src
+      - generated
+      - tools
     types:
       - opened
       - synchronize

--- a/.github/workflows/github_actions_aws_windows_python64.yml
+++ b/.github/workflows/github_actions_aws_windows_python64.yml
@@ -5,12 +5,12 @@ on:
     branches:
       - master
       - releases/*
-    paths-ignore:
-      - CHANGELOG.md
-      - CONTRIBUTING.md
-      - .gitattributes
-      - LICENSE
-      - VERSION
+    paths:
+      - .github/workflows/github_actions_aws_windows_python64.yml
+      - .github/actions/windows
+      - src
+      - generated
+      - tools
     types:
       - opened
       - synchronize


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [ ] ~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- [ ] ~I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
Right now we pretty much always run system tests on our PRs, even if we're just changing the README.md.

This changes our triggering so we only run system tests in the following cases:
* A workflow or the action it uses is changed
* We change a generated module or its source
* We change the tools folder (where we keep the coverage rc files)

I'm not changing the trigger for merges at this time.
* A special setting would be needed to not mess up the reported coverage in cases where we don't run the tests
  * I'm sure I could look it up, but there could be some churn
* I feel more secure knowing we pretty much always run tests on the latest commit, in case I overlooked something important in our triggering requirements

### List issues fixed by this Pull Request below, if any.
None

### What testing has been done?
None