### PR TITLE
Eliminate use of dead and deprecated imports and options in setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 * ### ALL
     * #### Added
     * #### Changed
+        * Fix [#2069](https://github.com/ni/nimi-python/issues/2069)
     * #### Removed
 * ### `nidcpower` (NI-DCPower)
     * #### Added

--- a/build/templates/setup.py.mako
+++ b/build/templates/setup.py.mako
@@ -8,19 +8,7 @@ grpc_supported = template_parameters['include_grpc_support']
 module_version = config['module_version']
 %>
 
-from setuptools.command.test import test as test_command
 from setuptools import setup
-
-
-class PyTest(test_command):
-    def finalize_options(self):
-        test_command.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-        pytest.main(self.test_args)
 
 
 pypi_name = '${config['module_name']}'
@@ -62,8 +50,6 @@ setup(
     },
     % endif
     setup_requires=['pytest-runner', ],
-    tests_require=['pytest'],
-    test_suite='tests',
     classifiers=[
         "Development Status :: ${helper.get_development_status(config)}",
         "Intended Audience :: Developers",
@@ -81,6 +67,5 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: System :: Hardware :: Hardware Drivers"
     ],
-    cmdclass={'test': PyTest},
     package_data={pypi_name: ['VERSION']},
 )

--- a/build/templates/setup.py.mako
+++ b/build/templates/setup.py.mako
@@ -49,7 +49,6 @@ setup(
         ],
     },
     % endif
-    setup_requires=['pytest-runner', ],
     classifiers=[
         "Development Status :: ${helper.get_development_status(config)}",
         "Intended Audience :: Developers",

--- a/generated/nidcpower/setup.py
+++ b/generated/nidcpower/setup.py
@@ -38,7 +38,6 @@ setup(
             'protobuf>=4.21.6,<5.0'
         ],
     },
-    setup_requires=['pytest-runner', ],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",

--- a/generated/nidcpower/setup.py
+++ b/generated/nidcpower/setup.py
@@ -2,19 +2,7 @@
 # This file was generated
 
 
-from setuptools.command.test import test as test_command
 from setuptools import setup
-
-
-class PyTest(test_command):
-    def finalize_options(self):
-        test_command.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-        pytest.main(self.test_args)
 
 
 pypi_name = 'nidcpower'
@@ -51,8 +39,6 @@ setup(
         ],
     },
     setup_requires=['pytest-runner', ],
-    tests_require=['pytest'],
-    test_suite='tests',
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
@@ -70,6 +56,5 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: System :: Hardware :: Hardware Drivers"
     ],
-    cmdclass={'test': PyTest},
     package_data={pypi_name: ['VERSION']},
 )

--- a/generated/nidigital/setup.py
+++ b/generated/nidigital/setup.py
@@ -39,7 +39,6 @@ setup(
             'protobuf>=4.21.6,<5.0'
         ],
     },
-    setup_requires=['pytest-runner', ],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",

--- a/generated/nidigital/setup.py
+++ b/generated/nidigital/setup.py
@@ -2,19 +2,7 @@
 # This file was generated
 
 
-from setuptools.command.test import test as test_command
 from setuptools import setup
-
-
-class PyTest(test_command):
-    def finalize_options(self):
-        test_command.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-        pytest.main(self.test_args)
 
 
 pypi_name = 'nidigital'
@@ -52,8 +40,6 @@ setup(
         ],
     },
     setup_requires=['pytest-runner', ],
-    tests_require=['pytest'],
-    test_suite='tests',
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
@@ -71,6 +57,5 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: System :: Hardware :: Hardware Drivers"
     ],
-    cmdclass={'test': PyTest},
     package_data={pypi_name: ['VERSION']},
 )

--- a/generated/nidmm/setup.py
+++ b/generated/nidmm/setup.py
@@ -38,7 +38,6 @@ setup(
             'protobuf>=4.21.6,<5.0'
         ],
     },
-    setup_requires=['pytest-runner', ],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",

--- a/generated/nidmm/setup.py
+++ b/generated/nidmm/setup.py
@@ -2,19 +2,7 @@
 # This file was generated
 
 
-from setuptools.command.test import test as test_command
 from setuptools import setup
-
-
-class PyTest(test_command):
-    def finalize_options(self):
-        test_command.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-        pytest.main(self.test_args)
 
 
 pypi_name = 'nidmm'
