### PR TITLE
Update nidcpower metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,7 @@ All notable changes to this project will be documented in this file.
             * Enum value added:
                 * `INHIBITED` added to enum `OutputStates`.
     * #### Changed
-        * **[Source Breaker]:** Enum value names in `OutputStates` have been changed:
-            * `OutputStates.VOLTAGE` -> `OutputStates.CONSTANT_VOLTAGE`
-            * `OutputStates.CURRENT` -> `OutputStates.CONSTANT_CURRENT`
+        * Fixed #2067: `nidcpower.OutputStates` values are incorrect.
     * #### Removed
 * ### `nidigital` (NI-Digital Pattern Driver)
     * #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,12 +46,6 @@ All notable changes to this project will be documented in this file.
             * Enum value added:
                 * `INHIBITED` added to enum `OutputStates`.
     * #### Changed
-        * Function documentation updated:
-            * `query_output_state`
-                * Updated enum descriptions for the `output_state` arg.
-        * Attribute documentation updated:
-            * `measure_buffer_size`, `measure_complete_event_delay`, and `source_delay` descriptions updated to specify `PXIe-4150/4151` instead of `PXIe-4151`.
-            * Updated `merged_channels` description wording.
     * #### Removed
 * ### `nidigital` (NI-Digital Pattern Driver)
     * #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,16 @@ All notable changes to this project will be documented in this file.
     * #### Removed
 * ### `nidcpower` (NI-DCPower)
     * #### Added
+        * API parity with NI-DCPower 2025 Q1.
+            * Enum value added:
+                * `INHIBITED` added to enum `OutputStates`.
     * #### Changed
+        * Function documentation updated:
+            * `query_output_state`
+                * Updated enum descriptions for the `output_state` arg.
+        * Attribute documentation updated:
+            * `measure_buffer_size`, `measure_complete_event_delay`, and `source_delay` descriptions updated to specify `PXIe-4150/4151` instead of `PXIe-4151`.
+            * Updated `merged_channels` description wording.
     * #### Removed
 * ### `nidigital` (NI-Digital Pattern Driver)
     * #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ All notable changes to this project will be documented in this file.
             * Enum value added:
                 * `INHIBITED` added to enum `OutputStates`.
     * #### Changed
+        * **[Source Breaker]:** Enum value names in `OutputStates` have been changed:
+            * `OutputStates.VOLTAGE` -> `OutputStates.CONSTANT_VOLTAGE`
+            * `OutputStates.CURRENT` -> `OutputStates.CONSTANT_CURRENT`
     * #### Removed
 * ### `nidigital` (NI-Digital Pattern Driver)
     * #### Added

--- a/docs/nidcpower/class.rst
+++ b/docs/nidcpower/class.rst
@@ -2480,13 +2480,13 @@ query_output_state
                 Specifies the output state of the channel that is being queried.
                 **Defined Values**:
 
-                +----------------------------------------------+--------------------------------------------------------------------+
-                | :py:data:`~nidcpower.OutputStates.VOLTAGE`   | The channel maintains a constant voltage by adjusting the current. |
-                +----------------------------------------------+--------------------------------------------------------------------+
-                | :py:data:`~nidcpower.OutputStates.CURRENT`   | The channel maintains a constant current by adjusting the voltage. |
-                +----------------------------------------------+--------------------------------------------------------------------+
-                | :py:data:`~nidcpower.OutputStates.INHIBITED` | The channel is in the inhibited state.                             |
-                +----------------------------------------------+--------------------------------------------------------------------+
+                +-----------------------------------------------------+--------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputStates.CONSTANT_VOLTAGE` | The channel maintains a constant voltage by adjusting the current. |
+                +-----------------------------------------------------+--------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputStates.CONSTANT_CURRENT` | The channel maintains a constant current by adjusting the voltage. |
+                +-----------------------------------------------------+--------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputStates.INHIBITED`        | The channel is in the inhibited state.                             |
+                +-----------------------------------------------------+--------------------------------------------------------------------+
 
 
             :type output_state: :py:data:`nidcpower.OutputStates`

--- a/docs/nidcpower/class.rst
+++ b/docs/nidcpower/class.rst
@@ -2480,11 +2480,13 @@ query_output_state
                 Specifies the output state of the channel that is being queried.
                 **Defined Values**:
 
-                +--------------------------------------------+-------------------------------------------------------------------+
-                | :py:data:`~nidcpower.OutputStates.VOLTAGE` | The device maintains a constant voltage by adjusting the current. |
-                +--------------------------------------------+-------------------------------------------------------------------+
-                | :py:data:`~nidcpower.OutputStates.CURRENT` | The device maintains a constant current by adjusting the voltage. |
-                +--------------------------------------------+-------------------------------------------------------------------+
+                +-----------------------------------------------------+--------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputStates.CONSTANT_VOLTAGE` | The channel maintains a constant voltage by adjusting the current. |
+                +-----------------------------------------------------+--------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputStates.CONSTANT_CURRENT` | The channel maintains a constant current by adjusting the voltage. |
+                +-----------------------------------------------------+--------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputStates.INHIBITED`        | The channel is in the inhibited state.                             |
+                +-----------------------------------------------------+--------------------------------------------------------------------+
 
 
             :type output_state: :py:data:`nidcpower.OutputStates`
