### PR TITLE
NI-DCPower: Add API parity with NI-DCPower 2025 Q2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 #### [nidcpower] Unreleased
 - Added
   - API parity with NI-DCPower 2025 Q2.
-      - Properties added:
+      - Properties:
         - `constant_power_compensation_frequency`
         - `constant_power_current_limit`
         - `constant_power_gain_bandwidth`
@@ -64,7 +64,7 @@
         - `constant_resistance_level_range`
         - `constant_resistance_pole_zero_ratio`
         - `output_shorted`
-      - Enum values added:
+      - Enum values:
         - `CONSTANT_RESISTANCE` and `CONSTANT_POWER` added to enum `OutputFunction`
 - Changed
 - Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
- 
+
 ## Packages
 - [nidcpower (NI-DCPower)](#nidcpower-ni-dcpower)
 - [nidigital (NI-Digital Pattern Driver)](#nidigital-ni-digital-pattern-driver)
@@ -49,6 +49,23 @@
 
 #### [nidcpower] Unreleased
 - Added
+  - API parity with NI-DCPower 2025 Q2.
+      - Properties added:
+        - `constant_power_compensation_frequency`
+        - `constant_power_current_limit`
+        - `constant_power_gain_bandwidth`
+        - `constant_power_level`
+        - `constant_power_level_range`
+        - `constant_power_pole_zero_ratio`
+        - `constant_resistance_compensation_frequency`
+        - `constant_resistance_current_limit`
+        - `constant_resistance_gain_bandwidth`
+        - `constant_resistance_level`
+        - `constant_resistance_level_range`
+        - `constant_resistance_pole_zero_ratio`
+        - `output_shorted`
+      - Enum values added:
+        - `CONSTANT_RESISTANCE` and `CONSTANT_POWER` added to enum `OutputFunction`
 - Changed
 - Removed
 
@@ -187,7 +204,7 @@
          - `lcr_source_delay_mode`
          - `lcr_stimulus_function`
          - `lcr_voltage_amplitude`
-         - `lcr_voltage_range`      
+         - `lcr_voltage_range`
       - Enums added:
          - `ApertureTimeAutoMode`
          - `CableLength`
@@ -199,7 +216,7 @@
          - `LCROpenShortLoadCompensationDataSource`
          - `LCRReferenceValueType`
          - `LCRSourceDelayMode`
-         - `LCRStimulusFunction`    
+         - `LCRStimulusFunction`
       - Methods added:
          - `configure_lcr_custom_cable_compensation`
          - `fetch_multiple_lcr`
@@ -210,7 +227,7 @@
          - `perform_lcr_open_compensation`
          - `perform_lcr_open_custom_cable_compensation`
          - `perform_lcr_short_compensation`
-         - `perform_lcr_short_custom_cable_compensation`  
+         - `perform_lcr_short_custom_cable_compensation`
       - Custom types added:
          - `LCRLoadCompensationSpot`
          - `LCRMeasurement`
@@ -222,7 +239,7 @@
 #### [nidcpower] 1.4.1 - 2021-08-23
 - Added
   - (Common) Support for Python 3.9
-  - API parity with NI-DCPower 21.0.0.     
+  - API parity with NI-DCPower 21.0.0.
       - Properties added:
          - `output_cutoff_delay`
 - Removed
@@ -1654,7 +1671,7 @@
       i = 0
       with nimodinst.Session('nidmm') as session:
           name = session[i].device_name
-      ``` 
+      ```
 
 #### [nimodinst] 0.1.0 - 2017-09-01
 - Added
@@ -1669,7 +1686,7 @@
 - Added
   - Enabled selected public APIs
   - Basic example
-  - Documentation for APIs (not final) 
+  - Documentation for APIs (not final)
 - Changed
 - Removed
 

--- a/docs/nidcpower/class.rst
+++ b/docs/nidcpower/class.rst
@@ -2184,32 +2184,17 @@ query_in_compliance
 
     .. py:method:: query_in_compliance()
 
-            Queries the specified output device to determine if it is operating at
-            the `compliance <REPLACE_DRIVER_SPECIFIC_URL_2(compliance)>`__ limit.
+            Queries the specified channel to determine if it is operating at the compliance limit.
 
-            The compliance limit is the current limit when the output method is
-            set to :py:data:`~nidcpower.OutputFunction.DC_VOLTAGE`. If the output is operating at the
-            compliance limit, the output reaches the current limit before the
-            desired voltage level. Refer to the :py:meth:`nidcpower.Session.ConfigureOutputFunction`
-            method and the :py:meth:`nidcpower.Session.ConfigureCurrentLimit` method for more
-            information about output method and current limit, respectively.
+            The compliance limit is the current limit when the :py:attr:`nidcpower.Session.output_function` property is set to :py:data:`~nidcpower.OutputFunction.DC_VOLTAGE`, :py:data:`~nidcpower.OutputFunction.PULSE_VOLTAGE`, :py:data:`~nidcpower.OutputFunction.CONSTANT_RESISTANCE` or :py:data:`~nidcpower.OutputFunction.CONSTANT_POWER`. If the output is operating at the compliance limit, the output reaches the current limit before the desired voltage, resistance or power level.
 
-            The compliance limit is the voltage limit when the output method is
-            set to :py:data:`~nidcpower.OutputFunction.DC_CURRENT`. If the output is operating at the
-            compliance limit, the output reaches the voltage limit before the
-            desired current level. Refer to the :py:meth:`nidcpower.Session.ConfigureOutputFunction`
-            method and the :py:meth:`nidcpower.Session.ConfigureVoltageLimit` method for more
-            information about output method and voltage limit, respectively.
+            The compliance limit is the voltage limit when the :py:attr:`nidcpower.Session.output_function` property is set to :py:data:`~nidcpower.OutputFunction.DC_CURRENT` or :py:data:`~nidcpower.OutputFunction.PULSE_CURRENT`. If the output is operating at the compliance limit, the output reaches the voltage limit before the desired current level.
 
-            **Related Topics:**
-
-            `Compliance <REPLACE_DRIVER_SPECIFIC_URL_1(compliance)>`__
+            Refer to the :py:attr:`nidcpower.Session.output_function` property for more information about the applicable properties to configure for each output method.
 
             
 
             .. note:: NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
-
-            .. note:: One or more of the referenced methods are not in the Python API for this driver.
 
 
             .. tip:: This method can be called on specific channels within your :py:class:`nidcpower.Session` instance.
@@ -2739,21 +2724,14 @@ set_sequence
 
     .. py:method:: set_sequence(values, source_delays)
 
-            Configures a series of voltage or current outputs and corresponding
-            source delays. The source mode must be set to
-            `Sequence <REPLACE_DRIVER_SPECIFIC_URL_1(sequencing)>`__ for this
-            method to take effect.
+            Configures a series of voltage, current, resistance or power outputs and corresponding source delays. The source mode must be set to :py:data:`~nidcpower.SourceMode.SEQUENCE` for this method to take effect.
 
-            Refer to the `Configuring the Source
-            Unit <REPLACE_DRIVER_SPECIFIC_URL_1(configuringthesourceunit)>`__ topic
-            in the *NI DC Power Supplies and SMUs Help* for more information about
-            how to configure your device.
+            Refer to the Configuring the Source Unit topic in the *NI DC Power Supplies and SMUs Help* for more information about how to configure your device.
 
             Use this method in the Uncommitted or Committed programming states.
-            Refer to the `Programming
-            States <REPLACE_DRIVER_SPECIFIC_URL_1(programmingstates)>`__ topic in
-            the *NI DC Power Supplies and SMUs Help* for more information about
-            NI-DCPower programming states.
+            Refer to the Programming States topic in the *NI DC Power Supplies and SMUs Help* for more information about NI-DCPower programming states.
+
+            Using this method with Advanced Sequence methods for the same channel in the same session is not supported.
 
             
 
@@ -2776,12 +2754,8 @@ set_sequence
             :param values:
 
 
-                Specifies the series of voltage levels or current levels, depending on
-                the configured `output
-                method <REPLACE_DRIVER_SPECIFIC_URL_1(programming_output)>`__.
-                **Valid values**:
-                The valid values for this parameter are defined by the voltage level
-                range or current level range.
+                Specifies the series of voltage, current, resistance or power levels, depending on the configured :py:attr:`nidcpower.Session.output_function`.
+                **Valid values**: The valid values for this parameter are defined by the voltage level range, current level range, constant resistance level range or constant power level range.
 
                 
 
@@ -3809,6 +3783,532 @@ conduction_voltage_on_threshold
 
                 - LabVIEW Property: **Source:Advanced:Conduction Voltage:On Threshold**
                 - C Attribute: **NIDCPOWER_ATTR_CONDUCTION_VOLTAGE_ON_THRESHOLD**
+
+constant_power_compensation_frequency
+-------------------------------------
+
+    .. py:attribute:: constant_power_compensation_frequency
+
+        The frequency at which a pole-zero pair is added to the system when the :py:attr:`nidcpower.Session.output_function` property is set to :py:data:`~nidcpower.OutputFunction.CONSTANT_POWER` and the output current is below the current limit.
+
+        Default Value: Determined by the value of the :py:data:`~nidcpower.TransientResponse.NORMAL` setting of the :py:attr:`nidcpower.Session.transient_response` property.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+            NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].constant_power_compensation_frequency`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.constant_power_compensation_frequency`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Source:Custom Transient Response:Constant Power:Compensation Frequency**
+                - C Attribute: **NIDCPOWER_ATTR_CONSTANT_POWER_COMPENSATION_FREQUENCY**
+
+constant_power_current_limit
+----------------------------
+
+    .. py:attribute:: constant_power_current_limit
+
+        Specifies the current limit, in amps, that the output cannot exceed when generating the desired power level on the specified channel(s).
+        The device will operate in Constant Current mode if the current exceeds the specified limit.
+        This property is applicable only if the :py:attr:`nidcpower.Session.output_function` property is set to :py:data:`~nidcpower.OutputFunction.CONSTANT_POWER` and the :py:attr:`nidcpower.Session.compliance_limit_symmetry` property is set to :py:data:`~nidcpower.ComplianceLimitSymmetry.SYMMETRIC`.
+
+        Valid Values: The valid values for this property are determined by the selected value for :py:attr:`nidcpower.Session.constant_power_level_range`.
+
+
+
+        .. note:: The channel must be enabled for the specified current limit to take effect. Refer to the :py:attr:`nidcpower.Session.output_enabled` property for more information about enabling the channel.
+
+            NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].constant_power_current_limit`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.constant_power_current_limit`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Source:Constant Power:Current Limit**
+                - C Attribute: **NIDCPOWER_ATTR_CONSTANT_POWER_CURRENT_LIMIT**
+
+constant_power_gain_bandwidth
+-----------------------------
+
+    .. py:attribute:: constant_power_gain_bandwidth
+
+        The frequency at which the unloaded loop gain extrapolates to 0 dB in the absence of additional poles and zeroes. This property takes effect when the :py:attr:`nidcpower.Session.output_function` property is set to :py:data:`~nidcpower.OutputFunction.CONSTANT_POWER` and the output current is below the current limit.
+
+        Default Value: Determined by the value of the :py:data:`~nidcpower.TransientResponse.NORMAL` setting of the :py:attr:`nidcpower.Session.transient_response` property.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+            NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].constant_power_gain_bandwidth`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.constant_power_gain_bandwidth`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Source:Custom Transient Response:Constant Power:Gain Bandwidth**
+                - C Attribute: **NIDCPOWER_ATTR_CONSTANT_POWER_GAIN_BANDWIDTH**
+
+constant_power_level
+--------------------
+
+    .. py:attribute:: constant_power_level
+
+        Specifies the power level, in watts, that the device attempts to generate on the specified channel(s).
+        This property is applicable only if the :py:attr:`nidcpower.Session.output_function` property is set to :py:data:`~nidcpower.OutputFunction.CONSTANT_POWER`.
+
+        Valid Values: The valid values for this property are determined by the selected value for :py:attr:`nidcpower.Session.constant_power_level_range`.
+
+
+
+        .. note:: The channel must be enabled for the specified power level to take effect. Refer to the :py:attr:`nidcpower.Session.output_enabled` property for more information about enabling the channel.
+
+            NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].constant_power_level`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.constant_power_level`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Source:Constant Power:Level**
+                - C Attribute: **NIDCPOWER_ATTR_CONSTANT_POWER_LEVEL**
+
+constant_power_level_range
+--------------------------
+
+    .. py:attribute:: constant_power_level_range
+
+        Specifies the power level range, in watts, for the specified channel(s).
+        The range defines the valid values to which you can set the power level.
+        This property is applicable only if the :py:attr:`nidcpower.Session.output_function` property is set to :py:data:`~nidcpower.OutputFunction.CONSTANT_POWER`.
+
+        For valid ranges, refer to the specifications for your instrument.
+
+
+
+        .. note:: The voltage range and current range used by the instrument are automatically determined by the selected power level range. For more information, refer to the specifications for your instrument.
+
+            NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].constant_power_level_range`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.constant_power_level_range`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Source:Constant Power:Level Range**
+                - C Attribute: **NIDCPOWER_ATTR_CONSTANT_POWER_LEVEL_RANGE**
+
+constant_power_pole_zero_ratio
+------------------------------
+
+    .. py:attribute:: constant_power_pole_zero_ratio
+
+        The ratio of the pole frequency to the zero frequency when the :py:attr:`nidcpower.Session.output_function` property is set to :py:data:`~nidcpower.OutputFunction.CONSTANT_POWER` and the output current is below the current limit.
+
+        Default Value: Determined by the value of the :py:data:`~nidcpower.TransientResponse.NORMAL` setting of the :py:attr:`nidcpower.Session.transient_response` property.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+            NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].constant_power_pole_zero_ratio`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.constant_power_pole_zero_ratio`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Source:Custom Transient Response:Constant Power:Pole-Zero Ratio**
+                - C Attribute: **NIDCPOWER_ATTR_CONSTANT_POWER_POLE_ZERO_RATIO**
+
+constant_resistance_compensation_frequency
+------------------------------------------
+
+    .. py:attribute:: constant_resistance_compensation_frequency
+
+        The frequency at which a pole-zero pair is added to the system when the :py:attr:`nidcpower.Session.output_function` property is set to :py:data:`~nidcpower.OutputFunction.CONSTANT_RESISTANCE` and the output current is below the current limit.
+
+        Default Value: Determined by the value of the :py:data:`~nidcpower.TransientResponse.NORMAL` setting of the :py:attr:`nidcpower.Session.transient_response` property.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+            NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].constant_resistance_compensation_frequency`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.constant_resistance_compensation_frequency`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Source:Custom Transient Response:Constant Resistance:Compensation Frequency**
+                - C Attribute: **NIDCPOWER_ATTR_CONSTANT_RESISTANCE_COMPENSATION_FREQUENCY**
+
+constant_resistance_current_limit
+---------------------------------
+
+    .. py:attribute:: constant_resistance_current_limit
+
+        Specifies the current limit, in amps, that the output cannot exceed when generating the desired resistance level on the specified channel(s).
+        The device will operate in Constant Current mode if the current exceeds the specified limit.
+        This property is applicable only if the :py:attr:`nidcpower.Session.output_function` property is set to :py:data:`~nidcpower.OutputFunction.CONSTANT_RESISTANCE` and the :py:attr:`nidcpower.Session.compliance_limit_symmetry` property is set to :py:data:`~nidcpower.ComplianceLimitSymmetry.SYMMETRIC`.
+
+        Valid Values: The valid values for this property are determined by the selected value for :py:attr:`nidcpower.Session.constant_resistance_level_range`.
+
+
+
+        .. note:: The channel must be enabled for the specified current limit to take effect. Refer to the :py:attr:`nidcpower.Session.output_enabled` property for more information about enabling the channel.
+
+            NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].constant_resistance_current_limit`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.constant_resistance_current_limit`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Source:Constant Resistance:Current Limit**
+                - C Attribute: **NIDCPOWER_ATTR_CONSTANT_RESISTANCE_CURRENT_LIMIT**
+
+constant_resistance_gain_bandwidth
+----------------------------------
+
+    .. py:attribute:: constant_resistance_gain_bandwidth
+
+        The frequency at which the unloaded loop gain extrapolates to 0 dB in the absence of additional poles and zeroes. This property takes effect when the :py:attr:`nidcpower.Session.output_function` property is set to :py:data:`~nidcpower.OutputFunction.CONSTANT_RESISTANCE` and the output current is below the current limit.
+
+        Default Value: Determined by the value of the :py:data:`~nidcpower.TransientResponse.NORMAL` setting of the :py:attr:`nidcpower.Session.transient_response` property.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+            NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].constant_resistance_gain_bandwidth`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.constant_resistance_gain_bandwidth`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Source:Custom Transient Response:Constant Resistance:Gain Bandwidth**
+                - C Attribute: **NIDCPOWER_ATTR_CONSTANT_RESISTANCE_GAIN_BANDWIDTH**
+
+constant_resistance_level
+-------------------------
+
+    .. py:attribute:: constant_resistance_level
+
+        Specifies the resistance level, in ohms, that the device attempts to generate on the specified channel(s).
+        This property is applicable only if the :py:attr:`nidcpower.Session.output_function` property is set to :py:data:`~nidcpower.OutputFunction.CONSTANT_RESISTANCE`.
+
+        Valid Values: The valid values for this property are determined by the selected value for :py:attr:`nidcpower.Session.constant_resistance_level_range`.
+
+
+
+        .. note:: The channel must be enabled for the specified resistance level to take effect. Refer to the :py:attr:`nidcpower.Session.output_enabled` property for more information about enabling the channel.
+
+            NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].constant_resistance_level`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.constant_resistance_level`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Source:Constant Resistance:Level**
+                - C Attribute: **NIDCPOWER_ATTR_CONSTANT_RESISTANCE_LEVEL**
+
+constant_resistance_level_range
+-------------------------------
+
+    .. py:attribute:: constant_resistance_level_range
+
+        Specifies the resistance level range, in ohms, for the specified channel(s).
+        The range defines the valid values to which you can set the resistance level.
+        This property is applicable only if the :py:attr:`nidcpower.Session.output_function` property is set to :py:data:`~nidcpower.OutputFunction.CONSTANT_RESISTANCE`.
+
+        For valid ranges, refer to the specifications for your instrument.
+
+
+
+        .. note:: The voltage range and current range used by the instrument are automatically determined by the selected resistance level range. For more information, refer to the specifications for your instrument.
+
+            NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].constant_resistance_level_range`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.constant_resistance_level_range`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Source:Constant Resistance:Level Range**
+                - C Attribute: **NIDCPOWER_ATTR_CONSTANT_RESISTANCE_LEVEL_RANGE**
+
+constant_resistance_pole_zero_ratio
+-----------------------------------
+
+    .. py:attribute:: constant_resistance_pole_zero_ratio
+
+        The ratio of the pole frequency to the zero frequency when the :py:attr:`nidcpower.Session.output_function` property is set to :py:data:`~nidcpower.OutputFunction.CONSTANT_RESISTANCE` and the output current is below the current limit.
+
+        Default Value: Determined by the value of the :py:data:`~nidcpower.TransientResponse.NORMAL` setting of the :py:attr:`nidcpower.Session.transient_response` property.
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+            NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].constant_resistance_pole_zero_ratio`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.constant_resistance_pole_zero_ratio`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Source:Custom Transient Response:Constant Resistance:Pole-Zero Ratio**
+                - C Attribute: **NIDCPOWER_ATTR_CONSTANT_RESISTANCE_POLE_ZERO_RATIO**
 
 current_compensation_frequency
 ------------------------------