@@ -51,8 +39,6 @@ setup(
         ],
     },
     setup_requires=['pytest-runner', ],
-    tests_require=['pytest'],
-    test_suite='tests',
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
@@ -70,6 +56,5 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: System :: Hardware :: Hardware Drivers"
     ],
-    cmdclass={'test': PyTest},
     package_data={pypi_name: ['VERSION']},
 )

--- a/generated/nifake/setup.py
+++ b/generated/nifake/setup.py
@@ -39,7 +39,6 @@ setup(
             'protobuf>=4.21.6,<5.0'
         ],
     },
-    setup_requires=['pytest-runner', ],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",

--- a/generated/nifake/setup.py
+++ b/generated/nifake/setup.py
@@ -2,19 +2,7 @@
 # This file was generated
 
 
-from setuptools.command.test import test as test_command
 from setuptools import setup
-
-
-class PyTest(test_command):
-    def finalize_options(self):
-        test_command.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-        pytest.main(self.test_args)
 
 
 pypi_name = 'nifake'
@@ -52,8 +40,6 @@ setup(
         ],
     },
     setup_requires=['pytest-runner', ],
-    tests_require=['pytest'],
-    test_suite='tests',
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
@@ -71,6 +57,5 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: System :: Hardware :: Hardware Drivers"
     ],
-    cmdclass={'test': PyTest},
     package_data={pypi_name: ['VERSION']},
 )

--- a/generated/nifgen/setup.py
+++ b/generated/nifgen/setup.py
@@ -39,7 +39,6 @@ setup(
             'protobuf>=4.21.6,<5.0'
         ],
     },
-    setup_requires=['pytest-runner', ],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",

--- a/generated/nifgen/setup.py
+++ b/generated/nifgen/setup.py
@@ -2,19 +2,7 @@
 # This file was generated
 
 
-from setuptools.command.test import test as test_command
 from setuptools import setup
-
-
-class PyTest(test_command):
-    def finalize_options(self):
-        test_command.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-        pytest.main(self.test_args)
 
 
 pypi_name = 'nifgen'
@@ -52,8 +40,6 @@ setup(
         ],
     },
     setup_requires=['pytest-runner', ],
-    tests_require=['pytest'],
-    test_suite='tests',
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
@@ -71,6 +57,5 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: System :: Hardware :: Hardware Drivers"
     ],
-    cmdclass={'test': PyTest},
     package_data={pypi_name: ['VERSION']},
 )

--- a/generated/nimodinst/setup.py
+++ b/generated/nimodinst/setup.py
@@ -32,7 +32,6 @@ setup(
     install_requires=[
         'hightime>=0.2.0',
     ],
-    setup_requires=['pytest-runner', ],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",

--- a/generated/nimodinst/setup.py
+++ b/generated/nimodinst/setup.py
@@ -2,19 +2,7 @@
 # This file was generated
 
 
-from setuptools.command.test import test as test_command
 from setuptools import setup
-
-
-class PyTest(test_command):
-    def finalize_options(self):
-        test_command.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-        pytest.main(self.test_args)
 
 
 pypi_name = 'nimodinst'
@@ -45,8 +33,6 @@ setup(
         'hightime>=0.2.0',
     ],
     setup_requires=['pytest-runner', ],
-    tests_require=['pytest'],
-    test_suite='tests',
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
@@ -64,6 +50,5 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: System :: Hardware :: Hardware Drivers"
     ],
-    cmdclass={'test': PyTest},
     package_data={pypi_name: ['VERSION']},
 )

--- a/generated/niscope/setup.py
+++ b/generated/niscope/setup.py
@@ -2,19 +2,7 @@
 # This file was generated
 
 
-from setuptools.command.test import test as test_command
 from setuptools import setup
-
-
-class PyTest(test_command):
-    def finalize_options(self):
-        test_command.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-        pytest.main(self.test_args)
 
 
 pypi_name = 'niscope'
@@ -52,8 +40,6 @@ setup(
         ],
     },
     setup_requires=['pytest-runner', ],
-    tests_require=['pytest'],
-    test_suite='tests',
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
@@ -71,6 +57,5 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: System :: Hardware :: Hardware Drivers"
     ],