@@ -6868,7 +6870,7 @@ measure_buffer_size
 
         Specifies the number of samples that the active channel measurement buffer can hold.
         The default value is the maximum number of samples that a device is capable of recording in one second.
-        Valid Values: The PXIe-4051, PXIe-4147, and PXIe-4151 support values from 170 to 18000110.
+        Valid Values: The PXIe-4051, PXIe-4147, and PXIe-4150/4151 support values from 170 to 18000110.
         The PXIe-4162/4163 supports values from  256 to 1000192.
         The PXIe-4190 supports values from 102 to 6000048.
         The PXIe-4112, PXIe-4113, and PXIe-4154 support values from 1000 to 178956970.
@@ -6915,7 +6917,7 @@ measure_complete_event_delay
         Specifies the amount of time to delay the generation of the Measure Complete event, in seconds.
         Valid Values: The PXIe-4051 supports values from 0 seconds to 39 seconds.
         The PXIe-4147 supports values from 0 seconds to 26.5 seconds.
-        The PXIe-4151 supports values from 0 seconds to 42 seconds.
+        The PXIe-4150/4151 supports values from 0 seconds to 42 seconds.
         The PXIe-4162/4163 and PXIe-4190 support values from 0 seconds to 23 seconds.
         All other supported instruments support values from 0 to 167 seconds.
         Default Value: Varies by device. Refer to Supported Properties by Device topic in the NI DC Power Supplies and SMUs Help for more information about default values.
@@ -7372,10 +7374,9 @@ merged_channels
 
     .. py:attribute:: merged_channels
 
-        Specifies the channel(s) to merge with a designated primary channel of an instrument in order to increase the maximum current you can source from the instrument.
-        This property designates the merge channels to combine with a primary channel. To designate the primary channel, initialize the session to the primary channel only.
-        Note: You cannot change the merge configuration with this property when the session is in the Running state.
-        For complete information on using merged channels with this property, refer to Merged Channels in the NI DC Power Supplies and SMUs Help.
+        Specifies the merge channel(s) to combine with a designated primary channel of an instrument in order to increase the maximum current you can source from the instrument.
+        Set this property on the primary channel only, and pass the merge channels as the value of this property.
+        Refer to the Merged Channels topic in your instrument user manual for more information about using merged channels.
 
 
 
@@ -11034,7 +11035,7 @@ source_delay
         Refer to the Single Point Source Mode and Sequence Source Mode topics for more information.
         Valid Values: The PXIe-4051 supports values from 0 to 39 seconds.
         The PXIe-4147 supports values from 0 to 26.5 seconds.
-        The PXIe-4151 supports values from 0 to 42 seconds.
+        The PXIe-4150/4151 supports values from 0 to 42 seconds.
         The PXIe-4162/4163 and PXIe-4190 support values from 0 to 23 seconds.
         All other supported instruments support values from 0 to 167 seconds.
         Default Value: 0.01667 seconds

--- a/docs/nidcpower/class.rst
+++ b/docs/nidcpower/class.rst
@@ -2480,13 +2480,13 @@ query_output_state
                 Specifies the output state of the channel that is being queried.
                 **Defined Values**:
 