@@ -8077,7 +8577,9 @@ output_enabled
     .. py:attribute:: output_enabled
 
         Specifies whether the output is enabled (True) or disabled (False).
-        Depending on the value you specify for the :py:attr:`nidcpower.Session.output_function` property, you also must set the voltage level or current level in addition to enabling the output
+
+        Depending on the value you specify for the :py:attr:`nidcpower.Session.output_function` property, you also must set the corresponding level properties or :py:attr:`nidcpower.Session.output_resistance` in addition to enabling the output to generate the desired level.
+        For more information about configuring the output level, refer to the :py:attr:`nidcpower.Session.output_function` property.
 
         Default Value: The default value is True if you use the :py:meth:`nidcpower.Session.__init__` method to open the session. Otherwise the default value is False, including when you use a calibration session or the deprecated programming model.
 
@@ -8121,22 +8623,60 @@ output_function
     .. py:attribute:: output_function
 
         Configures the method to generate on the specified channel(s).
-        When :py:data:`~nidcpower.OutputFunction.DC_VOLTAGE` is selected, the device generates the desired voltage level on the output as long as the output current is below the current limit. You can use the following properties to configure the channel when :py:data:`~nidcpower.OutputFunction.DC_VOLTAGE` is selected:
-        :py:attr:`nidcpower.Session.voltage_level`
-        :py:attr:`nidcpower.Session.current_limit`
-        :py:attr:`nidcpower.Session.current_limit_high`
-        :py:attr:`nidcpower.Session.current_limit_low`
-        :py:attr:`nidcpower.Session.voltage_level_range`
-        :py:attr:`nidcpower.Session.current_limit_range`
-        :py:attr:`nidcpower.Session.compliance_limit_symmetry`
-        When :py:data:`~nidcpower.OutputFunction.DC_CURRENT` is selected, the device generates the desired current level on the output as long as the output voltage is below the voltage limit. You can use the following properties to configure the channel when :py:data:`~nidcpower.OutputFunction.DC_CURRENT` is selected:
-        :py:attr:`nidcpower.Session.current_level`
-        :py:attr:`nidcpower.Session.voltage_limit`
-        :py:attr:`nidcpower.Session.voltage_limit_high`
-        :py:attr:`nidcpower.Session.voltage_limit_low`
-        :py:attr:`nidcpower.Session.current_level_range`
-        :py:attr:`nidcpower.Session.voltage_limit_range`
-        :py:attr:`nidcpower.Session.compliance_limit_symmetry`
+
+        When :py:data:`~nidcpower.OutputFunction.DC_VOLTAGE` is selected, the device generates the desired voltage level on the output as long as the output current is below the current limit. Use the following properties to configure the channel when :py:data:`~nidcpower.OutputFunction.DC_VOLTAGE` is selected:
+         - :py:attr:`nidcpower.Session.voltage_level`
+         - :py:attr:`nidcpower.Session.current_limit`
+         - :py:attr:`nidcpower.Session.current_limit_high`
+         - :py:attr:`nidcpower.Session.current_limit_low`
+         - :py:attr:`nidcpower.Session.voltage_level_range`
+         - :py:attr:`nidcpower.Session.current_limit_range`
+         - :py:attr:`nidcpower.Session.compliance_limit_symmetry`
+
+        When :py:data:`~nidcpower.OutputFunction.DC_CURRENT` is selected, the device generates the desired current level on the output as long as the output voltage is below the voltage limit. Use the following properties to configure the channel when :py:data:`~nidcpower.OutputFunction.DC_CURRENT` is selected:
+         - :py:attr:`nidcpower.Session.current_level`
+         - :py:attr:`nidcpower.Session.voltage_limit`
+         - :py:attr:`nidcpower.Session.voltage_limit_high`
+         - :py:attr:`nidcpower.Session.voltage_limit_low`
+         - :py:attr:`nidcpower.Session.current_level_range`
+         - :py:attr:`nidcpower.Session.voltage_limit_range`
+         - :py:attr:`nidcpower.Session.compliance_limit_symmetry`
+
+        When :py:data:`~nidcpower.OutputFunction.PULSE_VOLTAGE` is selected, the device generates pulses at the desired pulse voltage levels on the output as long as the output current is below the pulse current limit. Use the following properties to configure the channel when :py:data:`~nidcpower.OutputFunction.PULSE_VOLTAGE` is selected:
+         - :py:attr:`nidcpower.Session.pulse_voltage_level`
+         - :py:attr:`nidcpower.Session.pulse_bias_voltage_level`
+         - :py:attr:`nidcpower.Session.pulse_current_limit`
+         - :py:attr:`nidcpower.Session.pulse_current_limit_high`
+         - :py:attr:`nidcpower.Session.pulse_current_limit_low`
+         - :py:attr:`nidcpower.Session.pulse_bias_current_limit`
+         - :py:attr:`nidcpower.Session.pulse_bias_current_limit_high`
+         - :py:attr:`nidcpower.Session.pulse_bias_current_limit_low`
+         - :py:attr:`nidcpower.Session.pulse_voltage_level_range`
+         - :py:attr:`nidcpower.Session.pulse_current_limit_range`
+         - :py:attr:`nidcpower.Session.compliance_limit_symmetry`
+
+        When :py:data:`~nidcpower.OutputFunction.PULSE_CURRENT` is selected, the device generates pulses at the desired pulse current levels on the output as long as the output voltage is below the pulse voltage limit. Use the following properties to configure the channel when :py:data:`~nidcpower.OutputFunction.PULSE_CURRENT` is selected:
+         - :py:attr:`nidcpower.Session.pulse_current_level`
+         - :py:attr:`nidcpower.Session.pulse_bias_current_level`
+         - :py:attr:`nidcpower.Session.pulse_voltage_limit`
+         - :py:attr:`nidcpower.Session.pulse_voltage_limit_high`
+         - :py:attr:`nidcpower.Session.pulse_voltage_limit_low`
+         - :py:attr:`nidcpower.Session.pulse_bias_voltage_limit`
+         - :py:attr:`nidcpower.Session.pulse_bias_voltage_limit_high`
+         - :py:attr:`nidcpower.Session.pulse_bias_voltage_limit_low`
+         - :py:attr:`nidcpower.Session.pulse_current_level_range`
+         - :py:attr:`nidcpower.Session.pulse_voltage_limit_range`
+         - :py:attr:`nidcpower.Session.compliance_limit_symmetry`
+
+        When :py:data:`~nidcpower.OutputFunction.CONSTANT_RESISTANCE` is selected, the device generates the desired resistance level on the output as long as the output current is below the current limit. Use the following properties to configure the channel when :py:data:`~nidcpower.OutputFunction.CONSTANT_RESISTANCE` is selected:
+         - :py:attr:`nidcpower.Session.constant_resistance_level`
+         - :py:attr:`nidcpower.Session.constant_resistance_current_limit`
+         - :py:attr:`nidcpower.Session.constant_resistance_level_range`
+
+        When :py:data:`~nidcpower.OutputFunction.CONSTANT_POWER` is selected, the device generates the desired power level on the output as long as the output current is below the current limit. Use the following properties to configure the channel when :py:data:`~nidcpower.OutputFunction.CONSTANT_POWER` is selected:
+         - :py:attr:`nidcpower.Session.constant_power_level`
+         - :py:attr:`nidcpower.Session.constant_power_current_limit`
+         - :py:attr:`nidcpower.Session.constant_power_level_range`
 
 
 
