### PR TITLE
Drop Python 3.8 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ matrix:
       # We run tests on the latest supported version of Python first.
       # This is where additional tests are run so we give it more time.
       - python: "3.12"
-      - python: "3.8"
       - python: "3.9"
       - python: "3.10"
       - python: "3.11"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
     * #### Added
     * #### Changed
     * #### Removed
+        * Support for Python 3.8
 * ### `nidcpower` (NI-DCPower)
     * #### Added
         * API parity with NI-DCPower 2025 Q1.

--- a/build/templates/setup.py.mako
+++ b/build/templates/setup.py.mako
@@ -73,7 +73,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/build/templates/setup.py.mako
+++ b/build/templates/setup.py.mako
@@ -47,6 +47,7 @@ setup(
     license='MIT',
     include_package_data=True,
     packages=['${config['module_name']}'],
+    python_requires='>=3.9',
     install_requires=[
         'hightime>=0.2.0',
         % if config['uses_nitclk']:

--- a/build/templates/tox-system_tests.ini.mako
+++ b/build/templates/tox-system_tests.ini.mako
@@ -26,7 +26,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/${module_name})
 [tox]
-envlist = ${wheel_env}py{38,39,310,311,312}-${module_name}-system_tests, py312-${module_name}-coverage
+envlist = ${wheel_env}py{39,310,311,312}-${module_name}-system_tests, py312-${module_name}-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -85,7 +85,7 @@ deps =
     ${module_name}-coverage: coverage
 
 depends =
-    ${module_name}-coverage: py{38,39,310,311,312}-${module_name}-system_tests
+    ${module_name}-coverage: py{39,310,311,312}-${module_name}-system_tests
 % if uses_other_wheel:
     ${module_name}-system_tests: ${wheel_env}
 % endif

--- a/build/templates/tox-system_tests.ini.mako
+++ b/build/templates/tox-system_tests.ini.mako
@@ -9,7 +9,9 @@
     driver_name = config['driver_name']
     if config['uses_nitclk'] or module_name == 'nitclk':
         wheel_env_no_py = '{}-wheel_dep'.format(module_name)
-        wheel_env = 'py3-' + wheel_env_no_py + ','
+        # We only actually need to build it once, but we specify multiple versions here
+        # to prevent tox from trying to build the wheel with an unsupported (earlier) Python version
+        wheel_env = 'py{39,310,311,312}-' + wheel_env_no_py + ','
         uses_other_wheel = True
         if module_name == 'nitclk':
             # nitclk system tests use niscope

--- a/generated/nidcpower/setup.py
+++ b/generated/nidcpower/setup.py
@@ -41,6 +41,7 @@ setup(
     license='MIT',
     include_package_data=True,
     packages=['nidcpower'],
+    python_requires='>=3.9',
     install_requires=[
         'hightime>=0.2.0',
     ],

--- a/generated/nidcpower/setup.py
+++ b/generated/nidcpower/setup.py
@@ -62,7 +62,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/generated/nidcpower/tox-system_tests.ini
+++ b/generated/nidcpower/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/nidcpower)
 [tox]
-envlist = py{38,39,310,311,312}-nidcpower-system_tests, py312-nidcpower-coverage
+envlist = py{39,310,311,312}-nidcpower-system_tests, py312-nidcpower-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -43,7 +43,7 @@ deps =
     nidcpower-coverage: coverage
 
 depends =
-    nidcpower-coverage: py{38,39,310,311,312}-nidcpower-system_tests
+    nidcpower-coverage: py{39,310,311,312}-nidcpower-system_tests
 
 passenv =
     GIT_BRANCH

--- a/generated/nidigital/setup.py
+++ b/generated/nidigital/setup.py
@@ -63,7 +63,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/generated/nidigital/setup.py
+++ b/generated/nidigital/setup.py
@@ -41,6 +41,7 @@ setup(
     license='MIT',
     include_package_data=True,
     packages=['nidigital'],
+    python_requires='>=3.9',
     install_requires=[
         'hightime>=0.2.0',
         'nitclk',

--- a/generated/nidigital/tox-system_tests.ini
+++ b/generated/nidigital/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/nidigital)
 [tox]
-envlist = py3-nidigital-wheel_dep,py{39,310,311,312}-nidigital-system_tests, py312-nidigital-coverage
+envlist = py{39,310,311,312}-nidigital-wheel_dep,py{39,310,311,312}-nidigital-system_tests, py312-nidigital-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -51,7 +51,7 @@ deps =
 
 depends =
     nidigital-coverage: py{39,310,311,312}-nidigital-system_tests
-    nidigital-system_tests: py3-nidigital-wheel_dep,
+    nidigital-system_tests: py{39,310,311,312}-nidigital-wheel_dep,
 
 passenv =
     GIT_BRANCH

--- a/generated/nidigital/tox-system_tests.ini
+++ b/generated/nidigital/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/nidigital)
 [tox]
-envlist = py3-nidigital-wheel_dep,py{38,39,310,311,312}-nidigital-system_tests, py312-nidigital-coverage
+envlist = py3-nidigital-wheel_dep,py{39,310,311,312}-nidigital-system_tests, py312-nidigital-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -50,7 +50,7 @@ deps =
     nidigital-coverage: coverage
 
 depends =
-    nidigital-coverage: py{38,39,310,311,312}-nidigital-system_tests
+    nidigital-coverage: py{39,310,311,312}-nidigital-system_tests
     nidigital-system_tests: py3-nidigital-wheel_dep,
 
 passenv =

--- a/generated/nidmm/setup.py
+++ b/generated/nidmm/setup.py
@@ -41,6 +41,7 @@ setup(
     license='MIT',
     include_package_data=True,
     packages=['nidmm'],
+    python_requires='>=3.9',
     install_requires=[
         'hightime>=0.2.0',
     ],

--- a/generated/nidmm/setup.py
+++ b/generated/nidmm/setup.py
@@ -62,7 +62,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/generated/nidmm/tox-system_tests.ini
+++ b/generated/nidmm/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/nidmm)
 [tox]
-envlist = py{38,39,310,311,312}-nidmm-system_tests, py312-nidmm-coverage
+envlist = py{39,310,311,312}-nidmm-system_tests, py312-nidmm-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -43,7 +43,7 @@ deps =
     nidmm-coverage: coverage
 
 depends =
-    nidmm-coverage: py{38,39,310,311,312}-nidmm-system_tests
+    nidmm-coverage: py{39,310,311,312}-nidmm-system_tests
 
 passenv =
     GIT_BRANCH

--- a/generated/nifake/setup.py
+++ b/generated/nifake/setup.py
@@ -63,7 +63,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/generated/nifake/setup.py
+++ b/generated/nifake/setup.py
@@ -41,6 +41,7 @@ setup(
     license='MIT',
     include_package_data=True,
     packages=['nifake'],
+    python_requires='>=3.9',
     install_requires=[
         'hightime>=0.2.0',
         'nitclk',

--- a/generated/nifake/tox-system_tests.ini
+++ b/generated/nifake/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/nifake)
 [tox]
-envlist = py3-nifake-wheel_dep,py{39,310,311,312}-nifake-system_tests, py312-nifake-coverage
+envlist = py{39,310,311,312}-nifake-wheel_dep,py{39,310,311,312}-nifake-system_tests, py312-nifake-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -51,7 +51,7 @@ deps =
 
 depends =
     nifake-coverage: py{39,310,311,312}-nifake-system_tests
-    nifake-system_tests: py3-nifake-wheel_dep,
+    nifake-system_tests: py{39,310,311,312}-nifake-wheel_dep,
 
 passenv =
     GIT_BRANCH

--- a/generated/nifake/tox-system_tests.ini
+++ b/generated/nifake/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/nifake)
 [tox]
-envlist = py3-nifake-wheel_dep,py{38,39,310,311,312}-nifake-system_tests, py312-nifake-coverage
+envlist = py3-nifake-wheel_dep,py{39,310,311,312}-nifake-system_tests, py312-nifake-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -50,7 +50,7 @@ deps =
     nifake-coverage: coverage
 
 depends =
-    nifake-coverage: py{38,39,310,311,312}-nifake-system_tests
+    nifake-coverage: py{39,310,311,312}-nifake-system_tests
     nifake-system_tests: py3-nifake-wheel_dep,
 
 passenv =

--- a/generated/nifgen/setup.py
+++ b/generated/nifgen/setup.py
@@ -63,7 +63,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/generated/nifgen/setup.py
+++ b/generated/nifgen/setup.py
@@ -41,6 +41,7 @@ setup(
     license='MIT',
     include_package_data=True,
     packages=['nifgen'],
+    python_requires='>=3.9',
     install_requires=[
         'hightime>=0.2.0',
         'nitclk',

--- a/generated/nifgen/tox-system_tests.ini
+++ b/generated/nifgen/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/nifgen)
 [tox]
-envlist = py3-nifgen-wheel_dep,py{39,310,311,312}-nifgen-system_tests, py312-nifgen-coverage
+envlist = py{39,310,311,312}-nifgen-wheel_dep,py{39,310,311,312}-nifgen-system_tests, py312-nifgen-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -51,7 +51,7 @@ deps =
 
 depends =
     nifgen-coverage: py{39,310,311,312}-nifgen-system_tests
-    nifgen-system_tests: py3-nifgen-wheel_dep,
+    nifgen-system_tests: py{39,310,311,312}-nifgen-wheel_dep,
 
 passenv =
     GIT_BRANCH

--- a/generated/nifgen/tox-system_tests.ini
+++ b/generated/nifgen/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/nifgen)
 [tox]
-envlist = py3-nifgen-wheel_dep,py{38,39,310,311,312}-nifgen-system_tests, py312-nifgen-coverage
+envlist = py3-nifgen-wheel_dep,py{39,310,311,312}-nifgen-system_tests, py312-nifgen-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -50,7 +50,7 @@ deps =
     nifgen-coverage: coverage
 
 depends =
-    nifgen-coverage: py{38,39,310,311,312}-nifgen-system_tests
+    nifgen-coverage: py{39,310,311,312}-nifgen-system_tests
     nifgen-system_tests: py3-nifgen-wheel_dep,
 
 passenv =

--- a/generated/nimodinst/setup.py
+++ b/generated/nimodinst/setup.py
@@ -41,6 +41,7 @@ setup(
     license='MIT',
     include_package_data=True,
     packages=['nimodinst'],
+    python_requires='>=3.9',
     install_requires=[
         'hightime>=0.2.0',
     ],

--- a/generated/nimodinst/setup.py
+++ b/generated/nimodinst/setup.py
@@ -56,7 +56,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/generated/nimodinst/tox-system_tests.ini
+++ b/generated/nimodinst/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/nimodinst)
 [tox]
-envlist = py{38,39,310,311,312}-nimodinst-system_tests, py312-nimodinst-coverage
+envlist = py{39,310,311,312}-nimodinst-system_tests, py312-nimodinst-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -42,7 +42,7 @@ deps =
     nimodinst-coverage: coverage
 
 depends =
-    nimodinst-coverage: py{38,39,310,311,312}-nimodinst-system_tests
+    nimodinst-coverage: py{39,310,311,312}-nimodinst-system_tests
 
 passenv =
     GIT_BRANCH

--- a/generated/niscope/setup.py
+++ b/generated/niscope/setup.py
@@ -63,7 +63,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/generated/niscope/setup.py
+++ b/generated/niscope/setup.py
@@ -41,6 +41,7 @@ setup(
     license='MIT',
     include_package_data=True,
     packages=['niscope'],
+    python_requires='>=3.9',
     install_requires=[
         'hightime>=0.2.0',
         'nitclk',

--- a/generated/niscope/tox-system_tests.ini
+++ b/generated/niscope/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/niscope)
 [tox]
-envlist = py3-niscope-wheel_dep,py{39,310,311,312}-niscope-system_tests, py312-niscope-coverage
+envlist = py{39,310,311,312}-niscope-wheel_dep,py{39,310,311,312}-niscope-system_tests, py312-niscope-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -51,7 +51,7 @@ deps =
 
 depends =
     niscope-coverage: py{39,310,311,312}-niscope-system_tests
-    niscope-system_tests: py3-niscope-wheel_dep,
+    niscope-system_tests: py{39,310,311,312}-niscope-wheel_dep,
 
 passenv =
     GIT_BRANCH

--- a/generated/niscope/tox-system_tests.ini
+++ b/generated/niscope/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/niscope)
 [tox]
-envlist = py3-niscope-wheel_dep,py{38,39,310,311,312}-niscope-system_tests, py312-niscope-coverage
+envlist = py3-niscope-wheel_dep,py{39,310,311,312}-niscope-system_tests, py312-niscope-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -50,7 +50,7 @@ deps =
     niscope-coverage: coverage
 
 depends =
-    niscope-coverage: py{38,39,310,311,312}-niscope-system_tests
+    niscope-coverage: py{39,310,311,312}-niscope-system_tests
     niscope-system_tests: py3-niscope-wheel_dep,
 
 passenv =

--- a/generated/nise/setup.py
+++ b/generated/nise/setup.py
@@ -41,6 +41,7 @@ setup(
     license='MIT',
     include_package_data=True,
     packages=['nise'],
+    python_requires='>=3.9',
     install_requires=[
         'hightime>=0.2.0',
     ],

--- a/generated/nise/setup.py
+++ b/generated/nise/setup.py
@@ -56,7 +56,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/generated/nise/tox-system_tests.ini
+++ b/generated/nise/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/nise)
 [tox]
-envlist = py{38,39,310,311,312}-nise-system_tests, py312-nise-coverage
+envlist = py{39,310,311,312}-nise-system_tests, py312-nise-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -42,7 +42,7 @@ deps =
     nise-coverage: coverage
 
 depends =
-    nise-coverage: py{38,39,310,311,312}-nise-system_tests
+    nise-coverage: py{39,310,311,312}-nise-system_tests
 
 passenv =
     GIT_BRANCH

--- a/generated/niswitch/setup.py
+++ b/generated/niswitch/setup.py
@@ -62,7 +62,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/generated/niswitch/setup.py
+++ b/generated/niswitch/setup.py
@@ -41,6 +41,7 @@ setup(
     license='MIT',
     include_package_data=True,
     packages=['niswitch'],
+    python_requires='>=3.9',
     install_requires=[
         'hightime>=0.2.0',
     ],

--- a/generated/niswitch/tox-system_tests.ini
+++ b/generated/niswitch/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/niswitch)
 [tox]
-envlist = py{38,39,310,311,312}-niswitch-system_tests, py312-niswitch-coverage
+envlist = py{39,310,311,312}-niswitch-system_tests, py312-niswitch-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -43,7 +43,7 @@ deps =
     niswitch-coverage: coverage
 
 depends =
-    niswitch-coverage: py{38,39,310,311,312}-niswitch-system_tests
+    niswitch-coverage: py{39,310,311,312}-niswitch-system_tests
 
 passenv =
     GIT_BRANCH

--- a/generated/nitclk/setup.py
+++ b/generated/nitclk/setup.py
@@ -41,6 +41,7 @@ setup(
     license='MIT',
     include_package_data=True,
     packages=['nitclk'],
+    python_requires='>=3.9',
     install_requires=[
         'hightime>=0.2.0',
     ],

--- a/generated/nitclk/setup.py
+++ b/generated/nitclk/setup.py
@@ -56,7 +56,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/generated/nitclk/tox-system_tests.ini
+++ b/generated/nitclk/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/nitclk)
 [tox]
-envlist = py3-nitclk-wheel_dep,py{39,310,311,312}-nitclk-system_tests, py312-nitclk-coverage
+envlist = py{39,310,311,312}-nitclk-wheel_dep,py{39,310,311,312}-nitclk-system_tests, py312-nitclk-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -50,7 +50,7 @@ deps =
 
 depends =
     nitclk-coverage: py{39,310,311,312}-nitclk-system_tests
-    nitclk-system_tests: py3-nitclk-wheel_dep,
+    nitclk-system_tests: py{39,310,311,312}-nitclk-wheel_dep,
 
 passenv =
     GIT_BRANCH

--- a/generated/nitclk/tox-system_tests.ini
+++ b/generated/nitclk/tox-system_tests.ini
@@ -3,7 +3,7 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox -c tox-system_tests.ini" from the driver directory. (generated/nitclk)
 [tox]
-envlist = py3-nitclk-wheel_dep,py{38,39,310,311,312}-nitclk-system_tests, py312-nitclk-coverage
+envlist = py3-nitclk-wheel_dep,py{39,310,311,312}-nitclk-system_tests, py312-nitclk-coverage
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 # We put the .tox directory outside of the Jenkins workspace so that it isn't wiped with the rest of the repo
@@ -49,7 +49,7 @@ deps =
     nitclk-coverage: coverage
 
 depends =
-    nitclk-coverage: py{38,39,310,311,312}-nitclk-system_tests
+    nitclk-coverage: py{39,310,311,312}-nitclk-system_tests
     nitclk-system_tests: py3-nitclk-wheel_dep,
 
 passenv =

--- a/tox-travis.ini
+++ b/tox-travis.ini
@@ -7,9 +7,9 @@
 # tox-travis.ini will have pyXX-clean and all pyXX-installers in the default envlist, while the developer tox.ini
 # does not have clean and only has one pyXX-installers
 # Uncomment this line for tox.ini
-# envlist = py312-build_test,py312-codegen,py312-installers,py{38,39,310,311,312}-test,py312-flake8,py312-docs,py312-pkg
+# envlist = py312-build_test,py312-codegen,py312-installers,py{39,310,311,312}-test,py312-flake8,py312-docs,py312-pkg
 # Uncomment this line for tox-travis.ini
-envlist = py312-clean,py312-build_test,py312-codegen,py{38,39,310,311,312}-installers,py{38,39,310,311,312}-test,py312-flake8,py312-docs,py312-pkg
+envlist = py312-clean,py312-build_test,py312-codegen,py{39,310,311,312}-installers,py{39,310,311,312}-test,py312-flake8,py312-docs,py312-pkg
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 skipsdist = true

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,9 @@
 # tox-travis.ini will have pyXX-clean and all pyXX-installers in the default envlist, while the developer tox.ini
 # does not have clean and only has one pyXX-installers
 # Uncomment this line for tox.ini
-envlist = py312-build_test,py312-codegen,py312-installers,py{38,39,310,311,312}-test,py312-flake8,py312-docs,py312-pkg
+envlist = py312-build_test,py312-codegen,py312-installers,py{39,310,311,312}-test,py312-flake8,py312-docs,py312-pkg
 # Uncomment this line for tox-travis.ini
-# envlist = py312-clean,py312-build_test,py312-codegen,py{38,39,310,311,312}-installers,py{38,39,310,311,312}-test,py312-flake8,py312-docs,py312-pkg
+# envlist = py312-clean,py312-build_test,py312-codegen,py{39,310,311,312}-installers,py{39,310,311,312}-test,py312-flake8,py312-docs,py312-pkg
 skip_missing_interpreters=True
 ignore_basepython_conflict=True
 skipsdist = true


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

* Drop Python 3.8 support, by removing it from our testing and list of officially supported versions.
* (For the first time) enforce our version support policy at installation: disallow installation of APIs on Python versions earlier than 3.9
  * As part of this we now need to specify a list of supported Python versions for building wheel_dep in tox-system_tests.ini

### List issues fixed by this Pull Request below, if any.
None

### What testing has been done?
PR Checks