-                +-----------------------------------------------------+--------------------------------------------------------------------+
-                | :py:data:`~nidcpower.OutputStates.CONSTANT_VOLTAGE` | The channel maintains a constant voltage by adjusting the current. |
-                +-----------------------------------------------------+--------------------------------------------------------------------+
-                | :py:data:`~nidcpower.OutputStates.CONSTANT_CURRENT` | The channel maintains a constant current by adjusting the voltage. |
-                +-----------------------------------------------------+--------------------------------------------------------------------+
-                | :py:data:`~nidcpower.OutputStates.INHIBITED`        | The channel is in the inhibited state.                             |
-                +-----------------------------------------------------+--------------------------------------------------------------------+
+                +----------------------------------------------+--------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputStates.VOLTAGE`   | The channel maintains a constant voltage by adjusting the current. |
+                +----------------------------------------------+--------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputStates.CURRENT`   | The channel maintains a constant current by adjusting the voltage. |
+                +----------------------------------------------+--------------------------------------------------------------------+
+                | :py:data:`~nidcpower.OutputStates.INHIBITED` | The channel is in the inhibited state.                             |
+                +----------------------------------------------+--------------------------------------------------------------------+
 
 
             :type output_state: :py:data:`nidcpower.OutputStates`

--- a/docs/nidcpower/conf.py
+++ b/docs/nidcpower/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI-DCPower Python API'
-copyright = '2017-2024, National Instruments Corporation'
+copyright = '2017-2025, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/nidcpower/enums.rst
+++ b/docs/nidcpower/enums.rst
@@ -1166,7 +1166,7 @@ OutputStates
 
 .. py:class:: OutputStates
 
-    .. py:attribute:: OutputStates.VOLTAGE
+    .. py:attribute:: OutputStates.CONSTANT_VOLTAGE
 
 
 
@@ -1176,7 +1176,7 @@ OutputStates
 
 
 
-    .. py:attribute:: OutputStates.CURRENT
+    .. py:attribute:: OutputStates.CONSTANT_CURRENT
 
 
 

--- a/docs/nidcpower/enums.rst
+++ b/docs/nidcpower/enums.rst
@@ -1166,7 +1166,7 @@ OutputStates
 
 .. py:class:: OutputStates
 
-    .. py:attribute:: OutputStates.CONSTANT_VOLTAGE
+    .. py:attribute:: OutputStates.VOLTAGE
 
 
 
@@ -1176,7 +1176,7 @@ OutputStates
 
 
 
-    .. py:attribute:: OutputStates.CONSTANT_CURRENT
+    .. py:attribute:: OutputStates.CURRENT
 
 
 

--- a/docs/nidcpower/enums.rst
+++ b/docs/nidcpower/enums.rst
@@ -1166,7 +1166,7 @@ OutputStates
 
 .. py:class:: OutputStates
 
-    .. py:attribute:: OutputStates.VOLTAGE
+    .. py:attribute:: OutputStates.CONSTANT_VOLTAGE
 
 
 
@@ -1176,11 +1176,21 @@ OutputStates
 
 
 
-    .. py:attribute:: OutputStates.CURRENT
+    .. py:attribute:: OutputStates.CONSTANT_CURRENT
 
 
 
         The channel maintains a constant current by adjusting the voltage.
+
+        
+
+
+
+    .. py:attribute:: OutputStates.INHIBITED
+
+
+
+        The channel is in the inhibited state.
 
         
 

--- a/docs/nidigital/conf.py
+++ b/docs/nidigital/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI-Digital Pattern Driver Python API'
-copyright = '2019-2024, National Instruments Corporation'
+copyright = '2019-2025, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/nidmm/conf.py
+++ b/docs/nidmm/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI-DMM Python API'
-copyright = '2017-2024, National Instruments Corporation'
+copyright = '2017-2025, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/nifgen/conf.py
+++ b/docs/nifgen/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI-FGEN Python API'
-copyright = '2017-2024, National Instruments Corporation'
+copyright = '2017-2025, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/nimodinst/conf.py
+++ b/docs/nimodinst/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI-ModInst Python API'
-copyright = '2017-2024, National Instruments Corporation'
+copyright = '2017-2025, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/niscope/conf.py
+++ b/docs/niscope/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI-SCOPE Python API'
-copyright = '2017-2024, National Instruments Corporation'
+copyright = '2017-2025, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/nise/conf.py
+++ b/docs/nise/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI Switch Executive Python API'
-copyright = '2018-2024, National Instruments Corporation'
+copyright = '2018-2025, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/niswitch/conf.py
+++ b/docs/niswitch/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI-SWITCH Python API'
-copyright = '2017-2024, National Instruments Corporation'
+copyright = '2017-2025, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/nitclk/conf.py
+++ b/docs/nitclk/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'NI-TClk Python API'
-copyright = '2019-2024, National Instruments Corporation'
+copyright = '2019-2025, National Instruments Corporation'
 author = 'NI'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/generated/nidcpower/nidcpower/enums.py
