### PR TITLE
Fix _add_enum_value_python_name() to respect hardcoded value names

### DIFF
--- a/build/unit_tests/test_metadata_add_all.py
+++ b/build/unit_tests/test_metadata_add_all.py
@@ -870,6 +870,57 @@ enums_input = {
             }
         ]
     },
+    'EnumWithCommonPrefixInValueNames': {
+        'codegen_method': 'public',
+        'values': [
+            {
+                'name': 'COLOR_BRIGHT_RED',
+                'value': 1
+            },
+            {
+                'name': 'COLOR_BRIGHT_BLUE',
+                'value': 2
+            }
+        ]
+    },
+    'EnumWithHardcodedValueNames': {
+        'codegen_method': 'public',
+        'values': [
+            {
+                'name': 'THE_COLOR_RED',
+                'python_name': 'COLOR_DARK_RED',
+                'value': 1
+            },
+            {
+                'name': 'THE_COLOR_BLUE',
+                'python_name': 'COLOR_DARK_BLUE',
+                'value': 2
+            }
+        ]
+    },
+    'EnumWithHardcodedValueNamesMixedIn': {
+        'codegen_method': 'public',
+        'values': [
+            {
+                'name': 'DISTANCE_MILES',
+                'value': 1
+            },
+            {
+                'name': 'DISTANCE_KILOMETERS',
+                'python_name': 'DISTANCE_KILOMETERS',
+                'value': 2
+            },
+            {
+                'name': 'DISTANCE_METERS',
+                'python_name': 'DISTANCE_METERS',
+                'value': 5
+            },
+            {
+                'name': 'DISTANCE_YARDS',
+                'value': 42
+            }
+        ]
+    },
 }
 
 
@@ -893,7 +944,33 @@ enums_expected = {
             {'name': 'RED', 'value': 1, 'converts_to_value': True, 'python_name': 'RED'},
             {'name': 'BLUE', 'value': 2, 'converts_to_value': False, 'python_name': 'BLUE'},
             {'name': 'YELLOW', 'value': 5, 'converts_to_value': 'yellow', 'python_name': 'YELLOW'},
-            {'name': 'BLACK', 'value': 42, 'converts_to_value': 42, 'python_name': 'BLACK'}
+            {'name': 'BLACK', 'value': 42, 'converts_to_value': 42, 'python_name': 'BLACK', }
+        ]
+    },
+    'EnumWithCommonPrefixInValueNames': {
+        'codegen_method': 'public',
+        'python_name': 'EnumWithCommonPrefixInValueNames',
+        'values': [
+            {'name': 'COLOR_BRIGHT_RED', 'value': 1, 'python_name': 'RED', 'prefix': 'COLOR_BRIGHT_'},
+            {'name': 'COLOR_BRIGHT_BLUE', 'value': 2, 'python_name': 'BLUE', 'prefix': 'COLOR_BRIGHT_'}
+        ]
+    },
+    'EnumWithHardcodedValueNames': {
+        'codegen_method': 'public',
+        'python_name': 'EnumWithHardcodedValueNames',
+        'values': [
+            {'name': 'THE_COLOR_RED', 'value': 1, 'python_name': 'COLOR_DARK_RED'},
+            {'name': 'THE_COLOR_BLUE', 'value': 2, 'python_name': 'COLOR_DARK_BLUE'}
+        ]
+    },
+    'EnumWithHardcodedValueNamesMixedIn': {
+        'codegen_method': 'public',
+        'python_name': 'EnumWithHardcodedValueNamesMixedIn',
+        'values': [
+            {'name': 'DISTANCE_MILES', 'value': 1, 'python_name': 'MILES', 'prefix': 'DISTANCE_'},
+            {'name': 'DISTANCE_KILOMETERS', 'value': 2, 'python_name': 'DISTANCE_KILOMETERS'},
+            {'name': 'DISTANCE_METERS', 'value': 5, 'python_name': 'DISTANCE_METERS'},
+            {'name': 'DISTANCE_YARDS', 'value': 42, 'python_name': 'YARDS', 'prefix': 'DISTANCE_'}
         ]
     },
 }
@@ -1113,6 +1190,9 @@ def test_get_functions_that_use_enums():
     expected_output = {
         'Color': ['PythonOnlyMethod'],
         'EnumWithConverter': ['PublicMethod', 'PrivateMethod'],
+        'EnumWithCommonPrefixInValueNames': [],
+        'EnumWithHardcodedValueNames': [],
+        'EnumWithHardcodedValueNamesMixedIn': [],
     }
     actual_output = _get_functions_that_use_enums(actual_enums, actual_config)
     _compare_dicts(actual_output, expected_output)