@@ -8175,13 +8715,25 @@ output_resistance
 
     .. py:attribute:: output_resistance
 
-        Specifies the output resistance that the device attempts to generate for the specified channel(s). This property is available only when you set the :py:attr:`nidcpower.Session.output_function` property on a support device. Refer to a supported device's topic about output resistance for more information about selecting an output resistance.
-        about supported devices.
-        Default Value: 0.0
+        Specifies the output resistance that the device attempts to generate for the specified channel(s).
+
+        Depending on the instrument, output resistance is configurable only if you set the :py:attr:`nidcpower.Session.output_function` of the channel as follows:
+         - PXIe-4141, PXIe-4143, PXIe-4145: :py:data:`~nidcpower.OutputFunction.DC_VOLTAGE`
+         - PXIe-4135, PXIe-4137, PXIe-4139, PXIe-4147: :py:data:`~nidcpower.OutputFunction.DC_CURRENT` or :py:data:`~nidcpower.OutputFunction.DC_VOLTAGE`
+
+        **Valid Values**: Vary by device. Refer to the device specifications for your device for more information about supported values.
+
+        **Default Value:** Search ni.com for Supported Properties by Device for the default value by device.
 
 
 
-        .. note:: NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+        .. note:: The channel must be enabled for the specified output resistance to take effect. Refer to the :py:attr:`nidcpower.Session.output_enabled` property for more information about enabling the channel.
+
+            Using the :py:attr:`nidcpower.Session.merged_channels` property to merge instrument outputs affects the valid output resistance range you can program. Refer to the Merged Channels topic for your device for details.
+
+            To specify the resistance level that the device attempts to generate when :py:attr:`nidcpower.Session.output_function` is set to :py:data:`~nidcpower.OutputFunction.CONSTANT_RESISTANCE`, use the :py:attr:`nidcpower.Session.constant_resistance_level` property.
+
+            NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
 
             This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
 
@@ -8212,6 +8764,48 @@ output_resistance
 
                 - LabVIEW Property: **Source:Output Resistance**
                 - C Attribute: **NIDCPOWER_ATTR_OUTPUT_RESISTANCE**
+
+output_shorted
+--------------
+
+    .. py:attribute:: output_shorted
+
+        Specifies whether the input of the instrument simulates a short circuit.
+        When this property is set to True, the electronic load will simulate a short circuit across the channel/input terminals. The electronic load uses the maximum rated current and range to simulate the short circuit. This property will only take effect when both :py:attr:`nidcpower.Session.output_enabled` and :py:attr:`nidcpower.Session.output_connected` are True.
+
+        When this property is set to False, the instrument will resume normal operation based on its existing settings on the specified channel(s).
+
+
+
+        .. note:: This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+            Example: :py:attr:`my_session.channels[ ... ].output_shorted`
+
+            To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+            Example: :py:attr:`my_session.output_shorted`
+
+        The following table lists the characteristics of this property.
+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | bool       |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | channels   |
+            +-----------------------+------------+
+
+        .. tip::
+            This property corresponds to the following LabVIEW Property or C Attribute:
+
+                - LabVIEW Property: **Source:Advanced:Output Shorted**
+                - C Attribute: **NIDCPOWER_ATTR_OUTPUT_SHORTED**
 
 overranging_enabled
 -------------------

--- a/docs/nidcpower/enums.rst
+++ b/docs/nidcpower/enums.rst
@@ -365,7 +365,7 @@ ConductionVoltageMode
 
 
 
-        The conduction voltage feature is only enabled when you set the :py:attr:`nidcpower.Session.output_function` property to :py:data:`~nidcpower.OutputFunction.DC_CURRENT`.
+        The conduction voltage feature is only enabled when you set the :py:attr:`nidcpower.Session.output_function` property to :py:data:`~nidcpower.OutputFunction.DC_CURRENT` or :py:data:`~nidcpower.OutputFunction.CONSTANT_POWER`.
 
         
 