+++ b/generated/nidcpower/nidcpower/enums.py
@@ -512,13 +512,17 @@ class OutputFunction(Enum):
 
 
 class OutputStates(Enum):
-    VOLTAGE = 0
+    CONSTANT_VOLTAGE = 0
     r'''
     The channel maintains a constant voltage by adjusting the current.
     '''
-    CURRENT = 1
+    CONSTANT_CURRENT = 1
     r'''
     The channel maintains a constant current by adjusting the voltage.
+    '''
+    INHIBITED = 1163
+    r'''
+    The channel is in the inhibited state.
     '''
 
 

--- a/generated/nidcpower/nidcpower/enums.py
+++ b/generated/nidcpower/nidcpower/enums.py
@@ -512,11 +512,11 @@ class OutputFunction(Enum):
 
 
 class OutputStates(Enum):
-    VOLTAGE = 0
+    CONSTANT_VOLTAGE = 0
     r'''
     The channel maintains a constant voltage by adjusting the current.
     '''
-    CURRENT = 1
+    CONSTANT_CURRENT = 1
     r'''
     The channel maintains a constant current by adjusting the voltage.
     '''

--- a/generated/nidcpower/nidcpower/enums.py
+++ b/generated/nidcpower/nidcpower/enums.py
@@ -512,11 +512,11 @@ class OutputFunction(Enum):
 
 
 class OutputStates(Enum):
-    CONSTANT_VOLTAGE = 0
+    VOLTAGE = 0
     r'''
     The channel maintains a constant voltage by adjusting the current.
     '''
-    CONSTANT_CURRENT = 1
+    CURRENT = 1
     r'''
     The channel maintains a constant current by adjusting the voltage.
     '''

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -6874,13 +6874,13 @@ class _SessionBase(object):
             output_state (enums.OutputStates): Specifies the output state of the channel that is being queried.
                 **Defined Values**:
 
-                +-------------------------------+--------------------------------------------------------------------+
-                | OutputStates.CONSTANT_VOLTAGE | The channel maintains a constant voltage by adjusting the current. |
-                +-------------------------------+--------------------------------------------------------------------+
-                | OutputStates.CONSTANT_CURRENT | The channel maintains a constant current by adjusting the voltage. |
-                +-------------------------------+--------------------------------------------------------------------+
-                | OutputStates.INHIBITED        | The channel is in the inhibited state.                             |
-                +-------------------------------+--------------------------------------------------------------------+
+                +------------------------+--------------------------------------------------------------------+
+                | OutputStates.VOLTAGE   | The channel maintains a constant voltage by adjusting the current. |
+                +------------------------+--------------------------------------------------------------------+
+                | OutputStates.CURRENT   | The channel maintains a constant current by adjusting the voltage. |
+                +------------------------+--------------------------------------------------------------------+
+                | OutputStates.INHIBITED | The channel is in the inhibited state.                             |
+                +------------------------+--------------------------------------------------------------------+
 
 
         Returns:

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -2018,7 +2018,7 @@ class _SessionBase(object):
 
     Specifies the number of samples that the active channel measurement buffer can hold.
     The default value is the maximum number of samples that a device is capable of recording in one second.
-    Valid Values: The PXIe-4051, PXIe-4147, and PXIe-4151 support values from 170 to 18000110.
+    Valid Values: The PXIe-4051, PXIe-4147, and PXIe-4150/4151 support values from 170 to 18000110.
     The PXIe-4162/4163 supports values from  256 to 1000192.
     The PXIe-4190 supports values from 102 to 6000048.
     The PXIe-4112, PXIe-4113, and PXIe-4154 support values from 1000 to 178956970.