-    cmdclass={'test': PyTest},
     package_data={pypi_name: ['VERSION']},
 )

--- a/generated/niscope/setup.py
+++ b/generated/niscope/setup.py
@@ -39,7 +39,6 @@ setup(
             'protobuf>=4.21.6,<5.0'
         ],
     },
-    setup_requires=['pytest-runner', ],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",

--- a/generated/nise/setup.py
+++ b/generated/nise/setup.py
@@ -2,19 +2,7 @@
 # This file was generated
 
 
-from setuptools.command.test import test as test_command
 from setuptools import setup
-
-
-class PyTest(test_command):
-    def finalize_options(self):
-        test_command.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-        pytest.main(self.test_args)
 
 
 pypi_name = 'nise'
@@ -45,8 +33,6 @@ setup(
         'hightime>=0.2.0',
     ],
     setup_requires=['pytest-runner', ],
-    tests_require=['pytest'],
-    test_suite='tests',
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
@@ -64,6 +50,5 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: System :: Hardware :: Hardware Drivers"
     ],
-    cmdclass={'test': PyTest},
     package_data={pypi_name: ['VERSION']},
 )

--- a/generated/nise/setup.py
+++ b/generated/nise/setup.py
@@ -32,7 +32,6 @@ setup(
     install_requires=[
         'hightime>=0.2.0',
     ],
-    setup_requires=['pytest-runner', ],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",

--- a/generated/niswitch/setup.py
+++ b/generated/niswitch/setup.py
@@ -38,7 +38,6 @@ setup(
             'protobuf>=4.21.6,<5.0'
         ],
     },
-    setup_requires=['pytest-runner', ],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",

--- a/generated/niswitch/setup.py
+++ b/generated/niswitch/setup.py
@@ -2,19 +2,7 @@
 # This file was generated
 
 
-from setuptools.command.test import test as test_command
 from setuptools import setup
-
-
-class PyTest(test_command):
-    def finalize_options(self):
-        test_command.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-        pytest.main(self.test_args)
 
 
 pypi_name = 'niswitch'
@@ -51,8 +39,6 @@ setup(
         ],
     },
     setup_requires=['pytest-runner', ],
-    tests_require=['pytest'],
-    test_suite='tests',
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
@@ -70,6 +56,5 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: System :: Hardware :: Hardware Drivers"
     ],
-    cmdclass={'test': PyTest},
     package_data={pypi_name: ['VERSION']},
 )

--- a/generated/nitclk/setup.py
+++ b/generated/nitclk/setup.py
@@ -2,19 +2,7 @@
 # This file was generated
 
 
-from setuptools.command.test import test as test_command
 from setuptools import setup
-
-
-class PyTest(test_command):
-    def finalize_options(self):
-        test_command.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-        pytest.main(self.test_args)
 
 
 pypi_name = 'nitclk'
@@ -45,8 +33,6 @@ setup(
         'hightime>=0.2.0',
     ],
     setup_requires=['pytest-runner', ],
-    tests_require=['pytest'],
-    test_suite='tests',
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
@@ -64,6 +50,5 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: System :: Hardware :: Hardware Drivers"
     ],
-    cmdclass={'test': PyTest},
     package_data={pypi_name: ['VERSION']},
 )

--- a/generated/nitclk/setup.py
+++ b/generated/nitclk/setup.py
@@ -32,7 +32,6 @@ setup(
     install_requires=[
         'hightime>=0.2.0',
     ],
-    setup_requires=['pytest-runner', ],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Delete deprecated / unsupported imports and distribution options from setup.py. By doing this proactively, we can avoid being broken in the future.

According to GitHub Copilot, `setuptools.command.test` provides a way to setup for and run tests. It would happen in this case when users run `python setup.py test`.

The problems with that are:

1. We don't ship tests with our python packages
1. If someone has cloned the repo, we have guidelines for how to run tests and they don't involve making that call
1. 2 of the distribution options associated with this feature (`tests_require` and `test_suite`) are no longer recognized.
1. setuptools.command.test has been deprecated for years

For these reasons, it makes sense to just remove the import and everything related to it.

I also eliminated the setup_requires [because it's considered deprecated](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html) and we won't be needing pytest-runner.

### List issues fixed by this Pull Request below, if any.

* Fix #2069

### What testing has been done?

PR Checks