@@ -1156,6 +1156,26 @@ OutputFunction
 
 
         Sets the output method to pulse current.
+
+        
+
+
+
+    .. py:attribute:: OutputFunction.CONSTANT_RESISTANCE
+
+
+
+        Sets the output method to constant resistance.
+
+        
+
+
+
+    .. py:attribute:: OutputFunction.CONSTANT_POWER
+
+
+
+        Sets the output method to constant power.
 
         
 

--- a/generated/nidcpower/nidcpower/enums.py
+++ b/generated/nidcpower/nidcpower/enums.py
@@ -155,7 +155,7 @@ class ComplianceLimitSymmetry(Enum):
 class ConductionVoltageMode(Enum):
     AUTOMATIC = 1155
     r'''
-    The conduction voltage feature is only enabled when you set the output_function property to OutputFunction.DC_CURRENT.
+    The conduction voltage feature is only enabled when you set the output_function property to OutputFunction.DC_CURRENT or OutputFunction.CONSTANT_POWER.
     '''
     ENABLED = 1156
     r'''
@@ -508,6 +508,14 @@ class OutputFunction(Enum):
     PULSE_CURRENT = 1050
     r'''
     Sets the output method to pulse current.
+    '''
+    CONSTANT_RESISTANCE = 1161
+    r'''
+    Sets the output method to constant resistance.
+    '''
+    CONSTANT_POWER = 1162
+    r'''
+    Sets the output method to constant power.
     '''
 
 

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -535,6 +535,280 @@ class _SessionBase(object):
 
     Example: :py:attr:`my_session.conduction_voltage_on_threshold`
     '''
+    constant_power_compensation_frequency = _attributes.AttributeViReal64(1150360)
+    '''Type: float
+
+    The frequency at which a pole-zero pair is added to the system when the output_function property is set to OutputFunction.CONSTANT_POWER and the output current is below the current limit.
+
+    Default Value: Determined by the value of the TransientResponse.NORMAL setting of the transient_response property.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].constant_power_compensation_frequency`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.constant_power_compensation_frequency`
+    '''
+    constant_power_current_limit = _attributes.AttributeViReal64(1150361)
+    '''Type: float
+
+    Specifies the current limit, in amps, that the output cannot exceed when generating the desired power level on the specified channel(s).
+    The device will operate in Constant Current mode if the current exceeds the specified limit.
+    This property is applicable only if the output_function property is set to OutputFunction.CONSTANT_POWER and the compliance_limit_symmetry property is set to ComplianceLimitSymmetry.SYMMETRIC.
+
+    Valid Values: The valid values for this property are determined by the selected value for constant_power_level_range.
+
+    Note:
+    The channel must be enabled for the specified current limit to take effect. Refer to the output_enabled property for more information about enabling the channel.
+
+    NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].constant_power_current_limit`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.constant_power_current_limit`
+    '''
+    constant_power_gain_bandwidth = _attributes.AttributeViReal64(1150362)
+    '''Type: float
+
+    The frequency at which the unloaded loop gain extrapolates to 0 dB in the absence of additional poles and zeroes. This property takes effect when the output_function property is set to OutputFunction.CONSTANT_POWER and the output current is below the current limit.
+
+    Default Value: Determined by the value of the TransientResponse.NORMAL setting of the transient_response property.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].constant_power_gain_bandwidth`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.constant_power_gain_bandwidth`
+    '''
+    constant_power_level = _attributes.AttributeViReal64(1150363)
+    '''Type: float
+
+    Specifies the power level, in watts, that the device attempts to generate on the specified channel(s).
+    This property is applicable only if the output_function property is set to OutputFunction.CONSTANT_POWER.
+
+    Valid Values: The valid values for this property are determined by the selected value for constant_power_level_range.
+
+    Note:
+    The channel must be enabled for the specified power level to take effect. Refer to the output_enabled property for more information about enabling the channel.
+
+    NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].constant_power_level`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.constant_power_level`
+    '''
+    constant_power_level_range = _attributes.AttributeViReal64(1150364)
+    '''Type: float
+
+    Specifies the power level range, in watts, for the specified channel(s).
+    The range defines the valid values to which you can set the power level.
+    This property is applicable only if the output_function property is set to OutputFunction.CONSTANT_POWER.
+
+    For valid ranges, refer to the specifications for your instrument.
+
+    Note:
+    The voltage range and current range used by the instrument are automatically determined by the selected power level range. For more information, refer to the specifications for your instrument.
+
+    NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].constant_power_level_range`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.constant_power_level_range`
+    '''
+    constant_power_pole_zero_ratio = _attributes.AttributeViReal64(1150365)
+    '''Type: float
+
+    The ratio of the pole frequency to the zero frequency when the output_function property is set to OutputFunction.CONSTANT_POWER and the output current is below the current limit.
+
+    Default Value: Determined by the value of the TransientResponse.NORMAL setting of the transient_response property.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].constant_power_pole_zero_ratio`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.constant_power_pole_zero_ratio`
+    '''
+    constant_resistance_compensation_frequency = _attributes.AttributeViReal64(1150366)
+    '''Type: float
+
+    The frequency at which a pole-zero pair is added to the system when the output_function property is set to OutputFunction.CONSTANT_RESISTANCE and the output current is below the current limit.
+
+    Default Value: Determined by the value of the TransientResponse.NORMAL setting of the transient_response property.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].constant_resistance_compensation_frequency`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.constant_resistance_compensation_frequency`
+    '''
+    constant_resistance_current_limit = _attributes.AttributeViReal64(1150367)
+    '''Type: float
+
+    Specifies the current limit, in amps, that the output cannot exceed when generating the desired resistance level on the specified channel(s).
+    The device will operate in Constant Current mode if the current exceeds the specified limit.
+    This property is applicable only if the output_function property is set to OutputFunction.CONSTANT_RESISTANCE and the compliance_limit_symmetry property is set to ComplianceLimitSymmetry.SYMMETRIC.
+
+    Valid Values: The valid values for this property are determined by the selected value for constant_resistance_level_range.
+
+    Note:
+    The channel must be enabled for the specified current limit to take effect. Refer to the output_enabled property for more information about enabling the channel.
+
+    NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].constant_resistance_current_limit`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.constant_resistance_current_limit`
+    '''
+    constant_resistance_gain_bandwidth = _attributes.AttributeViReal64(1150368)
+    '''Type: float
+
+    The frequency at which the unloaded loop gain extrapolates to 0 dB in the absence of additional poles and zeroes. This property takes effect when the output_function property is set to OutputFunction.CONSTANT_RESISTANCE and the output current is below the current limit.
+
+    Default Value: Determined by the value of the TransientResponse.NORMAL setting of the transient_response property.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].constant_resistance_gain_bandwidth`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.constant_resistance_gain_bandwidth`
+    '''
+    constant_resistance_level = _attributes.AttributeViReal64(1150369)
+    '''Type: float
+
+    Specifies the resistance level, in ohms, that the device attempts to generate on the specified channel(s).
+    This property is applicable only if the output_function property is set to OutputFunction.CONSTANT_RESISTANCE.
+
+    Valid Values: The valid values for this property are determined by the selected value for constant_resistance_level_range.
+
+    Note:
+    The channel must be enabled for the specified resistance level to take effect. Refer to the output_enabled property for more information about enabling the channel.
+
+    NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].constant_resistance_level`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.constant_resistance_level`
+    '''
+    constant_resistance_level_range = _attributes.AttributeViReal64(1150370)
+    '''Type: float
+
+    Specifies the resistance level range, in ohms, for the specified channel(s).
+    The range defines the valid values to which you can set the resistance level.
+    This property is applicable only if the output_function property is set to OutputFunction.CONSTANT_RESISTANCE.
+
+    For valid ranges, refer to the specifications for your instrument.
+
+    Note:
+    The voltage range and current range used by the instrument are automatically determined by the selected resistance level range. For more information, refer to the specifications for your instrument.
+
+    NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].constant_resistance_level_range`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.constant_resistance_level_range`
+    '''
+    constant_resistance_pole_zero_ratio = _attributes.AttributeViReal64(1150371)
+    '''Type: float
+
+    The ratio of the pole frequency to the zero frequency when the output_function property is set to OutputFunction.CONSTANT_RESISTANCE and the output current is below the current limit.
+
+    Default Value: Determined by the value of the TransientResponse.NORMAL setting of the transient_response property.
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].constant_resistance_pole_zero_ratio`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.constant_resistance_pole_zero_ratio`
+    '''
     current_compensation_frequency = _attributes.AttributeViReal64(1150071)
     '''Type: float
 
@@ -2637,7 +2911,9 @@ class _SessionBase(object):
     '''Type: bool
 
     Specifies whether the output is enabled (True) or disabled (False).
-    Depending on the value you specify for the output_function property, you also must set the voltage level or current level in addition to enabling the output
+
+    Depending on the value you specify for the output_function property, you also must set the corresponding level properties or output_resistance in addition to enabling the output to generate the desired level.
+    For more information about configuring the output level, refer to the output_function property.
 
     Default Value: The default value is True if you use the __init__ method to open the session. Otherwise the default value is False, including when you use a calibration session or the deprecated programming model.
 