@@ -2044,7 +2044,7 @@ class _SessionBase(object):
     Specifies the amount of time to delay the generation of the Measure Complete event, in seconds.
     Valid Values: The PXIe-4051 supports values from 0 seconds to 39 seconds.
     The PXIe-4147 supports values from 0 seconds to 26.5 seconds.
-    The PXIe-4151 supports values from 0 seconds to 42 seconds.
+    The PXIe-4150/4151 supports values from 0 seconds to 42 seconds.
     The PXIe-4162/4163 and PXIe-4190 support values from 0 seconds to 23 seconds.
     All other supported instruments support values from 0 to 167 seconds.
     Default Value: Varies by device. Refer to Supported Properties by Device topic in the NI DC Power Supplies and SMUs Help for more information about default values.
@@ -2270,10 +2270,9 @@ class _SessionBase(object):
     merged_channels = _attributes.AttributeViStringRepeatedCapability(1150249)
     '''Type: str
 
-    Specifies the channel(s) to merge with a designated primary channel of an instrument in order to increase the maximum current you can source from the instrument.
-    This property designates the merge channels to combine with a primary channel. To designate the primary channel, initialize the session to the primary channel only.
-    Note: You cannot change the merge configuration with this property when the session is in the Running state.
-    For complete information on using merged channels with this property, refer to Merged Channels in the NI DC Power Supplies and SMUs Help.
+    Specifies the merge channel(s) to combine with a designated primary channel of an instrument in order to increase the maximum current you can source from the instrument.
+    Set this property on the primary channel only, and pass the merge channels as the value of this property.
+    Refer to the Merged Channels topic in your instrument user manual for more information about using merged channels.
 
     Note:
     NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
@@ -4155,7 +4154,7 @@ class _SessionBase(object):
     Refer to the Single Point Source Mode and Sequence Source Mode topics for more information.
     Valid Values: The PXIe-4051 supports values from 0 to 39 seconds.
     The PXIe-4147 supports values from 0 to 26.5 seconds.
-    The PXIe-4151 supports values from 0 to 42 seconds.
+    The PXIe-4150/4151 supports values from 0 to 42 seconds.
     The PXIe-4162/4163 and PXIe-4190 support values from 0 to 23 seconds.
     All other supported instruments support values from 0 to 167 seconds.
     Default Value: 0.01667 seconds
@@ -6875,11 +6874,13 @@ class _SessionBase(object):
             output_state (enums.OutputStates): Specifies the output state of the channel that is being queried.
                 **Defined Values**:
 
-                +----------------------+-------------------------------------------------------------------+
-                | OutputStates.VOLTAGE | The device maintains a constant voltage by adjusting the current. |
-                +----------------------+-------------------------------------------------------------------+
-                | OutputStates.CURRENT | The device maintains a constant current by adjusting the voltage. |
-                +----------------------+-------------------------------------------------------------------+
+                +-------------------------------+--------------------------------------------------------------------+
+                | OutputStates.CONSTANT_VOLTAGE | The channel maintains a constant voltage by adjusting the current. |
+                +-------------------------------+--------------------------------------------------------------------+
+                | OutputStates.CONSTANT_CURRENT | The channel maintains a constant current by adjusting the voltage. |
+                +-------------------------------+--------------------------------------------------------------------+
+                | OutputStates.INHIBITED        | The channel is in the inhibited state.                             |
+                +-------------------------------+--------------------------------------------------------------------+
 
 
         Returns:

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -6874,13 +6874,13 @@ class _SessionBase(object):
             output_state (enums.OutputStates): Specifies the output state of the channel that is being queried.
                 **Defined Values**:
 
-                +------------------------+--------------------------------------------------------------------+
-                | OutputStates.VOLTAGE   | The channel maintains a constant voltage by adjusting the current. |
-                +------------------------+--------------------------------------------------------------------+
-                | OutputStates.CURRENT   | The channel maintains a constant current by adjusting the voltage. |
-                +------------------------+--------------------------------------------------------------------+
-                | OutputStates.INHIBITED | The channel is in the inhibited state.                             |
-                +------------------------+--------------------------------------------------------------------+
+                +-------------------------------+--------------------------------------------------------------------+
+                | OutputStates.CONSTANT_VOLTAGE | The channel maintains a constant voltage by adjusting the current. |
+                +-------------------------------+--------------------------------------------------------------------+
+                | OutputStates.CONSTANT_CURRENT | The channel maintains a constant current by adjusting the voltage. |
+                +-------------------------------+--------------------------------------------------------------------+
+                | OutputStates.INHIBITED        | The channel is in the inhibited state.                             |
+                +-------------------------------+--------------------------------------------------------------------+
 
 
         Returns:

--- a/src/nidcpower/metadata/attributes.py
+++ b/src/nidcpower/metadata/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 24.3.0f264
+# This file is generated from NI-DCPower API metadata version 25.0.0d98
 attributes = {
     1050003: {
         'access': 'read-write',
@@ -673,7 +673,7 @@ attributes = {
         'access': 'read-write',
         'attribute_class': 'AttributeViReal64TimeDeltaSeconds',
         'documentation': {
-            'description': '\nSpecifies the amount of time to delay the generation of the Measure Complete event, in seconds.\nValid Values: The PXIe-4051 supports values from 0 seconds to 39 seconds.\nThe PXIe-4147 supports values from 0 seconds to 26.5 seconds.\nThe PXIe-4151 supports values from 0 seconds to 42 seconds.\nThe PXIe-4162/4163 and PXIe-4190 support values from 0 seconds to 23 seconds.\nAll other supported instruments support values from 0 to 167 seconds.\nDefault Value: Varies by device. Refer to Supported Attributes by Device topic in the NI DC Power Supplies and SMUs Help for more information about default values.\n',
+            'description': '\nSpecifies the amount of time to delay the generation of the Measure Complete event, in seconds.\nValid Values: The PXIe-4051 supports values from 0 seconds to 39 seconds.\nThe PXIe-4147 supports values from 0 seconds to 26.5 seconds.\nThe PXIe-4150/4151 supports values from 0 seconds to 42 seconds.\nThe PXIe-4162/4163 and PXIe-4190 support values from 0 seconds to 23 seconds.\nAll other supported instruments support values from 0 to 167 seconds.\nDefault Value: Varies by device. Refer to Supported Attributes by Device topic in the NI DC Power Supplies and SMUs Help for more information about default values.\n',
             'note': '\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device.\n'
         },
         'lv_property': 'Events:Measure Complete Event:Event Delay',
@@ -741,7 +741,7 @@ attributes = {
         'access': 'read-write',
         'attribute_class': 'AttributeViReal64TimeDeltaSeconds',
         'documentation': {
-            'description': '\nDetermines when, in seconds, the device generates the Source Complete event, potentially starting a measurement if the NIDCPOWER_ATTR_MEASURE_WHEN attribute is set to NIDCPOWER_VAL_AUTOMATICALLY_AFTER_SOURCE_COMPLETE.\nRefer to the Single Point Source Mode and Sequence Source Mode topics for more information.\nValid Values: The PXIe-4051 supports values from 0 to 39 seconds.\nThe PXIe-4147 supports values from 0 to 26.5 seconds.\nThe PXIe-4151 supports values from 0 to 42 seconds.\nThe PXIe-4162/4163 and PXIe-4190 support values from 0 to 23 seconds.\nAll other supported instruments support values from 0 to 167 seconds.\nDefault Value: 0.01667 seconds\n',
+            'description': '\nDetermines when, in seconds, the device generates the Source Complete event, potentially starting a measurement if the NIDCPOWER_ATTR_MEASURE_WHEN attribute is set to NIDCPOWER_VAL_AUTOMATICALLY_AFTER_SOURCE_COMPLETE.\nRefer to the Single Point Source Mode and Sequence Source Mode topics for more information.\nValid Values: The PXIe-4051 supports values from 0 to 39 seconds.\nThe PXIe-4147 supports values from 0 to 26.5 seconds.\nThe PXIe-4150/4151 supports values from 0 to 42 seconds.\nThe PXIe-4162/4163 and PXIe-4190 support values from 0 to 23 seconds.\nAll other supported instruments support values from 0 to 167 seconds.\nDefault Value: 0.01667 seconds\n',
             'note': '\nNI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.\n\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device.\n\n'
         },
         'lv_property': 'Source:Advanced:Source Delay',
@@ -1048,7 +1048,7 @@ attributes = {
     1150077: {
         'access': 'read-write',
         'documentation': {
-            'description': '\nSpecifies the number of samples that the active channel measurement buffer can hold.\nThe default value is the maximum number of samples that a device is capable of recording in one second.\nValid Values: The PXIe-4051, PXIe-4147, and PXIe-4151 support values from 170 to 18000110.\nThe PXIe-4162/4163 supports values from  256 to 1000192.\nThe PXIe-4190 supports values from 102 to 6000048.\nThe PXIe-4112, PXIe-4113, and PXIe-4154 support values from 1000 to 178956970.\nAll other supported instruments support values from 1000 to 268435455.\nDefault Value: Varies by device. Refer to Supported Attributes by Device topic in the NI DC Power Supplies and SMUs Help for more information about default values.\n',
+            'description': '\nSpecifies the number of samples that the active channel measurement buffer can hold.\nThe default value is the maximum number of samples that a device is capable of recording in one second.\nValid Values: The PXIe-4051, PXIe-4147, and PXIe-4150/4151 support values from 170 to 18000110.\nThe PXIe-4162/4163 supports values from  256 to 1000192.\nThe PXIe-4190 supports values from 102 to 6000048.\nThe PXIe-4112, PXIe-4113, and PXIe-4154 support values from 1000 to 178956970.\nAll other supported instruments support values from 1000 to 268435455.\nDefault Value: Varies by device. Refer to Supported Attributes by Device topic in the NI DC Power Supplies and SMUs Help for more information about default values.\n',
             'note': '\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device.\n'
         },
         'lv_property': 'Measurement:Advanced:Measure Buffer Size',
@@ -1994,7 +1994,7 @@ attributes = {
         'access': 'read-write',
         'attribute_class': 'AttributeViStringRepeatedCapability',
         'documentation': {
-            'description': '\nSpecifies the channel(s) to merge with a designated primary channel of an instrument in order to increase the maximum current you can source from the instrument.\nThis attribute designates the merge channels to combine with a primary channel. To designate the primary channel, initialize the session to the primary channel only.\nNote: You cannot change the merge configuration with this attribute when the session is in the Running state.\nFor complete information on using merged channels with this attribute, refer to Merged Channels in the NI DC Power Supplies and SMUs Help.\n',
+            'description': '\nSpecifies the merge channel(s) to combine with a designated primary channel of an instrument in order to increase the maximum current you can source from the instrument.\nSet this attribute on the primary channel only, and pass the merge channels as the value of this attribute.\nRefer to the Merged Channels topic in your instrument user manual for more information about using merged channels.\n',
             'note': '\nNI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.\n\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device. Devices that do not support this property behave as if no channels were merged.\nDefault Value: Refer to the Supported Attributes by Device topic for the default value by device.\n'
         },
         'lv_property': 'Source:Advanced:Merged Channels',

--- a/src/nidcpower/metadata/config.py
+++ b/src/nidcpower/metadata/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 24.3.0f264
+# This file is generated from NI-DCPower API metadata version 25.0.0d98
 config = {
-    'api_version': '24.3.0f264',
+    'api_version': '25.0.0d98',
     'c_function_prefix': 'niDCPower_',
     'close_function': 'close',
     'context_manager_name': {

--- a/src/nidcpower/metadata/enums.py
+++ b/src/nidcpower/metadata/enums.py
@@ -986,6 +986,7 @@ enums = {
                     'description': 'The channel maintains a constant voltage by adjusting the current.'
                 },
                 'name': 'NIDCPOWER_VAL_OUTPUT_CONSTANT_VOLTAGE',
+                'python_name': 'NIDCPOWER_VAL_OUTPUT_VOLTAGE',
                 'value': 0
             },
             {
@@ -993,6 +994,7 @@ enums = {
                     'description': 'The channel maintains a constant current by adjusting the voltage.'
                 },
                 'name': 'NIDCPOWER_VAL_OUTPUT_CONSTANT_CURRENT',
+                'python_name': 'NIDCPOWER_VAL_OUTPUT_CURRENT',
                 'value': 1
             },
             {
@@ -1000,6 +1002,7 @@ enums = {
                     'description': 'The channel is in the inhibited state.'
                 },
                 'name': 'NIDCPOWER_VAL_OUTPUT_INHIBITED',
+                'python_name': 'NIDCPOWER_VAL_OUTPUT_INHIBITED',
                 'value': 1163
             }
         ]

--- a/src/nidcpower/metadata/enums.py
+++ b/src/nidcpower/metadata/enums.py
@@ -986,7 +986,6 @@ enums = {
                     'description': 'The channel maintains a constant voltage by adjusting the current.'
                 },
                 'name': 'NIDCPOWER_VAL_OUTPUT_CONSTANT_VOLTAGE',
-                'python_name': 'NIDCPOWER_VAL_OUTPUT_VOLTAGE',
                 'value': 0
             },
             {
@@ -994,7 +993,6 @@ enums = {
                     'description': 'The channel maintains a constant current by adjusting the voltage.'
                 },
                 'name': 'NIDCPOWER_VAL_OUTPUT_CONSTANT_CURRENT',
-                'python_name': 'NIDCPOWER_VAL_OUTPUT_CURRENT',
                 'value': 1
             },
             {
@@ -1002,7 +1000,6 @@ enums = {
                     'description': 'The channel is in the inhibited state.'
                 },
                 'name': 'NIDCPOWER_VAL_OUTPUT_INHIBITED',
-                'python_name': 'NIDCPOWER_VAL_OUTPUT_INHIBITED',
                 'value': 1163
             }
         ]

--- a/src/nidcpower/metadata/enums.py
+++ b/src/nidcpower/metadata/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 24.3.0f264
+# This file is generated from NI-DCPower API metadata version 25.0.0d98
 enums = {
     'ApertureTimeAutoMode': {
         'values': [
@@ -994,6 +994,13 @@ enums = {
                 },
                 'name': 'NIDCPOWER_VAL_OUTPUT_CONSTANT_CURRENT',
                 'value': 1
+            },
+            {
+                'documentation': {
+                    'description': 'The channel is in the inhibited state.'
+                },
+                'name': 'NIDCPOWER_VAL_OUTPUT_INHIBITED',
+                'value': 1163
             }
         ]
     },

--- a/src/nidcpower/metadata/functions.py
+++ b/src/nidcpower/metadata/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 24.3.0f264
+# This file is generated from NI-DCPower API metadata version 25.0.0d98
 functions = {
     'AbortWithChannels': {
         'documentation': {
@@ -3236,11 +3236,15 @@ functions = {
                     'table_body': [
                         [
                             'NIDCPOWER_VAL_OUTPUT_CONSTANT_VOLTAGE',
-                            'The device maintains a constant voltage by adjusting the current.'
+                            'The channel maintains a constant voltage by adjusting the current.'
                         ],
                         [
                             'NIDCPOWER_VAL_OUTPUT_CONSTANT_CURRENT',
-                            'The device maintains a constant current by adjusting the voltage.'
+                            'The channel maintains a constant current by adjusting the voltage.'
+                        ],
+                        [
+                            'NIDCPOWER_VAL_OUTPUT_INHIBITED',
+                            'The channel is in the inhibited state.'
                         ]
                     ]
                 },

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -175,8 +175,8 @@ class SystemTests:
     @pytest.mark.channels('0')
     def test_query_output_state(self, session):
         with session.initiate():
-            assert session.query_output_state(nidcpower.OutputStates.VOLTAGE) is True   # since default function is DCVolt when initiated output state for DC Volt\DC current should be True and False respectively
-            assert session.query_output_state(nidcpower.OutputStates.CURRENT) is False
+            assert session.query_output_state(nidcpower.OutputStates.CONSTANT_VOLTAGE) is True   # since default function is DCVolt when initiated output state for DC Volt\DC current should be True and False respectively
+            assert session.query_output_state(nidcpower.OutputStates.CONSTANT_CURRENT) is False
 
     @pytest.mark.channels('0')
     def test_config_aperture_time(self, session):


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- [ ] ~~I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

Updates metadata for nidcpower to latest 25.0 export.
Resulting changes:
- Adds `INHIBITED` to enum `OutputStates`
- Changes `OuputStates.VOLTAGE` and `OutputStates.CURRENT` enum value names to `OuputStates.CONSTANT_VOLTAGE` and `OutputStates.CONSTANT_CURRENT` respectively
- Updates documentation for `measure_buffer_size`, `measure_complete_event_delay`, `source_delay`, and `merged_channels` attributes
- Updates copyright year in the `conf.py` files in other modules so that the build passes

### List issues fixed by this Pull Request below, if any.

- Fix #2067

### What testing has been done?

PR checks