@@ -1123,6 +1203,9 @@ def test_get_attributes_that_use_enums():
     expected_output = {
         'Color': ['1000002'],
         'EnumWithConverter': ['1000001', '1000003'],
+        'EnumWithCommonPrefixInValueNames': [],
+        'EnumWithHardcodedValueNames': [],
+        'EnumWithHardcodedValueNamesMixedIn': [],
     }
     actual_output = _get_attributes_that_use_enums(actual_enums, actual_config)
     _compare_dicts(actual_output, expected_output)

--- a/build/unit_tests/test_metadata_add_all.py
+++ b/build/unit_tests/test_metadata_add_all.py
@@ -929,10 +929,10 @@ enums_expected = {
         'codegen_method': 'no',
         'python_name': 'Color',
         'values': [
-            {'documentation': {'description': 'Like blood.'}, 'name': 'RED', 'value': 1, 'python_name': 'RED'},
-            {'documentation': {'description': 'Like the sky.'}, 'name': 'BLUE', 'value': 2, 'python_name': 'BLUE'},
-            {'documentation': {'description': 'Like a banana.'}, 'name': 'YELLOW', 'value': 2, 'python_name': 'YELLOW'},
-            {'documentation': {'description': "Like this developer's conscience."}, 'name': 'BLACK', 'value': 2, 'python_name': 'BLACK'}
+            {'documentation': {'description': 'Like blood.'}, 'name': 'RED', 'value': 1, 'python_name': 'RED', 'user_set_python_name': False},
+            {'documentation': {'description': 'Like the sky.'}, 'name': 'BLUE', 'value': 2, 'python_name': 'BLUE', 'user_set_python_name': False},
+            {'documentation': {'description': 'Like a banana.'}, 'name': 'YELLOW', 'value': 2, 'python_name': 'YELLOW', 'user_set_python_name': False},
+            {'documentation': {'description': "Like this developer's conscience."}, 'name': 'BLACK', 'value': 2, 'python_name': 'BLACK', 'user_set_python_name': False}
         ]
     },
     'EnumWithConverter': {
@@ -941,36 +941,36 @@ enums_expected = {
         'converted_value_to_enum_function_name': 'convert_to_enum_with_converter_enum',
         'enum_to_converted_value_function_name': 'convert_from_enum_with_converter_enum',
         'values': [
-            {'name': 'RED', 'value': 1, 'converts_to_value': True, 'python_name': 'RED'},
-            {'name': 'BLUE', 'value': 2, 'converts_to_value': False, 'python_name': 'BLUE'},
-            {'name': 'YELLOW', 'value': 5, 'converts_to_value': 'yellow', 'python_name': 'YELLOW'},
-            {'name': 'BLACK', 'value': 42, 'converts_to_value': 42, 'python_name': 'BLACK', }
+            {'name': 'RED', 'value': 1, 'converts_to_value': True, 'python_name': 'RED', 'user_set_python_name': False},
+            {'name': 'BLUE', 'value': 2, 'converts_to_value': False, 'python_name': 'BLUE', 'user_set_python_name': False},
+            {'name': 'YELLOW', 'value': 5, 'converts_to_value': 'yellow', 'python_name': 'YELLOW', 'user_set_python_name': False},
+            {'name': 'BLACK', 'value': 42, 'converts_to_value': 42, 'python_name': 'BLACK', 'user_set_python_name': False}
         ]
     },
     'EnumWithCommonPrefixInValueNames': {
         'codegen_method': 'public',
         'python_name': 'EnumWithCommonPrefixInValueNames',
         'values': [
-            {'name': 'COLOR_BRIGHT_RED', 'value': 1, 'python_name': 'RED', 'prefix': 'COLOR_BRIGHT_'},
-            {'name': 'COLOR_BRIGHT_BLUE', 'value': 2, 'python_name': 'BLUE', 'prefix': 'COLOR_BRIGHT_'}
+            {'name': 'COLOR_BRIGHT_RED', 'value': 1, 'python_name': 'RED', 'user_set_python_name': False, 'prefix': 'COLOR_BRIGHT_'},
+            {'name': 'COLOR_BRIGHT_BLUE', 'value': 2, 'python_name': 'BLUE', 'user_set_python_name': False, 'prefix': 'COLOR_BRIGHT_'}
         ]
     },
     'EnumWithHardcodedValueNames': {
         'codegen_method': 'public',
         'python_name': 'EnumWithHardcodedValueNames',
         'values': [
-            {'name': 'THE_COLOR_RED', 'value': 1, 'python_name': 'COLOR_DARK_RED'},
-            {'name': 'THE_COLOR_BLUE', 'value': 2, 'python_name': 'COLOR_DARK_BLUE'}
+            {'name': 'THE_COLOR_RED', 'value': 1, 'python_name': 'COLOR_DARK_RED', 'user_set_python_name': True},
+            {'name': 'THE_COLOR_BLUE', 'value': 2, 'python_name': 'COLOR_DARK_BLUE', 'user_set_python_name': True}
         ]
     },
     'EnumWithHardcodedValueNamesMixedIn': {
         'codegen_method': 'public',
         'python_name': 'EnumWithHardcodedValueNamesMixedIn',
         'values': [
-            {'name': 'DISTANCE_MILES', 'value': 1, 'python_name': 'MILES', 'prefix': 'DISTANCE_'},
-            {'name': 'DISTANCE_KILOMETERS', 'value': 2, 'python_name': 'DISTANCE_KILOMETERS'},
-            {'name': 'DISTANCE_METERS', 'value': 5, 'python_name': 'DISTANCE_METERS'},
-            {'name': 'DISTANCE_YARDS', 'value': 42, 'python_name': 'YARDS', 'prefix': 'DISTANCE_'}
+            {'name': 'DISTANCE_MILES', 'value': 1, 'python_name': 'MILES', 'user_set_python_name': False, 'prefix': 'DISTANCE_'},
+            {'name': 'DISTANCE_KILOMETERS', 'value': 2, 'python_name': 'DISTANCE_KILOMETERS', 'user_set_python_name': True},
+            {'name': 'DISTANCE_METERS', 'value': 5, 'python_name': 'DISTANCE_METERS', 'user_set_python_name': True},
+            {'name': 'DISTANCE_YARDS', 'value': 42, 'python_name': 'YARDS', 'user_set_python_name': False, 'prefix': 'DISTANCE_'}
         ]
     },
 }

