### PR TITLE
Make each product use their own gRPC Device Server ports in the System Tests

### DIFF
--- a/src/nidcpower/system_tests/grpc_server_config.json
+++ b/src/nidcpower/system_tests/grpc_server_config.json
@@ -1,0 +1,9 @@
+{
+    "address": "[::1]",
+    "port": 31760,
+    "security" : {
+       "server_cert": "",
+       "server_key": "",
+       "root_cert": ""
+    }
+ }

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -1100,7 +1100,7 @@ class TestGrpc(SystemTests):
     @pytest.fixture(scope='class')
     def grpc_channel(self):
         current_directory = os.path.dirname(os.path.abspath(__file__))
-        config_file_path = os.path.join(current_directory, 'grpc_server_config,json')
+        config_file_path = os.path.join(current_directory, 'grpc_server_config.json')
         with system_test_utilities.GrpcServerProcess(config_file_path) as proc:
             channel = grpc.insecure_channel(f"localhost:{proc.server_port}")
             yield channel

--- a/src/nidcpower/system_tests/test_system_nidcpower.py
+++ b/src/nidcpower/system_tests/test_system_nidcpower.py
@@ -1099,7 +1099,9 @@ class TestLibrary(SystemTests):
 class TestGrpc(SystemTests):
     @pytest.fixture(scope='class')
     def grpc_channel(self):
-        with system_test_utilities.GrpcServerProcess() as proc:
+        current_directory = os.path.dirname(os.path.abspath(__file__))
+        config_file_path = os.path.join(current_directory, 'grpc_server_config,json')
+        with system_test_utilities.GrpcServerProcess(config_file_path) as proc:
             channel = grpc.insecure_channel(f"localhost:{proc.server_port}")
             yield channel
 

--- a/src/nidigital/system_tests/grpc_server_config.json
+++ b/src/nidigital/system_tests/grpc_server_config.json
@@ -1,0 +1,9 @@
+{
+    "address": "[::1]",
+    "port": 31761,
+    "security" : {
+       "server_cert": "",
+       "server_key": "",
+       "root_cert": ""
+    }
+ }

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -1350,7 +1350,9 @@ class TestLibrary(SystemTests):
 class TestGrpc(SystemTests):
     @pytest.fixture(scope='class')
     def grpc_channel(self):
-        with system_test_utilities.GrpcServerProcess() as proc:
+        current_directory = os.path.dirname(os.path.abspath(__file__))
+        config_file_path = os.path.join(current_directory, 'grpc_server_config,json')
+        with system_test_utilities.GrpcServerProcess(config_file_path) as proc:
             channel = grpc.insecure_channel(f"localhost:{proc.server_port}")
             yield channel
 

--- a/src/nidigital/system_tests/test_system_nidigital.py
+++ b/src/nidigital/system_tests/test_system_nidigital.py
@@ -1351,7 +1351,7 @@ class TestGrpc(SystemTests):
     @pytest.fixture(scope='class')
     def grpc_channel(self):
         current_directory = os.path.dirname(os.path.abspath(__file__))
-        config_file_path = os.path.join(current_directory, 'grpc_server_config,json')
+        config_file_path = os.path.join(current_directory, 'grpc_server_config.json')
         with system_test_utilities.GrpcServerProcess(config_file_path) as proc:
             channel = grpc.insecure_channel(f"localhost:{proc.server_port}")
             yield channel

--- a/src/nidmm/system_tests/grpc_server_config.json
+++ b/src/nidmm/system_tests/grpc_server_config.json
@@ -1,0 +1,9 @@
+{
+    "address": "[::1]",
+    "port": 31762,
+    "security" : {
+       "server_cert": "",
+       "server_key": "",
+       "root_cert": ""
+    }
+ }

--- a/src/nidmm/system_tests/test_system_nidmm.py
+++ b/src/nidmm/system_tests/test_system_nidmm.py
@@ -330,7 +330,9 @@ class TestLibrary(SystemTests):
 class TestGrpc(SystemTests):
     @pytest.fixture(scope='class')
     def grpc_channel(self):
-        with system_test_utilities.GrpcServerProcess() as proc:
+        current_directory = os.path.dirname(os.path.abspath(__file__))
+        config_file_path = os.path.join(current_directory, 'grpc_server_config,json')
+        with system_test_utilities.GrpcServerProcess(config_file_path) as proc:
             channel = grpc.insecure_channel(f"localhost:{proc.server_port}")
             yield channel
 

--- a/src/nidmm/system_tests/test_system_nidmm.py
+++ b/src/nidmm/system_tests/test_system_nidmm.py
@@ -331,7 +331,7 @@ class TestGrpc(SystemTests):
     @pytest.fixture(scope='class')
     def grpc_channel(self):
         current_directory = os.path.dirname(os.path.abspath(__file__))
-        config_file_path = os.path.join(current_directory, 'grpc_server_config,json')
+        config_file_path = os.path.join(current_directory, 'grpc_server_config.json')
         with system_test_utilities.GrpcServerProcess(config_file_path) as proc:
             channel = grpc.insecure_channel(f"localhost:{proc.server_port}")
             yield channel

--- a/src/nifgen/system_tests/grpc_server_config.json
+++ b/src/nifgen/system_tests/grpc_server_config.json
@@ -1,0 +1,9 @@
+{
+    "address": "[::1]",
+    "port": 31763,
+    "security" : {
+       "server_cert": "",
+       "server_key": "",
+       "root_cert": ""
+    }
+ }

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -517,7 +517,7 @@ class TestGrpc(SystemTests):
     @pytest.fixture(scope='class')
     def grpc_channel(self):
         current_directory = os.path.dirname(os.path.abspath(__file__))