@@ -2660,22 +2936,60 @@ class _SessionBase(object):
     '''Type: enums.OutputFunction
 
     Configures the method to generate on the specified channel(s).
-    When OutputFunction.DC_VOLTAGE is selected, the device generates the desired voltage level on the output as long as the output current is below the current limit. You can use the following properties to configure the channel when OutputFunction.DC_VOLTAGE is selected:
-    voltage_level
-    current_limit
-    current_limit_high
-    current_limit_low
-    voltage_level_range
-    current_limit_range
-    compliance_limit_symmetry
-    When OutputFunction.DC_CURRENT is selected, the device generates the desired current level on the output as long as the output voltage is below the voltage limit. You can use the following properties to configure the channel when OutputFunction.DC_CURRENT is selected:
-    current_level
-    voltage_limit
-    voltage_limit_high
-    voltage_limit_low
-    current_level_range
-    voltage_limit_range
-    compliance_limit_symmetry
+
+    When OutputFunction.DC_VOLTAGE is selected, the device generates the desired voltage level on the output as long as the output current is below the current limit. Use the following properties to configure the channel when OutputFunction.DC_VOLTAGE is selected:
+     - voltage_level
+     - current_limit
+     - current_limit_high
+     - current_limit_low
+     - voltage_level_range
+     - current_limit_range
+     - compliance_limit_symmetry
+
+    When OutputFunction.DC_CURRENT is selected, the device generates the desired current level on the output as long as the output voltage is below the voltage limit. Use the following properties to configure the channel when OutputFunction.DC_CURRENT is selected:
+     - current_level
+     - voltage_limit
+     - voltage_limit_high
+     - voltage_limit_low
+     - current_level_range
+     - voltage_limit_range
+     - compliance_limit_symmetry
+
+    When OutputFunction.PULSE_VOLTAGE is selected, the device generates pulses at the desired pulse voltage levels on the output as long as the output current is below the pulse current limit. Use the following properties to configure the channel when OutputFunction.PULSE_VOLTAGE is selected:
+     - pulse_voltage_level
+     - pulse_bias_voltage_level
+     - pulse_current_limit
+     - pulse_current_limit_high
+     - pulse_current_limit_low
+     - pulse_bias_current_limit
+     - pulse_bias_current_limit_high
+     - pulse_bias_current_limit_low
+     - pulse_voltage_level_range
+     - pulse_current_limit_range
+     - compliance_limit_symmetry
+
+    When OutputFunction.PULSE_CURRENT is selected, the device generates pulses at the desired pulse current levels on the output as long as the output voltage is below the pulse voltage limit. Use the following properties to configure the channel when OutputFunction.PULSE_CURRENT is selected:
+     - pulse_current_level
+     - pulse_bias_current_level
+     - pulse_voltage_limit
+     - pulse_voltage_limit_high
+     - pulse_voltage_limit_low
+     - pulse_bias_voltage_limit
+     - pulse_bias_voltage_limit_high
+     - pulse_bias_voltage_limit_low
+     - pulse_current_level_range
+     - pulse_voltage_limit_range
+     - compliance_limit_symmetry
+
+    When OutputFunction.CONSTANT_RESISTANCE is selected, the device generates the desired resistance level on the output as long as the output current is below the current limit. Use the following properties to configure the channel when OutputFunction.CONSTANT_RESISTANCE is selected:
+     - constant_resistance_level
+     - constant_resistance_current_limit
+     - constant_resistance_level_range
+
+    When OutputFunction.CONSTANT_POWER is selected, the device generates the desired power level on the output as long as the output current is below the current limit. Use the following properties to configure the channel when OutputFunction.CONSTANT_POWER is selected:
+     - constant_power_level
+     - constant_power_current_limit
+     - constant_power_level_range
 
     Note:
     NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
@@ -2693,11 +3007,23 @@ class _SessionBase(object):
     output_resistance = _attributes.AttributeViReal64(1150061)
     '''Type: float
 
-    Specifies the output resistance that the device attempts to generate for the specified channel(s). This property is available only when you set the output_function property on a support device. Refer to a supported device's topic about output resistance for more information about selecting an output resistance.
-    about supported devices.
-    Default Value: 0.0
+    Specifies the output resistance that the device attempts to generate for the specified channel(s).
+
+    Depending on the instrument, output resistance is configurable only if you set the output_function of the channel as follows:
+     - PXIe-4141, PXIe-4143, PXIe-4145: OutputFunction.DC_VOLTAGE
+     - PXIe-4135, PXIe-4137, PXIe-4139, PXIe-4147: OutputFunction.DC_CURRENT or OutputFunction.DC_VOLTAGE
+
+    **Valid Values**: Vary by device. Refer to the device specifications for your device for more information about supported values.
+
+    **Default Value:** Search ni.com for Supported Properties by Device for the default value by device.
 
     Note:
+    The channel must be enabled for the specified output resistance to take effect. Refer to the output_enabled property for more information about enabling the channel.
+
+    Using the merged_channels property to merge instrument outputs affects the valid output resistance range you can program. Refer to the Merged Channels topic for your device for details.
+
+    To specify the resistance level that the device attempts to generate when output_function is set to OutputFunction.CONSTANT_RESISTANCE, use the constant_resistance_level property.
+
     NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
 
     This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
@@ -2711,6 +3037,27 @@ class _SessionBase(object):
     To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
 
     Example: :py:attr:`my_session.output_resistance`