--- a/src/nidcpower/metadata/enums_addon.py
+++ b/src/nidcpower/metadata/enums_addon.py
@@ -2,5 +2,130 @@
 # Any changes to the API should be made here. enums.py is code generated
 
 enums_override_metadata = {
+    # TODO (ni-jfitzger): delete this override once python_name is corrected for each value. See https://github.com/ni/nimi-python/issues/2072
+    'ComplianceLimitSymmetry': {
+        'values': [
+            {
+                'documentation': {
+                    'description': 'Compliance limits are specified symmetrically about 0.'
+                },
+                'name': 'NIDCPOWER_VAL_COMPLIANCE_LIMIT_SYMMETRY_SYMMETRIC',
+                'value': 0
+            },
+            {
+                'documentation': {
+                    'description': 'Compliance limits can be specified asymmetrically with respect to 0.'
+                },
+                'name': 'NIDCPOWER_VAL_COMPLIANCE_LIMIT_SYMMETRY_ASYMMETRIC',
+                'value': 1
+            }
+        ]
+    },
+    # TODO (ni-jfitzger): delete this override once python_name is corrected for each value. See https://github.com/ni/nimi-python/issues/2072
+    'Event': {
+        'values': [
+            {
+                'documentation': {
+                    'description': 'Specifies the Source Complete event.'
+                },
+                'name': 'NIDCPOWER_VAL_SOURCE_COMPLETE_EVENT',
+                'python_name': 'SOURCE_COMPLETE',
+                'value': 1030
+            },
+            {
+                'documentation': {
+                    'description': 'Specifies the Measure Complete event.'
+                },
+                'name': 'NIDCPOWER_VAL_MEASURE_COMPLETE_EVENT',
+                'python_name': 'MEASURE_COMPLETE',
+                'value': 1031
+            },
+            {
+                'documentation': {
+                    'description': 'Specifies the Sequence Iteration Complete event.'
+                },
+                'name': 'NIDCPOWER_VAL_SEQUENCE_ITERATION_COMPLETE_EVENT',
+                'python_name': 'SEQUENCE_ITERATION_COMPLETE',
+                'value': 1032
+            },
+            {
+                'documentation': {
+                    'description': 'Specifies the Sequence Engine Done event.'
+                },
+                'name': 'NIDCPOWER_VAL_SEQUENCE_ENGINE_DONE_EVENT',
+                'python_name': 'SEQUENCE_ENGINE_DONE',
+                'value': 1033
+            },
+            {
+                'documentation': {
+                    'description': 'Specifies the Pulse Complete event.'
+                },
+                'name': 'NIDCPOWER_VAL_PULSE_COMPLETE_EVENT',
+                'python_name': 'PULSE_COMPLETE',
+                'value': 1051
+            },
+            {
+                'documentation': {
+                    'description': 'Specifies the Ready for Pulse Trigger event.'
+                },
+                'name': 'NIDCPOWER_VAL_READY_FOR_PULSE_TRIGGER_EVENT',
+                'python_name': 'READY_FOR_PULSE_TRIGGER',
+                'value': 1052
+            }
+        ]
+    },
+    # TODO (ni-jfitzger): delete this override once python_name is corrected for each value. See https://github.com/ni/nimi-python/issues/2072
+    'SendSoftwareEdgeTriggerType': {
+        'values': [
+            {
+                'documentation': {
+                    'description': 'Asserts the Start trigger.'
+                },
+                'name': 'NIDCPOWER_VAL_START_TRIGGER',
+                'python_name': 'START',
+                'value': 1034
+            },
+            {
+                'documentation': {
+                    'description': 'Asserts the Source trigger.'
+                },
+                'name': 'NIDCPOWER_VAL_SOURCE_TRIGGER',
+                'python_name': 'SOURCE',
+                'value': 1035
+            },
+            {
+                'documentation': {
+                    'description': 'Asserts the Measure trigger.'
+                },
+                'name': 'NIDCPOWER_VAL_MEASURE_TRIGGER',
+                'python_name': 'MEASURE',
+                'value': 1036
+            },
+            {
+                'documentation': {
+                    'description': 'Asserts the Sequence Advance trigger.'
+                },
+                'name': 'NIDCPOWER_VAL_SEQUENCE_ADVANCE_TRIGGER',
+                'python_name': 'SEQUENCE_ADVANCE',
+                'value': 1037
+            },
+            {
+                'documentation': {
+                    'description': 'Asserts the Pulse trigger.'
+                },
+                'name': 'NIDCPOWER_VAL_PULSE_TRIGGER',
+                'python_name': 'PULSE',
+                'value': 1053
+            },
+            {
+                'documentation': {
+                    'description': 'Asserts the Shutdown trigger.'
+                },
+                'name': 'NIDCPOWER_VAL_SHUTDOWN_TRIGGER',
+                'python_name': 'SHUTDOWN',
+                'value': 1118
+            }
+        ]
+    },
 }
 