-        config_file_path = os.path.join(current_directory, 'grpc_server_config,json')
+        config_file_path = os.path.join(current_directory, 'grpc_server_config.json')
         with system_test_utilities.GrpcServerProcess(config_file_path) as proc:
             channel = grpc.insecure_channel(f"localhost:{proc.server_port}")
             yield channel

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -516,7 +516,9 @@ class TestLibrary(SystemTests):
 class TestGrpc(SystemTests):
     @pytest.fixture(scope='class')
     def grpc_channel(self):
-        with system_test_utilities.GrpcServerProcess() as proc:
+        current_directory = os.path.dirname(os.path.abspath(__file__))
+        config_file_path = os.path.join(current_directory, 'grpc_server_config,json')
+        with system_test_utilities.GrpcServerProcess(config_file_path) as proc:
             channel = grpc.insecure_channel(f"localhost:{proc.server_port}")
             yield channel
 

--- a/src/niscope/system_tests/grpc_server_config.json
+++ b/src/niscope/system_tests/grpc_server_config.json
@@ -1,0 +1,9 @@
+{
+    "address": "[::1]",
+    "port": 31764,
+    "security" : {
+       "server_cert": "",
+       "server_key": "",
+       "root_cert": ""
+    }
+ }

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -612,7 +612,9 @@ class TestLibrary(SystemTests):
 class TestGrpc(SystemTests):
     @pytest.fixture(scope='class')
     def grpc_channel(self):
-        with system_test_utilities.GrpcServerProcess() as proc:
+        current_directory = os.path.dirname(os.path.abspath(__file__))
+        config_file_path = os.path.join(current_directory, 'grpc_server_config,json')
+        with system_test_utilities.GrpcServerProcess(config_file_path) as proc:
             channel = grpc.insecure_channel(f"localhost:{proc.server_port}")
             yield channel
 

--- a/src/niscope/system_tests/test_system_niscope.py
+++ b/src/niscope/system_tests/test_system_niscope.py
@@ -613,7 +613,7 @@ class TestGrpc(SystemTests):
     @pytest.fixture(scope='class')
     def grpc_channel(self):
         current_directory = os.path.dirname(os.path.abspath(__file__))
-        config_file_path = os.path.join(current_directory, 'grpc_server_config,json')
+        config_file_path = os.path.join(current_directory, 'grpc_server_config.json')
         with system_test_utilities.GrpcServerProcess(config_file_path) as proc:
             channel = grpc.insecure_channel(f"localhost:{proc.server_port}")
             yield channel

--- a/src/niswitch/system_tests/grpc_server_config.json
+++ b/src/niswitch/system_tests/grpc_server_config.json
@@ -1,0 +1,9 @@
+{
+    "address": "[::1]",
+    "port": 31765,
+    "security" : {
+       "server_cert": "",
+       "server_key": "",
+       "root_cert": ""
+    }
+ }

--- a/src/niswitch/system_tests/test_system_niswitch.py
+++ b/src/niswitch/system_tests/test_system_niswitch.py
@@ -195,7 +195,9 @@ class TestLibrary(SystemTests):
 class TestGrpc(SystemTests):
     @pytest.fixture(scope='class')
     def grpc_channel(self):
-        with system_test_utilities.GrpcServerProcess() as proc:
+        current_directory = os.path.dirname(os.path.abspath(__file__))
+        config_file_path = os.path.join(current_directory, 'grpc_server_config,json')
+        with system_test_utilities.GrpcServerProcess(config_file_path) as proc:
             channel = grpc.insecure_channel(f"localhost:{proc.server_port}")
             yield channel
 

--- a/src/niswitch/system_tests/test_system_niswitch.py
+++ b/src/niswitch/system_tests/test_system_niswitch.py
@@ -196,7 +196,7 @@ class TestGrpc(SystemTests):
     @pytest.fixture(scope='class')
     def grpc_channel(self):
         current_directory = os.path.dirname(os.path.abspath(__file__))
-        config_file_path = os.path.join(current_directory, 'grpc_server_config,json')
+        config_file_path = os.path.join(current_directory, 'grpc_server_config.json')
         with system_test_utilities.GrpcServerProcess(config_file_path) as proc:
             channel = grpc.insecure_channel(f"localhost:{proc.server_port}")
             yield channel

--- a/src/shared/system_test_utilities.py
+++ b/src/shared/system_test_utilities.py
@@ -8,9 +8,9 @@ import time
 
 
 class GrpcServerProcess:
-    def __init__(self):
+    def __init__(self, config_file_path):
         server_exe = self._get_grpc_server_exe()
-        self._proc = subprocess.Popen([str(server_exe)], stdout=subprocess.PIPE)
+        self._proc = subprocess.Popen([str(server_exe), config_file_path], stdout=subprocess.PIPE)
 
         # Read/parse output until we find the port number or the process exits; discard the rest.
         try:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

~~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~

~~- [ ] I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

Several different gRPC device server processes are created when running system tests, but all these different processes default to the same port, 31763. This collision is causing tests to fail to run.

### List issues fixed by this Pull Request below, if any.

[AB#3048787](https://dev.azure.com/ni/DevCentral/_workitems/edit/3048787)

### What testing has been done?