### PR TITLE
Correct 1.2.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -545,7 +545,7 @@ All notable changes to this project will be documented in this file.
     * #### Added
         * Zip file per driver for all examples and any helper files
         * Link to zip file on examples documentation
-        * Support for Python 3.8
+        * Python 3.8 Classifier for PyPI (support was added in 1.1.4)
     * #### Changed
         * `import_attribute_configuration_buffer()` now accepts `list` of numbers that are integers less than 255, `array.array('b')`, `bytes`, `bytearray` for configuration buffer - [#1013](https://github.com/ni/nimi-python/issues/1013)
         * `export_attribute_configuration_buffer()` now returns `bytes` as the buffer type - [#1013](https://github.com/ni/nimi-python/issues/1013)


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [X] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

Our CHANGELOG incorrectly stated that we added Python 3.8 support in both 1.1.4 and 1.2.0.  In 1.2.0, we added the classifier to declare support on the PyPI page, because we neglected to do so in 1.1.4.

This change clarifies the 1.2.0 section of the CHANGELOG.

### List issues fixed by this Pull Request below, if any.

None

### What testing has been done?

PR Checks