--- a/src/nidmm/metadata/enums_addon.py
+++ b/src/nidmm/metadata/enums_addon.py
@@ -2,5 +2,42 @@
 # Any changes to the API should be made here. enums.py is code generated
 
 enums_override_metadata = {
+    # TODO (ni-jfitzger): delete this override once python_name is corrected for each value. See https://github.com/ni/nimi-python/issues/2072
+    'ThermistorType': {
+        'values': [
+            {
+                'documentation': {
+                    'description': 'Custom'
+                },
+                'name': 'NIDMM_VAL_TEMP_THERMISTOR_CUSTOM',
+                'python_name': 'CUSTOM',
+                'value': 0
+            },
+            {
+                'documentation': {
+                    'description': '44004'
+                },
+                'name': 'NIDMM_VAL_TEMP_THERMISTOR_44004',
+                'python_name': 'THERMISTOR_44004',
+                'value': 1
+            },
+            {
+                'documentation': {
+                    'description': '44006'
+                },
+                'name': 'NIDMM_VAL_TEMP_THERMISTOR_44006',
+                'python_name': 'THERMISTOR_44006',
+                'value': 2
+            },
+            {
+                'documentation': {
+                    'description': '44007'
+                },
+                'name': 'NIDMM_VAL_TEMP_THERMISTOR_44007',
+                'python_name': 'THERMISTOR_44007',
+                'value': 3
+            }
+        ]
+    },
 }
 


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- [X] I've added tests applicable for this pull request

### What does this Pull Request accomplish?
The `python_name` metadata key is supposed to allow us to hardcode the name that will be used by the Python API. For enum values, this was not being respected.

This change fixes that and adds additional unit test coverage for enum value expansion.

As part of this, we have to temporarily override some enum value metadata. Followup item: #2072

### List issues fixed by this Pull Request below, if any.

* Fix #2066

### What testing has been done?

* Unit tests pass
* Codegen has run and API is unchanged
* PR Checks