+    '''
+    output_shorted = _attributes.AttributeViBoolean(1150372)
+    '''Type: bool
+
+    Specifies whether the input of the instrument simulates a short circuit.
+    When this property is set to True, the electronic load will simulate a short circuit across the channel/input terminals. The electronic load uses the maximum rated current and range to simulate the short circuit. This property will only take effect when both output_enabled and output_connected are True.
+
+    When this property is set to False, the instrument will resume normal operation based on its existing settings on the specified channel(s).
+
+    Note:
+    This property is not supported on all devices. For more information about supported devices, search ni.com for Supported Properties by Device.
+
+    Tip:
+    This property can be set/get on specific channels within your :py:class:`nidcpower.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
+
+    Example: :py:attr:`my_session.channels[ ... ].output_shorted`
+
+    To set/get on all channels, you can call the property directly on the :py:class:`nidcpower.Session`.
+
+    Example: :py:attr:`my_session.output_shorted`
     '''
     overranging_enabled = _attributes.AttributeViBoolean(1150007)
     '''Type: bool
@@ -6642,32 +6989,16 @@ class _SessionBase(object):
     def query_in_compliance(self):
         r'''query_in_compliance
 
-        Queries the specified output device to determine if it is operating at
-        the `compliance <REPLACE_DRIVER_SPECIFIC_URL_2(compliance)>`__ limit.
+        Queries the specified channel to determine if it is operating at the compliance limit.
 
-        The compliance limit is the current limit when the output method is
-        set to OutputFunction.DC_VOLTAGE. If the output is operating at the
-        compliance limit, the output reaches the current limit before the
-        desired voltage level. Refer to the ConfigureOutputFunction
-        method and the ConfigureCurrentLimit method for more
-        information about output method and current limit, respectively.
+        The compliance limit is the current limit when the output_function property is set to OutputFunction.DC_VOLTAGE, OutputFunction.PULSE_VOLTAGE, OutputFunction.CONSTANT_RESISTANCE or OutputFunction.CONSTANT_POWER. If the output is operating at the compliance limit, the output reaches the current limit before the desired voltage, resistance or power level.
 
-        The compliance limit is the voltage limit when the output method is
-        set to OutputFunction.DC_CURRENT. If the output is operating at the
-        compliance limit, the output reaches the voltage limit before the
-        desired current level. Refer to the ConfigureOutputFunction
-        method and the ConfigureVoltageLimit method for more
-        information about output method and voltage limit, respectively.
+        The compliance limit is the voltage limit when the output_function property is set to OutputFunction.DC_CURRENT or OutputFunction.PULSE_CURRENT. If the output is operating at the compliance limit, the output reaches the voltage limit before the desired current level.
 
-        **Related Topics:**
-
-        `Compliance <REPLACE_DRIVER_SPECIFIC_URL_1(compliance)>`__
+        Refer to the output_function property for more information about the applicable properties to configure for each output method.
 
         Note:
         NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
-
-        Note:
-        One or more of the referenced methods are not in the Python API for this driver.
 
         Tip:
         This method can be called on specific channels within your :py:class:`nidcpower.Session` instance.
@@ -7247,21 +7578,14 @@ class _SessionBase(object):
     def set_sequence(self, values, source_delays):
         r'''set_sequence
 
-        Configures a series of voltage or current outputs and corresponding
-        source delays. The source mode must be set to
-        `Sequence <REPLACE_DRIVER_SPECIFIC_URL_1(sequencing)>`__ for this
-        method to take effect.
+        Configures a series of voltage, current, resistance or power outputs and corresponding source delays. The source mode must be set to SourceMode.SEQUENCE for this method to take effect.
 
-        Refer to the `Configuring the Source
-        Unit <REPLACE_DRIVER_SPECIFIC_URL_1(configuringthesourceunit)>`__ topic
-        in the *NI DC Power Supplies and SMUs Help* for more information about
-        how to configure your device.
+        Refer to the Configuring the Source Unit topic in the *NI DC Power Supplies and SMUs Help* for more information about how to configure your device.
 
         Use this method in the Uncommitted or Committed programming states.
-        Refer to the `Programming
-        States <REPLACE_DRIVER_SPECIFIC_URL_1(programmingstates)>`__ topic in
-        the *NI DC Power Supplies and SMUs Help* for more information about
-        NI-DCPower programming states.
+        Refer to the Programming States topic in the *NI DC Power Supplies and SMUs Help* for more information about NI-DCPower programming states.
+
+        Using this method with Advanced Sequence methods for the same channel in the same session is not supported.
 
         Note:
         NI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.
@@ -7280,12 +7604,8 @@ class _SessionBase(object):
         Example: :py:meth:`my_session.set_sequence`
 
         Args:
-            values (list of float): Specifies the series of voltage levels or current levels, depending on
-                the configured `output
-                method <REPLACE_DRIVER_SPECIFIC_URL_1(programming_output)>`__.
-                **Valid values**:
-                The valid values for this parameter are defined by the voltage level
-                range or current level range.
+            values (list of float): Specifies the series of voltage, current, resistance or power levels, depending on the configured output_function.
+                **Valid values**: The valid values for this parameter are defined by the voltage level range, current level range, constant resistance level range or constant power level range.
 
             source_delays (list of float): Specifies the source delay that follows the configuration of each value
                 in the sequence.

--- a/src/nidcpower/metadata/attributes.py
+++ b/src/nidcpower/metadata/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 25.0.0f266
+# This file is generated from NI-DCPower API metadata version 25.3.0f265
 attributes = {
     1050003: {
         'access': 'read-write',
@@ -233,7 +233,7 @@ attributes = {
     1150008: {
         'access': 'read-write',
         'documentation': {
-            'description': '\nConfigures the function to generate on the specified channel(s).\nWhen NIDCPOWER_VAL_DC_VOLTAGE is selected, the device generates the desired voltage level on the output as long as the output current is below the current limit. You can use the following attributes to configure the channel when NIDCPOWER_VAL_DC_VOLTAGE is selected:\nNIDCPOWER_ATTR_VOLTAGE_LEVEL\nNIDCPOWER_ATTR_CURRENT_LIMIT\nNIDCPOWER_ATTR_CURRENT_LIMIT_HIGH\nNIDCPOWER_ATTR_CURRENT_LIMIT_LOW\nNIDCPOWER_ATTR_VOLTAGE_LEVEL_RANGE\nNIDCPOWER_ATTR_CURRENT_LIMIT_RANGE\nNIDCPOWER_ATTR_COMPLIANCE_LIMIT_SYMMETRY\nWhen NIDCPOWER_VAL_DC_CURRENT is selected, the device generates the desired current level on the output as long as the output voltage is below the voltage limit. You can use the following attributes to configure the channel when NIDCPOWER_VAL_DC_CURRENT is selected:\nNIDCPOWER_ATTR_CURRENT_LEVEL\nNIDCPOWER_ATTR_VOLTAGE_LIMIT\nNIDCPOWER_ATTR_VOLTAGE_LIMIT_HIGH\nNIDCPOWER_ATTR_VOLTAGE_LIMIT_LOW\nNIDCPOWER_ATTR_CURRENT_LEVEL_RANGE\nNIDCPOWER_ATTR_VOLTAGE_LIMIT_RANGE\nNIDCPOWER_ATTR_COMPLIANCE_LIMIT_SYMMETRY\n',
+            'description': '\nConfigures the function to generate on the specified channel(s).\n\nWhen NIDCPOWER_VAL_DC_VOLTAGE is selected, the device generates the desired voltage level on the output as long as the output current is below the current limit. Use the following attributes to configure the channel when NIDCPOWER_VAL_DC_VOLTAGE is selected:\n - NIDCPOWER_ATTR_VOLTAGE_LEVEL\n - NIDCPOWER_ATTR_CURRENT_LIMIT\n - NIDCPOWER_ATTR_CURRENT_LIMIT_HIGH\n - NIDCPOWER_ATTR_CURRENT_LIMIT_LOW\n - NIDCPOWER_ATTR_VOLTAGE_LEVEL_RANGE\n - NIDCPOWER_ATTR_CURRENT_LIMIT_RANGE\n - NIDCPOWER_ATTR_COMPLIANCE_LIMIT_SYMMETRY\n\nWhen NIDCPOWER_VAL_DC_CURRENT is selected, the device generates the desired current level on the output as long as the output voltage is below the voltage limit. Use the following attributes to configure the channel when NIDCPOWER_VAL_DC_CURRENT is selected:\n - NIDCPOWER_ATTR_CURRENT_LEVEL\n - NIDCPOWER_ATTR_VOLTAGE_LIMIT\n - NIDCPOWER_ATTR_VOLTAGE_LIMIT_HIGH\n - NIDCPOWER_ATTR_VOLTAGE_LIMIT_LOW\n - NIDCPOWER_ATTR_CURRENT_LEVEL_RANGE\n - NIDCPOWER_ATTR_VOLTAGE_LIMIT_RANGE\n - NIDCPOWER_ATTR_COMPLIANCE_LIMIT_SYMMETRY\n\nWhen NIDCPOWER_VAL_PULSE_VOLTAGE is selected, the device generates pulses at the desired pulse voltage levels on the output as long as the output current is below the pulse current limit. Use the following attributes to configure the channel when NIDCPOWER_VAL_PULSE_VOLTAGE is selected:\n - NIDCPOWER_ATTR_PULSE_VOLTAGE_LEVEL\n - NIDCPOWER_ATTR_PULSE_BIAS_VOLTAGE_LEVEL\n - NIDCPOWER_ATTR_PULSE_CURRENT_LIMIT\n - NIDCPOWER_ATTR_PULSE_CURRENT_LIMIT_HIGH\n - NIDCPOWER_ATTR_PULSE_CURRENT_LIMIT_LOW\n - NIDCPOWER_ATTR_PULSE_BIAS_CURRENT_LIMIT\n - NIDCPOWER_ATTR_PULSE_BIAS_CURRENT_LIMIT_HIGH\n - NIDCPOWER_ATTR_PULSE_BIAS_CURRENT_LIMIT_LOW\n - NIDCPOWER_ATTR_PULSE_VOLTAGE_LEVEL_RANGE\n - NIDCPOWER_ATTR_PULSE_CURRENT_LIMIT_RANGE\n - NIDCPOWER_ATTR_COMPLIANCE_LIMIT_SYMMETRY\n\nWhen NIDCPOWER_VAL_PULSE_CURRENT is selected, the device generates pulses at the desired pulse current levels on the output as long as the output voltage is below the pulse voltage limit. Use the following attributes to configure the channel when NIDCPOWER_VAL_PULSE_CURRENT is selected:\n - NIDCPOWER_ATTR_PULSE_CURRENT_LEVEL\n - NIDCPOWER_ATTR_PULSE_BIAS_CURRENT_LEVEL\n - NIDCPOWER_ATTR_PULSE_VOLTAGE_LIMIT\n - NIDCPOWER_ATTR_PULSE_VOLTAGE_LIMIT_HIGH\n - NIDCPOWER_ATTR_PULSE_VOLTAGE_LIMIT_LOW\n - NIDCPOWER_ATTR_PULSE_BIAS_VOLTAGE_LIMIT\n - NIDCPOWER_ATTR_PULSE_BIAS_VOLTAGE_LIMIT_HIGH\n - NIDCPOWER_ATTR_PULSE_BIAS_VOLTAGE_LIMIT_LOW\n - NIDCPOWER_ATTR_PULSE_CURRENT_LEVEL_RANGE\n - NIDCPOWER_ATTR_PULSE_VOLTAGE_LIMIT_RANGE\n - NIDCPOWER_ATTR_COMPLIANCE_LIMIT_SYMMETRY\n\nWhen NIDCPOWER_VAL_CONSTANT_RESISTANCE is selected, the device generates the desired resistance level on the output as long as the output current is below the current limit. Use the following attributes to configure the channel when NIDCPOWER_VAL_CONSTANT_RESISTANCE is selected:\n - NIDCPOWER_ATTR_CONSTANT_RESISTANCE_LEVEL\n - NIDCPOWER_ATTR_CONSTANT_RESISTANCE_CURRENT_LIMIT\n - NIDCPOWER_ATTR_CONSTANT_RESISTANCE_LEVEL_RANGE\n\nWhen NIDCPOWER_VAL_CONSTANT_POWER is selected, the device generates the desired power level on the output as long as the output current is below the current limit. Use the following attributes to configure the channel when NIDCPOWER_VAL_CONSTANT_POWER is selected:\n - NIDCPOWER_ATTR_CONSTANT_POWER_LEVEL\n - NIDCPOWER_ATTR_CONSTANT_POWER_CURRENT_LIMIT\n - NIDCPOWER_ATTR_CONSTANT_POWER_LEVEL_RANGE\n',
             'note': '\nNI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.\n'
         },
         'enum': 'OutputFunction',
@@ -848,8 +848,8 @@ attributes = {
     1150061: {
         'access': 'read-write',
         'documentation': {
-            'description': "\nSpecifies the output resistance that the device attempts to generate for the specified channel(s). This attribute is available only when you set the NIDCPOWER_ATTR_OUTPUT_FUNCTION attribute on a support device. Refer to a supported device's topic about output resistance for more information about selecting an output resistance.\nabout supported devices.\nDefault Value: 0.0\n",
-            'note': '\nNI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.\n\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device.\n'
+            'description': '\nSpecifies the output resistance that the device attempts to generate for the specified channel(s).\n\nDepending on the instrument, output resistance is configurable only if you set the NIDCPOWER_ATTR_OUTPUT_FUNCTION of the channel as follows:\n - PXIe-4141, PXIe-4143, PXIe-4145: NIDCPOWER_VAL_DC_VOLTAGE\n - PXIe-4135, PXIe-4137, PXIe-4139, PXIe-4147: NIDCPOWER_VAL_DC_CURRENT or NIDCPOWER_VAL_DC_VOLTAGE\n\n**Valid Values**: Vary by device. Refer to the device specifications for your device for more information about supported values.\n\n**Default Value:** Search ni.com for Supported Attributes by Device for the default value by device.\n',
+            'note': '\nThe channel must be enabled for the specified output resistance to take effect. Refer to the NIDCPOWER_ATTR_OUTPUT_ENABLED attribute for more information about enabling the channel.\n\nUsing the NIDCPOWER_ATTR_MERGED_CHANNELS attribute to merge instrument outputs affects the valid output resistance range you can program. Refer to the Merged Channels topic for your device for details.\n\nTo specify the resistance level that the device attempts to generate when NIDCPOWER_ATTR_OUTPUT_FUNCTION is set to NIDCPOWER_VAL_CONSTANT_RESISTANCE, use the NIDCPOWER_ATTR_CONSTANT_RESISTANCE_LEVEL attribute.\n\nNI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.\n\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device.\n'
         },
         'lv_property': 'Source:Output Resistance',
         'name': 'OUTPUT_RESISTANCE',
@@ -2750,6 +2750,175 @@ attributes = {
         ],
         'type': 'ViReal64'
     },
+    1150360: {
+        'access': 'read-write',
+        'documentation': {
+            'description': '\nThe frequency at which a pole-zero pair is added to the system when the NIDCPOWER_ATTR_OUTPUT_FUNCTION attribute is set to NIDCPOWER_VAL_CONSTANT_POWER and the output current is below the current limit.\n\nDefault Value: Determined by the value of the NIDCPOWER_VAL_NORMAL setting of the NIDCPOWER_ATTR_TRANSIENT_RESPONSE attribute.\n',
+            'note': '\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device.\n\nNI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.\n'
+        },
+        'lv_property': 'Source:Custom Transient Response:Constant Power:Compensation Frequency',
+        'name': 'CONSTANT_POWER_COMPENSATION_FREQUENCY',
+        'supported_rep_caps': [
+            'channels'
+        ],
+        'type': 'ViReal64'
+    },
+    1150361: {
+        'access': 'read-write',
+        'documentation': {
+            'description': '\nSpecifies the current limit, in amps, that the output cannot exceed when generating the desired power level on the specified channel(s).\nThe device will operate in Constant Current mode if the current exceeds the specified limit.\nThis attribute is applicable only if the NIDCPOWER_ATTR_OUTPUT_FUNCTION attribute is set to NIDCPOWER_VAL_CONSTANT_POWER and the NIDCPOWER_ATTR_COMPLIANCE_LIMIT_SYMMETRY attribute is set to NIDCPOWER_VAL_COMPLIANCE_LIMIT_SYMMETRY_SYMMETRIC.\n\nValid Values: The valid values for this attribute are determined by the selected value for NIDCPOWER_ATTR_CONSTANT_POWER_LEVEL_RANGE.\n',
+            'note': '\nThe channel must be enabled for the specified current limit to take effect. Refer to the NIDCPOWER_ATTR_OUTPUT_ENABLED attribute for more information about enabling the channel.\n\nNI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.\n'
+        },
+        'lv_property': 'Source:Constant Power:Current Limit',
+        'name': 'CONSTANT_POWER_CURRENT_LIMIT',
+        'supported_rep_caps': [
+            'channels'
+        ],
+        'type': 'ViReal64'
+    },
+    1150362: {
+        'access': 'read-write',
+        'documentation': {
+            'description': '\nThe frequency at which the unloaded loop gain extrapolates to 0 dB in the absence of additional poles and zeroes. This attribute takes effect when the NIDCPOWER_ATTR_OUTPUT_FUNCTION attribute is set to NIDCPOWER_VAL_CONSTANT_POWER and the output current is below the current limit.\n\nDefault Value: Determined by the value of the NIDCPOWER_VAL_NORMAL setting of the NIDCPOWER_ATTR_TRANSIENT_RESPONSE attribute.\n',
+            'note': '\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device.\n\nNI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.\n'
+        },
+        'lv_property': 'Source:Custom Transient Response:Constant Power:Gain Bandwidth',
+        'name': 'CONSTANT_POWER_GAIN_BANDWIDTH',
+        'supported_rep_caps': [
+            'channels'
+        ],
+        'type': 'ViReal64'
+    },
+    1150363: {
+        'access': 'read-write',
+        'documentation': {
+            'description': '\nSpecifies the power level, in watts, that the device attempts to generate on the specified channel(s).\nThis attribute is applicable only if the NIDCPOWER_ATTR_OUTPUT_FUNCTION attribute is set to NIDCPOWER_VAL_CONSTANT_POWER.\n\nValid Values: The valid values for this attribute are determined by the selected value for NIDCPOWER_ATTR_CONSTANT_POWER_LEVEL_RANGE.\n',
+            'note': '\nThe channel must be enabled for the specified power level to take effect. Refer to the NIDCPOWER_ATTR_OUTPUT_ENABLED attribute for more information about enabling the channel.\n\nNI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.\n'
+        },
+        'lv_property': 'Source:Constant Power:Level',
+        'name': 'CONSTANT_POWER_LEVEL',
+        'supported_rep_caps': [
+            'channels'
+        ],
+        'type': 'ViReal64'
+    },
+    1150364: {
+        'access': 'read-write',
+        'documentation': {
+            'description': '\nSpecifies the power level range, in watts, for the specified channel(s).\nThe range defines the valid values to which you can set the power level.\nThis attribute is applicable only if the NIDCPOWER_ATTR_OUTPUT_FUNCTION attribute is set to NIDCPOWER_VAL_CONSTANT_POWER.\n\nFor valid ranges, refer to the specifications for your instrument.\n',
+            'note': '\nThe voltage range and current range used by the instrument are automatically determined by the selected power level range. For more information, refer to the specifications for your instrument.\n\nNI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.\n'
+        },
+        'lv_property': 'Source:Constant Power:Level Range',
+        'name': 'CONSTANT_POWER_LEVEL_RANGE',
+        'supported_rep_caps': [
+            'channels'
+        ],
+        'type': 'ViReal64'
+    },
+    1150365: {
+        'access': 'read-write',
+        'documentation': {
+            'description': '\nThe ratio of the pole frequency to the zero frequency when the NIDCPOWER_ATTR_OUTPUT_FUNCTION attribute is set to NIDCPOWER_VAL_CONSTANT_POWER and the output current is below the current limit.\n\nDefault Value: Determined by the value of the NIDCPOWER_VAL_NORMAL setting of the NIDCPOWER_ATTR_TRANSIENT_RESPONSE attribute.\n',
+            'note': '\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device.\n\nNI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.\n'
+        },
+        'lv_property': 'Source:Custom Transient Response:Constant Power:Pole-Zero Ratio',
+        'name': 'CONSTANT_POWER_POLE_ZERO_RATIO',
+        'supported_rep_caps': [
+            'channels'
+        ],
+        'type': 'ViReal64'
+    },
+    1150366: {
+        'access': 'read-write',
+        'documentation': {
+            'description': '\nThe frequency at which a pole-zero pair is added to the system when the NIDCPOWER_ATTR_OUTPUT_FUNCTION attribute is set to NIDCPOWER_VAL_CONSTANT_RESISTANCE and the output current is below the current limit.\n\nDefault Value: Determined by the value of the NIDCPOWER_VAL_NORMAL setting of the NIDCPOWER_ATTR_TRANSIENT_RESPONSE attribute.\n',
+            'note': '\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device.\n\nNI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.\n'
+        },
+        'lv_property': 'Source:Custom Transient Response:Constant Resistance:Compensation Frequency',
+        'name': 'CONSTANT_RESISTANCE_COMPENSATION_FREQUENCY',
+        'supported_rep_caps': [
+            'channels'
+        ],
+        'type': 'ViReal64'
+    },
+    1150367: {
+        'access': 'read-write',
+        'documentation': {
+            'description': '\nSpecifies the current limit, in amps, that the output cannot exceed when generating the desired resistance level on the specified channel(s).\nThe device will operate in Constant Current mode if the current exceeds the specified limit.\nThis attribute is applicable only if the NIDCPOWER_ATTR_OUTPUT_FUNCTION attribute is set to NIDCPOWER_VAL_CONSTANT_RESISTANCE and the NIDCPOWER_ATTR_COMPLIANCE_LIMIT_SYMMETRY attribute is set to NIDCPOWER_VAL_COMPLIANCE_LIMIT_SYMMETRY_SYMMETRIC.\n\nValid Values: The valid values for this attribute are determined by the selected value for NIDCPOWER_ATTR_CONSTANT_RESISTANCE_LEVEL_RANGE.\n',
+            'note': '\nThe channel must be enabled for the specified current limit to take effect. Refer to the NIDCPOWER_ATTR_OUTPUT_ENABLED attribute for more information about enabling the channel.\n\nNI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.\n'
+        },
+        'lv_property': 'Source:Constant Resistance:Current Limit',
+        'name': 'CONSTANT_RESISTANCE_CURRENT_LIMIT',
+        'supported_rep_caps': [
+            'channels'
+        ],
+        'type': 'ViReal64'
+    },
+    1150368: {
+        'access': 'read-write',
+        'documentation': {
+            'description': '\nThe frequency at which the unloaded loop gain extrapolates to 0 dB in the absence of additional poles and zeroes. This attribute takes effect when the NIDCPOWER_ATTR_OUTPUT_FUNCTION attribute is set to NIDCPOWER_VAL_CONSTANT_RESISTANCE and the output current is below the current limit.\n\nDefault Value: Determined by the value of the NIDCPOWER_VAL_NORMAL setting of the NIDCPOWER_ATTR_TRANSIENT_RESPONSE attribute.\n',
+            'note': '\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device.\n\nNI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.\n'
+        },
+        'lv_property': 'Source:Custom Transient Response:Constant Resistance:Gain Bandwidth',
+        'name': 'CONSTANT_RESISTANCE_GAIN_BANDWIDTH',
+        'supported_rep_caps': [
+            'channels'
+        ],
+        'type': 'ViReal64'
+    },
+    1150369: {
+        'access': 'read-write',
+        'documentation': {
+            'description': '\nSpecifies the resistance level, in ohms, that the device attempts to generate on the specified channel(s).\nThis attribute is applicable only if the NIDCPOWER_ATTR_OUTPUT_FUNCTION attribute is set to NIDCPOWER_VAL_CONSTANT_RESISTANCE.\n\nValid Values: The valid values for this attribute are determined by the selected value for NIDCPOWER_ATTR_CONSTANT_RESISTANCE_LEVEL_RANGE.\n',
+            'note': '\nThe channel must be enabled for the specified resistance level to take effect. Refer to the NIDCPOWER_ATTR_OUTPUT_ENABLED attribute for more information about enabling the channel.\n\nNI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.\n'
+        },
+        'lv_property': 'Source:Constant Resistance:Level',
+        'name': 'CONSTANT_RESISTANCE_LEVEL',
+        'supported_rep_caps': [
+            'channels'
+        ],
+        'type': 'ViReal64'
+    },
+    1150370: {
+        'access': 'read-write',
+        'documentation': {
+            'description': '\nSpecifies the resistance level range, in ohms, for the specified channel(s).\nThe range defines the valid values to which you can set the resistance level.\nThis attribute is applicable only if the NIDCPOWER_ATTR_OUTPUT_FUNCTION attribute is set to NIDCPOWER_VAL_CONSTANT_RESISTANCE.\n\nFor valid ranges, refer to the specifications for your instrument.\n',
+            'note': '\nThe voltage range and current range used by the instrument are automatically determined by the selected resistance level range. For more information, refer to the specifications for your instrument.\n\nNI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.\n'
+        },
+        'lv_property': 'Source:Constant Resistance:Level Range',
+        'name': 'CONSTANT_RESISTANCE_LEVEL_RANGE',
+        'supported_rep_caps': [
+            'channels'
+        ],
+        'type': 'ViReal64'
+    },
+    1150371: {
+        'access': 'read-write',
+        'documentation': {
+            'description': '\nThe ratio of the pole frequency to the zero frequency when the NIDCPOWER_ATTR_OUTPUT_FUNCTION attribute is set to NIDCPOWER_VAL_CONSTANT_RESISTANCE and the output current is below the current limit.\n\nDefault Value: Determined by the value of the NIDCPOWER_VAL_NORMAL setting of the NIDCPOWER_ATTR_TRANSIENT_RESPONSE attribute.\n',
+            'note': '\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device.\n\nNI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.\n'
+        },
+        'lv_property': 'Source:Custom Transient Response:Constant Resistance:Pole-Zero Ratio',
+        'name': 'CONSTANT_RESISTANCE_POLE_ZERO_RATIO',
+        'supported_rep_caps': [
+            'channels'
+        ],
+        'type': 'ViReal64'
+    },
+    1150372: {
+        'access': 'read-write',
+        'documentation': {
+            'description': '\nSpecifies whether the input of the instrument simulates a short circuit.\nWhen this attribute is set to VI_TRUE, the electronic load will simulate a short circuit across the channel/input terminals. The electronic load uses the maximum rated current and range to simulate the short circuit. This attribute will only take effect when both NIDCPOWER_ATTR_OUTPUT_ENABLED and NIDCPOWER_ATTR_OUTPUT_CONNECTED are VI_TRUE.\n\nWhen this attribute is set to VI_FALSE, the instrument will resume normal operation based on its existing settings on the specified channel(s).\n',
+            'note': '\nThis attribute is not supported on all devices. For more information about supported devices, search ni.com for Supported Attributes by Device.\n'
+        },
+        'lv_property': 'Source:Advanced:Output Shorted',
+        'name': 'OUTPUT_SHORTED',
+        'supported_rep_caps': [
+            'channels'
+        ],
+        'type': 'ViBoolean'
+    },
     1250001: {
         'access': 'read-write',
         'documentation': {
@@ -2814,7 +2983,7 @@ attributes = {
     1250006: {
         'access': 'read-write',
         'documentation': {
-            'description': '\nSpecifies whether the output is enabled (VI_TRUE) or disabled (VI_FALSE).\nDepending on the value you specify for the NIDCPOWER_ATTR_OUTPUT_FUNCTION attribute, you also must set the voltage level or current level in addition to enabling the output\n\nDefault Value: The default value is VI_TRUE if you use the niDCPower_InitializeWithChannels function to open the session. Otherwise the default value is VI_FALSE, including when you use a calibration session or the deprecated programming model.\n',
+            'description': '\nSpecifies whether the output is enabled (VI_TRUE) or disabled (VI_FALSE).\n\nDepending on the value you specify for the NIDCPOWER_ATTR_OUTPUT_FUNCTION property, you also must set the corresponding level properties or NIDCPOWER_ATTR_OUTPUT_RESISTANCE in addition to enabling the output to generate the desired level.\nFor more information about configuring the output level, refer to the NIDCPOWER_ATTR_OUTPUT_FUNCTION property.\n\nDefault Value: The default value is VI_TRUE if you use the niDCPower_InitializeWithIndependentChannels function to open the session. Otherwise the default value is VI_FALSE, including when you use a calibration session or the deprecated programming model.\n',
             'note': '\nIf the session is in the Committed or Uncommitted states, enabling the output does not take effect until you call the niDCPower_InitiateWithChannels function. Refer to the Programming States topic in the NI DC Power Supplies and SMUs Help for more information about NI-DCPower programming states.\n\nNI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.\n'
         },
         'lv_property': 'Source:Output Enabled',

--- a/src/nidcpower/metadata/config.py
+++ b/src/nidcpower/metadata/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 25.0.0f266
+# This file is generated from NI-DCPower API metadata version 25.3.0f265
 config = {
-    'api_version': '25.0.0f266',
+    'api_version': '25.3.0f265',
     'c_function_prefix': 'niDCPower_',
     'close_function': 'close',
     'context_manager_name': {

--- a/src/nidcpower/metadata/enums.py
+++ b/src/nidcpower/metadata/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 25.0.0f266
+# This file is generated from NI-DCPower API metadata version 25.3.0f265
 enums = {
     'ApertureTimeAutoMode': {
         'values': [
@@ -256,7 +256,7 @@ enums = {
         'values': [
             {
                 'documentation': {
-                    'description': 'The conduction voltage feature is only enabled when you set the NIDCPOWER_ATTR_OUTPUT_FUNCTION attribute to NIDCPOWER_VAL_DC_CURRENT.'
+                    'description': 'The conduction voltage feature is only enabled when you set the NIDCPOWER_ATTR_OUTPUT_FUNCTION attribute to NIDCPOWER_VAL_DC_CURRENT or NIDCPOWER_VAL_CONSTANT_POWER.'
                 },
                 'name': 'NIDCPOWER_VAL_CONDUCTION_VOLTAGE_MODE_AUTOMATIC',
                 'value': 1155
@@ -976,6 +976,20 @@ enums = {
                 },
                 'name': 'NIDCPOWER_VAL_PULSE_CURRENT',
                 'value': 1050
+            },
+            {
+                'documentation': {
+                    'description': 'Sets the output function to constant resistance.'
+                },
+                'name': 'NIDCPOWER_VAL_CONSTANT_RESISTANCE',
+                'value': 1161
+            },
+            {
+                'documentation': {
+                    'description': 'Sets the output function to constant power.'
+                },
+                'name': 'NIDCPOWER_VAL_CONSTANT_POWER',
+                'value': 1162
             }
         ]
     },

--- a/src/nidcpower/metadata/functions.py
+++ b/src/nidcpower/metadata/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 25.0.0f266
+# This file is generated from NI-DCPower API metadata version 25.3.0f265
 functions = {
     'AbortWithChannels': {
         'documentation': {
@@ -2948,7 +2948,7 @@ functions = {
     },
     'QueryInCompliance': {
         'documentation': {
-            'description': '\nQueries the specified output device to determine if it is operating at\nthe `compliance <REPLACE_DRIVER_SPECIFIC_URL_2(compliance)>`__ limit.\n\nThe compliance limit is the current limit when the output function is\nset to NIDCPOWER_VAL_DC_VOLTAGE. If the output is operating at the\ncompliance limit, the output reaches the current limit before the\ndesired voltage level. Refer to the niDCPower_ConfigureOutputFunction\nfunction and the niDCPower_ConfigureCurrentLimit function for more\ninformation about output function and current limit, respectively.\n\nThe compliance limit is the voltage limit when the output function is\nset to NIDCPOWER_VAL_DC_CURRENT. If the output is operating at the\ncompliance limit, the output reaches the voltage limit before the\ndesired current level. Refer to the niDCPower_ConfigureOutputFunction\nfunction and the niDCPower_ConfigureVoltageLimit function for more\ninformation about output function and voltage limit, respectively.\n\n**Related Topics:**\n\n`Compliance <REPLACE_DRIVER_SPECIFIC_URL_1(compliance)>`__\n',
+            'description': '\nQueries the specified channel to determine if it is operating at the compliance limit.\n\nThe compliance limit is the current limit when the NIDCPOWER_ATTR_OUTPUT_FUNCTION property is set to NIDCPOWER_VAL_DC_VOLTAGE, NIDCPOWER_VAL_PULSE_VOLTAGE, NIDCPOWER_VAL_CONSTANT_RESISTANCE or NIDCPOWER_VAL_CONSTANT_POWER. If the output is operating at the compliance limit, the output reaches the current limit before the desired voltage, resistance or power level.\n\nThe compliance limit is the voltage limit when the NIDCPOWER_ATTR_OUTPUT_FUNCTION property is set to NIDCPOWER_VAL_DC_CURRENT or NIDCPOWER_VAL_PULSE_CURRENT. If the output is operating at the compliance limit, the output reaches the voltage limit before the desired current level.\n\nRefer to the NIDCPOWER_ATTR_OUTPUT_FUNCTION property for more information about the applicable properties to configure for each output function.\n',
             'note': '\nNI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.\n'
         },
         'included_in_proto': True,
@@ -3664,7 +3664,7 @@ functions = {
     },
     'SetSequence': {
         'documentation': {
-            'description': '\nConfigures a series of voltage or current outputs and corresponding\nsource delays. The source mode must be set to\n`Sequence <REPLACE_DRIVER_SPECIFIC_URL_1(sequencing)>`__ for this\nfunction to take effect.\n\nRefer to the `Configuring the Source\nUnit <REPLACE_DRIVER_SPECIFIC_URL_1(configuringthesourceunit)>`__ topic\nin the *NI DC Power Supplies and SMUs Help* for more information about\nhow to configure your device.\n\nUse this function in the Uncommitted or Committed programming states.\nRefer to the `Programming\nStates <REPLACE_DRIVER_SPECIFIC_URL_1(programmingstates)>`__ topic in\nthe *NI DC Power Supplies and SMUs Help* for more information about\nNI-DCPower programming states.\n',
+            'description': '\nConfigures a series of voltage, current, resistance or power outputs and corresponding source delays. The source mode must be set to NIDCPOWER_VAL_SEQUENCE for this function to take effect.\n\nRefer to the Configuring the Source Unit topic in the *NI DC Power Supplies and SMUs Help* for more information about how to configure your device.\n\nUse this function in the Uncommitted or Committed programming states.\nRefer to the Programming States topic in the *NI DC Power Supplies and SMUs Help* for more information about NI-DCPower programming states.\n\nUsing this function with Advanced Sequence functions for the same channel in the same session is not supported.\n',
             'note': '\nNI-DCPower uses the terms "source" and "output". However, while sinking with electronic loads and SMUs these correspond to "sinking" and "input", respectively.\n\nThis function is not supported on all devices. For more information about supported devices, search ni.com for Supported Functions by Device.\n'
         },
         'included_in_proto': True,
@@ -3688,7 +3688,7 @@ functions = {
             {
                 'direction': 'in',
                 'documentation': {
-                    'description': '\nSpecifies the series of voltage levels or current levels, depending on\nthe configured `output\nfunction <REPLACE_DRIVER_SPECIFIC_URL_1(programming_output)>`__.\n**Valid values**:\nThe valid values for this parameter are defined by the voltage level\nrange or current level range.\n'
+                    'description': '\nSpecifies the series of voltage, current, resistance or power levels, depending on the configured NIDCPOWER_ATTR_OUTPUT_FUNCTION.\n**Valid values**: The valid values for this parameter are defined by the voltage level range, current level range, constant resistance level range or constant power level range.\n'
                 },
                 'name': 'values',
                 'size': {


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

- Update the metadata for NI-DCPower to 25.3.0f265
- Update the generated enums.py and session.py files as well as the docs files
- Update CHANGELOG.md to call out the API parity changes

### What testing has been done?

Local run of tox was successful.
Local run of the system tests (`py312-nidcpower-system_tests`) was also successful.
