### PR TITLE
Adding and removing few methods and few more fixes in RFSG

### DIFF
--- a/docs/nirfsg/class.rst
+++ b/docs/nirfsg/class.rst
@@ -478,9 +478,7 @@ check_generation_status
 
             **Related Topics**
 
-            `NI-RFSG Instrument Driver Programming Flow <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/progflow.html>`_
-
-            `Stopping Pear-to-Peer Generation <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_stopping_generation.html>`_
+            `NI-RFSG Instrument Driver Programming Flow <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/progflow.html>`
 
             
 
@@ -2003,13 +2001,13 @@ get_waveform_burst_start_locations
             
 
 
-            .. tip:: This method can be called on specific waveform within your :py:class:`nirfsg.Session` instance.
-                Use Python index notation on the repeated capabilities container waveform to specify a subset,
+            .. tip:: This method can be called on specific waveforms within your :py:class:`nirfsg.Session` instance.
+                Use Python index notation on the repeated capabilities container waveforms to specify a subset,
                 and then call this method on the result.
 
-                Example: :py:meth:`my_session.waveform[ ... ].get_waveform_burst_start_locations`
+                Example: :py:meth:`my_session.waveforms[ ... ].get_waveform_burst_start_locations`
 
-                To call the method on all waveform, you can call it directly on the :py:class:`nirfsg.Session`.
+                To call the method on all waveforms, you can call it directly on the :py:class:`nirfsg.Session`.
 
                 Example: :py:meth:`my_session.get_waveform_burst_start_locations`
 
@@ -2040,13 +2038,13 @@ get_waveform_burst_stop_locations
             
 
 
-            .. tip:: This method can be called on specific waveform within your :py:class:`nirfsg.Session` instance.
-                Use Python index notation on the repeated capabilities container waveform to specify a subset,
+            .. tip:: This method can be called on specific waveforms within your :py:class:`nirfsg.Session` instance.
+                Use Python index notation on the repeated capabilities container waveforms to specify a subset,
                 and then call this method on the result.
 
-                Example: :py:meth:`my_session.waveform[ ... ].get_waveform_burst_stop_locations`
+                Example: :py:meth:`my_session.waveforms[ ... ].get_waveform_burst_stop_locations`
 
-                To call the method on all waveform, you can call it directly on the :py:class:`nirfsg.Session`.
+                To call the method on all waveforms, you can call it directly on the :py:class:`nirfsg.Session`.
 
                 Example: :py:meth:`my_session.get_waveform_burst_stop_locations`
 
@@ -2611,7 +2609,7 @@ select_arb_waveform
 
     .. py:method:: select_arb_waveform(name)
 
-            Specifies the waveform that is generated upon a call to the :py:meth:`nirfsg.Session._initiate` method when the **generationMode** parameter of the :py:meth:`nirfsg.Session.ConfigureGenerationMode` method is set to :py:data:`~nirfsg.GenerationMode.ARB_WAVEFORM`.
+            Specifies the waveform that is generated upon a call to the :py:meth:`nirfsg.Session._initiate` method when the generation_mode property is set to :py:data:`~nirfsg.GenerationMode.ARB_WAVEFORM`.
 
             You must specify a waveform using the :py:attr:`nirfsg.Session.NAME` parameter if you have written multiple waveforms. The NI-RFSG device must be in the Configuration state before you call this method.
 
@@ -2945,13 +2943,13 @@ set_waveform_burst_start_locations
             
 
 
-            .. tip:: This method can be called on specific waveform within your :py:class:`nirfsg.Session` instance.
-                Use Python index notation on the repeated capabilities container waveform to specify a subset,
+            .. tip:: This method can be called on specific waveforms within your :py:class:`nirfsg.Session` instance.
+                Use Python index notation on the repeated capabilities container waveforms to specify a subset,
                 and then call this method on the result.
 
-                Example: :py:meth:`my_session.waveform[ ... ].set_waveform_burst_start_locations`
+                Example: :py:meth:`my_session.waveforms[ ... ].set_waveform_burst_start_locations`
 
-                To call the method on all waveform, you can call it directly on the :py:class:`nirfsg.Session`.
+                To call the method on all waveforms, you can call it directly on the :py:class:`nirfsg.Session`.
 
                 Example: :py:meth:`my_session.set_waveform_burst_start_locations`
 
@@ -2982,13 +2980,13 @@ set_waveform_burst_stop_locations
             
 
 
-            .. tip:: This method can be called on specific waveform within your :py:class:`nirfsg.Session` instance.
-                Use Python index notation on the repeated capabilities container waveform to specify a subset,
+            .. tip:: This method can be called on specific waveforms within your :py:class:`nirfsg.Session` instance.
+                Use Python index notation on the repeated capabilities container waveforms to specify a subset,
                 and then call this method on the result.
 
-                Example: :py:meth:`my_session.waveform[ ... ].set_waveform_burst_stop_locations`
+                Example: :py:meth:`my_session.waveforms[ ... ].set_waveform_burst_stop_locations`
 
-                To call the method on all waveform, you can call it directly on the :py:class:`nirfsg.Session`.
+                To call the method on all waveforms, you can call it directly on the :py:class:`nirfsg.Session`.
 
                 Example: :py:meth:`my_session.set_waveform_burst_stop_locations`
 
@@ -3146,7 +3144,7 @@ write_script
 
             Writes a script to the device to control waveform generation in Script mode.
 
-            First, configure your device for Script mode by calling the :py:meth:`nirfsg.Session.ConfigureGenerationMode` method. The NI-RFSG device must be in the Configuration state before calling the :py:meth:`nirfsg.Session.write_script` method.
+            First, configure your device for Script mode by setting the generation_mode property. The NI-RFSG device must be in the Configuration state before calling the :py:meth:`nirfsg.Session.write_script` method.
 
             **Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 
@@ -5191,12 +5189,12 @@ deembedding_compensation_gain
 
 
 
-        .. tip:: This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container port to specify a subset.
+        .. tip:: This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container ports to specify a subset.
 
-            Example: :py:attr:`my_session.port[ ... ].deembedding_compensation_gain`
+            Example: :py:attr:`my_session.ports[ ... ].deembedding_compensation_gain`
 
-            To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.deembedding_compensation_gain`
 
@@ -5209,7 +5207,7 @@ deembedding_compensation_gain
             +-----------------------+-----------+
             | Permissions           | read only |
             +-----------------------+-----------+
-            | Repeated Capabilities | port      |
+            | Repeated Capabilities | ports     |
             +-----------------------+-----------+
 
         .. tip::
@@ -5236,12 +5234,12 @@ deembedding_selected_table
 
 
 
-        .. tip:: This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container port to specify a subset.
+        .. tip:: This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container ports to specify a subset.
 
-            Example: :py:attr:`my_session.port[ ... ].deembedding_selected_table`
+            Example: :py:attr:`my_session.ports[ ... ].deembedding_selected_table`
 
-            To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.deembedding_selected_table`
 
@@ -5254,7 +5252,7 @@ deembedding_selected_table
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | port       |
+            | Repeated Capabilities | ports      |
             +-----------------------+------------+
 
         .. tip::
@@ -5272,49 +5270,49 @@ deembedding_type
 
         To use this property, you must use the channelName parameter of the :py:meth:`nirfsg.Session._set_attribute_vi_int32` method to specify the name of the port to configure for de-embedding.
 
-        If you set this property to :py:data:`~nirfsg.DeembeddingTypeAttrVals.SCALAR` or :py:data:`~nirfsg.DeembeddingTypeAttrVals.VECTOR`, NI-RFSG adjusts the instrument settings and the returned data to remove the effects of the external network between the instrument and the DUT.
+        If you set this property to :py:data:`~nirfsg.DeembeddingType.SCALAR` or :py:data:`~nirfsg.DeembeddingType.VECTOR`, NI-RFSG adjusts the instrument settings and the returned data to remove the effects of the external network between the instrument and the DUT.
 
-        **Default Value**: :py:data:`~nirfsg.DeembeddingTypeAttrVals.SCALAR`
+        **Default Value**: :py:data:`~nirfsg.DeembeddingType.SCALAR`
 
-        **Valid Values for PXIe-5830/5832/5840/5841/5842/5860** : :py:data:`~nirfsg.DeembeddingTypeAttrVals.SCALAR` or :py:data:`~nirfsg.DeembeddingTypeAttrVals.NONE`
+        **Valid Values for PXIe-5830/5832/5840/5841/5842/5860** : :py:data:`~nirfsg.DeembeddingType.SCALAR` or :py:data:`~nirfsg.DeembeddingType.NONE`
 
-        **Valid Values for PXIe-5831** :py:data:`~nirfsg.DeembeddingTypeAttrVals.SCALAR`, :py:data:`~nirfsg.DeembeddingTypeAttrVals.VECTOR`, or :py:data:`~nirfsg.DeembeddingTypeAttrVals.NONE`. :py:data:`~nirfsg.DeembeddingTypeAttrVals.VECTOR` is only supported for TRX Ports in a Semiconductor Test System (STS).
+        **Valid Values for PXIe-5831** :py:data:`~nirfsg.DeembeddingType.SCALAR`, :py:data:`~nirfsg.DeembeddingType.VECTOR`, or :py:data:`~nirfsg.DeembeddingType.NONE`. :py:data:`~nirfsg.DeembeddingType.VECTOR` is only supported for TRX Ports in a Semiconductor Test System (STS).
 
         **Supported Devices**: PXIe-5830/5831/5832/5840/5841/5842/5860
 
         **Defined Values**:
 
-        +---------------------------------------------------+----------------+------------------------------------------------------------------------+
-        | Name                                              | Value          | Description                                                            |
-        +===================================================+================+========================================================================+
-        | :py:data:`~nirfsg.DeembeddingTypeAttrVals.NONE`   | 25000 (0x61a8) | De-embedding is not applied to the measurement.                        |
-        +---------------------------------------------------+----------------+------------------------------------------------------------------------+
-        | :py:data:`~nirfsg.DeembeddingTypeAttrVals.SCALAR` | 25001 (0x61a9) | De-embeds the measurement using only the gain term.                    |
-        +---------------------------------------------------+----------------+------------------------------------------------------------------------+
-        | :py:data:`~nirfsg.DeembeddingTypeAttrVals.VECTOR` | 25002 (0x61aa) | De-embeds the measurement using the gain term and the reflection term. |
-        +---------------------------------------------------+----------------+------------------------------------------------------------------------+
+        +-------------------------------------------+----------------+------------------------------------------------------------------------+
+        | Name                                      | Value          | Description                                                            |
+        +===========================================+================+========================================================================+
+        | :py:data:`~nirfsg.DeembeddingType.NONE`   | 25000 (0x61a8) | De-embedding is not applied to the measurement.                        |
+        +-------------------------------------------+----------------+------------------------------------------------------------------------+
+        | :py:data:`~nirfsg.DeembeddingType.SCALAR` | 25001 (0x61a9) | De-embeds the measurement using only the gain term.                    |
+        +-------------------------------------------+----------------+------------------------------------------------------------------------+
+        | :py:data:`~nirfsg.DeembeddingType.VECTOR` | 25002 (0x61aa) | De-embeds the measurement using the gain term and the reflection term. |
+        +-------------------------------------------+----------------+------------------------------------------------------------------------+
 
 
-        .. tip:: This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container port to specify a subset.
+        .. tip:: This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container ports to specify a subset.
 
-            Example: :py:attr:`my_session.port[ ... ].deembedding_type`
+            Example: :py:attr:`my_session.ports[ ... ].deembedding_type`
 
-            To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.deembedding_type`
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+-------------------------------+
-            | Characteristic        | Value                         |
-            +=======================+===============================+
-            | Datatype              | enums.DeembeddingTypeAttrVals |
-            +-----------------------+-------------------------------+
-            | Permissions           | read-write                    |
-            +-----------------------+-------------------------------+
-            | Repeated Capabilities | port                          |
-            +-----------------------+-------------------------------+
+            +-----------------------+-----------------------+
+            | Characteristic        | Value                 |
+            +=======================+=======================+
+            | Datatype              | enums.DeembeddingType |
+            +-----------------------+-----------------------+
+            | Permissions           | read-write            |
+            +-----------------------+-----------------------+
+            | Repeated Capabilities | ports                 |
+            +-----------------------+-----------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -5407,12 +5405,12 @@ device_temperature
         +----------------------------+--------------------------+-------------------------+
 
 
-        .. tip:: This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container port to specify a subset.
+        .. tip:: This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container ports to specify a subset.
 
-            Example: :py:attr:`my_session.port[ ... ].device_temperature`
+            Example: :py:attr:`my_session.ports[ ... ].device_temperature`
 
-            To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.device_temperature`
 
@@ -5425,7 +5423,7 @@ device_temperature
             +-----------------------+-----------+
             | Permissions           | read only |
             +-----------------------+-----------+
-            | Repeated Capabilities | port      |
+            | Repeated Capabilities | ports     |
             +-----------------------+-----------+
 
         .. tip::
@@ -8066,12 +8064,12 @@ iq_out_port_common_mode_offset
              - The valid range is dependent on the load impedance.
 
 
-        .. tip:: This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container port to specify a subset.
+        .. tip:: This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container ports to specify a subset.
 
-            Example: :py:attr:`my_session.port[ ... ].iq_out_port_common_mode_offset`
+            Example: :py:attr:`my_session.ports[ ... ].iq_out_port_common_mode_offset`
 
-            To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.iq_out_port_common_mode_offset`
 
@@ -8084,7 +8082,7 @@ iq_out_port_common_mode_offset
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | port       |
+            | Repeated Capabilities | ports      |
             +-----------------------+------------+
 
         .. tip::
@@ -8129,12 +8127,12 @@ iq_out_port_level
              - The valid values are only applicable when you set the :py:attr:`nirfsg.Session.iq_out_port_load_impedance` property to 50 Ω and when you set the :py:attr:`nirfsg.Session.iq_out_port_offset` property to 0.
 
 
-        .. tip:: This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container port to specify a subset.
+        .. tip:: This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container ports to specify a subset.
 
-            Example: :py:attr:`my_session.port[ ... ].iq_out_port_level`
+            Example: :py:attr:`my_session.ports[ ... ].iq_out_port_level`
 
-            To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.iq_out_port_level`
 
@@ -8147,7 +8145,7 @@ iq_out_port_level
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | port       |
+            | Repeated Capabilities | ports      |
             +-----------------------+------------+
 
         .. tip::
@@ -8178,12 +8176,12 @@ iq_out_port_load_impedance
         .. note:: For the PXIe-5645, this property is ignored if you are using the RF ports.
 
 
-        .. tip:: This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container port to specify a subset.
+        .. tip:: This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container ports to specify a subset.
 
-            Example: :py:attr:`my_session.port[ ... ].iq_out_port_load_impedance`
+            Example: :py:attr:`my_session.ports[ ... ].iq_out_port_load_impedance`
 
-            To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.iq_out_port_load_impedance`
 
@@ -8196,7 +8194,7 @@ iq_out_port_load_impedance
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | port       |
+            | Repeated Capabilities | ports      |
             +-----------------------+------------+
 
         .. tip::
@@ -8227,12 +8225,12 @@ iq_out_port_offset
         .. note:: For the PXIe-5645, this property is ignored if you are using the RF ports.
 
 
-        .. tip:: This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container port to specify a subset.
+        .. tip:: This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container ports to specify a subset.
 
-            Example: :py:attr:`my_session.port[ ... ].iq_out_port_offset`
+            Example: :py:attr:`my_session.ports[ ... ].iq_out_port_offset`
 
-            To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.iq_out_port_offset`
 
@@ -8245,7 +8243,7 @@ iq_out_port_offset
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | port       |
+            | Repeated Capabilities | ports      |
             +-----------------------+------------+
 
         .. tip::
@@ -8323,12 +8321,12 @@ iq_out_port_terminal_configuration
         .. note:: For the PXIe-5645, this property is ignored if you are using the RF ports.
 
 
-        .. tip:: This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container port to specify a subset.
+        .. tip:: This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container ports to specify a subset.
 
-            Example: :py:attr:`my_session.port[ ... ].iq_out_port_terminal_configuration`
+            Example: :py:attr:`my_session.ports[ ... ].iq_out_port_terminal_configuration`
 
-            To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.iq_out_port_terminal_configuration`
 
@@ -8341,7 +8339,7 @@ iq_out_port_terminal_configuration
             +-----------------------+------------------------+
             | Permissions           | read-write             |
             +-----------------------+------------------------+
-            | Repeated Capabilities | port                   |
+            | Repeated Capabilities | ports                  |
             +-----------------------+------------------------+
 
         .. tip::
@@ -8687,12 +8685,12 @@ loop_bandwidth
         .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
 
-        .. tip:: This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container lo to specify a subset.
+        .. tip:: This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
 
-            Example: :py:attr:`my_session.lo[ ... ].loop_bandwidth`
+            Example: :py:attr:`my_session.lo_channels[ ... ].loop_bandwidth`
 
-            To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.loop_bandwidth`
 
@@ -8705,7 +8703,7 @@ loop_bandwidth
             +-----------------------+---------------------+
             | Permissions           | read-write          |
             +-----------------------+---------------------+
-            | Repeated Capabilities | lo                  |
+            | Repeated Capabilities | lo_channels         |
             +-----------------------+---------------------+
 
         .. tip::
@@ -8736,26 +8734,26 @@ lo_frequency
         .. note:: This property is read/write if you are using an external LO. Otherwise, this property is read-only.
 
 
-        .. tip:: This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container lo to specify a subset.
+        .. tip:: This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
 
-            Example: :py:attr:`my_session.lo[ ... ].lo_frequency`
+            Example: :py:attr:`my_session.lo_channels[ ... ].lo_frequency`
 
-            To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.lo_frequency`
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+------------+
-            | Characteristic        | Value      |
-            +=======================+============+
-            | Datatype              | float      |
-            +-----------------------+------------+
-            | Permissions           | read-write |
-            +-----------------------+------------+
-            | Repeated Capabilities | lo         |
-            +-----------------------+------------+
+            +-----------------------+-------------+
+            | Characteristic        | Value       |
+            +=======================+=============+
+            | Datatype              | float       |
+            +-----------------------+-------------+
+            | Permissions           | read-write  |
+            +-----------------------+-------------+
+            | Repeated Capabilities | lo_channels |
+            +-----------------------+-------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -8861,26 +8859,26 @@ lo_in_power
              - For the PXIe-5644/5645/5646, this property is always read-only.
 
 
-        .. tip:: This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container lo to specify a subset.
+        .. tip:: This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
 
-            Example: :py:attr:`my_session.lo[ ... ].lo_in_power`
+            Example: :py:attr:`my_session.lo_channels[ ... ].lo_in_power`
 
-            To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.lo_in_power`
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+------------+
-            | Characteristic        | Value      |
-            +=======================+============+
-            | Datatype              | float      |
-            +-----------------------+------------+
-            | Permissions           | read-write |
-            +-----------------------+------------+
-            | Repeated Capabilities | lo         |
-            +-----------------------+------------+
+            +-----------------------+-------------+
+            | Characteristic        | Value       |
+            +=======================+=============+
+            | Datatype              | float       |
+            +-----------------------+-------------+
+            | Permissions           | read-write  |
+            +-----------------------+-------------+
+            | Repeated Capabilities | lo_channels |
+            +-----------------------+-------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -8918,26 +8916,26 @@ lo_out_enabled
         .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
 
-        .. tip:: This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container lo to specify a subset.
+        .. tip:: This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
 
-            Example: :py:attr:`my_session.lo[ ... ].lo_out_enabled`
+            Example: :py:attr:`my_session.lo_channels[ ... ].lo_out_enabled`
 
-            To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.lo_out_enabled`
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+------------+
-            | Characteristic        | Value      |
-            +=======================+============+
-            | Datatype              | bool       |
-            +-----------------------+------------+
-            | Permissions           | read-write |
-            +-----------------------+------------+
-            | Repeated Capabilities | lo         |
-            +-----------------------+------------+
+            +-----------------------+-------------+
+            | Characteristic        | Value       |
+            +=======================+=============+
+            | Datatype              | bool        |
+            +-----------------------+-------------+
+            | Permissions           | read-write  |
+            +-----------------------+-------------+
+            | Repeated Capabilities | lo_channels |
+            +-----------------------+-------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -9010,26 +9008,26 @@ lo_out_power
         .. note:: For the PXIe-5644/5645/5646 and PXIe-5673/5673E, this property is always read-only.
 
 
-        .. tip:: This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container lo to specify a subset.
+        .. tip:: This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
 
-            Example: :py:attr:`my_session.lo[ ... ].lo_out_power`
+            Example: :py:attr:`my_session.lo_channels[ ... ].lo_out_power`
 
-            To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.lo_out_power`
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+------------+
-            | Characteristic        | Value      |
-            +=======================+============+
-            | Datatype              | float      |
-            +-----------------------+------------+
-            | Permissions           | read-write |
-            +-----------------------+------------+
-            | Repeated Capabilities | lo         |
-            +-----------------------+------------+
+            +-----------------------+-------------+
+            | Characteristic        | Value       |
+            +=======================+=============+
+            | Datatype              | float       |
+            +-----------------------+-------------+
+            | Permissions           | read-write  |
+            +-----------------------+-------------+
+            | Repeated Capabilities | lo_channels |
+            +-----------------------+-------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -9071,12 +9069,12 @@ lo_pll_fractional_mode_enabled
         .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
 
-        .. tip:: This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container lo to specify a subset.
+        .. tip:: This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
 
-            Example: :py:attr:`my_session.lo[ ... ].lo_pll_fractional_mode_enabled`
+            Example: :py:attr:`my_session.lo_channels[ ... ].lo_pll_fractional_mode_enabled`
 
-            To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.lo_pll_fractional_mode_enabled`
 
@@ -9089,7 +9087,7 @@ lo_pll_fractional_mode_enabled
             +-----------------------+----------------------------------+
             | Permissions           | read-write                       |
             +-----------------------+----------------------------------+
-            | Repeated Capabilities | lo                               |
+            | Repeated Capabilities | lo_channels                      |
             +-----------------------+----------------------------------+
 
         .. tip::
@@ -9136,26 +9134,26 @@ lo_source
         .. note:: For the PXIe-5841 with PXIe-5655, RF list mode is not supported when this property is set to SG_SA_Shared.
 
 
-        .. tip:: This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container lo to specify a subset.
+        .. tip:: This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
 
-            Example: :py:attr:`my_session.lo[ ... ].lo_source`
+            Example: :py:attr:`my_session.lo_channels[ ... ].lo_source`
 
-            To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.lo_source`
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+------------+
-            | Characteristic        | Value      |
-            +=======================+============+
-            | Datatype              | str        |
-            +-----------------------+------------+
-            | Permissions           | read-write |
-            +-----------------------+------------+
-            | Repeated Capabilities | lo         |
-            +-----------------------+------------+
+            +-----------------------+-------------+
+            | Characteristic        | Value       |
+            +=======================+=============+
+            | Datatype              | str         |
+            +-----------------------+-------------+
+            | Permissions           | read-write  |
+            +-----------------------+-------------+
+            | Repeated Capabilities | lo_channels |
+            +-----------------------+-------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -11419,19 +11417,15 @@ start_trigger_type
 
         **Defined Values**:
 
-        +-----------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-        | Value                                                     | Description                                                                                                                                                                                                                                                                                                |
-        +===========================================================+============================================================================================================================================================================================================================================================================================================+
-        | :py:data:`~nirfsg.StartTriggerType.NONE`                  | No trigger is configured.                                                                                                                                                                                                                                                                                  |
-        +-----------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-        | :py:data:`~nirfsg.StartTriggerType.DIGITAL_EDGE`          | The data operation does not start until a digital edge is detected. The source of the digital edge is specified with the :py:attr:`nirfsg.Session.digital_edge_start_trigger_source` property, and the active edge is specified in the :py:attr:`nirfsg.Session.digital_edge_start_trigger_edge` property. |
-        +-----------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-        | :py:data:`~nirfsg.StartTriggerType.SOFTWARE`              | The data operation does not start until a software event occurs. You may create a software trigger by calling the :py:meth:`nirfsg.Session.send_software_edge_trigger` method.                                                                                                                             |
-        +-----------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-        | :py:data:`~nirfsg.StartTriggerType.P2P_ENDPOINT_FULLNESS` | The data operation does not start until the endpoint reaches the threshold specified in the :py:attr:`nirfsg.Session.P2P_ENDPOINT_FULLNESS_START_TRIGGER_LEVEL` property.                                                                                                                                  |
-        +-----------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-        .. note:: One or more of the referenced properties are not in the Python API for this driver.
+        +--------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+        | Value                                            | Description                                                                                                                                                                                                                                                                                                |
+        +==================================================+============================================================================================================================================================================================================================================================================================================+
+        | :py:data:`~nirfsg.StartTriggerType.NONE`         | No trigger is configured.                                                                                                                                                                                                                                                                                  |
+        +--------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+        | :py:data:`~nirfsg.StartTriggerType.DIGITAL_EDGE` | The data operation does not start until a digital edge is detected. The source of the digital edge is specified with the :py:attr:`nirfsg.Session.digital_edge_start_trigger_source` property, and the active edge is specified in the :py:attr:`nirfsg.Session.digital_edge_start_trigger_edge` property. |
+        +--------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+        | :py:data:`~nirfsg.StartTriggerType.SOFTWARE`     | The data operation does not start until a software event occurs. You may create a software trigger by calling the :py:meth:`nirfsg.Session.send_software_edge_trigger` method.                                                                                                                             |
+        +--------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
         .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
@@ -12246,12 +12240,12 @@ waveform_iq_rate
 
 
 
-        .. tip:: This property can be set/get on specific waveform within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container waveform to specify a subset.
+        .. tip:: This property can be set/get on specific waveforms within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container waveforms to specify a subset.
 
-            Example: :py:attr:`my_session.waveform[ ... ].waveform_iq_rate`
+            Example: :py:attr:`my_session.waveforms[ ... ].waveform_iq_rate`
 
-            To set/get on all waveform, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all waveforms, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.waveform_iq_rate`
 
@@ -12264,7 +12258,7 @@ waveform_iq_rate
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | waveform   |
+            | Repeated Capabilities | waveforms  |
             +-----------------------+------------+
 
         .. tip::
@@ -12285,12 +12279,12 @@ waveform_papr
 
 
 
-        .. tip:: This property can be set/get on specific waveform within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container waveform to specify a subset.
+        .. tip:: This property can be set/get on specific waveforms within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container waveforms to specify a subset.
 
-            Example: :py:attr:`my_session.waveform[ ... ].waveform_papr`
+            Example: :py:attr:`my_session.waveforms[ ... ].waveform_papr`
 
-            To set/get on all waveform, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all waveforms, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.waveform_papr`
 
@@ -12303,7 +12297,7 @@ waveform_papr
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | waveform   |
+            | Repeated Capabilities | waveforms  |
             +-----------------------+------------+
 
         .. tip::
@@ -12352,12 +12346,12 @@ waveform_rf_blanking
         .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
 
-        .. tip:: This property can be set/get on specific waveform within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container waveform to specify a subset.
+        .. tip:: This property can be set/get on specific waveforms within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container waveforms to specify a subset.
 
-            Example: :py:attr:`my_session.waveform[ ... ].waveform_rf_blanking`
+            Example: :py:attr:`my_session.waveforms[ ... ].waveform_rf_blanking`
 
-            To set/get on all waveform, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all waveforms, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.waveform_rf_blanking`
 
@@ -12370,7 +12364,7 @@ waveform_rf_blanking
             +-----------------------+------------------+
             | Permissions           | read-write       |
             +-----------------------+------------------+
-            | Repeated Capabilities | waveform         |
+            | Repeated Capabilities | waveforms        |
             +-----------------------+------------------+
 
         .. tip::
@@ -12393,12 +12387,12 @@ waveform_runtime_scaling
 
 
 
-        .. tip:: This property can be set/get on specific waveform within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container waveform to specify a subset.
+        .. tip:: This property can be set/get on specific waveforms within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container waveforms to specify a subset.
 
-            Example: :py:attr:`my_session.waveform[ ... ].waveform_runtime_scaling`
+            Example: :py:attr:`my_session.waveforms[ ... ].waveform_runtime_scaling`
 
-            To set/get on all waveform, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all waveforms, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.waveform_runtime_scaling`
 
@@ -12411,7 +12405,7 @@ waveform_runtime_scaling
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | waveform   |
+            | Repeated Capabilities | waveforms  |
             +-----------------------+------------+
 
         .. tip::
@@ -12434,12 +12428,12 @@ waveform_signal_bandwidth
 
 
 
-        .. tip:: This property can be set/get on specific waveform within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container waveform to specify a subset.
+        .. tip:: This property can be set/get on specific waveforms within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container waveforms to specify a subset.
 
-            Example: :py:attr:`my_session.waveform[ ... ].waveform_signal_bandwidth`
+            Example: :py:attr:`my_session.waveforms[ ... ].waveform_signal_bandwidth`
 
-            To set/get on all waveform, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all waveforms, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.waveform_signal_bandwidth`
 
@@ -12452,7 +12446,7 @@ waveform_signal_bandwidth
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | waveform   |
+            | Repeated Capabilities | waveforms  |
             +-----------------------+------------+
 
         .. tip::
@@ -12473,12 +12467,12 @@ waveform_waveform_size
 
 
 
-        .. tip:: This property can be set/get on specific waveform within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container waveform to specify a subset.
+        .. tip:: This property can be set/get on specific waveforms within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container waveforms to specify a subset.
 
-            Example: :py:attr:`my_session.waveform[ ... ].waveform_waveform_size`
+            Example: :py:attr:`my_session.waveforms[ ... ].waveform_waveform_size`
 
-            To set/get on all waveform, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all waveforms, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.waveform_waveform_size`
 
@@ -12491,7 +12485,7 @@ waveform_waveform_size
             +-----------------------+-----------+
             | Permissions           | read only |
             +-----------------------+-----------+
-            | Repeated Capabilities | waveform  |
+            | Repeated Capabilities | waveforms |
             +-----------------------+-----------+
 
         .. tip::

--- a/docs/nirfsg/class.rst
+++ b/docs/nirfsg/class.rst
@@ -1278,13 +1278,13 @@ create_deembedding_sparameter_table_s2p_file
 
                 Specifies the orientation of the data in the S2P file relative to the port on the DUT port. **Defined Values** :
 
-                +------------------------------------------------+----------------+-----------------------------------------------------+
-                | Name                                           | Value          | Description                                         |
-                +================================================+================+=====================================================+
-                | :py:data:`~nirfsg.SparameterOrientation.PORT1` | 24000 (0x5dc0) | Port 1 of the S2P is oriented towards the DUT port. |
-                +------------------------------------------------+----------------+-----------------------------------------------------+
-                | :py:data:`~nirfsg.SparameterOrientation.PORT2` | 24001 (0x5dc1) | Port 2 of the S2P is oriented towards the DUT port. |
-                +------------------------------------------------+----------------+-----------------------------------------------------+
+                +------------------------------------------------------------+----------------+-----------------------------------------------------+
+                | Name                                                       | Value          | Description                                         |
+                +============================================================+================+=====================================================+
+                | :py:data:`~nirfsg.SparameterOrientation.PORT1_TOWARDS_DUT` | 24000 (0x5dc0) | Port 1 of the S2P is oriented towards the DUT port. |
+                +------------------------------------------------------------+----------------+-----------------------------------------------------+
+                | :py:data:`~nirfsg.SparameterOrientation.PORT2_TOWARDS_DUT` | 24001 (0x5dc1) | Port 2 of the S2P is oriented towards the DUT port. |
+                +------------------------------------------------------------+----------------+-----------------------------------------------------+
 
 
             :type sparameter_orientation: :py:data:`nirfsg.SparameterOrientation`
@@ -1517,25 +1517,25 @@ export_signal
 
                  **Defined Values** :
 
-                +-----------------------------------------------------------+---------+--------------------------------------------+
-                | Name                                                      | Value   | Description                                |
-                +===========================================================+=========+============================================+
-                | :py:data:`~nirfsg.Signal.START_TRIGGER`                   | 0 (0x0) | Exports a Start Trigger.                   |
-                +-----------------------------------------------------------+---------+--------------------------------------------+
-                | :py:data:`~nirfsg.Signal.SCRIPT_TRIGGER`                  | 1 (0x1) | Exports a Script Trigger.                  |
-                +-----------------------------------------------------------+---------+--------------------------------------------+
-                | :py:data:`~nirfsg.Signal.MARKER_EVENT`                    | 2 (0x2) | Exports a Marker Event.                    |
-                +-----------------------------------------------------------+---------+--------------------------------------------+
-                | :py:data:`~nirfsg.Signal.REF_CLOCK`                       | 3 (0x3) | Exports the Reference Clock.               |
-                +-----------------------------------------------------------+---------+--------------------------------------------+
-                | :py:data:`~nirfsg.Signal.STARTED_EVENT`                   | 4 (0x4) | Exports a Started Event.                   |
-                +-----------------------------------------------------------+---------+--------------------------------------------+
-                | :py:data:`~nirfsg.Signal.DONE_EVENT`                      | 5 (0x5) | Exports a Done Event.                      |
-                +-----------------------------------------------------------+---------+--------------------------------------------+
-                | :py:data:`~nirfsg.Signal.CONFIGURATION_LIST_STEP_TRIGGER` | 6 (0x6) | Exports a Configuration List Step Trigger. |
-                +-----------------------------------------------------------+---------+--------------------------------------------+
-                | :py:data:`~nirfsg.Signal.CONFIGURATION_SETTLED_EVENT`     | 7 (0x7) | Exports a Configuration Settled Event.     |
-                +-----------------------------------------------------------+---------+--------------------------------------------+
+                +---------------------------------------------------------------+---------+--------------------------------------------+
+                | Name                                                          | Value   | Description                                |
+                +===============================================================+=========+============================================+
+                | :py:data:`~nirfsg.Signal.START_TRIGGER`                       | 0 (0x0) | Exports a Start Trigger.                   |
+                +---------------------------------------------------------------+---------+--------------------------------------------+
+                | :py:data:`~nirfsg.Signal.SCRIPT_TRIGGER`                      | 1 (0x1) | Exports a Script Trigger.                  |
+                +---------------------------------------------------------------+---------+--------------------------------------------+
+                | :py:data:`~nirfsg.Signal.MARKER_EVENT`                        | 2 (0x2) | Exports a Marker Event.                    |
+                +---------------------------------------------------------------+---------+--------------------------------------------+
+                | :py:data:`~nirfsg.Signal.REF_CLOCK`                           | 3 (0x3) | Exports the Reference Clock.               |
+                +---------------------------------------------------------------+---------+--------------------------------------------+
+                | :py:data:`~nirfsg.Signal.STARTED_EVENT`                       | 4 (0x4) | Exports a Started Event.                   |
+                +---------------------------------------------------------------+---------+--------------------------------------------+
+                | :py:data:`~nirfsg.Signal.DONE_EVENT`                          | 5 (0x5) | Exports a Done Event.                      |
+                +---------------------------------------------------------------+---------+--------------------------------------------+
+                | :py:data:`~nirfsg.NIRFSG_VAL_CONFIGURATION_LIST_STEP_TRIGGER` | 6 (0x6) | Exports a Configuration List Step Trigger. |
+                +---------------------------------------------------------------+---------+--------------------------------------------+
+                | :py:data:`~nirfsg.NIRFSG_VAL_CONFIGURATION_SETTLED_EVENT`     | 7 (0x7) | Exports a Configuration Settled Event.     |
+                +---------------------------------------------------------------+---------+--------------------------------------------+
 
                 .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
@@ -1921,25 +1921,25 @@ get_terminal_name
 
                 Specifies the signal to query. **Defined Values** :
 
-                +-----------------------------------------------------------+---------+--------------------------------------------+
-                | Name                                                      | Value   | Description                                |
-                +===========================================================+=========+============================================+
-                | :py:data:`~nirfsg.Signal.START_TRIGGER`                   | 0 (0x0) | Exports a Start Trigger.                   |
-                +-----------------------------------------------------------+---------+--------------------------------------------+
-                | :py:data:`~nirfsg.Signal.SCRIPT_TRIGGER`                  | 1 (0x1) | Exports a Script Trigger.                  |
-                +-----------------------------------------------------------+---------+--------------------------------------------+
-                | :py:data:`~nirfsg.Signal.MARKER_EVENT`                    | 2 (0x2) | Exports a Marker Event.                    |
-                +-----------------------------------------------------------+---------+--------------------------------------------+
-                | :py:data:`~nirfsg.Signal.REF_CLOCK`                       | 3 (0x3) | Exports the Reference Clock.               |
-                +-----------------------------------------------------------+---------+--------------------------------------------+
-                | :py:data:`~nirfsg.Signal.STARTED_EVENT`                   | 4 (0x4) | Exports a Started Event.                   |
-                +-----------------------------------------------------------+---------+--------------------------------------------+
-                | :py:data:`~nirfsg.Signal.DONE_EVENT`                      | 5 (0x5) | Exports a Done Event.                      |
-                +-----------------------------------------------------------+---------+--------------------------------------------+
-                | :py:data:`~nirfsg.Signal.CONFIGURATION_LIST_STEP_TRIGGER` | 6 (0x6) | Exports a Configuration List Step Trigger. |
-                +-----------------------------------------------------------+---------+--------------------------------------------+
-                | :py:data:`~nirfsg.Signal.CONFIGURATION_SETTLED_EVENT`     | 7 (0x7) | Exports a Configuration Settled Event.     |
-                +-----------------------------------------------------------+---------+--------------------------------------------+
+                +---------------------------------------------------------------+---------+--------------------------------------------+
+                | Name                                                          | Value   | Description                                |
+                +===============================================================+=========+============================================+
+                | :py:data:`~nirfsg.Signal.START_TRIGGER`                       | 0 (0x0) | Exports a Start Trigger.                   |
+                +---------------------------------------------------------------+---------+--------------------------------------------+
+                | :py:data:`~nirfsg.Signal.SCRIPT_TRIGGER`                      | 1 (0x1) | Exports a Script Trigger.                  |
+                +---------------------------------------------------------------+---------+--------------------------------------------+
+                | :py:data:`~nirfsg.Signal.MARKER_EVENT`                        | 2 (0x2) | Exports a Marker Event.                    |
+                +---------------------------------------------------------------+---------+--------------------------------------------+
+                | :py:data:`~nirfsg.Signal.REF_CLOCK`                           | 3 (0x3) | Exports the Reference Clock.               |
+                +---------------------------------------------------------------+---------+--------------------------------------------+
+                | :py:data:`~nirfsg.Signal.STARTED_EVENT`                       | 4 (0x4) | Exports a Started Event.                   |
+                +---------------------------------------------------------------+---------+--------------------------------------------+
+                | :py:data:`~nirfsg.Signal.DONE_EVENT`                          | 5 (0x5) | Exports a Done Event.                      |
+                +---------------------------------------------------------------+---------+--------------------------------------------+
+                | :py:data:`~nirfsg.NIRFSG_VAL_CONFIGURATION_LIST_STEP_TRIGGER` | 6 (0x6) | Exports a Configuration List Step Trigger. |
+                +---------------------------------------------------------------+---------+--------------------------------------------+
+                | :py:data:`~nirfsg.NIRFSG_VAL_CONFIGURATION_SETTLED_EVENT`     | 7 (0x7) | Exports a Configuration Settled Event.     |
+                +---------------------------------------------------------------+---------+--------------------------------------------+
 
                 .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
@@ -3572,7 +3572,7 @@ analog_modulation_fm_narrowband_integrator
 
         This property is valid only when you set the :py:attr:`nirfsg.Session.analog_modulation_type` property to :py:data:`~nirfsg.AnalogModulationType.FM` and the :py:attr:`nirfsg.Session.analog_modulation_fm_band` property to :py:data:`~nirfsg.AnalogModulationFmBand.NARROWBAND`.
 
-        **Default Value:** :py:data:`~nirfsg.AnalogModulationFmNarrowbandIntegrator._100Hzto1kHz`
+        **Default Value:** :py:data:`~nirfsg.AnalogModulationFmNarrowbandIntegrator.RANGE_100_HERTZ_TO_1_KILOHERTZ`
 
         **Supported Devices:** PXIe-5654/5654 with PXIe-5696
 
@@ -3582,15 +3582,15 @@ analog_modulation_fm_narrowband_integrator
 
         **Defined Values**:
 
-        +--------------------------------------------------------------------------+----------------+---------------------------------------------+
-        | Name                                                                     | Value          | Description                                 |
-        +==========================================================================+================+=============================================+
-        | :py:data:`~nirfsg.AnalogModulationFmNarrowbandIntegrator._100Hzto1kHz`   | 18000 (0x4650) | Specifies a range from 100Â Hz to 1Â kHz.   |
-        +--------------------------------------------------------------------------+----------------+---------------------------------------------+
-        | :py:data:`~nirfsg.AnalogModulationFmNarrowbandIntegrator._10kHzto100kHz` | 18002 (0x4652) | Specifies a range from 10Â kHz to 100Â kHz. |
-        +--------------------------------------------------------------------------+----------------+---------------------------------------------+
-        | :py:data:`~nirfsg.AnalogModulationFmNarrowbandIntegrator._1kHzto10kHz`   | 18001 (0x4651) | Specifies a range from 1Â kHz to 10Â kHz.   |
-        +--------------------------------------------------------------------------+----------------+---------------------------------------------+
+        +-----------------------------------------------------------------------------------------------+----------------+---------------------------------------------+
+        | Name                                                                                          | Value          | Description                                 |
+        +===============================================================================================+================+=============================================+
+        | :py:data:`~nirfsg.AnalogModulationFmNarrowbandIntegrator.RANGE_100_HERTZ_TO_1_KILOHERTZ`      | 18000 (0x4650) | Specifies a range from 100Â Hz to 1Â kHz.   |
+        +-----------------------------------------------------------------------------------------------+----------------+---------------------------------------------+
+        | :py:data:`~nirfsg.AnalogModulationFmNarrowbandIntegrator.RANGE_10_KILOHERTZ_TO_100_KILOHERTZ` | 18002 (0x4652) | Specifies a range from 10Â kHz to 100Â kHz. |
+        +-----------------------------------------------------------------------------------------------+----------------+---------------------------------------------+
+        | :py:data:`~nirfsg.AnalogModulationFmNarrowbandIntegrator.RANGE_1_KILOHERTZ_TO_10_KILOHERTZ`   | 18001 (0x4651) | Specifies a range from 1Â kHz to 10Â kHz.   |
+        +-----------------------------------------------------------------------------------------------+----------------+---------------------------------------------+
 
         The following table lists the characteristics of this property.
 
@@ -6768,21 +6768,21 @@ exported_ref_clock_rate
 
         Specifies the Reference Clock Rate, in Hz, of the signal sent to the Reference Clock Export Output Terminal. To set this property, the NI-RFSG device must be in the Configuration state.
 
-        **Default Value:** :py:data:`~nirfsg.ReferenceClockExportedRate._10MHz`
+        **Default Value:** :py:data:`~nirfsg.ReferenceClockExportedRate.CLOCK_RATE_10_MEGAHERTZ`
 
         **Supported Devices:** PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 
         **Defined Values**:
 
-        +-------------------------------------------------------+--------------+-------------------------------------+
-        | Name                                                  | Value        | Description                         |
-        +=======================================================+==============+=====================================+
-        | :py:data:`~nirfsg.ReferenceClockExportedRate._10MHz`  | 10000000.0   | Uses a 10MHz Reference Clock rate.  |
-        +-------------------------------------------------------+--------------+-------------------------------------+
-        | :py:data:`~nirfsg.ReferenceClockExportedRate._100MHz` | 100000000.0  | Uses a 100MHz Reference Clock rate. |
-        +-------------------------------------------------------+--------------+-------------------------------------+
-        | :py:data:`~nirfsg.ReferenceClockExportedRate._1GHz`   | 1000000000.0 | Uses a 1GHz Reference Clock rate.   |
-        +-------------------------------------------------------+--------------+-------------------------------------+
+        +------------------------------------------------------------------------+--------------+-------------------------------------+
+        | Name                                                                   | Value        | Description                         |
+        +========================================================================+==============+=====================================+
+        | :py:data:`~nirfsg.ReferenceClockExportedRate.CLOCK_RATE_10_MEGAHERTZ`  | 10000000.0   | Uses a 10MHz Reference Clock rate.  |
+        +------------------------------------------------------------------------+--------------+-------------------------------------+
+        | :py:data:`~nirfsg.ReferenceClockExportedRate.CLOCK_RATE_100_MEGAHERTZ` | 100000000.0  | Uses a 100MHz Reference Clock rate. |
+        +------------------------------------------------------------------------+--------------+-------------------------------------+
+        | :py:data:`~nirfsg.ReferenceClockExportedRate.CLOCK_RATE_1_GIGAHERTZ`   | 1000000000.0 | Uses a 1GHz Reference Clock rate.   |
+        +------------------------------------------------------------------------+--------------+-------------------------------------+
 
         .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
@@ -10434,7 +10434,7 @@ ref_clock_rate
 
         **Valid Values:**
 
-        PXIe-5654/5654 with PXIe-5696: Values between 1MHz to 20MHz in 1MHz steps are supported in addition to the :py:data:`~nirfsg.ReferenceClockRate.AUTO` and :py:data:`~nirfsg.ReferenceClockRate._10MHz` values.
+        PXIe-5654/5654 with PXIe-5696: Values between 1MHz to 20MHz in 1MHz steps are supported in addition to the :py:data:`~nirfsg.ReferenceClockRate.AUTO` and :py:data:`~nirfsg.ReferenceClockRate.CLOCK_RATE_10_MEGAHERTZ` values.
 
         PXIe-5841 with PXIe-5655, PXIe-5842: 10 MHz, 100 MHz, 270 MHz, and 3.84 MHz
 
@@ -10460,13 +10460,13 @@ ref_clock_rate
 
         **Defined Values**:
 
-        +----------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
-        | Value                                        | Description                                                                                                                       |
-        +==============================================+===================================================================================================================================+
-        | :py:data:`~nirfsg.ReferenceClockRate.AUTO`   | Uses the default Reference Clock rate for the device or automatically detects the Reference Clock rate if the device supports it. |
-        +----------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
-        | :py:data:`~nirfsg.ReferenceClockRate._10MHz` | Uses a 10 MHz Reference Clock rate.                                                                                               |
-        +----------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
+        +---------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
+        | Value                                                         | Description                                                                                                                       |
+        +===============================================================+===================================================================================================================================+
+        | :py:data:`~nirfsg.ReferenceClockRate.AUTO`                    | Uses the default Reference Clock rate for the device or automatically detects the Reference Clock rate if the device supports it. |
+        +---------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
+        | :py:data:`~nirfsg.ReferenceClockRate.CLOCK_RATE_10_MEGAHERTZ` | Uses a 10 MHz Reference Clock rate.                                                                                               |
+        +---------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
 
         .. note:: Automatic detection of the Reference Clock rate is supported on only the PXIe-5654/5654 with PXIe-5696. For all other supported devices, NI-RFSG uses the default Reference Clock rate of 10MHz.
 

--- a/docs/nirfsg/class.rst
+++ b/docs/nirfsg/class.rst
@@ -850,7 +850,7 @@ configure_digital_edge_script_trigger
 
     .. py:currentmodule:: nirfsg.Session
 
-    .. py:method:: configure_digital_edge_script_trigger(trigger_id, source, edge)
+    .. py:method:: configure_digital_edge_script_trigger(source, edge)
 
             Configures the specified Script Trigger for digital edge triggering.
 
@@ -867,16 +867,17 @@ configure_digital_edge_script_trigger
             
 
 
+            .. tip:: This method can be called on specific script_triggers within your :py:class:`nirfsg.Session` instance.
+                Use Python index notation on the repeated capabilities container script_triggers to specify a subset,
+                and then call this method on the result.
 
-            :param trigger_id:
+                Example: :py:meth:`my_session.script_triggers[ ... ].configure_digital_edge_script_trigger`
+
+                To call the method on all script_triggers, you can call it directly on the :py:class:`nirfsg.Session`.
+
+                Example: :py:meth:`my_session.configure_digital_edge_script_trigger`
 
 
-                Specifies the Script Trigger to configure.
-
-                
-
-
-            :type trigger_id: str
             :param source:
 
 
@@ -894,7 +895,7 @@ configure_digital_edge_script_trigger
                 
 
 
-            :type edge: :py:data:`nirfsg.ScriptTrigDigEdgeEdge`
+            :type edge: :py:data:`nirfsg.ScriptTriggerDigitalEdgeEdge`
 
 configure_digital_edge_start_trigger
 ------------------------------------
@@ -938,7 +939,7 @@ configure_digital_edge_start_trigger
                 
 
 
-            :type edge: :py:data:`nirfsg.StartTrigDigEdgeEdge`
+            :type edge: :py:data:`nirfsg.StartTriggerDigitalEdgeEdge`
 
 configure_digital_level_script_trigger
 --------------------------------------
@@ -1026,164 +1027,6 @@ configure_digital_modulation_user_defined_waveform
 
 
             :type user_defined_waveform: list of int
-
-configure_generation_mode
--------------------------
-
-    .. py:currentmodule:: nirfsg.Session
-
-    .. py:method:: configure_generation_mode(generation_mode)
-
-            Configures the NI-RFSG device to generate a continuous sine tone (CW), apply I/Q (vector) modulation to the RF output signal, or generate arbitrary waveforms according to scripts.
-
-            The NI-RFSG device must be in the Configuration state before you call this method.
-
-            **Supported Devices** : PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
-
-            **Related Topics**
-
-            `Assigning Properties or Properties to a Waveform <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/assigning_properties_or_attributes_to_a_waveform.html>`_
-
-            `Scripting Instructions <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/scripting_instructions.html>`_--Refer to this topic for more information about VST restrictions on scripts.
-
-            
-
-
-
-            :param generation_mode:
-
-
-                Specifies the mode used by NI-RFSG for generating an RF output signal.
-
-                        **Default Value** : :py:data:`~nirfsg.GenerationMode.CW`
-
-                        **Defined Values** :
-
-                +------------------------------------------------+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------+
-                | Name                                           | Value        | Description                                                                                                                                      |
-                +================================================+==============+==================================================================================================================================================+
-                | :py:data:`~nirfsg.GenerationMode.CW`           | 1000 (0x3e8) | Configures the RF signal generator to generate a CW signal.                                                                                      |
-                +------------------------------------------------+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------+
-                | :py:data:`~nirfsg.GenerationMode.ARB_WAVEFORM` | 1001 (0x3e9) | Configures the RF signal generator to generate the arbitrary waveform specified by the :py:attr:`nirfsg.Session.arb_selected_waveform` property. |
-                +------------------------------------------------+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------+
-                | :py:data:`~nirfsg.GenerationMode.SCRIPT`       | 1002 (0x3ea) | Configures the RF signal generator to generate arbitrary waveforms as directed by the :py:attr:`nirfsg.Session.selected_script` property.        |
-                +------------------------------------------------+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------+
-
-                .. note:: - For the PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696, only :py:data:`~nirfsg.GenerationMode.CW` is supported.
-
-                     - If you are using an RF vector signal transceiver (VST) device, some script instructions may not be supported.
-
-
-            :type generation_mode: :py:data:`nirfsg.GenerationMode`
-
-configure_output_enabled
-------------------------
-
-    .. py:currentmodule:: nirfsg.Session
-
-    .. py:method:: configure_output_enabled(output_enabled)
-
-            Enables or disables signal output.
-
-            Setting :py:attr:`nirfsg.Session.output_enabled` to False while in the Generation state attenuates the generated signal so that no signal is output.
-
-            **Supported Devices** : PXI-5610, PXIe-5611, PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
-
-            **Related Topics**
-
-            `Output Enabled <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/outputenable.html>`_
-
-            `NI-RFSG Instrument Driver Programming Flow <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/progflow.html>`_
-
-            `RF List Mode <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/rf_list_mode_overview.html>`_
-
-            
-
-
-
-            :param output_enabled:
-
-
-                Specifies whether you want to enable or disable the output.
-
-                
-
-
-            :type output_enabled: bool
-
-configure_p2p_endpoint_fullness_start_trigger
----------------------------------------------
-
-    .. py:currentmodule:: nirfsg.Session
-
-    .. py:method:: configure_p2p_endpoint_fullness_start_trigger(p2p_endpoint_fullness_level)
-
-            Configures the Start Trigger to detect peer-to-peer endpoint fullness.
-
-            Generation begins when the number of samples in the peer-to-peer endpoint reaches the threshold specified by the :py:attr:`nirfsg.Session.P2P_ENDPOINT_FULLNESS_LEVEL` parameter. The NI-RFSG device must be in the Configuration state before calling this method.
-
-            **Supported Devices** : PXIe-5673E, PXIe-5820/5830/5831/5832/5840/5841/5842
-
-            **Related Topics**
-
-            `Start Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/start_triggers.html>`_
-
-            
-
-            .. note:: Due to an additional internal FIFO in the RF signal generator, the writer peer actually writes 2,304 bytes more than the quantity of data specified by this method to satisfy the trigger level.
-
-            .. note:: One or more of the referenced properties are not in the Python API for this driver.
-
-
-
-            :param p2p_endpoint_fullness_level:
-
-
-                Specifies the quantity of data in the FIFO endpoint that asserts the trigger. Units are samples per channel. The default value is -1, which allows NI-RFSG to select the appropriate fullness value.
-
-                
-
-
-            :type p2p_endpoint_fullness_level: int
-
-configure_power_level_type
---------------------------
-
-    .. py:currentmodule:: nirfsg.Session
-
-    .. py:method:: configure_power_level_type(power_level_type)
-
-            Specifies the way the driver interprets the :py:attr:`nirfsg.Session.power_level` property.
-
-            In average power mode, NI-RFSG automatically scales waveform data to use the maximum dynamic range. In peak power mode, waveforms are scaled according to the :py:attr:`nirfsg.Session.arb_waveform_software_scaling_factor` property.
-
-            **Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
-
-            **Related Topics**
-
-            `Spurious Performance <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/spurious_performance.html>`_
-
-            `Optimizing for Low Power Generation <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/optimizing_for_low_power_generation.html>`_
-
-            
-
-
-
-            :param power_level_type:
-
-
-                Specifies the way the driver interprets the value of the :py:attr:`nirfsg.Session.power_level` property. NI-RFSG sets the :py:attr:`nirfsg.Session.power_level_type` property to this value.
-
-                +-------------------------+-------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-                | Name                    | Value | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-                +=========================+=======+==================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================+
-                | Average Power (default) | 7000  | Indicates the desired power averaged in time. The driver maximizes the dynamic range by scaling the I/Q waveform so that its peak magnitude is equal to one. If you write more than one waveform, NI-RFSG scales each waveform without preserving the power level ratio between the waveforms. This value is not valid for the PXIe-5820.                                                                                                                                                                                                                                                                        |
-                +-------------------------+-------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-                | Peak Power              | 7001  | Indicates the maximum power level of the RF signal averaged over one period of the RF carrier frequency (the peak envelope power). This setting requires the magnitude of the I/Q waveform to be less than or equal to one. When using peak power, the power level of the RF signal matches the specified power level at moments when the magnitude of the I/Q waveform equals one. If you write more than one waveform, the relative scaling between waveforms is preserved. In peak power mode, waveforms are scaled according to the :py:attr:`nirfsg.Session.arb_waveform_software_scaling_factor` property. |
-                +-------------------------+-------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-
-            :type power_level_type: :py:data:`nirfsg.PowerLevelType`
 
 configure_pxi_chassis_clk10
 ---------------------------
@@ -1326,43 +1169,12 @@ configure_rf
 
             :type power_level: float
 
-configure_signal_bandwidth
---------------------------
-
-    .. py:currentmodule:: nirfsg.Session
-
-    .. py:method:: configure_signal_bandwidth(signal_bandwidth)
-
-            Configures the signal bandwidth of the arbitrary waveform.
-
-            The NI-RFSG device must be in the Configuration state before you call this method.
-
-            NI-RFSG defines *signal bandwidth* as twice the maximum baseband signal deviation from 0 Hz. Usually, the baseband signal center frequency is 0Hz. In such cases, the signal bandwidth is simply the baseband signal minimum frequency subtracted from its maximum frequency, or *f* <sub>max</sub> minus *f* <sub>min</sub>. NI-RFSG uses this value to optimally configure the center frequency of the upconverter to help minimize phase noise. The generated signal is not filtered to achieve the set bandwidth. However, specifying a bandwidth smaller than the actual bandwidth of the signal could potentially result in spectral distortion.
-
-            **Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
-
-            
-
-            .. note:: Based on your signal bandwidth, NI-RFSG decides whether to configure the upconverter center frequency on the PXI-5670/5671 or PXIe-5672 in increments of 1MHz or 5MHz. Failure to configure signal bandwidth may result in the signal being placed outside the upconverter passband.
-
-
-
-            :param signal_bandwidth:
-
-
-                Specifies the signal bandwidth used by NI-RFSG to generate an RF output signal. NI-RFSG sets the :py:attr:`nirfsg.Session.signal_bandwidth` property to this value.
-
-                
-
-
-            :type signal_bandwidth: float
-
 configure_software_script_trigger
 ---------------------------------
 
     .. py:currentmodule:: nirfsg.Session
 
-    .. py:method:: configure_software_script_trigger(trigger_id)
+    .. py:method:: configure_software_script_trigger()
 
             Configures the Script Trigger for software triggering.
 
@@ -1379,16 +1191,16 @@ configure_software_script_trigger
             
 
 
+            .. tip:: This method can be called on specific script_triggers within your :py:class:`nirfsg.Session` instance.
+                Use Python index notation on the repeated capabilities container script_triggers to specify a subset,
+                and then call this method on the result.
 
-            :param trigger_id:
+                Example: :py:meth:`my_session.script_triggers[ ... ].configure_software_script_trigger`
 
+                To call the method on all script_triggers, you can call it directly on the :py:class:`nirfsg.Session`.
 
-                Specifies the Script Trigger to configure.
+                Example: :py:meth:`my_session.configure_software_script_trigger`
 
-                
-
-
-            :type trigger_id: str
 
 configure_software_start_trigger
 --------------------------------
@@ -1548,7 +1360,7 @@ disable_script_trigger
 
     .. py:currentmodule:: nirfsg.Session
 
-    .. py:method:: disable_script_trigger(trigger_id)
+    .. py:method:: disable_script_trigger()
 
             Configures the device not to wait for the specified Script Trigger.
 
@@ -1563,16 +1375,16 @@ disable_script_trigger
             
 
 
+            .. tip:: This method can be called on specific script_triggers within your :py:class:`nirfsg.Session` instance.
+                Use Python index notation on the repeated capabilities container script_triggers to specify a subset,
+                and then call this method on the result.
 
-            :param trigger_id:
+                Example: :py:meth:`my_session.script_triggers[ ... ].disable_script_trigger`
 
+                To call the method on all script_triggers, you can call it directly on the :py:class:`nirfsg.Session`.
 
-                Specifies the Script trigger to configure.
+                Example: :py:meth:`my_session.disable_script_trigger`
 
-                
-
-
-            :type trigger_id: str
 
 disable_start_trigger
 ---------------------
@@ -2081,47 +1893,6 @@ get_self_calibration_temperature
 
 
 
-get_stream_endpoint_handle
---------------------------
-
-    .. py:currentmodule:: nirfsg.Session
-
-    .. py:method:: get_stream_endpoint_handle(stream_endpoint)
-
-            Returns a reader endpoint handle that can be used with NI-P2P to configure a peer-to-peer stream with an RF signal generator endpoint.
-
-            **Supported Devices** : PXIe-5673E, PXIe-5820/5830/5831/5832/5840/5841/5842
-
-            **Related Topics**
-
-            `Configuring a Peer-to-Peer Stream <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/configuring_a_p2p_stream.html>`_
-
-            `Configuring Flow Control <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_flow_control.html>`_
-
-            
-
-
-
-            :param stream_endpoint:
-
-
-                Specifies the stream endpoint FIFO to configure.
-
-                
-
-
-            :type stream_endpoint: str
-
-            :rtype: int
-            :return:
-
-
-                    Returns the reader endpoint handle that is used with NI-P2P to create a stream with the NI-RFSG device as an endpoint.
-
-                    
-
-
-
 get_terminal_name
 -----------------
 
@@ -2614,7 +2385,7 @@ reset
 
             Generally, calling this method instead of the :py:meth:`nirfsg.Session.reset_device` method is acceptable. The :py:meth:`nirfsg.Session.Reset` method executes faster than the :py:meth:`nirfsg.Session.reset_device` method.
 
-            To avoid resetting routes on the PXIe-5644/5645/5646 and PXIe-5820/5830/5831/5832/5840/5841/5842/5860 that are in use by NI-RFSA sessions, NI recommends using the :py:meth:`nirfsg.Session.ResetWithOptions` method, with **stepsToOmit** set to :py:data:`~nirfsg.ResetWithOptionsStepsToOmit.ROUTES` .
+            To avoid resetting routes on the PXIe-5644/5645/5646 and PXIe-5820/5830/5831/5832/5840/5841/5842/5860 that are in use by NI-RFSA sessions, NI recommends using the :py:meth:`nirfsg.Session.reset_with_options` method, with **stepsToOmit** set to :py:data:`~nirfsg.ResetWithOptionsStepsToOmit.ROUTES` .
 
             **Supported Devices** : PXI-5610, PXIe-5611, PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 
@@ -2706,6 +2477,58 @@ reset_with_defaults
 
 
 
+reset_with_options
+------------------
+
+    .. py:currentmodule:: nirfsg.Session
+
+    .. py:method:: reset_with_options(steps_to_omit)
+
+            Resets all properties to default values and specifies steps to omit during the reset process, such as signal routes.
+
+            By default, this method exhibits the same behavior as :py:meth:`nirfsg.Session.Reset`. You can specify steps to omit using the steps to omit parameter. For example, if you specify :py:data:`~nirfsg.ResetWithOptionsStepsToOmit.ROUTES` for the :py:attr:`nirfsg.Session.STEPS_TO_OMIT` parameter, this method does not release signal routes during the reset process.
+
+            When routes of signals between two devices are released, they are released regardless of which device created the route.
+
+            To avoid resetting routes on PXIe-5820/5830/5831/5832/5840/5841/5842/5860 that are in use by NI-RFSA sessions, NI recommends using this method instead of :py:meth:`nirfsg.Session.Reset`, with :py:attr:`nirfsg.Session.STEPS_TO_OMIT` set to :py:data:`~nirfsg.ResetWithOptionsStepsToOmit.ROUTES`.
+
+            **Supported Devices** : PXIe-5644/5645/5646, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
+
+            **Related Topics**
+
+            `Triggers <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/triggers.html>``Events <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/events.html>`_
+
+            
+
+            .. note:: One or more of the referenced properties are not in the Python API for this driver.
+
+
+
+            :param steps_to_omit:
+
+
+                Specifies a list of steps to skip during the reset process. The default value is :py:data:`~nirfsg.ResetWithOptionsStepsToOmit.NONE`, which specifies that no step is omitted during reset. **Defined Values** :
+
+                +-------------------------------------------------------------------+---------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+                | Name                                                              | Value   | Description                                                                                                                                                                                                |
+                +===================================================================+=========+============================================================================================================================================================================================================+
+                | :py:data:`~nirfsg.ResetWithOptionsStepsToOmit.NONE`               | 0 (0x0) | No step is omitted during reset.                                                                                                                                                                           |
+                +-------------------------------------------------------------------+---------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+                | :py:data:`~nirfsg.ResetWithOptionsStepsToOmit.WAVEFORMS`          | 1 (0x1) | Omits clearing waveforms.                                                                                                                                                                                  |
+                +-------------------------------------------------------------------+---------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+                | :py:data:`~nirfsg.ResetWithOptionsStepsToOmit.SCRIPTS`            | 2 (0x2) | Omits clearing scripts.                                                                                                                                                                                    |
+                +-------------------------------------------------------------------+---------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+                | :py:data:`~nirfsg.ResetWithOptionsStepsToOmit.ROUTES`             | 4 (0x4) | Omits the routing reset step. Routing is preserved after a reset. However, routing related properties are reset to default, and routing is released if the default properties are committed after a reset. |
+                +-------------------------------------------------------------------+---------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+                | :py:data:`~nirfsg.ResetWithOptionsStepsToOmit.DEEMBEDDING_TABLES` | 8 (0x8) | Omits deleting de-embedding tables. This step is valid only for the PXIe-5830/5831/5832/5840.                                                                                                              |
+                +-------------------------------------------------------------------+---------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+                .. note:: :py:data:`~nirfsg.ResetWithOptionsStepsToOmit.ROUTES` is not supported in external calibration or alignment sessions.
+                    You can combine multiple enums.ResetWithOptionsStepsToOmit flags using the bitwise OR (|) operator.
+
+
+            :type steps_to_omit: :py:data:`nirfsg.ResetWithOptionsStepsToOmit`
+
 revision_query
 --------------
 
@@ -2788,7 +2611,7 @@ select_arb_waveform
 
     .. py:method:: select_arb_waveform(name)
 
-            Specifies the waveform that is generated upon a call to the :py:meth:`nirfsg.Session._initiate` method when the **generationMode** parameter of the :py:meth:`nirfsg.Session.configure_generation_mode` method is set to :py:data:`~nirfsg.GenerationMode.ARB_WAVEFORM`.
+            Specifies the waveform that is generated upon a call to the :py:meth:`nirfsg.Session._initiate` method when the **generationMode** parameter of the :py:meth:`nirfsg.Session.ConfigureGenerationMode` method is set to :py:data:`~nirfsg.GenerationMode.ARB_WAVEFORM`.
 
             You must specify a waveform using the :py:attr:`nirfsg.Session.NAME` parameter if you have written multiple waveforms. The NI-RFSG device must be in the Configuration state before you call this method.
 
@@ -2886,6 +2709,8 @@ self_calibrate_range
                 +------------------------------------------------------------------------+-----------+---------------------------------------------------------------------------------------------------------------------+
                 | :py:data:`~nirfsg.SelfCalibrateRangeStepsToOmit.SYNTHESIZER_ALIGNMENT` | 16 (0x10) | Omits the Voltage Controlled Oscillator (VCO) Alignment step. If you omit this step, the LO PLL is not adjusted.    |
                 +------------------------------------------------------------------------+-----------+---------------------------------------------------------------------------------------------------------------------+
+
+                .. note:: You can combine multiple enums.SelfCalibrateRangeStepsToOmit flags using the bitwise OR (|) operator.
 
 
             :type steps_to_omit: :py:data:`nirfsg.SelfCalibrateRangeStepsToOmit`
@@ -3312,61 +3137,6 @@ write_arb_waveform
 
             :type more_data_pending: bool
 
-write_p2p_endpoint_i16
-----------------------
-
-    .. py:currentmodule:: nirfsg.Session
-
-    .. py:method:: write_p2p_endpoint_i16(stream_endpoint, number_of_samples, endpoint_data)
-
-            Writes an array of 16-bit integer data to the peer-to-peer endpoint.
-
-            Use this method to write initial data from the host to the endpoint before starting generation to avoid an underflow when you start the generation.
-
-            **Supported Devices** : PXIe-5673E
-
-            **Related Topics**
-
-            `Peer-to-Peer Data Streaming <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_streaming.html>`_--Refer to this topic for more information about configuring a stream.
-
-            `Configuring Flow Control <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_flow_control.html>`_
-
-            `Starting Peer-to-Peer Generation <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_starting_generation.html>`_
-
-            `Reconfiguring a Stream <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_reconfiguring_stream.html>`_
-
-            
-
-
-
-            :param stream_endpoint:
-
-
-                Specifies the stream endpoint FIFO to configure.
-
-                
-
-
-            :type stream_endpoint: str
-            :param number_of_samples:
-
-
-                Specifies the number of samples to write into the endpoint FIFO.
-
-                
-
-
-            :type number_of_samples: int
-            :param endpoint_data:
-
-
-                Specifies the array of data to write into the endpoint FIFO. The binary data is left-justified.
-
-                
-
-
-            :type endpoint_data: array.array("h")
-
 write_script
 ------------
 
@@ -3376,7 +3146,7 @@ write_script
 
             Writes a script to the device to control waveform generation in Script mode.
 
-            First, configure your device for Script mode by calling the :py:meth:`nirfsg.Session.configure_generation_mode` method. The NI-RFSG device must be in the Configuration state before calling the :py:meth:`nirfsg.Session.write_script` method.
+            First, configure your device for Script mode by calling the :py:meth:`nirfsg.Session.ConfigureGenerationMode` method. The NI-RFSG device must be in the Configuration state before calling the :py:meth:`nirfsg.Session.write_script` method.
 
             **Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 
@@ -3724,7 +3494,7 @@ analog_modulation_fm_band
 
         Specifies the analog modulation frequency modulation (FM) band to use. Wideband FM allows for modulating signals higher than 100kHz. Narrowband FM allows for modulating lower frequency signals.
 
-        **Default Value:** :py:data:`~nirfsg.AnlgModFmBand.WIDEBAND`
+        **Default Value:** :py:data:`~nirfsg.AnalogModulationFmBand.WIDEBAND`
 
         **Supported Devices:** PXIe-5654/5654 with PXIe-5696
 
@@ -3734,25 +3504,25 @@ analog_modulation_fm_band
 
         **Defined Values**:
 
-        +---------------------------------------------+----------------+--------------------------------------------+
-        | Name                                        | Value          | Description                                |
-        +=============================================+================+============================================+
-        | :py:data:`~nirfsg.AnlgModFmBand.NARROWBAND` | 17000 (0x4268) | Specifies narrowband frequency modulation. |
-        +---------------------------------------------+----------------+--------------------------------------------+
-        | :py:data:`~nirfsg.AnlgModFmBand.WIDEBAND`   | 17001 (0x4269) | Specifies wideband frequency modulation.   |
-        +---------------------------------------------+----------------+--------------------------------------------+
+        +------------------------------------------------------+----------------+--------------------------------------------+
+        | Name                                                 | Value          | Description                                |
+        +======================================================+================+============================================+
+        | :py:data:`~nirfsg.AnalogModulationFmBand.NARROWBAND` | 17000 (0x4268) | Specifies narrowband frequency modulation. |
+        +------------------------------------------------------+----------------+--------------------------------------------+
+        | :py:data:`~nirfsg.AnalogModulationFmBand.WIDEBAND`   | 17001 (0x4269) | Specifies wideband frequency modulation.   |
+        +------------------------------------------------------+----------------+--------------------------------------------+
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+---------------------+
-            | Characteristic        | Value               |
-            +=======================+=====================+
-            | Datatype              | enums.AnlgModFmBand |
-            +-----------------------+---------------------+
-            | Permissions           | read-write          |
-            +-----------------------+---------------------+
-            | Repeated Capabilities | None                |
-            +-----------------------+---------------------+
+            +-----------------------+------------------------------+
+            | Characteristic        | Value                        |
+            +=======================+==============================+
+            | Datatype              | enums.AnalogModulationFmBand |
+            +-----------------------+------------------------------+
+            | Permissions           | read-write                   |
+            +-----------------------+------------------------------+
+            | Repeated Capabilities | None                         |
+            +-----------------------+------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -3802,9 +3572,9 @@ analog_modulation_fm_narrowband_integrator
 
         Specifies the narrowband frequency modulation (FM) range to apply by sending the signal through an integrator.
 
-        This property is valid only when you set the :py:attr:`nirfsg.Session.analog_modulation_type` property to :py:data:`~nirfsg.AnlgModType.FM` and the :py:attr:`nirfsg.Session.analog_modulation_fm_band` property to :py:data:`~nirfsg.AnlgModFmBand.NARROWBAND`.
+        This property is valid only when you set the :py:attr:`nirfsg.Session.analog_modulation_type` property to :py:data:`~nirfsg.AnalogModulationType.FM` and the :py:attr:`nirfsg.Session.analog_modulation_fm_band` property to :py:data:`~nirfsg.AnalogModulationFmBand.NARROWBAND`.
 
-        **Default Value:** :py:data:`~nirfsg.AnlgModFmNarrowbandIntegrator._100hzto1khz`
+        **Default Value:** :py:data:`~nirfsg.AnalogModulationFmNarrowbandIntegrator._100hzto1khz`
 
         **Supported Devices:** PXIe-5654/5654 with PXIe-5696
 
@@ -3814,27 +3584,27 @@ analog_modulation_fm_narrowband_integrator
 
         **Defined Values**:
 
-        +-----------------------------------------------------------------+----------------+---------------------------------------------+
-        | Name                                                            | Value          | Description                                 |
-        +=================================================================+================+=============================================+
-        | :py:data:`~nirfsg.AnlgModFmNarrowbandIntegrator._100hzto1khz`   | 18000 (0x4650) | Specifies a range from 100Â Hz to 1Â kHz.   |
-        +-----------------------------------------------------------------+----------------+---------------------------------------------+
-        | :py:data:`~nirfsg.AnlgModFmNarrowbandIntegrator._10khzto100khz` | 18002 (0x4652) | Specifies a range from 10Â kHz to 100Â kHz. |
-        +-----------------------------------------------------------------+----------------+---------------------------------------------+
-        | :py:data:`~nirfsg.AnlgModFmNarrowbandIntegrator._1khzto10khz`   | 18001 (0x4651) | Specifies a range from 1Â kHz to 10Â kHz.   |
-        +-----------------------------------------------------------------+----------------+---------------------------------------------+
+        +--------------------------------------------------------------------------+----------------+---------------------------------------------+
+        | Name                                                                     | Value          | Description                                 |
+        +==========================================================================+================+=============================================+
+        | :py:data:`~nirfsg.AnalogModulationFmNarrowbandIntegrator._100hzto1khz`   | 18000 (0x4650) | Specifies a range from 100Â Hz to 1Â kHz.   |
+        +--------------------------------------------------------------------------+----------------+---------------------------------------------+
+        | :py:data:`~nirfsg.AnalogModulationFmNarrowbandIntegrator._10khzto100khz` | 18002 (0x4652) | Specifies a range from 10Â kHz to 100Â kHz. |
+        +--------------------------------------------------------------------------+----------------+---------------------------------------------+
+        | :py:data:`~nirfsg.AnalogModulationFmNarrowbandIntegrator._1khzto10khz`   | 18001 (0x4651) | Specifies a range from 1Â kHz to 10Â kHz.   |
+        +--------------------------------------------------------------------------+----------------+---------------------------------------------+
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+-------------------------------------+
-            | Characteristic        | Value                               |
-            +=======================+=====================================+
-            | Datatype              | enums.AnlgModFmNarrowbandIntegrator |
-            +-----------------------+-------------------------------------+
-            | Permissions           | read-write                          |
-            +-----------------------+-------------------------------------+
-            | Repeated Capabilities | None                                |
-            +-----------------------+-------------------------------------+
+            +-----------------------+----------------------------------------------+
+            | Characteristic        | Value                                        |
+            +=======================+==============================================+
+            | Datatype              | enums.AnalogModulationFmNarrowbandIntegrator |
+            +-----------------------+----------------------------------------------+
+            | Permissions           | read-write                                   |
+            +-----------------------+----------------------------------------------+
+            | Repeated Capabilities | None                                         |
+            +-----------------------+----------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -3919,7 +3689,7 @@ analog_modulation_pm_mode
 
         Specifies the phase modulation (PM) mode to use.
 
-        **Default Value:** :py:data:`~nirfsg.AnlgModPmMode.LOW_PHASE_NOISE`
+        **Default Value:** :py:data:`~nirfsg.AnalogModulationPmMode.LOW_PHASE_NOISE`
 
         **Supported Devices:** PXIe-5654/5654 with PXIe-5696
 
@@ -3929,25 +3699,25 @@ analog_modulation_pm_mode
 
         **Defined Values**:
 
-        +--------------------------------------------------+----------------+-----------------------------------------------------------------------------------------------+
-        | Name                                             | Value          | Description                                                                                   |
-        +==================================================+================+===============================================================================================+
-        | :py:data:`~nirfsg.AnlgModPmMode.HIGH_DEVIATION`  | 19000 (0x4a38) | Specifies high deviation. High deviation comes at the expense of a higher phase noise.        |
-        +--------------------------------------------------+----------------+-----------------------------------------------------------------------------------------------+
-        | :py:data:`~nirfsg.AnlgModPmMode.LOW_PHASE_NOISE` | 19001 (0x4a39) | Specifies low phase noise. Low phase noise comes at the expense of a lower maximum deviation. |
-        +--------------------------------------------------+----------------+-----------------------------------------------------------------------------------------------+
+        +-----------------------------------------------------------+----------------+-----------------------------------------------------------------------------------------------+
+        | Name                                                      | Value          | Description                                                                                   |
+        +===========================================================+================+===============================================================================================+
+        | :py:data:`~nirfsg.AnalogModulationPmMode.HIGH_DEVIATION`  | 19000 (0x4a38) | Specifies high deviation. High deviation comes at the expense of a higher phase noise.        |
+        +-----------------------------------------------------------+----------------+-----------------------------------------------------------------------------------------------+
+        | :py:data:`~nirfsg.AnalogModulationPmMode.LOW_PHASE_NOISE` | 19001 (0x4a39) | Specifies low phase noise. Low phase noise comes at the expense of a lower maximum deviation. |
+        +-----------------------------------------------------------+----------------+-----------------------------------------------------------------------------------------------+
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+---------------------+
-            | Characteristic        | Value               |
-            +=======================+=====================+
-            | Datatype              | enums.AnlgModPmMode |
-            +-----------------------+---------------------+
-            | Permissions           | read-write          |
-            +-----------------------+---------------------+
-            | Repeated Capabilities | None                |
-            +-----------------------+---------------------+
+            +-----------------------+------------------------------+
+            | Characteristic        | Value                        |
+            +=======================+==============================+
+            | Datatype              | enums.AnalogModulationPmMode |
+            +-----------------------+------------------------------+
+            | Permissions           | read-write                   |
+            +-----------------------+------------------------------+
+            | Repeated Capabilities | None                         |
+            +-----------------------+------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -3997,7 +3767,7 @@ analog_modulation_type
 
         Specifies the analog modulation format to use.
 
-        **Default Value:** :py:data:`~nirfsg.AnlgModType.NONE`
+        **Default Value:** :py:data:`~nirfsg.AnalogModulationType.NONE`
 
         **Supported Devices:** PXI/PXIe-5650/5651/5652, PXIe-5654/5654 with PXIe-5696
 
@@ -4011,31 +3781,31 @@ analog_modulation_type
 
         **Defined Values**:
 
-        +-------------------------------------+--------------+--------------------------------------------------+
-        | Name                                | Value        | Description                                      |
-        +=====================================+==============+==================================================+
-        | :py:data:`~nirfsg.AnlgModType.AM`   | 2002 (0x7d2) | Specifies that the analog modulation type is AM. |
-        +-------------------------------------+--------------+--------------------------------------------------+
-        | :py:data:`~nirfsg.AnlgModType.FM`   | 2000 (0x7d0) | Specifies that the analog modulation type is FM. |
-        +-------------------------------------+--------------+--------------------------------------------------+
-        | :py:data:`~nirfsg.AnlgModType.NONE` | 0 (0x0)      | Disables analog modulation.                      |
-        +-------------------------------------+--------------+--------------------------------------------------+
-        | :py:data:`~nirfsg.AnlgModType.PM`   | 2001 (0x7d1) | Specifies that the analog modulation type is PM. |
-        +-------------------------------------+--------------+--------------------------------------------------+
+        +----------------------------------------------+--------------+--------------------------------------------------+
+        | Name                                         | Value        | Description                                      |
+        +==============================================+==============+==================================================+
+        | :py:data:`~nirfsg.AnalogModulationType.AM`   | 2002 (0x7d2) | Specifies that the analog modulation type is AM. |
+        +----------------------------------------------+--------------+--------------------------------------------------+
+        | :py:data:`~nirfsg.AnalogModulationType.FM`   | 2000 (0x7d0) | Specifies that the analog modulation type is FM. |
+        +----------------------------------------------+--------------+--------------------------------------------------+
+        | :py:data:`~nirfsg.AnalogModulationType.NONE` | 0 (0x0)      | Disables analog modulation.                      |
+        +----------------------------------------------+--------------+--------------------------------------------------+
+        | :py:data:`~nirfsg.AnalogModulationType.PM`   | 2001 (0x7d1) | Specifies that the analog modulation type is PM. |
+        +----------------------------------------------+--------------+--------------------------------------------------+
 
         .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+-------------------+
-            | Characteristic        | Value             |
-            +=======================+===================+
-            | Datatype              | enums.AnlgModType |
-            +-----------------------+-------------------+
-            | Permissions           | read-write        |
-            +-----------------------+-------------------+
-            | Repeated Capabilities | None              |
-            +-----------------------+-------------------+
+            +-----------------------+----------------------------+
+            | Characteristic        | Value                      |
+            +=======================+============================+
+            | Datatype              | enums.AnalogModulationType |
+            +-----------------------+----------------------------+
+            | Permissions           | read-write                 |
+            +-----------------------+----------------------------+
+            | Repeated Capabilities | None                       |
+            +-----------------------+----------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -4085,7 +3855,7 @@ analog_modulation_waveform_type
 
         Specifies the type of waveform to use as the message signal for analog modulation.
 
-        **Default Value:** :py:data:`~nirfsg.AnlgModWfmType.SINE`
+        **Default Value:** :py:data:`~nirfsg.AnalogModulationWaveformType.SINE`
 
         **Supported Devices:** PXI/PXIe-5650/5651/5652
 
@@ -4095,27 +3865,27 @@ analog_modulation_waveform_type
 
         **Defined Values**:
 
-        +--------------------------------------------+--------------+-----------------------------------------------------------------+
-        | Name                                       | Value        | Description                                                     |
-        +============================================+==============+=================================================================+
-        | :py:data:`~nirfsg.AnlgModWfmType.SINE`     | 3000 (0xbb8) | Specifies that the analog modulation waveform type is sine.     |
-        +--------------------------------------------+--------------+-----------------------------------------------------------------+
-        | :py:data:`~nirfsg.AnlgModWfmType.SQUARE`   | 3001 (0xbb9) | Specifies that the analog modulation waveform type is square.   |
-        +--------------------------------------------+--------------+-----------------------------------------------------------------+
-        | :py:data:`~nirfsg.AnlgModWfmType.TRIANGLE` | 3002 (0xbba) | Specifies that the analog modulation waveform type is triangle. |
-        +--------------------------------------------+--------------+-----------------------------------------------------------------+
+        +----------------------------------------------------------+--------------+-----------------------------------------------------------------+
+        | Name                                                     | Value        | Description                                                     |
+        +==========================================================+==============+=================================================================+
+        | :py:data:`~nirfsg.AnalogModulationWaveformType.SINE`     | 3000 (0xbb8) | Specifies that the analog modulation waveform type is sine.     |
+        +----------------------------------------------------------+--------------+-----------------------------------------------------------------+
+        | :py:data:`~nirfsg.AnalogModulationWaveformType.SQUARE`   | 3001 (0xbb9) | Specifies that the analog modulation waveform type is square.   |
+        +----------------------------------------------------------+--------------+-----------------------------------------------------------------+
+        | :py:data:`~nirfsg.AnalogModulationWaveformType.TRIANGLE` | 3002 (0xbba) | Specifies that the analog modulation waveform type is triangle. |
+        +----------------------------------------------------------+--------------+-----------------------------------------------------------------+
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+----------------------+
-            | Characteristic        | Value                |
-            +=======================+======================+
-            | Datatype              | enums.AnlgModWfmType |
-            +-----------------------+----------------------+
-            | Permissions           | read-write           |
-            +-----------------------+----------------------+
-            | Repeated Capabilities | None                 |
-            +-----------------------+----------------------+
+            +-----------------------+------------------------------------+
+            | Characteristic        | Value                              |
+            +=======================+====================================+
+            | Datatype              | enums.AnalogModulationWaveformType |
+            +-----------------------+------------------------------------+
+            | Permissions           | read-write                         |
+            +-----------------------+------------------------------------+
+            | Repeated Capabilities | None                               |
+            +-----------------------+------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -5421,26 +5191,26 @@ deembedding_compensation_gain
 
 
 
-        .. tip:: This property can be set/get on specific deembedding_port within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container deembedding_port to specify a subset.
+        .. tip:: This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container port to specify a subset.
 
-            Example: :py:attr:`my_session.deembedding_port[ ... ].deembedding_compensation_gain`
+            Example: :py:attr:`my_session.port[ ... ].deembedding_compensation_gain`
 
-            To set/get on all deembedding_port, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.deembedding_compensation_gain`
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+------------------+
-            | Characteristic        | Value            |
-            +=======================+==================+
-            | Datatype              | float            |
-            +-----------------------+------------------+
-            | Permissions           | read only        |
-            +-----------------------+------------------+
-            | Repeated Capabilities | deembedding_port |
-            +-----------------------+------------------+
+            +-----------------------+-----------+
+            | Characteristic        | Value     |
+            +=======================+===========+
+            | Datatype              | float     |
+            +-----------------------+-----------+
+            | Permissions           | read only |
+            +-----------------------+-----------+
+            | Repeated Capabilities | port      |
+            +-----------------------+-----------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -5466,26 +5236,26 @@ deembedding_selected_table
 
 
 
-        .. tip:: This property can be set/get on specific deembedding_port within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container deembedding_port to specify a subset.
+        .. tip:: This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container port to specify a subset.
 
-            Example: :py:attr:`my_session.deembedding_port[ ... ].deembedding_selected_table`
+            Example: :py:attr:`my_session.port[ ... ].deembedding_selected_table`
 
-            To set/get on all deembedding_port, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.deembedding_selected_table`
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+------------------+
-            | Characteristic        | Value            |
-            +=======================+==================+
-            | Datatype              | str              |
-            +-----------------------+------------------+
-            | Permissions           | read-write       |
-            +-----------------------+------------------+
-            | Repeated Capabilities | deembedding_port |
-            +-----------------------+------------------+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | str        |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | port       |
+            +-----------------------+------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -5525,12 +5295,12 @@ deembedding_type
         +---------------------------------------------------+----------------+------------------------------------------------------------------------+
 
 
-        .. tip:: This property can be set/get on specific deembedding_port within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container deembedding_port to specify a subset.
+        .. tip:: This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container port to specify a subset.
 
-            Example: :py:attr:`my_session.deembedding_port[ ... ].deembedding_type`
+            Example: :py:attr:`my_session.port[ ... ].deembedding_type`
 
-            To set/get on all deembedding_port, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.deembedding_type`
 
@@ -5543,7 +5313,7 @@ deembedding_type
             +-----------------------+-------------------------------+
             | Permissions           | read-write                    |
             +-----------------------+-------------------------------+
-            | Repeated Capabilities | deembedding_port              |
+            | Repeated Capabilities | port                          |
             +-----------------------+-------------------------------+
 
         .. tip::
@@ -5636,6 +5406,16 @@ device_temperature
         | Second connected mmRH-5582 | SWITCHED TRX PORTS [0-7] | rf1switch1              |
         +----------------------------+--------------------------+-------------------------+
 
+
+        .. tip:: This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container port to specify a subset.
+
+            Example: :py:attr:`my_session.port[ ... ].device_temperature`
+
+            To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+            Example: :py:attr:`my_session.device_temperature`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+-----------+
@@ -5645,7 +5425,7 @@ device_temperature
             +-----------------------+-----------+
             | Permissions           | read only |
             +-----------------------+-----------+
-            | Repeated Capabilities | None      |
+            | Repeated Capabilities | port      |
             +-----------------------+-----------+
 
         .. tip::
@@ -5661,7 +5441,7 @@ digital_edge_script_trigger_edge
 
         Specifies the active edge for the Script Trigger. This property is used when the :py:attr:`nirfsg.Session.script_trigger_type` property is set to digital edge. To set the :py:attr:`nirfsg.Session.digital_edge_script_trigger_edge` property, the NI-RFSG device must be in the Configuration state.
 
-        **Default Value:** :py:data:`~nirfsg.ScriptTrigDigEdgeEdge.RISING`
+        **Default Value:** :py:data:`~nirfsg.ScriptTriggerDigitalEdgeEdge.RISING`
 
         **Supported Devices:** PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 
@@ -5677,13 +5457,13 @@ digital_edge_script_trigger_edge
 
         **Defined Values**:
 
-        +--------------------------------------------------+---------+-------------------------------------------------------------------------------+
-        | Name                                             | Value   | Description                                                                   |
-        +==================================================+=========+===============================================================================+
-        | :py:data:`~nirfsg.ScriptTrigDigEdgeEdge.FALLING` | 1 (0x1) | Asserts the trigger when the signal transitions from high level to low level. |
-        +--------------------------------------------------+---------+-------------------------------------------------------------------------------+
-        | :py:data:`~nirfsg.ScriptTrigDigEdgeEdge.RISING`  | 0 (0x0) | Asserts the trigger when the signal transitions from low level to high level. |
-        +--------------------------------------------------+---------+-------------------------------------------------------------------------------+
+        +---------------------------------------------------------+---------+-------------------------------------------------------------------------------+
+        | Name                                                    | Value   | Description                                                                   |
+        +=========================================================+=========+===============================================================================+
+        | :py:data:`~nirfsg.ScriptTriggerDigitalEdgeEdge.FALLING` | 1 (0x1) | Asserts the trigger when the signal transitions from high level to low level. |
+        +---------------------------------------------------------+---------+-------------------------------------------------------------------------------+
+        | :py:data:`~nirfsg.ScriptTriggerDigitalEdgeEdge.RISING`  | 0 (0x0) | Asserts the trigger when the signal transitions from low level to high level. |
+        +---------------------------------------------------------+---------+-------------------------------------------------------------------------------+
 
         .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
@@ -5699,15 +5479,15 @@ digital_edge_script_trigger_edge
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+-----------------------------+
-            | Characteristic        | Value                       |
-            +=======================+=============================+
-            | Datatype              | enums.ScriptTrigDigEdgeEdge |
-            +-----------------------+-----------------------------+
-            | Permissions           | read-write                  |
-            +-----------------------+-----------------------------+
-            | Repeated Capabilities | script_triggers             |
-            +-----------------------+-----------------------------+
+            +-----------------------+------------------------------------+
+            | Characteristic        | Value                              |
+            +=======================+====================================+
+            | Datatype              | enums.ScriptTriggerDigitalEdgeEdge |
+            +-----------------------+------------------------------------+
+            | Permissions           | read-write                         |
+            +-----------------------+------------------------------------+
+            | Repeated Capabilities | script_triggers                    |
+            +-----------------------+------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -5827,7 +5607,7 @@ digital_edge_start_trigger_edge
 
         PXIe-5654/5654 with PXIe-5696: The Start Trigger is valid only with a timer-based list when RF list mode is enabled.
 
-        **Default Value:** :py:data:`~nirfsg.StartTrigDigEdgeEdge.RISING`
+        **Default Value:** :py:data:`~nirfsg.StartTriggerDigitalEdgeEdge.RISING`
 
         **Supported Devices:** PXIe-5644/5645/5646, PXIe-5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 
@@ -5843,27 +5623,27 @@ digital_edge_start_trigger_edge
 
         **Defined Values**:
 
-        +-------------------------------------------------+---------+------------------------------------------------------------------+
-        | Name                                            | Value   | Description                                                      |
-        +=================================================+=========+==================================================================+
-        | :py:data:`~nirfsg.StartTrigDigEdgeEdge.FALLING` | 1 (0x1) | Occurs when the signal transitions from high level to low level. |
-        +-------------------------------------------------+---------+------------------------------------------------------------------+
-        | :py:data:`~nirfsg.StartTrigDigEdgeEdge.RISING`  | 0 (0x0) | Occurs when the signal transitions from low level to high level. |
-        +-------------------------------------------------+---------+------------------------------------------------------------------+
+        +--------------------------------------------------------+---------+------------------------------------------------------------------+
+        | Name                                                   | Value   | Description                                                      |
+        +========================================================+=========+==================================================================+
+        | :py:data:`~nirfsg.StartTriggerDigitalEdgeEdge.FALLING` | 1 (0x1) | Occurs when the signal transitions from high level to low level. |
+        +--------------------------------------------------------+---------+------------------------------------------------------------------+
+        | :py:data:`~nirfsg.StartTriggerDigitalEdgeEdge.RISING`  | 0 (0x0) | Occurs when the signal transitions from low level to high level. |
+        +--------------------------------------------------------+---------+------------------------------------------------------------------+
 
         .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+----------------------------+
-            | Characteristic        | Value                      |
-            +=======================+============================+
-            | Datatype              | enums.StartTrigDigEdgeEdge |
-            +-----------------------+----------------------------+
-            | Permissions           | read-write                 |
-            +-----------------------+----------------------------+
-            | Repeated Capabilities | None                       |
-            +-----------------------+----------------------------+
+            +-----------------------+-----------------------------------+
+            | Characteristic        | Value                             |
+            +=======================+===================================+
+            | Datatype              | enums.StartTriggerDigitalEdgeEdge |
+            +-----------------------+-----------------------------------+
+            | Permissions           | read-write                        |
+            +-----------------------+-----------------------------------+
+            | Repeated Capabilities | None                              |
+            +-----------------------+-----------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -6028,9 +5808,9 @@ digital_level_script_trigger_active_level
 
     .. py:attribute:: digital_level_script_trigger_active_level
 
-        Specifies the active level for the Script Trigger. This property is used when the :py:attr:`nirfsg.Session.script_trigger_type` property is set to :py:data:`~nirfsg.ScriptTrigType.DIGITAL_LEVEL`.
+        Specifies the active level for the Script Trigger. This property is used when the :py:attr:`nirfsg.Session.script_trigger_type` property is set to :py:data:`~nirfsg.ScriptTriggerType.DIGITAL_LEVEL`.
 
-        **Default Value:** :py:data:`~nirfsg.ScriptTrigDigLevelActiveLevel.HIGH`
+        **Default Value:** :py:data:`~nirfsg.ScriptTriggerDigitalLevelActiveLevel.HIGH`
 
         **Supported Devices:** PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 
@@ -6042,13 +5822,13 @@ digital_level_script_trigger_active_level
 
         **Defined Values**:
 
-        +-------------------------------------------------------+---------------+--------------------------------------------------+
-        | Name                                                  | Value         | Description                                      |
-        +=======================================================+===============+==================================================+
-        | :py:data:`~nirfsg.ScriptTrigDigLevelActiveLevel.HIGH` | 9000 (0x2328) | Trigger when the digital trigger signal is high. |
-        +-------------------------------------------------------+---------------+--------------------------------------------------+
-        | :py:data:`~nirfsg.ScriptTrigDigLevelActiveLevel.LOW`  | 9001 (0x2329) | Trigger when the digital trigger signal is low.  |
-        +-------------------------------------------------------+---------------+--------------------------------------------------+
+        +--------------------------------------------------------------+---------------+--------------------------------------------------+
+        | Name                                                         | Value         | Description                                      |
+        +==============================================================+===============+==================================================+
+        | :py:data:`~nirfsg.ScriptTriggerDigitalLevelActiveLevel.HIGH` | 9000 (0x2328) | Trigger when the digital trigger signal is high. |
+        +--------------------------------------------------------------+---------------+--------------------------------------------------+
+        | :py:data:`~nirfsg.ScriptTriggerDigitalLevelActiveLevel.LOW`  | 9001 (0x2329) | Trigger when the digital trigger signal is low.  |
+        +--------------------------------------------------------------+---------------+--------------------------------------------------+
 
 
         .. tip:: This property can be set/get on specific script_triggers within your :py:class:`nirfsg.Session` instance.
@@ -6062,15 +5842,15 @@ digital_level_script_trigger_active_level
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+-------------------------------------+
-            | Characteristic        | Value                               |
-            +=======================+=====================================+
-            | Datatype              | enums.ScriptTrigDigLevelActiveLevel |
-            +-----------------------+-------------------------------------+
-            | Permissions           | read-write                          |
-            +-----------------------+-------------------------------------+
-            | Repeated Capabilities | script_triggers                     |
-            +-----------------------+-------------------------------------+
+            +-----------------------+--------------------------------------------+
+            | Characteristic        | Value                                      |
+            +=======================+============================================+
+            | Datatype              | enums.ScriptTriggerDigitalLevelActiveLevel |
+            +-----------------------+--------------------------------------------+
+            | Permissions           | read-write                                 |
+            +-----------------------+--------------------------------------------+
+            | Repeated Capabilities | script_triggers                            |
+            +-----------------------+--------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -6083,7 +5863,7 @@ digital_level_script_trigger_source
 
     .. py:attribute:: digital_level_script_trigger_source
 
-        Specifies the source terminal for the Script Trigger. This property is used when the :py:attr:`nirfsg.Session.script_trigger_type` property is set to :py:data:`~nirfsg.ScriptTrigType.DIGITAL_LEVEL`. The :py:attr:`nirfsg.Session.digital_level_script_trigger_source` property is not case-sensitive.
+        Specifies the source terminal for the Script Trigger. This property is used when the :py:attr:`nirfsg.Session.script_trigger_type` property is set to :py:data:`~nirfsg.ScriptTriggerType.DIGITAL_LEVEL`. The :py:attr:`nirfsg.Session.digital_level_script_trigger_source` property is not case-sensitive.
 
         To set the :py:attr:`nirfsg.Session.digital_level_script_trigger_source` property, the NI-RFSG device must be in the Configuration state.
 
@@ -6320,7 +6100,7 @@ digital_modulation_type
 
         Specifies the digital modulation format to use.
 
-        **Default Value:** :py:data:`~nirfsg.DigModType.NONE`
+        **Default Value:** :py:data:`~nirfsg.DigitalModulationType.NONE`
 
         **Supported Devices:** PXI/PXIe-5650/5651/5652
 
@@ -6330,31 +6110,31 @@ digital_modulation_type
 
         **Defined Values**:
 
-        +------------------------------------+--------------+-----------------------------------------------------------------------------+
-        | Name                               | Value        | Description                                                                 |
-        +====================================+==============+=============================================================================+
-        | :py:data:`~nirfsg.DigModType.FSK`  | 4000 (0xfa0) | Specifies that the digital modulation type is frequency-shift keying (FSK). |
-        +------------------------------------+--------------+-----------------------------------------------------------------------------+
-        | :py:data:`~nirfsg.DigModType.NONE` | 0 (0x0)      | Disables digital modulation.                                                |
-        +------------------------------------+--------------+-----------------------------------------------------------------------------+
-        | :py:data:`~nirfsg.DigModType.OOK`  | 4001 (0xfa1) | Specifies that the digital modulation type is on-off keying (OOK).          |
-        +------------------------------------+--------------+-----------------------------------------------------------------------------+
-        | :py:data:`~nirfsg.DigModType.PSK`  | 4002 (0xfa2) | Specifies that the digital modulation type is phase-shift keying (PSK).     |
-        +------------------------------------+--------------+-----------------------------------------------------------------------------+
+        +-----------------------------------------------+--------------+-----------------------------------------------------------------------------+
+        | Name                                          | Value        | Description                                                                 |
+        +===============================================+==============+=============================================================================+
+        | :py:data:`~nirfsg.DigitalModulationType.FSK`  | 4000 (0xfa0) | Specifies that the digital modulation type is frequency-shift keying (FSK). |
+        +-----------------------------------------------+--------------+-----------------------------------------------------------------------------+
+        | :py:data:`~nirfsg.DigitalModulationType.NONE` | 0 (0x0)      | Disables digital modulation.                                                |
+        +-----------------------------------------------+--------------+-----------------------------------------------------------------------------+
+        | :py:data:`~nirfsg.DigitalModulationType.OOK`  | 4001 (0xfa1) | Specifies that the digital modulation type is on-off keying (OOK).          |
+        +-----------------------------------------------+--------------+-----------------------------------------------------------------------------+
+        | :py:data:`~nirfsg.DigitalModulationType.PSK`  | 4002 (0xfa2) | Specifies that the digital modulation type is phase-shift keying (PSK).     |
+        +-----------------------------------------------+--------------+-----------------------------------------------------------------------------+
 
         .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+------------------+
-            | Characteristic        | Value            |
-            +=======================+==================+
-            | Datatype              | enums.DigModType |
-            +-----------------------+------------------+
-            | Permissions           | read-write       |
-            +-----------------------+------------------+
-            | Repeated Capabilities | None             |
-            +-----------------------+------------------+
+            +-----------------------+-----------------------------+
+            | Characteristic        | Value                       |
+            +=======================+=============================+
+            | Datatype              | enums.DigitalModulationType |
+            +-----------------------+-----------------------------+
+            | Permissions           | read-write                  |
+            +-----------------------+-----------------------------+
+            | Repeated Capabilities | None                        |
+            +-----------------------+-----------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -6369,7 +6149,7 @@ digital_modulation_waveform_type
 
         Specifies the type of waveform to use as the message signal in digital modulation.
 
-        **Default Value:** :py:data:`~nirfsg.DigModWfmType.PRBS`
+        **Default Value:** :py:data:`~nirfsg.DigitalModulationWaveformType.PRBS`
 
         **Supported Devices:** PXI/PXIe-5650/5651/5652
 
@@ -6379,27 +6159,27 @@ digital_modulation_waveform_type
 
         **Defined Values**:
 
-        +-----------------------------------------------+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-        | Name                                          | Value         | Description                                                                                                                                                                                              |
-        +===============================================+===============+==========================================================================================================================================================================================================+
-        | :py:data:`~nirfsg.DigModWfmType.PRBS`         | 5000 (0x1388) | Specifies that the digital modulation waveform type is pseudorandom bit sequence (PRBS).                                                                                                                 |
-        +-----------------------------------------------+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-        | :py:data:`~nirfsg.DigModWfmType.USER_DEFINED` | 5001 (0x1389) | Specifies that the digital modulation waveform type is user defined. To specify the user-defined waveform, call the :py:meth:`nirfsg.Session.configure_digital_modulation_user_defined_waveform` method. |
-        +-----------------------------------------------+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+        +---------------------------------------------------------------+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+        | Name                                                          | Value         | Description                                                                                                                                                                                              |
+        +===============================================================+===============+==========================================================================================================================================================================================================+
+        | :py:data:`~nirfsg.DigitalModulationWaveformType.PRBS`         | 5000 (0x1388) | Specifies that the digital modulation waveform type is pseudorandom bit sequence (PRBS).                                                                                                                 |
+        +---------------------------------------------------------------+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+        | :py:data:`~nirfsg.DigitalModulationWaveformType.USER_DEFINED` | 5001 (0x1389) | Specifies that the digital modulation waveform type is user defined. To specify the user-defined waveform, call the :py:meth:`nirfsg.Session.configure_digital_modulation_user_defined_waveform` method. |
+        +---------------------------------------------------------------+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
         .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+---------------------+
-            | Characteristic        | Value               |
-            +=======================+=====================+
-            | Datatype              | enums.DigModWfmType |
-            +-----------------------+---------------------+
-            | Permissions           | read-write          |
-            +-----------------------+---------------------+
-            | Repeated Capabilities | None                |
-            +-----------------------+---------------------+
+            +-----------------------+-------------------------------------+
+            | Characteristic        | Value                               |
+            +=======================+=====================================+
+            | Datatype              | enums.DigitalModulationWaveformType |
+            +-----------------------+-------------------------------------+
+            | Permissions           | read-write                          |
+            +-----------------------+-------------------------------------+
+            | Repeated Capabilities | None                                |
+            +-----------------------+-------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -6853,31 +6633,31 @@ exported_pulse_modulation_event_active_level
 
         Specifies the active level of the exported Pulse Modulation Event. When `property pulse modulation enabled` is Enabled, `pulse modulation active level` is `active high`, `exported pulse modulation event output terminal` is `PulseOut`, and this property is `active high`, then the Pulse Modulation Event will transition from Low to High after the the Pulse In signal is set to logic high, and the RF Output has settled. To set this property, the NI-RFSG device must be in the Configuration state.
 
-        **Default Value:** :py:data:`~nirfsg.ScriptTrigDigLevelActiveLevel.HIGH`
+        **Default Value:** :py:data:`~nirfsg.ScriptTriggerDigitalLevelActiveLevel.HIGH`
 
         **Supported Devices:**  PXIe-5842
 
         **Defined Values**:
 
-        +-------------------------------------------------------+---------------+--------------------------------------------------+
-        | Name                                                  | Value         | Description                                      |
-        +=======================================================+===============+==================================================+
-        | :py:data:`~nirfsg.ScriptTrigDigLevelActiveLevel.HIGH` | 9000 (0x2328) | Trigger when the digital trigger signal is high. |
-        +-------------------------------------------------------+---------------+--------------------------------------------------+
-        | :py:data:`~nirfsg.ScriptTrigDigLevelActiveLevel.LOW`  | 9001 (0x2329) | Trigger when the digital trigger signal is low.  |
-        +-------------------------------------------------------+---------------+--------------------------------------------------+
+        +--------------------------------------------------------------+---------------+--------------------------------------------------+
+        | Name                                                         | Value         | Description                                      |
+        +==============================================================+===============+==================================================+
+        | :py:data:`~nirfsg.ScriptTriggerDigitalLevelActiveLevel.HIGH` | 9000 (0x2328) | Trigger when the digital trigger signal is high. |
+        +--------------------------------------------------------------+---------------+--------------------------------------------------+
+        | :py:data:`~nirfsg.ScriptTriggerDigitalLevelActiveLevel.LOW`  | 9001 (0x2329) | Trigger when the digital trigger signal is low.  |
+        +--------------------------------------------------------------+---------------+--------------------------------------------------+
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+-------------------------------------+
-            | Characteristic        | Value                               |
-            +=======================+=====================================+
-            | Datatype              | enums.ScriptTrigDigLevelActiveLevel |
-            +-----------------------+-------------------------------------+
-            | Permissions           | read-write                          |
-            +-----------------------+-------------------------------------+
-            | Repeated Capabilities | None                                |
-            +-----------------------+-------------------------------------+
+            +-----------------------+--------------------------------------------+
+            | Characteristic        | Value                                      |
+            +=======================+============================================+
+            | Datatype              | enums.ScriptTriggerDigitalLevelActiveLevel |
+            +-----------------------+--------------------------------------------+
+            | Permissions           | read-write                                 |
+            +-----------------------+--------------------------------------------+
+            | Repeated Capabilities | None                                       |
+            +-----------------------+--------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -7776,10 +7556,6 @@ generation_mode
 
         `Scripting Instructions <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/scripting_instructions.html>`_—Refer to this topic for more information about scripting.
 
-        **High-Level Methods**:
-
-        - :py:meth:`nirfsg.Session.configure_generation_mode`
-
         **Defined Values**:
 
         +------------------------------------------------+--------------+--------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -8289,6 +8065,16 @@ iq_out_port_common_mode_offset
 
              - The valid range is dependent on the load impedance.
 
+
+        .. tip:: This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container port to specify a subset.
+
+            Example: :py:attr:`my_session.port[ ... ].iq_out_port_common_mode_offset`
+
+            To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+            Example: :py:attr:`my_session.iq_out_port_common_mode_offset`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------+
@@ -8298,7 +8084,7 @@ iq_out_port_common_mode_offset
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | None       |
+            | Repeated Capabilities | port       |
             +-----------------------+------------+
 
         .. tip::
@@ -8342,6 +8128,16 @@ iq_out_port_level
 
              - The valid values are only applicable when you set the :py:attr:`nirfsg.Session.iq_out_port_load_impedance` property to 50 Ω and when you set the :py:attr:`nirfsg.Session.iq_out_port_offset` property to 0.
 
+
+        .. tip:: This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container port to specify a subset.
+
+            Example: :py:attr:`my_session.port[ ... ].iq_out_port_level`
+
+            To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+            Example: :py:attr:`my_session.iq_out_port_level`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------+
@@ -8351,7 +8147,7 @@ iq_out_port_level
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | None       |
+            | Repeated Capabilities | port       |
             +-----------------------+------------+
 
         .. tip::
@@ -8381,6 +8177,16 @@ iq_out_port_load_impedance
 
         .. note:: For the PXIe-5645, this property is ignored if you are using the RF ports.
 
+
+        .. tip:: This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container port to specify a subset.
+
+            Example: :py:attr:`my_session.port[ ... ].iq_out_port_load_impedance`
+
+            To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+            Example: :py:attr:`my_session.iq_out_port_load_impedance`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------+
@@ -8390,7 +8196,7 @@ iq_out_port_load_impedance
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | None       |
+            | Repeated Capabilities | port       |
             +-----------------------+------------+
 
         .. tip::
@@ -8420,6 +8226,16 @@ iq_out_port_offset
 
         .. note:: For the PXIe-5645, this property is ignored if you are using the RF ports.
 
+
+        .. tip:: This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container port to specify a subset.
+
+            Example: :py:attr:`my_session.port[ ... ].iq_out_port_offset`
+
+            To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+            Example: :py:attr:`my_session.iq_out_port_offset`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------+
@@ -8429,7 +8245,7 @@ iq_out_port_offset
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | None       |
+            | Repeated Capabilities | port       |
             +-----------------------+------------+
 
         .. tip::
@@ -8506,6 +8322,16 @@ iq_out_port_terminal_configuration
 
         .. note:: For the PXIe-5645, this property is ignored if you are using the RF ports.
 
+
+        .. tip:: This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container port to specify a subset.
+
+            Example: :py:attr:`my_session.port[ ... ].iq_out_port_terminal_configuration`
+
+            To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+            Example: :py:attr:`my_session.iq_out_port_terminal_configuration`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------------------+
@@ -8515,7 +8341,7 @@ iq_out_port_terminal_configuration
             +-----------------------+------------------------+
             | Permissions           | read-write             |
             +-----------------------+------------------------+
-            | Repeated Capabilities | None                   |
+            | Repeated Capabilities | port                   |
             +-----------------------+------------------------+
 
         .. tip::
@@ -8860,6 +8686,16 @@ loop_bandwidth
 
         .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
+
+        .. tip:: This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container lo to specify a subset.
+
+            Example: :py:attr:`my_session.lo[ ... ].loop_bandwidth`
+
+            To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+            Example: :py:attr:`my_session.loop_bandwidth`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+---------------------+
@@ -8869,7 +8705,7 @@ loop_bandwidth
             +-----------------------+---------------------+
             | Permissions           | read-write          |
             +-----------------------+---------------------+
-            | Repeated Capabilities | None                |
+            | Repeated Capabilities | lo                  |
             +-----------------------+---------------------+
 
         .. tip::
@@ -8899,6 +8735,16 @@ lo_frequency
 
         .. note:: This property is read/write if you are using an external LO. Otherwise, this property is read-only.
 
+
+        .. tip:: This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container lo to specify a subset.
+
+            Example: :py:attr:`my_session.lo[ ... ].lo_frequency`
+
+            To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+            Example: :py:attr:`my_session.lo_frequency`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------+
@@ -8908,7 +8754,7 @@ lo_frequency
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | None       |
+            | Repeated Capabilities | lo         |
             +-----------------------+------------+
 
         .. tip::
@@ -9014,6 +8860,16 @@ lo_in_power
 
              - For the PXIe-5644/5645/5646, this property is always read-only.
 
+
+        .. tip:: This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container lo to specify a subset.
+
+            Example: :py:attr:`my_session.lo[ ... ].lo_in_power`
+
+            To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+            Example: :py:attr:`my_session.lo_in_power`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------+
@@ -9023,7 +8879,7 @@ lo_in_power
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | None       |
+            | Repeated Capabilities | lo         |
             +-----------------------+------------+
 
         .. tip::
@@ -9061,6 +8917,16 @@ lo_out_enabled
 
         .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
+
+        .. tip:: This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container lo to specify a subset.
+
+            Example: :py:attr:`my_session.lo[ ... ].lo_out_enabled`
+
+            To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+            Example: :py:attr:`my_session.lo_out_enabled`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------+
@@ -9070,7 +8936,7 @@ lo_out_enabled
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | None       |
+            | Repeated Capabilities | lo         |
             +-----------------------+------------+
 
         .. tip::
@@ -9143,6 +9009,16 @@ lo_out_power
 
         .. note:: For the PXIe-5644/5645/5646 and PXIe-5673/5673E, this property is always read-only.
 
+
+        .. tip:: This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container lo to specify a subset.
+
+            Example: :py:attr:`my_session.lo[ ... ].lo_out_power`
+
+            To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+            Example: :py:attr:`my_session.lo_out_power`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------+
@@ -9152,7 +9028,7 @@ lo_out_power
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | None       |
+            | Repeated Capabilities | lo         |
             +-----------------------+------------+
 
         .. tip::
@@ -9194,6 +9070,16 @@ lo_pll_fractional_mode_enabled
 
         .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
+
+        .. tip:: This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container lo to specify a subset.
+
+            Example: :py:attr:`my_session.lo[ ... ].lo_pll_fractional_mode_enabled`
+
+            To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+            Example: :py:attr:`my_session.lo_pll_fractional_mode_enabled`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+----------------------------------+
@@ -9203,7 +9089,7 @@ lo_pll_fractional_mode_enabled
             +-----------------------+----------------------------------+
             | Permissions           | read-write                       |
             +-----------------------+----------------------------------+
-            | Repeated Capabilities | None                             |
+            | Repeated Capabilities | lo                               |
             +-----------------------+----------------------------------+
 
         .. tip::
@@ -9249,6 +9135,16 @@ lo_source
 
         .. note:: For the PXIe-5841 with PXIe-5655, RF list mode is not supported when this property is set to SG_SA_Shared.
 
+
+        .. tip:: This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container lo to specify a subset.
+
+            Example: :py:attr:`my_session.lo[ ... ].lo_source`
+
+            To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+            Example: :py:attr:`my_session.lo_source`
+
         The following table lists the characteristics of this property.
 
             +-----------------------+------------+
@@ -9258,7 +9154,7 @@ lo_source
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | None       |
+            | Repeated Capabilities | lo         |
             +-----------------------+------------+
 
         .. tip::
@@ -9720,10 +9616,6 @@ output_enabled
 
         `NI-RFSG Instrument Driver Programming Flow <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/progflow.html>`_
 
-        **High-Level Methods**:
-
-        - :py:meth:`nirfsg.Session.configure_output_enabled`
-
         **Defined Values**:
 
         +-------+-------------------------+
@@ -9849,389 +9741,6 @@ overflow_error_reporting
 
                 - LabVIEW Property: **Arb:Advanced:Overflow Error Reporting**
                 - C Attribute: **NIRFSG_ATTR_OVERFLOW_ERROR_REPORTING**
-
-p2p_data_transfer_permission_initial_credits
---------------------------------------------
-
-    .. py:attribute:: p2p_data_transfer_permission_initial_credits
-
-        Specifies the initial amount of data that the writer peer can transfer over the bus into the configured endpoint when the peer-to-peer data stream is enabled. If this property is not set and the endpoint is empty, credits equal to the full endpoint size are issued to the writer peer. If data is written to the endpoint using the :py:meth:`nirfsg.Session.WriteP2pEndpointI16` method prior to enabling the stream, credits equal to the remaining space available in the endpoint are issued to the writer peer. This property is coerced up by NI-RFSG to 8-byte boundaries. This property is endpoint-based.
-
-        **Units**: samples per channel
-
-        **Default Value:** 1,024
-
-        **Supported Devices:** PXIe-5673E
-
-        **Related Topics**
-
-        `Configuring a Peer-to-Peer Endpoint <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_configuring_an_endpoint.html>`_
-
-        `Configuring Flow Control <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_flow_control.html>`_
-
-        The following table lists the characteristics of this property.
-
-            +-----------------------+------------+
-            | Characteristic        | Value      |
-            +=======================+============+
-            | Datatype              | int        |
-            +-----------------------+------------+
-            | Permissions           | read-write |
-            +-----------------------+------------+
-            | Repeated Capabilities | None       |
-            +-----------------------+------------+
-
-        .. tip::
-            This property corresponds to the following LabVIEW Property or C Attribute:
-
-                - LabVIEW Property: **Peer-to-Peer:Data Transfer Permission Initial Credits**
-                - C Attribute: **NIRFSG_ATTR_P2P_DATA_TRANSFER_PERMISSION_INITIAL_CREDITS**
-
-p2p_data_transfer_permission_interval
--------------------------------------
-
-    .. py:attribute:: p2p_data_transfer_permission_interval
-
-        Specifies the interval at which the RF signal generator issues credits to allow the writer peer to transfer data over the bus into the configured endpoint. This property is coerced up by NI-RFSG to the nearest 128-byte boundary. This property is endpoint-based.
-
-        **Units**: samples per channel
-
-        **Supported Devices:** PXIe-5673E
-
-        **Related Topics**
-
-        `Configuring a Peer-to-Peer Endpoint <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_configuring_an_endpoint.html>`_
-
-        `Configuring Flow Control <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_flow_control.html>`_
-
-        The following table lists the characteristics of this property.
-
-            +-----------------------+------------+
-            | Characteristic        | Value      |
-            +=======================+============+
-            | Datatype              | int        |
-            +-----------------------+------------+
-            | Permissions           | read-write |
-            +-----------------------+------------+
-            | Repeated Capabilities | None       |
-            +-----------------------+------------+
-
-        .. tip::
-            This property corresponds to the following LabVIEW Property or C Attribute:
-
-                - LabVIEW Property: **Peer-to-Peer:Data Transfer Permission Interval**
-                - C Attribute: **NIRFSG_ATTR_P2P_DATA_TRANSFER_PERMISSION_INTERVAL**
-
-p2p_enabled
------------
-
-    .. py:attribute:: p2p_enabled
-
-        Specifies whether the RF signal generator reads data from the peer-to-peer endpoint. This property is endpoint-based.
-
-        **Default Value**: False
-
-        **Supported Devices:** PXIe-5673E, PXIe-5820/5830/5831/5832/5840/5841/5842
-
-        **Related Topics**
-
-        `Configuring a Peer-to-Peer Endpoint <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_configuring_an_endpoint.html>`_
-
-        **Defined Values**:
-
-        +-------+------------------------------------------+
-        | Value | Description                              |
-        +=======+==========================================+
-        | True  | Peer-to-peer data streaming is enabled.  |
-        +-------+------------------------------------------+
-        | False | Peer-to-peer data streaming is disabled. |
-        +-------+------------------------------------------+
-
-        The following table lists the characteristics of this property.
-
-            +-----------------------+------------+
-            | Characteristic        | Value      |
-            +=======================+============+
-            | Datatype              | bool       |
-            +-----------------------+------------+
-            | Permissions           | read-write |
-            +-----------------------+------------+
-            | Repeated Capabilities | None       |
-            +-----------------------+------------+
-
-        .. tip::
-            This property corresponds to the following LabVIEW Property or C Attribute:
-
-                - LabVIEW Property: **Peer-to-Peer:Enabled**
-                - C Attribute: **NIRFSG_ATTR_P2P_ENABLED**
-
-p2p_endpoint_count
-------------------
-
-    .. py:attribute:: p2p_endpoint_count
-
-        Returns the number of peer-to-peer FIFO endpoints supported by the device.
-
-        **Supported Devices:** PXIe-5673E, PXIe-5820/5830/5831/5832/5840/5841/5842
-
-        **Related Topics**
-
-        `Configuring a Peer-to-Peer Endpoint <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_configuring_an_endpoint.html>`_
-
-        The following table lists the characteristics of this property.
-
-            +-----------------------+-----------+
-            | Characteristic        | Value     |
-            +=======================+===========+
-            | Datatype              | int       |
-            +-----------------------+-----------+
-            | Permissions           | read only |
-            +-----------------------+-----------+
-            | Repeated Capabilities | None      |
-            +-----------------------+-----------+
-
-        .. tip::
-            This property corresponds to the following LabVIEW Property or C Attribute:
-
-                - LabVIEW Property: **Peer-to-Peer:Endpoint Count**
-                - C Attribute: **NIRFSG_ATTR_P2P_ENDPOINT_COUNT**
-
-p2p_endpoint_fullness_start_trigger_level
------------------------------------------
-
-    .. py:attribute:: p2p_endpoint_fullness_start_trigger_level
-
-        Specifies the number of samples the endpoint must receive before the device starts generation. If no level is specified, NI-RFSG automatically sets this value to -1. This property applies only when the :py:attr:`nirfsg.Session.start_trigger_type` property is set to :py:data:`~nirfsg.StartTrigType.P2P_ENDPOINT_FULLNESS`
-
-        **Default Value:** -1, which allows NI-RFSG to select the appropriate fullness value.
-
-        **Supported Devices:** PXIe-5673E, PXIe-5820/5830/5831/5832/5840/5841/5842
-
-        **Related Topics**
-
-        `Start Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/start_triggers.html>`_
-
-
-
-        .. note:: Due to an additional internal FIFO in the RF signal generator, the writer peer actually needs to write 2,304 bytes more than the quantity of data specified by this property to satisfy the trigger level.
-
-        The following table lists the characteristics of this property.
-
-            +-----------------------+------------+
-            | Characteristic        | Value      |
-            +=======================+============+
-            | Datatype              | int        |
-            +-----------------------+------------+
-            | Permissions           | read-write |
-            +-----------------------+------------+
-            | Repeated Capabilities | None       |
-            +-----------------------+------------+
-
-        .. tip::
-            This property corresponds to the following LabVIEW Property or C Attribute:
-
-                - LabVIEW Property: **Triggers:Start:P2P Endpoint Fullness:Level**
-                - C Attribute: **NIRFSG_ATTR_P2P_ENDPOINT_FULLNESS_START_TRIGGER_LEVEL**
-
-p2p_endpoint_size
------------------
-
-    .. py:attribute:: p2p_endpoint_size
-
-        Returns the size, in samples, of the device endpoint. This property is endpoint-based.
-
-        **Units**: samples (s)
-
-        **Supported Devices:** PXIe-5673E, PXIe-5820/5830/5831/5832/5840/5841/5842
-
-        **Related Topics**
-
-        `Configuring a Peer-to-Peer Endpoint <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_configuring_an_endpoint.html>`_
-
-        The following table lists the characteristics of this property.
-
-            +-----------------------+-----------+
-            | Characteristic        | Value     |
-            +=======================+===========+
-            | Datatype              | int       |
-            +-----------------------+-----------+
-            | Permissions           | read only |
-            +-----------------------+-----------+
-            | Repeated Capabilities | None      |
-            +-----------------------+-----------+
-
-        .. tip::
-            This property corresponds to the following LabVIEW Property or C Attribute:
-
-                - LabVIEW Property: **Peer-to-Peer:Endpoint Size**
-                - C Attribute: **NIRFSG_ATTR_P2P_ENDPOINT_SIZE**
-
-p2p_generation_fifo_sample_quantum
-----------------------------------
-
-    .. py:attribute:: p2p_generation_fifo_sample_quantum
-
-        Returns how many samples NI-RFSG pulls from the peer-to-peer FIFO per read. You can use this property to determine how many samples to send across the peer-to-peer bus to ensure that no samples are ignored. If you send a number of samples that is not a multiple of this value, the remaining samples are not read from the FIFO during generation. This property is endpoint-based.
-
-        **Supported Devices:** PXIe-5820/5830/5831/5832/5840/5841/5842
-
-        The following table lists the characteristics of this property.
-
-            +-----------------------+-----------+
-            | Characteristic        | Value     |
-            +=======================+===========+
-            | Datatype              | int       |
-            +-----------------------+-----------+
-            | Permissions           | read only |
-            +-----------------------+-----------+
-            | Repeated Capabilities | None      |
-            +-----------------------+-----------+
-
-        .. tip::
-            This property corresponds to the following LabVIEW Property or C Attribute:
-
-                - LabVIEW Property: **Peer-to-Peer:Generation FIFO Sample Quantum**
-                - C Attribute: **NIRFSG_ATTR_P2P_GENERATION_FIFO_SAMPLE_QUANTUM**
-
-p2p_is_finite_generation
-------------------------
-
-    .. py:attribute:: p2p_is_finite_generation
-
-        Specifies whether peer-to-peer should continuously generate data from the peer-to-peer stream or from only a finite number of samples, according to the :py:attr:`nirfsg.Session.p2p_number_of_samples_to_generate` property. To use this property, peer-to-peer must be enabled. This property is endpoint-based.
-
-        **Default Value**: False
-
-        **Supported Devices:** PXIe-5820/5830/5831/5832/5840/5841/5842
-
-        **Defined Values**:
-
-        +-------+--------------------------------------------------------------+
-        | Value | Description                                                  |
-        +=======+==============================================================+
-        | True  | Data is generated from only a finite number of samples.      |
-        +-------+--------------------------------------------------------------+
-        | False | Data is continuously generated from the peer-to-peer stream. |
-        +-------+--------------------------------------------------------------+
-
-        The following table lists the characteristics of this property.
-
-            +-----------------------+------------+
-            | Characteristic        | Value      |
-            +=======================+============+
-            | Datatype              | bool       |
-            +-----------------------+------------+
-            | Permissions           | read-write |
-            +-----------------------+------------+
-            | Repeated Capabilities | None       |
-            +-----------------------+------------+
-
-        .. tip::
-            This property corresponds to the following LabVIEW Property or C Attribute:
-
-                - LabVIEW Property: **Peer-to-Peer:Is Finite Generation**
-                - C Attribute: **NIRFSG_ATTR_P2P_IS_FINITE_GENERATION**
-
-p2p_most_space_available_in_endpoint
-------------------------------------
-
-    .. py:attribute:: p2p_most_space_available_in_endpoint
-
-        Returns the largest number of samples per channel available in the endpoint since this property was last read. You can use this property to determine how much endpoint space to use as a buffer against bus traffic latencies by reading the property and keeping track of the largest value returned. This property is endpoint-based.
-
-        If you want to minimize the latency for data to move through the endpoint and be generated by the RF signal generator, use the :py:attr:`nirfsg.Session.p2p_data_transfer_permission_initial_credits` property to grant fewer initial credits than the default of the entire endpoint size.
-
-        **Units**: samples per channel
-
-        **Supported Devices:** PXIe-5673E, PXIe-5820/5830/5831/5832/5840/5841/5842
-
-        **Related Topics**
-
-        `Configuring a Peer-to-Peer Endpoint <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_configuring_an_endpoint.html>`_
-
-        The following table lists the characteristics of this property.
-
-            +-----------------------+-----------+
-            | Characteristic        | Value     |
-            +=======================+===========+
-            | Datatype              | int       |
-            +-----------------------+-----------+
-            | Permissions           | read only |
-            +-----------------------+-----------+
-            | Repeated Capabilities | None      |
-            +-----------------------+-----------+
-
-        .. tip::
-            This property corresponds to the following LabVIEW Property or C Attribute:
-
-                - LabVIEW Property: **Peer-to-Peer:Most Space Available in Endpoint**
-                - C Attribute: **NIRFSG_ATTR_P2P_MOST_SPACE_AVAILABLE_IN_ENDPOINT**
-
-p2p_number_of_samples_to_generate
----------------------------------
-
-    .. py:attribute:: p2p_number_of_samples_to_generate
-
-        Specifies how many samples are generated from the peer-to-peer subsystem when it is enabled. To use this property, peer-to-peer must be enabled and set to finite generation. This property is endpoint-based.
-
-        **Supported Devices:** PXIe-5820/5830/5831/5832/5840/5841/5842
-
-        **Related Topics**
-
-        `Configuring a Peer-to-Peer Endpoint <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_configuring_an_endpoint.html>`_
-
-        The following table lists the characteristics of this property.
-
-            +-----------------------+------------+
-            | Characteristic        | Value      |
-            +=======================+============+
-            | Datatype              | int        |
-            +-----------------------+------------+
-            | Permissions           | read-write |
-            +-----------------------+------------+
-            | Repeated Capabilities | None       |
-            +-----------------------+------------+
-
-        .. tip::
-            This property corresponds to the following LabVIEW Property or C Attribute:
-
-                - LabVIEW Property: **Peer-to-Peer:Number Of Samples To Generate**
-                - C Attribute: **NIRFSG_ATTR_P2P_NUMBER_OF_SAMPLES_TO_GENERATE**
-
-p2p_space_available_in_endpoint
--------------------------------
-
-    .. py:attribute:: p2p_space_available_in_endpoint
-
-        Returns the current space available in the endpoint. You can use this property when priming the endpoint with initial data using the :py:meth:`nirfsg.Session.WriteP2pEndpointI16` method to determine how many samples you can write. You also can use this property to characterize the performance and measure the latency of the peer-to-peer stream as data moves across the bus. This property is endpoint-based.
-
-        **Units**: samples per channel
-
-        **Supported Devices:** PXIe-5673E, PXIe-5820/5830/5831/5832/5840/5841/5842
-
-        **Related Topics**
-
-        `Configuring a Peer-to-Peer Endpoint <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_configuring_an_endpoint.html>`_
-
-        `Starting Peer-to-Peer Generation <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_starting_generation.html>`_
-
-        The following table lists the characteristics of this property.
-
-            +-----------------------+-----------+
-            | Characteristic        | Value     |
-            +=======================+===========+
-            | Datatype              | int       |
-            +-----------------------+-----------+
-            | Permissions           | read only |
-            +-----------------------+-----------+
-            | Repeated Capabilities | None      |
-            +-----------------------+-----------+
-
-        .. tip::
-            This property corresponds to the following LabVIEW Property or C Attribute:
-
-                - LabVIEW Property: **Peer-to-Peer:Space Available In Endpoint**
-                - C Attribute: **NIRFSG_ATTR_P2P_SPACE_AVAILABLE_IN_ENDPOINT**
 
 peak_envelope_power
 -------------------
@@ -10523,10 +10032,6 @@ power_level_type
 
         `Optimizing for Low Power Generation <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/optimizing_for_low_power_generation.html>`_
 
-        **High-Level Methods**:
-
-        - :py:meth:`nirfsg.Session.configure_power_level_type`
-
         **Defined Values**:
 
         +-------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -10562,31 +10067,31 @@ pulse_modulation_active_level
 
         Specifies the active level of the pulse modulation signal when pulse modulation is enabled. To set this property, the NI-RFSG device must be in the Configuration state.
 
-        **Default Value:** :py:data:`~nirfsg.ScriptTrigDigLevelActiveLevel.HIGH`
+        **Default Value:** :py:data:`~nirfsg.ScriptTriggerDigitalLevelActiveLevel.HIGH`
 
         **Supported Devices:**  PXIe-5842
 
         **Defined Values**:
 
-        +-------------------------------------------------------+---------------+--------------------------------------------------+
-        | Name                                                  | Value         | Description                                      |
-        +=======================================================+===============+==================================================+
-        | :py:data:`~nirfsg.ScriptTrigDigLevelActiveLevel.HIGH` | 9000 (0x2328) | Trigger when the digital trigger signal is high. |
-        +-------------------------------------------------------+---------------+--------------------------------------------------+
-        | :py:data:`~nirfsg.ScriptTrigDigLevelActiveLevel.LOW`  | 9001 (0x2329) | Trigger when the digital trigger signal is low.  |
-        +-------------------------------------------------------+---------------+--------------------------------------------------+
+        +--------------------------------------------------------------+---------------+--------------------------------------------------+
+        | Name                                                         | Value         | Description                                      |
+        +==============================================================+===============+==================================================+
+        | :py:data:`~nirfsg.ScriptTriggerDigitalLevelActiveLevel.HIGH` | 9000 (0x2328) | Trigger when the digital trigger signal is high. |
+        +--------------------------------------------------------------+---------------+--------------------------------------------------+
+        | :py:data:`~nirfsg.ScriptTriggerDigitalLevelActiveLevel.LOW`  | 9001 (0x2329) | Trigger when the digital trigger signal is low.  |
+        +--------------------------------------------------------------+---------------+--------------------------------------------------+
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+-------------------------------------+
-            | Characteristic        | Value                               |
-            +=======================+=====================================+
-            | Datatype              | enums.ScriptTrigDigLevelActiveLevel |
-            +-----------------------+-------------------------------------+
-            | Permissions           | read-write                          |
-            +-----------------------+-------------------------------------+
-            | Repeated Capabilities | None                                |
-            +-----------------------+-------------------------------------+
+            +-----------------------+--------------------------------------------+
+            | Characteristic        | Value                                      |
+            +=======================+============================================+
+            | Datatype              | enums.ScriptTriggerDigitalLevelActiveLevel |
+            +-----------------------+--------------------------------------------+
+            | Permissions           | read-write                                 |
+            +-----------------------+--------------------------------------------+
+            | Repeated Capabilities | None                                       |
+            +-----------------------+--------------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -11051,7 +10556,7 @@ ref_pll_bandwidth
 
         Configures the loop bandwidth of the reference PLL.
 
-        **Default Value:** :py:data:`~nirfsg.RefPllBandwidth.NARROW`
+        **Default Value:** :py:data:`~nirfsg.ReferencePllBandwidth.NARROW`
 
         **Supported Devices:** PXIe-5653
 
@@ -11061,29 +10566,29 @@ ref_pll_bandwidth
 
         **Defined Values**:
 
-        +-------------------------------------------+--------------------------------------------------------+
-        | Value                                     | Description                                            |
-        +===========================================+========================================================+
-        | :py:data:`~nirfsg.RefPllBandwidth.NARROW` | Uses the narrowest loop bandwidth setting for the PLL. |
-        +-------------------------------------------+--------------------------------------------------------+
-        | :py:data:`~nirfsg.RefPllBandwidth.MEDIUM` | Uses the medium loop bandwidth setting for the PLL.    |
-        +-------------------------------------------+--------------------------------------------------------+
-        | :py:data:`~nirfsg.RefPllBandwidth.WIDE`   | Uses the widest loop bandwidth setting for the PLL.    |
-        +-------------------------------------------+--------------------------------------------------------+
+        +-------------------------------------------------+--------------------------------------------------------+
+        | Value                                           | Description                                            |
+        +=================================================+========================================================+
+        | :py:data:`~nirfsg.ReferencePllBandwidth.NARROW` | Uses the narrowest loop bandwidth setting for the PLL. |
+        +-------------------------------------------------+--------------------------------------------------------+
+        | :py:data:`~nirfsg.ReferencePllBandwidth.MEDIUM` | Uses the medium loop bandwidth setting for the PLL.    |
+        +-------------------------------------------------+--------------------------------------------------------+
+        | :py:data:`~nirfsg.ReferencePllBandwidth.WIDE`   | Uses the widest loop bandwidth setting for the PLL.    |
+        +-------------------------------------------------+--------------------------------------------------------+
 
         .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+-----------------------+
-            | Characteristic        | Value                 |
-            +=======================+=======================+
-            | Datatype              | enums.RefPllBandwidth |
-            +-----------------------+-----------------------+
-            | Permissions           | read-write            |
-            +-----------------------+-----------------------+
-            | Repeated Capabilities | None                  |
-            +-----------------------+-----------------------+
+            +-----------------------+-----------------------------+
+            | Characteristic        | Value                       |
+            +=======================+=============================+
+            | Datatype              | enums.ReferencePllBandwidth |
+            +-----------------------+-----------------------------+
+            | Permissions           | read-write                  |
+            +-----------------------+-----------------------------+
+            | Repeated Capabilities | None                        |
+            +-----------------------+-----------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -11155,7 +10660,7 @@ rf_blanking_source
 
         PXIe-5840/5841: RF blanking does not occur for frequencies below 120MHz.
 
-        For PXIe-5830/5831/5832: The RF Blanking reserves a PXI trigger line. If you are calling any :py:meth:`nirfsg.Session.Reset` or `niRFSA_reset <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/cvinirfsa_reset.html>`_ on the same device, NI recommends calling it before committing blanking properties. Alternatively, you can call :py:meth:`nirfsg.Session.ResetWithOptions` or `niRFSA_ResetWithOptions <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/cvinirfsa_resetwithoptions.html>`_. Select **Routes** in the **steps to omit** parameter.
+        For PXIe-5830/5831/5832: The RF Blanking reserves a PXI trigger line. If you are calling any :py:meth:`nirfsg.Session.Reset` or `niRFSA_reset <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/cvinirfsa_reset.html>`_ on the same device, NI recommends calling it before committing blanking properties. Alternatively, you can call :py:meth:`nirfsg.Session.reset_with_options` or `niRFSA_ResetWithOptions <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/cvinirfsa_resetwithoptions.html>`_. Select **Routes** in the **steps to omit** parameter.
 
         **Default Value:** "" (empty string)
 
@@ -11314,7 +10819,7 @@ script_trigger_type
 
         Specifies the Script Trigger type. Depending upon the value of this property, more properties may be needed to fully configure the trigger. To set this property, the NI-RFSG device must be in the Configuration state.
 
-        **Default Value:** :py:data:`~nirfsg.ScriptTrigType.NONE`
+        **Default Value:** :py:data:`~nirfsg.ScriptTriggerType.NONE`
 
         **Supported Devices:** PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 
@@ -11330,17 +10835,17 @@ script_trigger_type
 
         **Defined Values**:
 
-        +-------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-        | Value                                           | Description                                                                                                                                                                                                                                                                                                               |
-        +=================================================+===========================================================================================================================================================================================================================================================================================================================+
-        | :py:data:`~nirfsg.ScriptTrigType.NONE`          | No trigger is configured. Signal generation starts immediately.                                                                                                                                                                                                                                                           |
-        +-------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-        | :py:data:`~nirfsg.ScriptTrigType.DIGITAL_EDGE`  | The data operation does not start until a digital edge is detected. The source of the digital edge is specified with the :py:attr:`nirfsg.Session.digital_edge_start_trigger_source` property, and the active edge is specified with the :py:attr:`nirfsg.Session.digital_edge_start_trigger_edge` property.              |
-        +-------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-        | :py:data:`~nirfsg.ScriptTrigType.DIGITAL_LEVEL` | The data operation does not start until the digital level is detected. The source of the digital level is specified in the :py:attr:`nirfsg.Session.digital_level_script_trigger_source` property, and the active level is specified in the :py:attr:`nirfsg.Session.digital_level_script_trigger_active_level` property. |
-        +-------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-        | :py:data:`~nirfsg.ScriptTrigType.SOFTWARE`      | The data operation does not start until a software trigger occurs. You can create a software event by calling the :py:meth:`nirfsg.Session.send_software_edge_trigger` method.                                                                                                                                            |
-        +-------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+        +----------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+        | Value                                              | Description                                                                                                                                                                                                                                                                                                               |
+        +====================================================+===========================================================================================================================================================================================================================================================================================================================+
+        | :py:data:`~nirfsg.ScriptTriggerType.NONE`          | No trigger is configured. Signal generation starts immediately.                                                                                                                                                                                                                                                           |
+        +----------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+        | :py:data:`~nirfsg.ScriptTriggerType.DIGITAL_EDGE`  | The data operation does not start until a digital edge is detected. The source of the digital edge is specified with the :py:attr:`nirfsg.Session.digital_edge_start_trigger_source` property, and the active edge is specified with the :py:attr:`nirfsg.Session.digital_edge_start_trigger_edge` property.              |
+        +----------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+        | :py:data:`~nirfsg.ScriptTriggerType.DIGITAL_LEVEL` | The data operation does not start until the digital level is detected. The source of the digital level is specified in the :py:attr:`nirfsg.Session.digital_level_script_trigger_source` property, and the active level is specified in the :py:attr:`nirfsg.Session.digital_level_script_trigger_active_level` property. |
+        +----------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+        | :py:data:`~nirfsg.ScriptTriggerType.SOFTWARE`      | The data operation does not start until a software trigger occurs. You can create a software event by calling the :py:meth:`nirfsg.Session.send_software_edge_trigger` method.                                                                                                                                            |
+        +----------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
         .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
@@ -11356,15 +10861,15 @@ script_trigger_type
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+----------------------+
-            | Characteristic        | Value                |
-            +=======================+======================+
-            | Datatype              | enums.ScriptTrigType |
-            +-----------------------+----------------------+
-            | Permissions           | read-write           |
-            +-----------------------+----------------------+
-            | Repeated Capabilities | script_triggers      |
-            +-----------------------+----------------------+
+            +-----------------------+-------------------------+
+            | Characteristic        | Value                   |
+            +=======================+=========================+
+            | Datatype              | enums.ScriptTriggerType |
+            +-----------------------+-------------------------+
+            | Permissions           | read-write              |
+            +-----------------------+-------------------------+
+            | Repeated Capabilities | script_triggers         |
+            +-----------------------+-------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -11896,7 +11401,7 @@ start_trigger_type
 
         Specifies the Start Trigger type. Depending upon the value of this property, more properties may be needed to fully configure the trigger. To set this property, the NI-RFSG device must be in the Configuration state.
 
-        **Default Value:** :py:data:`~nirfsg.StartTrigType.NONE`
+        **Default Value:** :py:data:`~nirfsg.StartTriggerType.NONE`
 
         **Supported Devices:** PXIe-5644/5645/5646, PXIe-5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 
@@ -11914,31 +11419,33 @@ start_trigger_type
 
         **Defined Values**:
 
-        +--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-        | Value                                                  | Description                                                                                                                                                                                                                                                                                                |
-        +========================================================+============================================================================================================================================================================================================================================================================================================+
-        | :py:data:`~nirfsg.StartTrigType.NONE`                  | No trigger is configured.                                                                                                                                                                                                                                                                                  |
-        +--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-        | :py:data:`~nirfsg.StartTrigType.DIGITAL_EDGE`          | The data operation does not start until a digital edge is detected. The source of the digital edge is specified with the :py:attr:`nirfsg.Session.digital_edge_start_trigger_source` property, and the active edge is specified in the :py:attr:`nirfsg.Session.digital_edge_start_trigger_edge` property. |
-        +--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-        | :py:data:`~nirfsg.StartTrigType.SOFTWARE`              | The data operation does not start until a software event occurs. You may create a software trigger by calling the :py:meth:`nirfsg.Session.send_software_edge_trigger` method.                                                                                                                             |
-        +--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-        | :py:data:`~nirfsg.StartTrigType.P2P_ENDPOINT_FULLNESS` | The data operation does not start until the endpoint reaches the threshold specified in the :py:attr:`nirfsg.Session.p2p_endpoint_fullness_start_trigger_level` property.                                                                                                                                  |
-        +--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+        +-----------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+        | Value                                                     | Description                                                                                                                                                                                                                                                                                                |
+        +===========================================================+============================================================================================================================================================================================================================================================================================================+
+        | :py:data:`~nirfsg.StartTriggerType.NONE`                  | No trigger is configured.                                                                                                                                                                                                                                                                                  |
+        +-----------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+        | :py:data:`~nirfsg.StartTriggerType.DIGITAL_EDGE`          | The data operation does not start until a digital edge is detected. The source of the digital edge is specified with the :py:attr:`nirfsg.Session.digital_edge_start_trigger_source` property, and the active edge is specified in the :py:attr:`nirfsg.Session.digital_edge_start_trigger_edge` property. |
+        +-----------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+        | :py:data:`~nirfsg.StartTriggerType.SOFTWARE`              | The data operation does not start until a software event occurs. You may create a software trigger by calling the :py:meth:`nirfsg.Session.send_software_edge_trigger` method.                                                                                                                             |
+        +-----------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+        | :py:data:`~nirfsg.StartTriggerType.P2P_ENDPOINT_FULLNESS` | The data operation does not start until the endpoint reaches the threshold specified in the :py:attr:`nirfsg.Session.P2P_ENDPOINT_FULLNESS_START_TRIGGER_LEVEL` property.                                                                                                                                  |
+        +-----------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+        .. note:: One or more of the referenced properties are not in the Python API for this driver.
 
         .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+---------------------+
-            | Characteristic        | Value               |
-            +=======================+=====================+
-            | Datatype              | enums.StartTrigType |
-            +-----------------------+---------------------+
-            | Permissions           | read-write          |
-            +-----------------------+---------------------+
-            | Repeated Capabilities | None                |
-            +-----------------------+---------------------+
+            +-----------------------+------------------------+
+            | Characteristic        | Value                  |
+            +=======================+========================+
+            | Datatype              | enums.StartTriggerType |
+            +-----------------------+------------------------+
+            | Permissions           | read-write             |
+            +-----------------------+------------------------+
+            | Repeated Capabilities | None                   |
+            +-----------------------+------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -12840,7 +12347,7 @@ waveform_rf_blanking
         | :py:data:`~nirfsg.NIRFSG_VAL_MARKER0`, :py:data:`~nirfsg.NIRFSG_VAL_MARKER1`, :py:data:`~nirfsg.NIRFSG_VAL_MARKER2`, or :py:data:`~nirfsg.NIRFSG_VAL_MARKER3` | :py:data:`~nirfsg.RFBlanking.ENABLE`           | Error is shown.                                                                                           |
         +---------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------+-----------------------------------------------------------------------------------------------------------+
 
-        .. note:: For PXIe-5830/5831/5832: The RF Blanking reserves a PXI trigger line. If you are calling any :py:meth:`nirfsg.Session.Reset` or `niRFSA_reset <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/cvinirfsa_reset.html>`_ on the same device, NI recommends calling it before committing blanking properties. Alternatively, you can call :py:meth:`nirfsg.Session.ResetWithOptions` or `niRFSA_ResetWithOptions <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/cvinirfsa_resetwithoptions.html>`_. Select **Routes** in the **steps to omit** parameter.
+        .. note:: For PXIe-5830/5831/5832: The RF Blanking reserves a PXI trigger line. If you are calling any :py:meth:`nirfsg.Session.Reset` or `niRFSA_reset <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/cvinirfsa_reset.html>`_ on the same device, NI recommends calling it before committing blanking properties. Alternatively, you can call :py:meth:`nirfsg.Session.reset_with_options` or `niRFSA_ResetWithOptions <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/cvinirfsa_resetwithoptions.html>`_. Select **Routes** in the **steps to omit** parameter.
 
         .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
@@ -13016,7 +12523,7 @@ write_waveform_burst_detection
 
         .. note:: - When you download a waveform using :py:meth:`nirfsg.Session.ReadAndDownloadWaveformFromFileTdms` method and if :py:attr:`nirfsg.Session.waveform_rf_blanking` property is enabled, you must set the :py:attr:`nirfsg.Session.write_waveform_burst_detection` property to :py:data:`~nirfsg.WriteWaveformBurstDetection.DISABLE`.
 
-             - For PXIe-5830/5831/5832: The RF Blanking reserves a PXI trigger line. If you are calling any :py:meth:`nirfsg.Session.Reset` or `niRFSA_reset <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/cvinirfsa_reset.html>`_ on the same device, NI recommends calling it before committing blanking properties. Alternatively, you can call :py:meth:`nirfsg.Session.ResetWithOptions` or `niRFSA_ResetWithOptions <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/cvinirfsa_resetwithoptions.html>`_. Select **Routes** in the **steps to omit** parameter.
+             - For PXIe-5830/5831/5832: The RF Blanking reserves a PXI trigger line. If you are calling any :py:meth:`nirfsg.Session.Reset` or `niRFSA_reset <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/cvinirfsa_reset.html>`_ on the same device, NI recommends calling it before committing blanking properties. Alternatively, you can call :py:meth:`nirfsg.Session.reset_with_options` or `niRFSA_ResetWithOptions <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/cvinirfsa_resetwithoptions.html>`_. Select **Routes** in the **steps to omit** parameter.
 
         .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 

--- a/docs/nirfsg/class.rst
+++ b/docs/nirfsg/class.rst
@@ -3572,7 +3572,7 @@ analog_modulation_fm_narrowband_integrator
 
         This property is valid only when you set the :py:attr:`nirfsg.Session.analog_modulation_type` property to :py:data:`~nirfsg.AnalogModulationType.FM` and the :py:attr:`nirfsg.Session.analog_modulation_fm_band` property to :py:data:`~nirfsg.AnalogModulationFmBand.NARROWBAND`.
 
-        **Default Value:** :py:data:`~nirfsg.AnalogModulationFmNarrowbandIntegrator._100hzto1khz`
+        **Default Value:** :py:data:`~nirfsg.AnalogModulationFmNarrowbandIntegrator._100Hzto1kHz`
 
         **Supported Devices:** PXIe-5654/5654 with PXIe-5696
 
@@ -3585,11 +3585,11 @@ analog_modulation_fm_narrowband_integrator
         +--------------------------------------------------------------------------+----------------+---------------------------------------------+
         | Name                                                                     | Value          | Description                                 |
         +==========================================================================+================+=============================================+
-        | :py:data:`~nirfsg.AnalogModulationFmNarrowbandIntegrator._100hzto1khz`   | 18000 (0x4650) | Specifies a range from 100Â Hz to 1Â kHz.   |
+        | :py:data:`~nirfsg.AnalogModulationFmNarrowbandIntegrator._100Hzto1kHz`   | 18000 (0x4650) | Specifies a range from 100Â Hz to 1Â kHz.   |
         +--------------------------------------------------------------------------+----------------+---------------------------------------------+
-        | :py:data:`~nirfsg.AnalogModulationFmNarrowbandIntegrator._10khzto100khz` | 18002 (0x4652) | Specifies a range from 10Â kHz to 100Â kHz. |
+        | :py:data:`~nirfsg.AnalogModulationFmNarrowbandIntegrator._10kHzto100kHz` | 18002 (0x4652) | Specifies a range from 10Â kHz to 100Â kHz. |
         +--------------------------------------------------------------------------+----------------+---------------------------------------------+
-        | :py:data:`~nirfsg.AnalogModulationFmNarrowbandIntegrator._1khzto10khz`   | 18001 (0x4651) | Specifies a range from 1Â kHz to 10Â kHz.   |
+        | :py:data:`~nirfsg.AnalogModulationFmNarrowbandIntegrator._1kHzto10kHz`   | 18001 (0x4651) | Specifies a range from 1Â kHz to 10Â kHz.   |
         +--------------------------------------------------------------------------+----------------+---------------------------------------------+
 
         The following table lists the characteristics of this property.
@@ -6768,7 +6768,7 @@ exported_ref_clock_rate
 
         Specifies the Reference Clock Rate, in Hz, of the signal sent to the Reference Clock Export Output Terminal. To set this property, the NI-RFSG device must be in the Configuration state.
 
-        **Default Value:** :py:data:`~nirfsg.ReferenceClockExportedRate._10mhz`
+        **Default Value:** :py:data:`~nirfsg.ReferenceClockExportedRate._10MHz`
 
         **Supported Devices:** PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 
@@ -6777,11 +6777,11 @@ exported_ref_clock_rate
         +-------------------------------------------------------+--------------+-------------------------------------+
         | Name                                                  | Value        | Description                         |
         +=======================================================+==============+=====================================+
-        | :py:data:`~nirfsg.ReferenceClockExportedRate._10mhz`  | 10000000.0   | Uses a 10MHz Reference Clock rate.  |
+        | :py:data:`~nirfsg.ReferenceClockExportedRate._10MHz`  | 10000000.0   | Uses a 10MHz Reference Clock rate.  |
         +-------------------------------------------------------+--------------+-------------------------------------+
-        | :py:data:`~nirfsg.ReferenceClockExportedRate._100mhz` | 100000000.0  | Uses a 100MHz Reference Clock rate. |
+        | :py:data:`~nirfsg.ReferenceClockExportedRate._100MHz` | 100000000.0  | Uses a 100MHz Reference Clock rate. |
         +-------------------------------------------------------+--------------+-------------------------------------+
-        | :py:data:`~nirfsg.ReferenceClockExportedRate._1ghz`   | 1000000000.0 | Uses a 1GHz Reference Clock rate.   |
+        | :py:data:`~nirfsg.ReferenceClockExportedRate._1GHz`   | 1000000000.0 | Uses a 1GHz Reference Clock rate.   |
         +-------------------------------------------------------+--------------+-------------------------------------+
 
         .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
@@ -10434,7 +10434,7 @@ ref_clock_rate
 
         **Valid Values:**
 
-        PXIe-5654/5654 with PXIe-5696: Values between 1MHz to 20MHz in 1MHz steps are supported in addition to the :py:data:`~nirfsg.ReferenceClockRate.AUTO` and :py:data:`~nirfsg.ReferenceClockRate._10mhz` values.
+        PXIe-5654/5654 with PXIe-5696: Values between 1MHz to 20MHz in 1MHz steps are supported in addition to the :py:data:`~nirfsg.ReferenceClockRate.AUTO` and :py:data:`~nirfsg.ReferenceClockRate._10MHz` values.
 
         PXIe-5841 with PXIe-5655, PXIe-5842: 10 MHz, 100 MHz, 270 MHz, and 3.84 MHz
 
@@ -10465,7 +10465,7 @@ ref_clock_rate
         +==============================================+===================================================================================================================================+
         | :py:data:`~nirfsg.ReferenceClockRate.AUTO`   | Uses the default Reference Clock rate for the device or automatically detects the Reference Clock rate if the device supports it. |
         +----------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
-        | :py:data:`~nirfsg.ReferenceClockRate._10mhz` | Uses a 10 MHz Reference Clock rate.                                                                                               |
+        | :py:data:`~nirfsg.ReferenceClockRate._10MHz` | Uses a 10 MHz Reference Clock rate.                                                                                               |
         +----------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
 
         .. note:: Automatic detection of the Reference Clock rate is supported on only the PXIe-5654/5654 with PXIe-5696. For all other supported devices, NI-RFSG uses the default Reference Clock rate of 10MHz.

--- a/docs/nirfsg/enums.rst
+++ b/docs/nirfsg/enums.rst
@@ -56,12 +56,12 @@ AmpPath
 
 
 
-AnlgModFmBand
--------------
+AnalogModulationFmBand
+----------------------
 
-.. py:class:: AnlgModFmBand
+.. py:class:: AnalogModulationFmBand
 
-    .. py:attribute:: AnlgModFmBand.NARROWBAND
+    .. py:attribute:: AnalogModulationFmBand.NARROWBAND
 
 
 
@@ -71,7 +71,7 @@ AnlgModFmBand
 
 
 
-    .. py:attribute:: AnlgModFmBand.WIDEBAND
+    .. py:attribute:: AnalogModulationFmBand.WIDEBAND
 
 
 
@@ -81,12 +81,12 @@ AnlgModFmBand
 
 
 
-AnlgModFmNarrowbandIntegrator
------------------------------
+AnalogModulationFmNarrowbandIntegrator
+--------------------------------------
 
-.. py:class:: AnlgModFmNarrowbandIntegrator
+.. py:class:: AnalogModulationFmNarrowbandIntegrator
 
-    .. py:attribute:: AnlgModFmNarrowbandIntegrator._100hzto1khz
+    .. py:attribute:: AnalogModulationFmNarrowbandIntegrator._100hzto1khz
 
 
 
@@ -96,7 +96,7 @@ AnlgModFmNarrowbandIntegrator
 
 
 
-    .. py:attribute:: AnlgModFmNarrowbandIntegrator._1khzto10khz
+    .. py:attribute:: AnalogModulationFmNarrowbandIntegrator._1khzto10khz
 
 
 
@@ -106,7 +106,7 @@ AnlgModFmNarrowbandIntegrator
 
 
 
-    .. py:attribute:: AnlgModFmNarrowbandIntegrator._10khzto100khz
+    .. py:attribute:: AnalogModulationFmNarrowbandIntegrator._10khzto100khz
 
 
 
@@ -116,12 +116,12 @@ AnlgModFmNarrowbandIntegrator
 
 
 
-AnlgModPmMode
--------------
+AnalogModulationPmMode
+----------------------
 
-.. py:class:: AnlgModPmMode
+.. py:class:: AnalogModulationPmMode
 
-    .. py:attribute:: AnlgModPmMode.HIGH_DEVIATION
+    .. py:attribute:: AnalogModulationPmMode.HIGH_DEVIATION
 
 
 
@@ -131,7 +131,7 @@ AnlgModPmMode
 
 
 
-    .. py:attribute:: AnlgModPmMode.LOW_PHASE_NOISE
+    .. py:attribute:: AnalogModulationPmMode.LOW_PHASE_NOISE
 
 
 
@@ -141,12 +141,12 @@ AnlgModPmMode
 
 
 
-AnlgModType
------------
+AnalogModulationType
+--------------------
 
-.. py:class:: AnlgModType
+.. py:class:: AnalogModulationType
 
-    .. py:attribute:: AnlgModType.NONE
+    .. py:attribute:: AnalogModulationType.NONE
 
 
 
@@ -156,7 +156,7 @@ AnlgModType
 
 
 
-    .. py:attribute:: AnlgModType.FM
+    .. py:attribute:: AnalogModulationType.FM
 
 
 
@@ -166,7 +166,7 @@ AnlgModType
 
 
 
-    .. py:attribute:: AnlgModType.PM
+    .. py:attribute:: AnalogModulationType.PM
 
 
 
@@ -176,7 +176,7 @@ AnlgModType
 
 
 
-    .. py:attribute:: AnlgModType.AM
+    .. py:attribute:: AnalogModulationType.AM
 
 
 
@@ -186,12 +186,12 @@ AnlgModType
 
 
 
-AnlgModWfmType
---------------
+AnalogModulationWaveformType
+----------------------------
 
-.. py:class:: AnlgModWfmType
+.. py:class:: AnalogModulationWaveformType
 
-    .. py:attribute:: AnlgModWfmType.SINE
+    .. py:attribute:: AnalogModulationWaveformType.SINE
 
 
 
@@ -201,7 +201,7 @@ AnlgModWfmType
 
 
 
-    .. py:attribute:: AnlgModWfmType.SQUARE
+    .. py:attribute:: AnalogModulationWaveformType.SQUARE
 
 
 
@@ -211,7 +211,7 @@ AnlgModWfmType
 
 
 
-    .. py:attribute:: AnlgModWfmType.TRIANGLE
+    .. py:attribute:: AnalogModulationWaveformType.TRIANGLE
 
 
 
@@ -321,79 +321,6 @@ AutomaticThermalCorrection
 
 
 
-ConfigListTrigDigEdgeEdge
--------------------------
-
-.. py:class:: ConfigListTrigDigEdgeEdge
-
-    .. py:attribute:: ConfigListTrigDigEdgeEdge.EDGE
-
-
-
-        Specifies the rising edge as the active edge. The rising edge occurs when the signal transitions from low level to high level.
-
-        
-
-
-
-ConfigListTrigType
-------------------
-
-.. py:class:: ConfigListTrigType
-
-    .. py:attribute:: ConfigListTrigType.NONE
-
-
-
-        Generation starts immediately, but the list does not advance.
-
-        
-
-
-
-    .. py:attribute:: ConfigListTrigType.DIGITAL_EDGE
-
-
-
-        Data operation does not start until a digital edge is detected. The source of the digital edge is specified in the :py:attr:`nirfsg.Session.DIGITAL_EDGE_CONFIGURATION_LIST_STEP_TRIGGER_SOURCE` property, and the active edge is always rising.
-
-        
-
-
-
-ConfigurationListRepeat
------------------------
-
-.. py:class:: ConfigurationListRepeat
-
-    .. py:attribute:: ConfigurationListRepeat.CONFIGURATION_LIST_REPEAT_CONTINUOUS
-
-
-
-        NI-RFSG runs the configuration list continuously.
-
-        
-
-
-
-    .. py:attribute:: ConfigurationListRepeat.MANUAL
-
-
-
-    .. py:attribute:: ConfigurationListRepeat.CONFIGURATION_LIST_REPEAT_SINGLE
-
-
-
-        NI-RFSG runs the configuration list only once.
-
-        
-
-
-
-    .. py:attribute:: ConfigurationListRepeat.SCRIPT_TRIGGER
-
-
-
 DeembeddingTypeAttrVals
 -----------------------
 
@@ -429,76 +356,6 @@ DeembeddingTypeAttrVals
 
 
 
-DigModType
-----------
-
-.. py:class:: DigModType
-
-    .. py:attribute:: DigModType.NONE
-
-
-
-        Disables digital modulation.
-
-        
-
-
-
-    .. py:attribute:: DigModType.FSK
-
-
-
-        Specifies that the digital modulation type is frequency-shift keying (FSK).
-
-        
-
-
-
-    .. py:attribute:: DigModType.OOK
-
-
-
-        Specifies that the digital modulation type is on-off keying (OOK).
-
-        
-
-
-
-    .. py:attribute:: DigModType.PSK
-
-
-
-        Specifies that the digital modulation type is phase-shift keying (PSK).
-
-        
-
-
-
-DigModWfmType
--------------
-
-.. py:class:: DigModWfmType
-
-    .. py:attribute:: DigModWfmType.PRBS
-
-
-
-        Specifies that the digital modulation waveform type is pseudorandom bit sequence (PRBS).
-
-        
-
-
-
-    .. py:attribute:: DigModWfmType.USER_DEFINED
-
-
-
-        Specifies that the digital modulation waveform type is user defined. To specify the user-defined waveform, call the :py:meth:`nirfsg.Session.configure_digital_modulation_user_defined_waveform` method.
-
-        
-
-
-
 DigitalEqualizationEnabled
 --------------------------
 
@@ -519,6 +376,76 @@ DigitalEqualizationEnabled
 
 
         Filter is applied.
+
+        
+
+
+
+DigitalModulationType
+---------------------
+
+.. py:class:: DigitalModulationType
+
+    .. py:attribute:: DigitalModulationType.NONE
+
+
+
+        Disables digital modulation.
+
+        
+
+
+
+    .. py:attribute:: DigitalModulationType.FSK
+
+
+
+        Specifies that the digital modulation type is frequency-shift keying (FSK).
+
+        
+
+
+
+    .. py:attribute:: DigitalModulationType.OOK
+
+
+
+        Specifies that the digital modulation type is on-off keying (OOK).
+
+        
+
+
+
+    .. py:attribute:: DigitalModulationType.PSK
+
+
+
+        Specifies that the digital modulation type is phase-shift keying (PSK).
+
+        
+
+
+
+DigitalModulationWaveformType
+-----------------------------
+
+.. py:class:: DigitalModulationWaveformType
+
+    .. py:attribute:: DigitalModulationWaveformType.PRBS
+
+
+
+        Specifies that the digital modulation waveform type is pseudorandom bit sequence (PRBS).
+
+        
+
+
+
+    .. py:attribute:: DigitalModulationWaveformType.USER_DEFINED
+
+
+
+        Specifies that the digital modulation waveform type is user defined. To specify the user-defined waveform, call the :py:meth:`nirfsg.Session.configure_digital_modulation_user_defined_waveform` method.
 
         
 
@@ -729,7 +656,7 @@ Lo1OutputFilter
 
 .. py:class:: Lo1OutputFilter
 
-    .. py:attribute:: Lo1OutputFilter.MANUAL
+    .. py:attribute:: Lo1OutputFilter.HIGH
 
 
 
@@ -739,7 +666,7 @@ Lo1OutputFilter
 
 
 
-    .. py:attribute:: Lo1OutputFilter.SCRIPT_TRIGGER
+    .. py:attribute:: Lo1OutputFilter.LOW
 
 
 
@@ -764,10 +691,6 @@ LoOutEnabled
 
 
 
-    .. py:attribute:: LoOutEnabled.MANUAL
-
-
-
     .. py:attribute:: LoOutEnabled.ENABLE
 
 
@@ -775,10 +698,6 @@ LoOutEnabled
         The local oscillator signal is  not present at the LO OUT front panel connector..
 
         
-
-
-
-    .. py:attribute:: LoOutEnabled.SCRIPT_TRIGGER
 
 
 
@@ -797,10 +716,6 @@ LoOutExportConfigureFromRFSaEnable
 
 
 
-    .. py:attribute:: LoOutExportConfigureFromRFSaEnable.MANUAL
-
-
-
     .. py:attribute:: LoOutExportConfigureFromRFSaEnable.ENABLE
 
 
@@ -808,10 +723,6 @@ LoOutExportConfigureFromRFSaEnable
         Allow NI-RFSA to control the NI-RFSG local oscillator export.
 
         
-
-
-
-    .. py:attribute:: LoOutExportConfigureFromRFSaEnable.SCRIPT_TRIGGER
 
 
 
@@ -830,10 +741,6 @@ LoPlLfractionalModeEnabled
 
 
 
-    .. py:attribute:: LoPlLfractionalModeEnabled.MANUAL
-
-
-
     .. py:attribute:: LoPlLfractionalModeEnabled.ENABLE
 
 
@@ -841,10 +748,6 @@ LoPlLfractionalModeEnabled
         Enables fractional mode for the LO PLL.
 
         
-
-
-
-    .. py:attribute:: LoPlLfractionalModeEnabled.SCRIPT_TRIGGER
 
 
 
@@ -1418,41 +1321,6 @@ RFInLoExportEnabled
 
 
 
-RefPllBandwidth
----------------
-
-.. py:class:: RefPllBandwidth
-
-    .. py:attribute:: RefPllBandwidth.NARROW
-
-
-
-        Uses the narrowest loop bandwidth setting for the PLL. Setting this property to :py:data:`~nirfsg.NIRFSG_VAL_NARROW` allows the PXIe-5653 to lock to a reference with worse phase noise than the PXIe-5653 and utilize the better phase noise of the PXIe-5653.
-
-        
-
-
-
-    .. py:attribute:: RefPllBandwidth.MEDIUM
-
-
-
-        Uses the medium loop bandwidth setting for the PLL.
-
-        
-
-
-
-    .. py:attribute:: RefPllBandwidth.WIDE
-
-
-
-        Uses the widest loop bandwidth setting for the PLL. Setting this property to :py:data:`~nirfsg.NIRFSG_VAL_WIDE` on the PXIe-5653 allows the reference PLL to lock to a better reference with better phase noise than the PXIe-5653 and utilize the better phase noise of the reference.
-
-        
-
-
-
 ReferenceClockExportedRate
 --------------------------
 
@@ -1508,6 +1376,41 @@ ReferenceClockRate
 
 
         Uses a 10MHz Reference Clock rate.
+
+        
+
+
+
+ReferencePllBandwidth
+---------------------
+
+.. py:class:: ReferencePllBandwidth
+
+    .. py:attribute:: ReferencePllBandwidth.NARROW
+
+
+
+        Uses the narrowest loop bandwidth setting for the PLL. Setting this property to :py:data:`~nirfsg.NIRFSG_VAL_NARROW` allows the PXIe-5653 to lock to a reference with worse phase noise than the PXIe-5653 and utilize the better phase noise of the PXIe-5653.
+
+        
+
+
+
+    .. py:attribute:: ReferencePllBandwidth.MEDIUM
+
+
+
+        Uses the medium loop bandwidth setting for the PLL.
+
+        
+
+
+
+    .. py:attribute:: ReferencePllBandwidth.WIDE
+
+
+
+        Uses the widest loop bandwidth setting for the PLL. Setting this property to :py:data:`~nirfsg.NIRFSG_VAL_WIDE` on the PXIe-5653 allows the reference PLL to lock to a better reference with better phase noise than the PXIe-5653 and utilize the better phase noise of the reference.
 
         
 
@@ -1593,12 +1496,12 @@ ResetWithOptionsStepsToOmit
 
 
 
-ScriptTrigDigEdgeEdge
----------------------
+ScriptTriggerDigitalEdgeEdge
+----------------------------
 
-.. py:class:: ScriptTrigDigEdgeEdge
+.. py:class:: ScriptTriggerDigitalEdgeEdge
 
-    .. py:attribute:: ScriptTrigDigEdgeEdge.RISING
+    .. py:attribute:: ScriptTriggerDigitalEdgeEdge.RISING
 
 
 
@@ -1608,7 +1511,7 @@ ScriptTrigDigEdgeEdge
 
 
 
-    .. py:attribute:: ScriptTrigDigEdgeEdge.FALLING
+    .. py:attribute:: ScriptTriggerDigitalEdgeEdge.FALLING
 
 
 
@@ -1618,12 +1521,12 @@ ScriptTrigDigEdgeEdge
 
 
 
-ScriptTrigDigLevelActiveLevel
------------------------------
+ScriptTriggerDigitalLevelActiveLevel
+------------------------------------
 
-.. py:class:: ScriptTrigDigLevelActiveLevel
+.. py:class:: ScriptTriggerDigitalLevelActiveLevel
 
-    .. py:attribute:: ScriptTrigDigLevelActiveLevel.HIGH
+    .. py:attribute:: ScriptTriggerDigitalLevelActiveLevel.HIGH
 
 
 
@@ -1633,7 +1536,7 @@ ScriptTrigDigLevelActiveLevel
 
 
 
-    .. py:attribute:: ScriptTrigDigLevelActiveLevel.LOW
+    .. py:attribute:: ScriptTriggerDigitalLevelActiveLevel.LOW
 
 
 
@@ -1643,12 +1546,12 @@ ScriptTrigDigLevelActiveLevel
 
 
 
-ScriptTrigType
---------------
+ScriptTriggerType
+-----------------
 
-.. py:class:: ScriptTrigType
+.. py:class:: ScriptTriggerType
 
-    .. py:attribute:: ScriptTrigType.NONE
+    .. py:attribute:: ScriptTriggerType.NONE
 
 
 
@@ -1658,7 +1561,7 @@ ScriptTrigType
 
 
 
-    .. py:attribute:: ScriptTrigType.DIGITAL_EDGE
+    .. py:attribute:: ScriptTriggerType.DIGITAL_EDGE
 
 
 
@@ -1668,7 +1571,7 @@ ScriptTrigType
 
 
 
-    .. py:attribute:: ScriptTrigType.DIGITAL_LEVEL
+    .. py:attribute:: ScriptTriggerType.DIGITAL_LEVEL
 
 
 
@@ -1678,7 +1581,7 @@ ScriptTrigType
 
 
 
-    .. py:attribute:: ScriptTrigType.SOFTWARE
+    .. py:attribute:: ScriptTriggerType.SOFTWARE
 
 
 
@@ -1888,12 +1791,12 @@ SparameterOrientation
 
 
 
-StartTrigDigEdgeEdge
---------------------
+StartTriggerDigitalEdgeEdge
+---------------------------
 
-.. py:class:: StartTrigDigEdgeEdge
+.. py:class:: StartTriggerDigitalEdgeEdge
 
-    .. py:attribute:: StartTrigDigEdgeEdge.RISING
+    .. py:attribute:: StartTriggerDigitalEdgeEdge.RISING
 
 
 
@@ -1903,7 +1806,7 @@ StartTrigDigEdgeEdge
 
 
 
-    .. py:attribute:: StartTrigDigEdgeEdge.FALLING
+    .. py:attribute:: StartTriggerDigitalEdgeEdge.FALLING
 
 
 
@@ -1913,12 +1816,12 @@ StartTrigDigEdgeEdge
 
 
 
-StartTrigType
--------------
+StartTriggerType
+----------------
 
-.. py:class:: StartTrigType
+.. py:class:: StartTriggerType
 
-    .. py:attribute:: StartTrigType.NONE
+    .. py:attribute:: StartTriggerType.NONE
 
 
 
@@ -1928,7 +1831,7 @@ StartTrigType
 
 
 
-    .. py:attribute:: StartTrigType.DIGITAL_EDGE
+    .. py:attribute:: StartTriggerType.DIGITAL_EDGE
 
 
 
@@ -1938,7 +1841,7 @@ StartTrigType
 
 
 
-    .. py:attribute:: StartTrigType.SOFTWARE
+    .. py:attribute:: StartTriggerType.SOFTWARE
 
 
 
@@ -1948,11 +1851,11 @@ StartTrigType
 
 
 
-    .. py:attribute:: StartTrigType.P2P_ENDPOINT_FULLNESS
+    .. py:attribute:: StartTriggerType.P2P_ENDPOINT_FULLNESS
 
 
 
-        The data operation does not start until the endpoint reaches the threshold specified in the :py:attr:`nirfsg.Session.p2p_endpoint_fullness_start_trigger_level` property.
+        The data operation does not start until the endpoint reaches the threshold specified in the :py:attr:`nirfsg.Session.P2P_ENDPOINT_FULLNESS_START_TRIGGER_LEVEL` property.
 
         
 

--- a/docs/nirfsg/enums.rst
+++ b/docs/nirfsg/enums.rst
@@ -86,7 +86,7 @@ AnalogModulationFmNarrowbandIntegrator
 
 .. py:class:: AnalogModulationFmNarrowbandIntegrator
 
-    .. py:attribute:: AnalogModulationFmNarrowbandIntegrator._100hzto1khz
+    .. py:attribute:: AnalogModulationFmNarrowbandIntegrator._100Hzto1kHz
 
 
 
@@ -96,7 +96,7 @@ AnalogModulationFmNarrowbandIntegrator
 
 
 
-    .. py:attribute:: AnalogModulationFmNarrowbandIntegrator._1khzto10khz
+    .. py:attribute:: AnalogModulationFmNarrowbandIntegrator._1kHzto10kHz
 
 
 
@@ -106,7 +106,7 @@ AnalogModulationFmNarrowbandIntegrator
 
 
 
-    .. py:attribute:: AnalogModulationFmNarrowbandIntegrator._10khzto100khz
+    .. py:attribute:: AnalogModulationFmNarrowbandIntegrator._10kHzto100kHz
 
 
 
@@ -651,56 +651,6 @@ IQOutPortTermCfg
 
 
 
-Lo1OutputFilter
----------------
-
-.. py:class:: Lo1OutputFilter
-
-    .. py:attribute:: Lo1OutputFilter.HIGH
-
-
-
-        yet to be defined
-
-        
-
-
-
-    .. py:attribute:: Lo1OutputFilter.LOW
-
-
-
-        yet to be defined
-
-        
-
-
-
-LoOutEnabled
-------------
-
-.. py:class:: LoOutEnabled
-
-    .. py:attribute:: LoOutEnabled.DISABLE
-
-
-
-        The local oscillator signal is present at the LO OUT front panel connector.
-
-        
-
-
-
-    .. py:attribute:: LoOutEnabled.ENABLE
-
-
-
-        The local oscillator signal is  not present at the LO OUT front panel connector..
-
-        
-
-
-
 LoOutExportConfigureFromRFSaEnable
 ----------------------------------
 
@@ -1096,31 +1046,6 @@ PhaseContinuityEnabled
 
 
 
-PortTypes
----------
-
-.. py:class:: PortTypes
-
-    .. py:attribute:: PortTypes.OUT
-
-
-
-        Specifies the PXIe-5840 RF OUT port.
-
-        
-
-
-
-    .. py:attribute:: PortTypes.IN
-
-
-
-        Specifies the PXIe-5840 RF IN port. This value is not supported as the first element of an array.
-
-        
-
-
-
 PowerLevelType
 --------------
 
@@ -1251,41 +1176,6 @@ RFBlanking
 
 
 
-RFFilter
---------
-
-.. py:class:: RFFilter
-
-    .. py:attribute:: RFFilter.HI_FREQ_MOD
-
-
-
-        yet to be defined
-
-        
-
-
-
-    .. py:attribute:: RFFilter.LO_FREQ_MOD_4000
-
-
-
-        yet to be defined
-
-        
-
-
-
-    .. py:attribute:: RFFilter.LO_FREQ_MOD_2500
-
-
-
-        yet to be defined
-
-        
-
-
-
 RFInLoExportEnabled
 -------------------
 
@@ -1326,7 +1216,7 @@ ReferenceClockExportedRate
 
 .. py:class:: ReferenceClockExportedRate
 
-    .. py:attribute:: ReferenceClockExportedRate._10mhz
+    .. py:attribute:: ReferenceClockExportedRate._10MHz
 
 
 
@@ -1336,7 +1226,7 @@ ReferenceClockExportedRate
 
 
 
-    .. py:attribute:: ReferenceClockExportedRate._100mhz
+    .. py:attribute:: ReferenceClockExportedRate._100MHz
 
 
 
@@ -1346,7 +1236,7 @@ ReferenceClockExportedRate
 
 
 
-    .. py:attribute:: ReferenceClockExportedRate._1ghz
+    .. py:attribute:: ReferenceClockExportedRate._1GHz
 
 
 
@@ -1371,7 +1261,7 @@ ReferenceClockRate
 
 
 
-    .. py:attribute:: ReferenceClockRate._10mhz
+    .. py:attribute:: ReferenceClockRate._10MHz
 
 
 

--- a/docs/nirfsg/enums.rst
+++ b/docs/nirfsg/enums.rst
@@ -321,12 +321,12 @@ AutomaticThermalCorrection
 
 
 
-DeembeddingTypeAttrVals
------------------------
+DeembeddingType
+---------------
 
-.. py:class:: DeembeddingTypeAttrVals
+.. py:class:: DeembeddingType
 
-    .. py:attribute:: DeembeddingTypeAttrVals.NONE
+    .. py:attribute:: DeembeddingType.NONE
 
 
 
@@ -336,7 +336,7 @@ DeembeddingTypeAttrVals
 
 
 
-    .. py:attribute:: DeembeddingTypeAttrVals.SCALAR
+    .. py:attribute:: DeembeddingType.SCALAR
 
 
 
@@ -346,7 +346,7 @@ DeembeddingTypeAttrVals
 
 
 
-    .. py:attribute:: DeembeddingTypeAttrVals.VECTOR
+    .. py:attribute:: DeembeddingType.VECTOR
 
 
 
@@ -1846,16 +1846,6 @@ StartTriggerType
 
 
         The data operation does not start until a software event occurs. You may create a software trigger by calling the :py:meth:`nirfsg.Session.send_software_edge_trigger` method.
-
-        
-
-
-
-    .. py:attribute:: StartTriggerType.P2P_ENDPOINT_FULLNESS
-
-
-
-        The data operation does not start until the endpoint reaches the threshold specified in the :py:attr:`nirfsg.Session.P2P_ENDPOINT_FULLNESS_START_TRIGGER_LEVEL` property.
 
         
 

--- a/docs/nirfsg/enums.rst
+++ b/docs/nirfsg/enums.rst
@@ -86,7 +86,7 @@ AnalogModulationFmNarrowbandIntegrator
 
 .. py:class:: AnalogModulationFmNarrowbandIntegrator
 
-    .. py:attribute:: AnalogModulationFmNarrowbandIntegrator._100Hzto1kHz
+    .. py:attribute:: AnalogModulationFmNarrowbandIntegrator.RANGE_100_HERTZ_TO_1_KILOHERTZ
 
 
 
@@ -96,7 +96,7 @@ AnalogModulationFmNarrowbandIntegrator
 
 
 
-    .. py:attribute:: AnalogModulationFmNarrowbandIntegrator._1kHzto10kHz
+    .. py:attribute:: AnalogModulationFmNarrowbandIntegrator.RANGE_1_KILOHERTZ_TO_10_KILOHERTZ
 
 
 
@@ -106,7 +106,7 @@ AnalogModulationFmNarrowbandIntegrator
 
 
 
-    .. py:attribute:: AnalogModulationFmNarrowbandIntegrator._10kHzto100kHz
+    .. py:attribute:: AnalogModulationFmNarrowbandIntegrator.RANGE_10_KILOHERTZ_TO_100_KILOHERTZ
 
 
 
@@ -1216,7 +1216,7 @@ ReferenceClockExportedRate
 
 .. py:class:: ReferenceClockExportedRate
 
-    .. py:attribute:: ReferenceClockExportedRate._10MHz
+    .. py:attribute:: ReferenceClockExportedRate.CLOCK_RATE_10_MEGAHERTZ
 
 
 
@@ -1226,7 +1226,7 @@ ReferenceClockExportedRate
 
 
 
-    .. py:attribute:: ReferenceClockExportedRate._100MHz
+    .. py:attribute:: ReferenceClockExportedRate.CLOCK_RATE_100_MEGAHERTZ
 
 
 
@@ -1236,7 +1236,7 @@ ReferenceClockExportedRate
 
 
 
-    .. py:attribute:: ReferenceClockExportedRate._1GHz
+    .. py:attribute:: ReferenceClockExportedRate.CLOCK_RATE_1_GIGAHERTZ
 
 
 
@@ -1261,7 +1261,7 @@ ReferenceClockRate
 
 
 
-    .. py:attribute:: ReferenceClockRate._10MHz
+    .. py:attribute:: ReferenceClockRate.CLOCK_RATE_10_MEGAHERTZ
 
 
 
@@ -1551,16 +1551,6 @@ Signal
 
 .. py:class:: Signal
 
-    .. py:attribute:: Signal.CONFIGURATION_SETTLED_EVENT
-
-
-
-        Exports a Configuration Settled Event.
-
-        
-
-
-
     .. py:attribute:: Signal.START_TRIGGER
 
 
@@ -1621,16 +1611,6 @@ Signal
 
 
 
-    .. py:attribute:: Signal.CONFIGURATION_LIST_STEP_TRIGGER
-
-
-
-        Exports a Configuration List Step Trigger.
-
-        
-
-
-
 SoftwareTriggerType
 -------------------
 
@@ -1661,7 +1641,7 @@ SparameterOrientation
 
 .. py:class:: SparameterOrientation
 
-    .. py:attribute:: SparameterOrientation.PORT1
+    .. py:attribute:: SparameterOrientation.PORT1_TOWARDS_DUT
 
 
 
@@ -1671,7 +1651,7 @@ SparameterOrientation
 
 
 
-    .. py:attribute:: SparameterOrientation.PORT2
+    .. py:attribute:: SparameterOrientation.PORT2_TOWARDS_DUT
 
 
 

--- a/docs/nirfsg/rep_caps.rst
+++ b/docs/nirfsg/rep_caps.rst
@@ -75,17 +75,17 @@ script_triggers
         passes a string of :python:`'scripttrigger0, scripttrigger1, scripttrigger2'` to the set attribute function.
 
 
-waveform
---------
+waveforms
+---------
 
-    .. py:attribute:: nirfsg.Session.waveform[]
+    .. py:attribute:: nirfsg.Session.waveforms[]
 
         If no prefix is added to the items in the parameter, the correct prefix will be added when
         the driver function call is made.
 
         .. code:: python
 
-            session.waveform['0-2'].channel_enabled = True
+            session.waveforms['0-2'].channel_enabled = True
 
         passes a string of :python:`'waveform::0, waveform::1, waveform::2'` to the set attribute function.
 
@@ -96,34 +96,34 @@ waveform
 
         .. code:: python
 
-            session.waveform['waveform::0-waveform::2'].channel_enabled = True
+            session.waveforms['waveform::0-waveform::2'].channel_enabled = True
 
         passes a string of :python:`'waveform::0, waveform::1, waveform::2'` to the set attribute function.
 
 
-port
-----
+ports
+-----
 
-    .. py:attribute:: nirfsg.Session.port[]
+    .. py:attribute:: nirfsg.Session.ports[]
 
         .. code:: python
 
-            session.port['0-2'].channel_enabled = True
+            session.ports['0-2'].channel_enabled = True
 
         passes a string of :python:`'0, 1, 2'` to the set attribute function.
 
 
-lo
---
+lo_channels
+-----------
 
-    .. py:attribute:: nirfsg.Session.lo[]
+    .. py:attribute:: nirfsg.Session.lo_channels[]
 
         If no prefix is added to the items in the parameter, the correct prefix will be added when
         the driver function call is made.
 
         .. code:: python
 
-            session.lo['0-2'].channel_enabled = True
+            session.lo_channels['0-2'].channel_enabled = True
 
         passes a string of :python:`'LO0, LO1, LO2'` to the set attribute function.
 
@@ -134,7 +134,7 @@ lo
 
         .. code:: python
 
-            session.lo['LO0-LO2'].channel_enabled = True
+            session.lo_channels['LO0-LO2'].channel_enabled = True
 
         passes a string of :python:`'LO0, LO1, LO2'` to the set attribute function.
 

--- a/docs/nirfsg/rep_caps.rst
+++ b/docs/nirfsg/rep_caps.rst
@@ -101,16 +101,42 @@ waveform
         passes a string of :python:`'waveform::0, waveform::1, waveform::2'` to the set attribute function.
 
 
-deembedding_port
-----------------
+port
+----
 
-    .. py:attribute:: nirfsg.Session.deembedding_port[]
+    .. py:attribute:: nirfsg.Session.port[]
 
         .. code:: python
 
-            session.deembedding_port['0-2'].channel_enabled = True
+            session.port['0-2'].channel_enabled = True
 
         passes a string of :python:`'0, 1, 2'` to the set attribute function.
+
+
+lo
+--
+
+    .. py:attribute:: nirfsg.Session.lo[]
+
+        If no prefix is added to the items in the parameter, the correct prefix will be added when
+        the driver function call is made.
+
+        .. code:: python
+
+            session.lo['0-2'].channel_enabled = True
+
+        passes a string of :python:`'LO0, LO1, LO2'` to the set attribute function.
+
+        If an invalid repeated capability is passed to the driver, the driver will return an error.
+
+        You can also explicitly use the prefix as part of the parameter, but it must be the correct prefix
+        for the specific repeated capability.
+
+        .. code:: python
+
+            session.lo['LO0-LO2'].channel_enabled = True
+
+        passes a string of :python:`'LO0, LO1, LO2'` to the set attribute function.
 
 
 

--- a/generated/nirfsg/nirfsg/_library.py
+++ b/generated/nirfsg/nirfsg/_library.py
@@ -44,14 +44,9 @@ class Library(object):
         self.niRFSG_ConfigureDigitalEdgeStartTrigger_cfunc = None
         self.niRFSG_ConfigureDigitalLevelScriptTrigger_cfunc = None
         self.niRFSG_ConfigureDigitalModulationUserDefinedWaveform_cfunc = None
-        self.niRFSG_ConfigureGenerationMode_cfunc = None
-        self.niRFSG_ConfigureOutputEnabled_cfunc = None
-        self.niRFSG_ConfigureP2PEndpointFullnessStartTrigger_cfunc = None
-        self.niRFSG_ConfigurePowerLevelType_cfunc = None
         self.niRFSG_ConfigurePxiChassisClk10_cfunc = None
         self.niRFSG_ConfigureRF_cfunc = None
         self.niRFSG_ConfigureRefClock_cfunc = None
-        self.niRFSG_ConfigureSignalBandwidth_cfunc = None
         self.niRFSG_ConfigureSoftwareScriptTrigger_cfunc = None
         self.niRFSG_ConfigureSoftwareStartTrigger_cfunc = None
         self.niRFSG_CreateDeembeddingSparameterTableS2PFile_cfunc = None
@@ -77,7 +72,6 @@ class Library(object):
         self.niRFSG_GetMaxSettablePower_cfunc = None
         self.niRFSG_GetSelfCalibrationDateAndTime_cfunc = None
         self.niRFSG_GetSelfCalibrationTemperature_cfunc = None
-        self.niRFSG_GetStreamEndpointHandle_cfunc = None
         self.niRFSG_GetTerminalName_cfunc = None
         self.niRFSG_GetWaveformBurstStartLocations_cfunc = None
         self.niRFSG_GetWaveformBurstStopLocations_cfunc = None
@@ -93,6 +87,7 @@ class Library(object):
         self.niRFSG_ResetAttribute_cfunc = None
         self.niRFSG_ResetDevice_cfunc = None
         self.niRFSG_ResetWithDefaults_cfunc = None
+        self.niRFSG_ResetWithOptions_cfunc = None
         self.niRFSG_RevisionQuery_cfunc = None
         self.niRFSG_SaveConfigurationsToFile_cfunc = None
         self.niRFSG_SelectArbWaveform_cfunc = None
@@ -115,7 +110,6 @@ class Library(object):
         self.niRFSG_WriteArbWaveformComplexF32_cfunc = None
         self.niRFSG_WriteArbWaveformComplexF64_cfunc = None
         self.niRFSG_WriteArbWaveformComplexI16_cfunc = None
-        self.niRFSG_WriteP2PEndpointI16_cfunc = None
         self.niRFSG_WriteScript_cfunc = None
         self.niRFSG_close_cfunc = None
         self.niRFSG_reset_cfunc = None
@@ -319,38 +313,6 @@ class Library(object):
                 self.niRFSG_ConfigureDigitalModulationUserDefinedWaveform_cfunc.restype = ViStatus  # noqa: F405
         return self.niRFSG_ConfigureDigitalModulationUserDefinedWaveform_cfunc(vi, number_of_samples, user_defined_waveform)
 
-    def niRFSG_ConfigureGenerationMode(self, vi, generation_mode):  # noqa: N802
-        with self._func_lock:
-            if self.niRFSG_ConfigureGenerationMode_cfunc is None:
-                self.niRFSG_ConfigureGenerationMode_cfunc = self._get_library_function('niRFSG_ConfigureGenerationMode')
-                self.niRFSG_ConfigureGenerationMode_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
-                self.niRFSG_ConfigureGenerationMode_cfunc.restype = ViStatus  # noqa: F405
-        return self.niRFSG_ConfigureGenerationMode_cfunc(vi, generation_mode)
-
-    def niRFSG_ConfigureOutputEnabled(self, vi, output_enabled):  # noqa: N802
-        with self._func_lock:
-            if self.niRFSG_ConfigureOutputEnabled_cfunc is None:
-                self.niRFSG_ConfigureOutputEnabled_cfunc = self._get_library_function('niRFSG_ConfigureOutputEnabled')
-                self.niRFSG_ConfigureOutputEnabled_cfunc.argtypes = [ViSession, ViBoolean]  # noqa: F405
-                self.niRFSG_ConfigureOutputEnabled_cfunc.restype = ViStatus  # noqa: F405
-        return self.niRFSG_ConfigureOutputEnabled_cfunc(vi, output_enabled)
-
-    def niRFSG_ConfigureP2PEndpointFullnessStartTrigger(self, vi, p2p_endpoint_fullness_level):  # noqa: N802
-        with self._func_lock:
-            if self.niRFSG_ConfigureP2PEndpointFullnessStartTrigger_cfunc is None:
-                self.niRFSG_ConfigureP2PEndpointFullnessStartTrigger_cfunc = self._get_library_function('niRFSG_ConfigureP2PEndpointFullnessStartTrigger')
-                self.niRFSG_ConfigureP2PEndpointFullnessStartTrigger_cfunc.argtypes = [ViSession, ViInt64]  # noqa: F405
-                self.niRFSG_ConfigureP2PEndpointFullnessStartTrigger_cfunc.restype = ViStatus  # noqa: F405
-        return self.niRFSG_ConfigureP2PEndpointFullnessStartTrigger_cfunc(vi, p2p_endpoint_fullness_level)
-
-    def niRFSG_ConfigurePowerLevelType(self, vi, power_level_type):  # noqa: N802
-        with self._func_lock:
-            if self.niRFSG_ConfigurePowerLevelType_cfunc is None:
-                self.niRFSG_ConfigurePowerLevelType_cfunc = self._get_library_function('niRFSG_ConfigurePowerLevelType')
-                self.niRFSG_ConfigurePowerLevelType_cfunc.argtypes = [ViSession, ViInt32]  # noqa: F405
-                self.niRFSG_ConfigurePowerLevelType_cfunc.restype = ViStatus  # noqa: F405
-        return self.niRFSG_ConfigurePowerLevelType_cfunc(vi, power_level_type)
-
     def niRFSG_ConfigurePxiChassisClk10(self, vi, pxi_clk10_source):  # noqa: N802
         with self._func_lock:
             if self.niRFSG_ConfigurePxiChassisClk10_cfunc is None:
@@ -374,14 +336,6 @@ class Library(object):
                 self.niRFSG_ConfigureRefClock_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViReal64]  # noqa: F405
                 self.niRFSG_ConfigureRefClock_cfunc.restype = ViStatus  # noqa: F405
         return self.niRFSG_ConfigureRefClock_cfunc(vi, ref_clock_source, ref_clock_rate)
-
-    def niRFSG_ConfigureSignalBandwidth(self, vi, signal_bandwidth):  # noqa: N802
-        with self._func_lock:
-            if self.niRFSG_ConfigureSignalBandwidth_cfunc is None:
-                self.niRFSG_ConfigureSignalBandwidth_cfunc = self._get_library_function('niRFSG_ConfigureSignalBandwidth')
-                self.niRFSG_ConfigureSignalBandwidth_cfunc.argtypes = [ViSession, ViReal64]  # noqa: F405
-                self.niRFSG_ConfigureSignalBandwidth_cfunc.restype = ViStatus  # noqa: F405
-        return self.niRFSG_ConfigureSignalBandwidth_cfunc(vi, signal_bandwidth)
 
     def niRFSG_ConfigureSoftwareScriptTrigger(self, vi, trigger_id):  # noqa: N802
         with self._func_lock:
@@ -583,14 +537,6 @@ class Library(object):
                 self.niRFSG_GetSelfCalibrationTemperature_cfunc.restype = ViStatus  # noqa: F405
         return self.niRFSG_GetSelfCalibrationTemperature_cfunc(vi, module, temperature)
 
-    def niRFSG_GetStreamEndpointHandle(self, vi, stream_endpoint, reader_handle):  # noqa: N802
-        with self._func_lock:
-            if self.niRFSG_GetStreamEndpointHandle_cfunc is None:
-                self.niRFSG_GetStreamEndpointHandle_cfunc = self._get_library_function('niRFSG_GetStreamEndpointHandle')
-                self.niRFSG_GetStreamEndpointHandle_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViUInt32)]  # noqa: F405
-                self.niRFSG_GetStreamEndpointHandle_cfunc.restype = ViStatus  # noqa: F405
-        return self.niRFSG_GetStreamEndpointHandle_cfunc(vi, stream_endpoint, reader_handle)
-
     def niRFSG_GetTerminalName(self, vi, signal, signal_identifier, buffer_size, terminal_name):  # noqa: N802
         with self._func_lock:
             if self.niRFSG_GetTerminalName_cfunc is None:
@@ -710,6 +656,14 @@ class Library(object):
                 self.niRFSG_ResetWithDefaults_cfunc.argtypes = [ViSession]  # noqa: F405
                 self.niRFSG_ResetWithDefaults_cfunc.restype = ViStatus  # noqa: F405
         return self.niRFSG_ResetWithDefaults_cfunc(vi)
+
+    def niRFSG_ResetWithOptions(self, vi, steps_to_omit):  # noqa: N802
+        with self._func_lock:
+            if self.niRFSG_ResetWithOptions_cfunc is None:
+                self.niRFSG_ResetWithOptions_cfunc = self._get_library_function('niRFSG_ResetWithOptions')
+                self.niRFSG_ResetWithOptions_cfunc.argtypes = [ViSession, ViUInt64]  # noqa: F405
+                self.niRFSG_ResetWithOptions_cfunc.restype = ViStatus  # noqa: F405
+        return self.niRFSG_ResetWithOptions_cfunc(vi, steps_to_omit)
 
     def niRFSG_RevisionQuery(self, vi, instrument_driver_revision, firmware_revision):  # noqa: N802
         with self._func_lock:
@@ -886,14 +840,6 @@ class Library(object):
                 self.niRFSG_WriteArbWaveformComplexI16_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(NIComplexI16)]  # noqa: F405
                 self.niRFSG_WriteArbWaveformComplexI16_cfunc.restype = ViStatus  # noqa: F405
         return self.niRFSG_WriteArbWaveformComplexI16_cfunc(vi, waveform_name, number_of_samples, waveform_data_array)
-
-    def niRFSG_WriteP2PEndpointI16(self, vi, stream_endpoint, number_of_samples, endpoint_data):  # noqa: N802
-        with self._func_lock:
-            if self.niRFSG_WriteP2PEndpointI16_cfunc is None:
-                self.niRFSG_WriteP2PEndpointI16_cfunc = self._get_library_function('niRFSG_WriteP2PEndpointI16')
-                self.niRFSG_WriteP2PEndpointI16_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ViInt32, ctypes.POINTER(ViInt16)]  # noqa: F405
-                self.niRFSG_WriteP2PEndpointI16_cfunc.restype = ViStatus  # noqa: F405
-        return self.niRFSG_WriteP2PEndpointI16_cfunc(vi, stream_endpoint, number_of_samples, endpoint_data)
 
     def niRFSG_WriteScript(self, vi, script):  # noqa: N802
         with self._func_lock:

--- a/generated/nirfsg/nirfsg/_library_interpreter.py
+++ b/generated/nirfsg/nirfsg/_library_interpreter.py
@@ -243,7 +243,7 @@ class LibraryInterpreter(object):
 
     def configure_digital_edge_script_trigger(self, trigger_id, source, edge):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        trigger_id_ctype = ctypes.create_string_buffer(trigger_id.encode(self._encoding))  # case C020
+        trigger_id_ctype = ctypes.create_string_buffer(trigger_id.encode(self._encoding))  # case C010
         source_ctype = ctypes.create_string_buffer(source.encode(self._encoding))  # case C020
         edge_ctype = _visatype.ViInt32(edge.value)  # case S130
         error_code = self._library.niRFSG_ConfigureDigitalEdgeScriptTrigger(vi_ctype, trigger_id_ctype, source_ctype, edge_ctype)
@@ -275,34 +275,6 @@ class LibraryInterpreter(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def configure_generation_mode(self, generation_mode):  # noqa: N802
-        vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        generation_mode_ctype = _visatype.ViInt32(generation_mode.value)  # case S130
-        error_code = self._library.niRFSG_ConfigureGenerationMode(vi_ctype, generation_mode_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return
-
-    def configure_output_enabled(self, output_enabled):  # noqa: N802
-        vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        output_enabled_ctype = _visatype.ViBoolean(output_enabled)  # case S150
-        error_code = self._library.niRFSG_ConfigureOutputEnabled(vi_ctype, output_enabled_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return
-
-    def configure_p2p_endpoint_fullness_start_trigger(self, p2p_endpoint_fullness_level):  # noqa: N802
-        vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        p2p_endpoint_fullness_level_ctype = _visatype.ViInt64(p2p_endpoint_fullness_level)  # case S150
-        error_code = self._library.niRFSG_ConfigureP2PEndpointFullnessStartTrigger(vi_ctype, p2p_endpoint_fullness_level_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return
-
-    def configure_power_level_type(self, power_level_type):  # noqa: N802
-        vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        power_level_type_ctype = _visatype.ViInt32(power_level_type.value)  # case S130
-        error_code = self._library.niRFSG_ConfigurePowerLevelType(vi_ctype, power_level_type_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return
-
     def configure_pxi_chassis_clk10(self, pxi_clk10_source):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         pxi_clk10_source_ctype = ctypes.create_string_buffer(pxi_clk10_source.encode(self._encoding))  # case C020
@@ -326,16 +298,9 @@ class LibraryInterpreter(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
-    def configure_signal_bandwidth(self, signal_bandwidth):  # noqa: N802
-        vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        signal_bandwidth_ctype = _visatype.ViReal64(signal_bandwidth)  # case S150
-        error_code = self._library.niRFSG_ConfigureSignalBandwidth(vi_ctype, signal_bandwidth_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return
-
     def configure_software_script_trigger(self, trigger_id):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        trigger_id_ctype = ctypes.create_string_buffer(trigger_id.encode(self._encoding))  # case C020
+        trigger_id_ctype = ctypes.create_string_buffer(trigger_id.encode(self._encoding))  # case C010
         error_code = self._library.niRFSG_ConfigureSoftwareScriptTrigger(vi_ctype, trigger_id_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
@@ -378,7 +343,7 @@ class LibraryInterpreter(object):
 
     def disable_script_trigger(self, trigger_id):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        trigger_id_ctype = ctypes.create_string_buffer(trigger_id.encode(self._encoding))  # case C020
+        trigger_id_ctype = ctypes.create_string_buffer(trigger_id.encode(self._encoding))  # case C010
         error_code = self._library.niRFSG_DisableScriptTrigger(vi_ctype, trigger_id_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
@@ -565,14 +530,6 @@ class LibraryInterpreter(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return float(temperature_ctype.value)
 
-    def get_stream_endpoint_handle(self, stream_endpoint):  # noqa: N802
-        vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        stream_endpoint_ctype = ctypes.create_string_buffer(stream_endpoint.encode(self._encoding))  # case C020
-        reader_handle_ctype = _visatype.ViUInt32()  # case S220
-        error_code = self._library.niRFSG_GetStreamEndpointHandle(vi_ctype, stream_endpoint_ctype, None if reader_handle_ctype is None else (ctypes.pointer(reader_handle_ctype)))
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return int(reader_handle_ctype.value)
-
     def get_terminal_name(self, signal, signal_identifier):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         signal_ctype = _visatype.ViInt32(signal.value)  # case S130
@@ -710,6 +667,13 @@ class LibraryInterpreter(object):
     def reset_with_defaults(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         error_code = self._library.niRFSG_ResetWithDefaults(vi_ctype)
+        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
+        return
+
+    def reset_with_options(self, steps_to_omit):  # noqa: N802
+        vi_ctype = _visatype.ViSession(self._vi)  # case S110
+        steps_to_omit_ctype = _visatype.ViUInt64(steps_to_omit.value)  # case S130
+        error_code = self._library.niRFSG_ResetWithOptions(vi_ctype, steps_to_omit_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
@@ -898,16 +862,6 @@ class LibraryInterpreter(object):
         number_of_samples_ctype = _visatype.ViInt32(0 if waveform_data_array is None else len(waveform_data_array) // 2)  # case S160
         waveform_data_array_ctype = _get_ctypes_pointer_for_buffer(value=waveform_data_array, library_type=_complextype.NIComplexI16)  # case B510
         error_code = self._library.niRFSG_WriteArbWaveformComplexI16(vi_ctype, waveform_name_ctype, number_of_samples_ctype, waveform_data_array_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return
-
-    def write_p2p_endpoint_i16(self, stream_endpoint, number_of_samples, endpoint_data):  # noqa: N802
-        vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        stream_endpoint_ctype = ctypes.create_string_buffer(stream_endpoint.encode(self._encoding))  # case C020
-        number_of_samples_ctype = _visatype.ViInt32(0 if endpoint_data is None else len(endpoint_data))  # case S160
-        endpoint_data_array = _convert_to_array(value=endpoint_data, array_type="h")  # case B550
-        endpoint_data_ctype = _get_ctypes_pointer_for_buffer(value=endpoint_data_array, library_type=_visatype.ViInt16)  # case B550
-        error_code = self._library.niRFSG_WriteP2PEndpointI16(vi_ctype, stream_endpoint_ctype, number_of_samples_ctype, endpoint_data_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 

--- a/generated/nirfsg/nirfsg/enums.py
+++ b/generated/nirfsg/nirfsg/enums.py
@@ -142,7 +142,7 @@ class AutomaticThermalCorrection(Enum):
     '''
 
 
-class DeembeddingTypeAttrVals(Enum):
+class DeembeddingType(Enum):
     NONE = 25000
     r'''
     De-embedding is not applied to the measurement.
@@ -797,10 +797,6 @@ class StartTriggerType(Enum):
     SOFTWARE = 2
     r'''
     The data operation does not start until a software event occurs. You may create a software trigger by calling the send_software_edge_trigger method.
-    '''
-    P2P_ENDPOINT_FULLNESS = 3
-    r'''
-    The data operation does not start until the endpoint reaches the threshold specified in the P2P_ENDPOINT_FULLNESS_START_TRIGGER_LEVEL property.
     '''
 
 

--- a/generated/nirfsg/nirfsg/enums.py
+++ b/generated/nirfsg/nirfsg/enums.py
@@ -2,6 +2,7 @@
 # This file was generated
 
 from enum import Enum
+from enum import IntFlag
 
 
 class AllowOutOfSpecificationUserSettings(Enum):
@@ -26,7 +27,7 @@ class AmpPath(Enum):
     '''
 
 
-class AnlgModFmBand(Enum):
+class AnalogModulationFmBand(Enum):
     NARROWBAND = 17000
     r'''
     Specifies narrowband frequency modulation.
@@ -37,7 +38,7 @@ class AnlgModFmBand(Enum):
     '''
 
 
-class AnlgModFmNarrowbandIntegrator(Enum):
+class AnalogModulationFmNarrowbandIntegrator(Enum):
     _100hzto1khz = 18000
     r'''
     Specifies a range from 100Hz to 1kHz.
@@ -52,7 +53,7 @@ class AnlgModFmNarrowbandIntegrator(Enum):
     '''
 
 
-class AnlgModPmMode(Enum):
+class AnalogModulationPmMode(Enum):
     HIGH_DEVIATION = 19000
     r'''
     Specifies high deviation. High deviation comes at the expense of a higher phase noise.
@@ -63,7 +64,7 @@ class AnlgModPmMode(Enum):
     '''
 
 
-class AnlgModType(Enum):
+class AnalogModulationType(Enum):
     NONE = 0
     r'''
     Disables analog modulation.
@@ -82,7 +83,7 @@ class AnlgModType(Enum):
     '''
 
 
-class AnlgModWfmType(Enum):
+class AnalogModulationWaveformType(Enum):
     SINE = 3000
     r'''
     Specifies that the analog modulation waveform type is sine.
@@ -141,37 +142,6 @@ class AutomaticThermalCorrection(Enum):
     '''
 
 
-class ConfigListTrigDigEdgeEdge(Enum):
-    EDGE = 0
-    r'''
-    Specifies the rising edge as the active edge. The rising edge occurs when the signal transitions from low level to high level.
-    '''
-
-
-class ConfigListTrigType(Enum):
-    NONE = 0
-    r'''
-    Generation starts immediately, but the list does not advance.
-    '''
-    DIGITAL_EDGE = 1
-    r'''
-    Data operation does not start until a digital edge is detected. The source of the digital edge is specified in the DIGITAL_EDGE_CONFIGURATION_LIST_STEP_TRIGGER_SOURCE property, and the active edge is always rising.
-    '''
-
-
-class ConfigurationListRepeat(Enum):
-    CONFIGURATION_LIST_REPEAT_CONTINUOUS = 0
-    r'''
-    NI-RFSG runs the configuration list continuously.
-    '''
-    MANUAL = 0
-    CONFIGURATION_LIST_REPEAT_SINGLE = 1
-    r'''
-    NI-RFSG runs the configuration list only once.
-    '''
-    SCRIPT_TRIGGER = 1
-
-
 class DeembeddingTypeAttrVals(Enum):
     NONE = 25000
     r'''
@@ -187,7 +157,18 @@ class DeembeddingTypeAttrVals(Enum):
     '''
 
 
-class DigModType(Enum):
+class DigitalEqualizationEnabled(Enum):
+    DISABLE = 0
+    r'''
+    Filter is not applied
+    '''
+    ENABLE = 1
+    r'''
+    Filter is applied.
+    '''
+
+
+class DigitalModulationType(Enum):
     NONE = 0
     r'''
     Disables digital modulation.
@@ -206,7 +187,7 @@ class DigModType(Enum):
     '''
 
 
-class DigModWfmType(Enum):
+class DigitalModulationWaveformType(Enum):
     PRBS = 5000
     r'''
     Specifies that the digital modulation waveform type is pseudorandom bit sequence (PRBS).
@@ -214,17 +195,6 @@ class DigModWfmType(Enum):
     USER_DEFINED = 5001
     r'''
     Specifies that the digital modulation waveform type is user defined. To specify the user-defined waveform, call the configure_digital_modulation_user_defined_waveform method.
-    '''
-
-
-class DigitalEqualizationEnabled(Enum):
-    DISABLE = 0
-    r'''
-    Filter is not applied
-    '''
-    ENABLE = 1
-    r'''
-    Filter is applied.
     '''
 
 
@@ -315,11 +285,11 @@ class IQOutPortTermCfg(Enum):
 
 
 class Lo1OutputFilter(Enum):
-    MANUAL = 0
+    HIGH = 0
     r'''
     yet to be defined
     '''
-    SCRIPT_TRIGGER = 1
+    LOW = 1
     r'''
     yet to be defined
     '''
@@ -330,12 +300,10 @@ class LoOutEnabled(Enum):
     r'''
     The local oscillator signal is present at the LO OUT front panel connector.
     '''
-    MANUAL = 0
     ENABLE = 1
     r'''
     The local oscillator signal is  not present at the LO OUT front panel connector..
     '''
-    SCRIPT_TRIGGER = 1
 
 
 class LoOutExportConfigureFromRFSaEnable(Enum):
@@ -343,12 +311,10 @@ class LoOutExportConfigureFromRFSaEnable(Enum):
     r'''
     Do not allow NI-RFSA to control the NI-RFSG local oscillator export.
     '''
-    MANUAL = 0
     ENABLE = 1
     r'''
     Allow NI-RFSA to control the NI-RFSG local oscillator export.
     '''
-    SCRIPT_TRIGGER = 1
 
 
 class LoPlLfractionalModeEnabled(Enum):
@@ -356,12 +322,10 @@ class LoPlLfractionalModeEnabled(Enum):
     r'''
     Disables fractional mode for the LO PLL.
     '''
-    MANUAL = 0
     ENABLE = 1
     r'''
     Enables fractional mode for the LO PLL.
     '''
-    SCRIPT_TRIGGER = 1
 
 
 class LoadConfigurationResetOptions(Enum):
@@ -610,21 +574,6 @@ class RFInLoExportEnabled(Enum):
     '''
 
 
-class RefPllBandwidth(Enum):
-    NARROW = 0
-    r'''
-    Uses the narrowest loop bandwidth setting for the PLL. Setting this property to NIRFSG_VAL_NARROW allows the PXIe-5653 to lock to a reference with worse phase noise than the PXIe-5653 and utilize the better phase noise of the PXIe-5653.
-    '''
-    MEDIUM = 1
-    r'''
-    Uses the medium loop bandwidth setting for the PLL.
-    '''
-    WIDE = 2
-    r'''
-    Uses the widest loop bandwidth setting for the PLL. Setting this property to NIRFSG_VAL_WIDE on the PXIe-5653 allows the reference PLL to lock to a better reference with better phase noise than the PXIe-5653 and utilize the better phase noise of the reference.
-    '''
-
-
 class ReferenceClockExportedRate(Enum):
     _10mhz = 10000000
     r'''
@@ -651,6 +600,21 @@ class ReferenceClockRate(Enum):
     '''
 
 
+class ReferencePllBandwidth(Enum):
+    NARROW = 0
+    r'''
+    Uses the narrowest loop bandwidth setting for the PLL. Setting this property to NIRFSG_VAL_NARROW allows the PXIe-5653 to lock to a reference with worse phase noise than the PXIe-5653 and utilize the better phase noise of the PXIe-5653.
+    '''
+    MEDIUM = 1
+    r'''
+    Uses the medium loop bandwidth setting for the PLL.
+    '''
+    WIDE = 2
+    r'''
+    Uses the widest loop bandwidth setting for the PLL. Setting this property to NIRFSG_VAL_WIDE on the PXIe-5653 allows the reference PLL to lock to a better reference with better phase noise than the PXIe-5653 and utilize the better phase noise of the reference.
+    '''
+
+
 class RelativeTo(Enum):
     CURRENT_POSITION = 8001
     r'''
@@ -662,7 +626,7 @@ class RelativeTo(Enum):
     '''
 
 
-class ResetWithOptionsStepsToOmit(Enum):
+class ResetWithOptionsStepsToOmit(IntFlag):
     DEEMBEDDING_TABLES = 8
     r'''
     Omits deleting de-embedding tables. This step is valid only for the PXIe-5830/5831/5832/5840.
@@ -685,7 +649,7 @@ class ResetWithOptionsStepsToOmit(Enum):
     '''
 
 
-class ScriptTrigDigEdgeEdge(Enum):
+class ScriptTriggerDigitalEdgeEdge(Enum):
     RISING = 0
     r'''
     Asserts the trigger when the signal transitions from low level to high level.
@@ -696,7 +660,7 @@ class ScriptTrigDigEdgeEdge(Enum):
     '''
 
 
-class ScriptTrigDigLevelActiveLevel(Enum):
+class ScriptTriggerDigitalLevelActiveLevel(Enum):
     HIGH = 9000
     r'''
     Trigger when the digital trigger signal is high.
@@ -707,7 +671,7 @@ class ScriptTrigDigLevelActiveLevel(Enum):
     '''
 
 
-class ScriptTrigType(Enum):
+class ScriptTriggerType(Enum):
     NONE = 0
     r'''
     No trigger is configured. Signal generation starts immediately.
@@ -726,7 +690,7 @@ class ScriptTrigType(Enum):
     '''
 
 
-class SelfCalibrateRangeStepsToOmit(Enum):
+class SelfCalibrateRangeStepsToOmit(IntFlag):
     IMAGE_SUPPRESSION = 8
     r'''
     Omits the Image Suppression step. If you omit this step, the Residual Sideband Image performance is not adjusted.
@@ -810,7 +774,7 @@ class SparameterOrientation(Enum):
     '''
 
 
-class StartTrigDigEdgeEdge(Enum):
+class StartTriggerDigitalEdgeEdge(Enum):
     RISING = 0
     r'''
     Occurs when the signal transitions from low level to high level.
@@ -821,7 +785,7 @@ class StartTrigDigEdgeEdge(Enum):
     '''
 
 
-class StartTrigType(Enum):
+class StartTriggerType(Enum):
     NONE = 0
     r'''
     No trigger is configured.
@@ -836,7 +800,7 @@ class StartTrigType(Enum):
     '''
     P2P_ENDPOINT_FULLNESS = 3
     r'''
-    The data operation does not start until the endpoint reaches the threshold specified in the p2p_endpoint_fullness_start_trigger_level property.
+    The data operation does not start until the endpoint reaches the threshold specified in the P2P_ENDPOINT_FULLNESS_START_TRIGGER_LEVEL property.
     '''
 
 

--- a/generated/nirfsg/nirfsg/enums.py
+++ b/generated/nirfsg/nirfsg/enums.py
@@ -39,15 +39,15 @@ class AnalogModulationFmBand(Enum):
 
 
 class AnalogModulationFmNarrowbandIntegrator(Enum):
-    _100Hzto1kHz = 18000
+    RANGE_100_HERTZ_TO_1_KILOHERTZ = 18000
     r'''
     Specifies a range from 100Hz to 1kHz.
     '''
-    _1kHzto10kHz = 18001
+    RANGE_1_KILOHERTZ_TO_10_KILOHERTZ = 18001
     r'''
     Specifies a range from 1kHz to 10kHz.
     '''
-    _10kHzto100kHz = 18002
+    RANGE_10_KILOHERTZ_TO_100_KILOHERTZ = 18002
     r'''
     Specifies a range from 10kHz to 100kHz.
     '''
@@ -527,15 +527,15 @@ class RFInLoExportEnabled(Enum):
 
 
 class ReferenceClockExportedRate(Enum):
-    _10MHz = 10000000
+    CLOCK_RATE_10_MEGAHERTZ = 10000000
     r'''
     Uses a 10MHz Reference Clock rate.
     '''
-    _100MHz = 100000000.0
+    CLOCK_RATE_100_MEGAHERTZ = 100000000.0
     r'''
     Uses a 100MHz Reference Clock rate.
     '''
-    _1GHz = 1000000000.0
+    CLOCK_RATE_1_GIGAHERTZ = 1000000000.0
     r'''
     Uses a 1GHz Reference Clock rate.
     '''
@@ -546,7 +546,7 @@ class ReferenceClockRate(Enum):
     r'''
     Uses the default Reference Clock rate for the device or automatically detects the Reference Clock rate if the device supports it.
     '''
-    _10MHz = 10000000
+    CLOCK_RATE_10_MEGAHERTZ = 10000000
     r'''
     Uses a 10MHz Reference Clock rate.
     '''
@@ -670,10 +670,6 @@ class SelfCalibrateRangeStepsToOmit(IntFlag):
 
 
 class Signal(Enum):
-    CONFIGURATION_SETTLED_EVENT = 7
-    r'''
-    Exports a Configuration Settled Event.
-    '''
     START_TRIGGER = 0
     r'''
     Exports a Start Trigger.
@@ -698,10 +694,6 @@ class Signal(Enum):
     r'''
     Exports a Done Event.
     '''
-    CONFIGURATION_LIST_STEP_TRIGGER = 6
-    r'''
-    Exports a Configuration List Step Trigger.
-    '''
 
 
 class SoftwareTriggerType(Enum):
@@ -716,11 +708,11 @@ class SoftwareTriggerType(Enum):
 
 
 class SparameterOrientation(Enum):
-    PORT1 = 24000
+    PORT1_TOWARDS_DUT = 24000
     r'''
     Port 1 of the S2P is oriented towards the DUT port.
     '''
-    PORT2 = 24001
+    PORT2_TOWARDS_DUT = 24001
     r'''
     Port 2 of the S2P is oriented towards the DUT port.
     '''

--- a/generated/nirfsg/nirfsg/enums.py
+++ b/generated/nirfsg/nirfsg/enums.py
@@ -39,15 +39,15 @@ class AnalogModulationFmBand(Enum):
 
 
 class AnalogModulationFmNarrowbandIntegrator(Enum):
-    _100hzto1khz = 18000
+    _100Hzto1kHz = 18000
     r'''
     Specifies a range from 100Hz to 1kHz.
     '''
-    _1khzto10khz = 18001
+    _1kHzto10kHz = 18001
     r'''
     Specifies a range from 1kHz to 10kHz.
     '''
-    _10khzto100khz = 18002
+    _10kHzto100kHz = 18002
     r'''
     Specifies a range from 10kHz to 100kHz.
     '''
@@ -284,28 +284,6 @@ class IQOutPortTermCfg(Enum):
     '''
 
 
-class Lo1OutputFilter(Enum):
-    HIGH = 0
-    r'''
-    yet to be defined
-    '''
-    LOW = 1
-    r'''
-    yet to be defined
-    '''
-
-
-class LoOutEnabled(Enum):
-    DISABLE = 0
-    r'''
-    The local oscillator signal is present at the LO OUT front panel connector.
-    '''
-    ENABLE = 1
-    r'''
-    The local oscillator signal is  not present at the LO OUT front panel connector..
-    '''
-
-
 class LoOutExportConfigureFromRFSaEnable(Enum):
     DISABLE = 0
     r'''
@@ -477,17 +455,6 @@ class PhaseContinuityEnabled(Enum):
     '''
 
 
-class PortTypes(Enum):
-    OUT = 14501
-    r'''
-    Specifies the PXIe-5840 RF OUT port.
-    '''
-    IN = 14500
-    r'''
-    Specifies the PXIe-5840 RF IN port. This value is not supported as the first element of an array.
-    '''
-
-
 class PowerLevelType(Enum):
     AVERAGE = 7000
     r'''
@@ -544,21 +511,6 @@ class RFBlanking(Enum):
     '''
 
 
-class RFFilter(Enum):
-    HI_FREQ_MOD = '0'
-    r'''
-    yet to be defined
-    '''
-    LO_FREQ_MOD_4000 = '1'
-    r'''
-    yet to be defined
-    '''
-    LO_FREQ_MOD_2500 = '2'
-    r'''
-    yet to be defined
-    '''
-
-
 class RFInLoExportEnabled(Enum):
     UNSPECIFIED = -2
     r'''
@@ -575,15 +527,15 @@ class RFInLoExportEnabled(Enum):
 
 
 class ReferenceClockExportedRate(Enum):
-    _10mhz = 10000000
+    _10MHz = 10000000
     r'''
     Uses a 10MHz Reference Clock rate.
     '''
-    _100mhz = 100000000.0
+    _100MHz = 100000000.0
     r'''
     Uses a 100MHz Reference Clock rate.
     '''
-    _1ghz = 1000000000.0
+    _1GHz = 1000000000.0
     r'''
     Uses a 1GHz Reference Clock rate.
     '''
@@ -594,7 +546,7 @@ class ReferenceClockRate(Enum):
     r'''
     Uses the default Reference Clock rate for the device or automatically detects the Reference Clock rate if the device supports it.
     '''
-    _10mhz = 10000000
+    _10MHz = 10000000
     r'''
     Uses a 10MHz Reference Clock rate.
     '''

--- a/generated/nirfsg/nirfsg/session.py
+++ b/generated/nirfsg/nirfsg/session.py
@@ -311,7 +311,7 @@ class _SessionBase(object):
 
     This property is valid only when you set the analog_modulation_type property to AnalogModulationType.FM and the analog_modulation_fm_band property to AnalogModulationFmBand.NARROWBAND.
 
-    **Default Value:** AnalogModulationFmNarrowbandIntegrator._100hzto1khz
+    **Default Value:** AnalogModulationFmNarrowbandIntegrator._100Hzto1kHz
 
     **Supported Devices:** PXIe-5654/5654 with PXIe-5696
 
@@ -324,11 +324,11 @@ class _SessionBase(object):
     +-------------------------------------------------------+----------------+---------------------------------------------+
     | Name                                                  | Value          | Description                                 |
     +=======================================================+================+=============================================+
-    | AnalogModulationFmNarrowbandIntegrator._100hzto1khz   | 18000 (0x4650) | Specifies a range from 100Â Hz to 1Â kHz.   |
+    | AnalogModulationFmNarrowbandIntegrator._100Hzto1kHz   | 18000 (0x4650) | Specifies a range from 100Â Hz to 1Â kHz.   |
     +-------------------------------------------------------+----------------+---------------------------------------------+
-    | AnalogModulationFmNarrowbandIntegrator._10khzto100khz | 18002 (0x4652) | Specifies a range from 10Â kHz to 100Â kHz. |
+    | AnalogModulationFmNarrowbandIntegrator._10kHzto100kHz | 18002 (0x4652) | Specifies a range from 10Â kHz to 100Â kHz. |
     +-------------------------------------------------------+----------------+---------------------------------------------+
-    | AnalogModulationFmNarrowbandIntegrator._1khzto10khz   | 18001 (0x4651) | Specifies a range from 1Â kHz to 10Â kHz.   |
+    | AnalogModulationFmNarrowbandIntegrator._1kHzto10kHz   | 18001 (0x4651) | Specifies a range from 1Â kHz to 10Â kHz.   |
     +-------------------------------------------------------+----------------+---------------------------------------------+
     '''
     analog_modulation_fm_sensitivity = _attributes.AttributeViReal64(1150166)
@@ -2084,7 +2084,7 @@ class _SessionBase(object):
 
     Specifies the Reference Clock Rate, in Hz, of the signal sent to the Reference Clock Export Output Terminal. To set this property, the NI-RFSG device must be in the Configuration state.
 
-    **Default Value:** ReferenceClockExportedRate._10mhz
+    **Default Value:** ReferenceClockExportedRate._10MHz
 
     **Supported Devices:** PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 
@@ -2093,11 +2093,11 @@ class _SessionBase(object):
     +------------------------------------+--------------+-------------------------------------+
     | Name                               | Value        | Description                         |
     +====================================+==============+=====================================+
-    | ReferenceClockExportedRate._10mhz  | 10000000.0   | Uses a 10MHz Reference Clock rate.  |
+    | ReferenceClockExportedRate._10MHz  | 10000000.0   | Uses a 10MHz Reference Clock rate.  |
     +------------------------------------+--------------+-------------------------------------+
-    | ReferenceClockExportedRate._100mhz | 100000000.0  | Uses a 100MHz Reference Clock rate. |
+    | ReferenceClockExportedRate._100MHz | 100000000.0  | Uses a 100MHz Reference Clock rate. |
     +------------------------------------+--------------+-------------------------------------+
-    | ReferenceClockExportedRate._1ghz   | 1000000000.0 | Uses a 1GHz Reference Clock rate.   |
+    | ReferenceClockExportedRate._1GHz   | 1000000000.0 | Uses a 1GHz Reference Clock rate.   |
     +------------------------------------+--------------+-------------------------------------+
 
     Note:
@@ -4123,7 +4123,7 @@ class _SessionBase(object):
 
     **Valid Values:**
 
-    PXIe-5654/5654 with PXIe-5696: Values between 1MHz to 20MHz in 1MHz steps are supported in addition to the ReferenceClockRate.AUTO and ReferenceClockRate._10mhz values.
+    PXIe-5654/5654 with PXIe-5696: Values between 1MHz to 20MHz in 1MHz steps are supported in addition to the ReferenceClockRate.AUTO and ReferenceClockRate._10MHz values.
 
     PXIe-5841 with PXIe-5655, PXIe-5842: 10 MHz, 100 MHz, 270 MHz, and 3.84 MHz
 
@@ -4154,7 +4154,7 @@ class _SessionBase(object):
     +===========================+===================================================================================================================================+
     | ReferenceClockRate.AUTO   | Uses the default Reference Clock rate for the device or automatically detects the Reference Clock rate if the device supports it. |
     +---------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
-    | ReferenceClockRate._10mhz | Uses a 10 MHz Reference Clock rate.                                                                                               |
+    | ReferenceClockRate._10MHz | Uses a 10 MHz Reference Clock rate.                                                                                               |
     +---------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
 
     Note: Automatic detection of the Reference Clock rate is supported on only the PXIe-5654/5654 with PXIe-5696. For all other supported devices, NI-RFSG uses the default Reference Clock rate of 10MHz.

--- a/generated/nirfsg/nirfsg/session.py
+++ b/generated/nirfsg/nirfsg/session.py
@@ -266,12 +266,12 @@ class _SessionBase(object):
 
     `Amplitude Modulation <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/ni_5654_5696_amplitude_modulation.html>`_
     '''
-    analog_modulation_fm_band = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.AnlgModFmBand, 1150191)
-    '''Type: enums.AnlgModFmBand
+    analog_modulation_fm_band = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.AnalogModulationFmBand, 1150191)
+    '''Type: enums.AnalogModulationFmBand
 
     Specifies the analog modulation frequency modulation (FM) band to use. Wideband FM allows for modulating signals higher than 100kHz. Narrowband FM allows for modulating lower frequency signals.
 
-    **Default Value:** AnlgModFmBand.WIDEBAND
+    **Default Value:** AnalogModulationFmBand.WIDEBAND
 
     **Supported Devices:** PXIe-5654/5654 with PXIe-5696
 
@@ -281,13 +281,13 @@ class _SessionBase(object):
 
     **Defined Values**:
 
-    +--------------------------+----------------+--------------------------------------------+
-    | Name                     | Value          | Description                                |
-    +==========================+================+============================================+
-    | AnlgModFmBand.NARROWBAND | 17000 (0x4268) | Specifies narrowband frequency modulation. |
-    +--------------------------+----------------+--------------------------------------------+
-    | AnlgModFmBand.WIDEBAND   | 17001 (0x4269) | Specifies wideband frequency modulation.   |
-    +--------------------------+----------------+--------------------------------------------+
+    +-----------------------------------+----------------+--------------------------------------------+
+    | Name                              | Value          | Description                                |
+    +===================================+================+============================================+
+    | AnalogModulationFmBand.NARROWBAND | 17000 (0x4268) | Specifies narrowband frequency modulation. |
+    +-----------------------------------+----------------+--------------------------------------------+
+    | AnalogModulationFmBand.WIDEBAND   | 17001 (0x4269) | Specifies wideband frequency modulation.   |
+    +-----------------------------------+----------------+--------------------------------------------+
     '''
     analog_modulation_fm_deviation = _attributes.AttributeViReal64(1150035)
     '''Type: float
@@ -304,14 +304,14 @@ class _SessionBase(object):
 
     `Modulation Schemes <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/modulation_modes.html>`_
     '''
-    analog_modulation_fm_narrowband_integrator = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.AnlgModFmNarrowbandIntegrator, 1150165)
-    '''Type: enums.AnlgModFmNarrowbandIntegrator
+    analog_modulation_fm_narrowband_integrator = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.AnalogModulationFmNarrowbandIntegrator, 1150165)
+    '''Type: enums.AnalogModulationFmNarrowbandIntegrator
 
     Specifies the narrowband frequency modulation (FM) range to apply by sending the signal through an integrator.
 
-    This property is valid only when you set the analog_modulation_type property to AnlgModType.FM and the analog_modulation_fm_band property to AnlgModFmBand.NARROWBAND.
+    This property is valid only when you set the analog_modulation_type property to AnalogModulationType.FM and the analog_modulation_fm_band property to AnalogModulationFmBand.NARROWBAND.
 
-    **Default Value:** AnlgModFmNarrowbandIntegrator._100hzto1khz
+    **Default Value:** AnalogModulationFmNarrowbandIntegrator._100hzto1khz
 
     **Supported Devices:** PXIe-5654/5654 with PXIe-5696
 
@@ -321,15 +321,15 @@ class _SessionBase(object):
 
     **Defined Values**:
 
-    +----------------------------------------------+----------------+---------------------------------------------+
-    | Name                                         | Value          | Description                                 |
-    +==============================================+================+=============================================+
-    | AnlgModFmNarrowbandIntegrator._100hzto1khz   | 18000 (0x4650) | Specifies a range from 100Â Hz to 1Â kHz.   |
-    +----------------------------------------------+----------------+---------------------------------------------+
-    | AnlgModFmNarrowbandIntegrator._10khzto100khz | 18002 (0x4652) | Specifies a range from 10Â kHz to 100Â kHz. |
-    +----------------------------------------------+----------------+---------------------------------------------+
-    | AnlgModFmNarrowbandIntegrator._1khzto10khz   | 18001 (0x4651) | Specifies a range from 1Â kHz to 10Â kHz.   |
-    +----------------------------------------------+----------------+---------------------------------------------+
+    +-------------------------------------------------------+----------------+---------------------------------------------+
+    | Name                                                  | Value          | Description                                 |
+    +=======================================================+================+=============================================+
+    | AnalogModulationFmNarrowbandIntegrator._100hzto1khz   | 18000 (0x4650) | Specifies a range from 100Â Hz to 1Â kHz.   |
+    +-------------------------------------------------------+----------------+---------------------------------------------+
+    | AnalogModulationFmNarrowbandIntegrator._10khzto100khz | 18002 (0x4652) | Specifies a range from 10Â kHz to 100Â kHz. |
+    +-------------------------------------------------------+----------------+---------------------------------------------+
+    | AnalogModulationFmNarrowbandIntegrator._1khzto10khz   | 18001 (0x4651) | Specifies a range from 1Â kHz to 10Â kHz.   |
+    +-------------------------------------------------------+----------------+---------------------------------------------+
     '''
     analog_modulation_fm_sensitivity = _attributes.AttributeViReal64(1150166)
     '''Type: float
@@ -361,12 +361,12 @@ class _SessionBase(object):
 
     `Modulation Schemes <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/modulation_modes.html>`_
     '''
-    analog_modulation_pm_mode = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.AnlgModPmMode, 1150192)
-    '''Type: enums.AnlgModPmMode
+    analog_modulation_pm_mode = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.AnalogModulationPmMode, 1150192)
+    '''Type: enums.AnalogModulationPmMode
 
     Specifies the phase modulation (PM) mode to use.
 
-    **Default Value:** AnlgModPmMode.LOW_PHASE_NOISE
+    **Default Value:** AnalogModulationPmMode.LOW_PHASE_NOISE
 
     **Supported Devices:** PXIe-5654/5654 with PXIe-5696
 
@@ -376,13 +376,13 @@ class _SessionBase(object):
 
     **Defined Values**:
 
-    +-------------------------------+----------------+-----------------------------------------------------------------------------------------------+
-    | Name                          | Value          | Description                                                                                   |
-    +===============================+================+===============================================================================================+
-    | AnlgModPmMode.HIGH_DEVIATION  | 19000 (0x4a38) | Specifies high deviation. High deviation comes at the expense of a higher phase noise.        |
-    +-------------------------------+----------------+-----------------------------------------------------------------------------------------------+
-    | AnlgModPmMode.LOW_PHASE_NOISE | 19001 (0x4a39) | Specifies low phase noise. Low phase noise comes at the expense of a lower maximum deviation. |
-    +-------------------------------+----------------+-----------------------------------------------------------------------------------------------+
+    +----------------------------------------+----------------+-----------------------------------------------------------------------------------------------+
+    | Name                                   | Value          | Description                                                                                   |
+    +========================================+================+===============================================================================================+
+    | AnalogModulationPmMode.HIGH_DEVIATION  | 19000 (0x4a38) | Specifies high deviation. High deviation comes at the expense of a higher phase noise.        |
+    +----------------------------------------+----------------+-----------------------------------------------------------------------------------------------+
+    | AnalogModulationPmMode.LOW_PHASE_NOISE | 19001 (0x4a39) | Specifies low phase noise. Low phase noise comes at the expense of a lower maximum deviation. |
+    +----------------------------------------+----------------+-----------------------------------------------------------------------------------------------+
     '''
     analog_modulation_pm_sensitivity = _attributes.AttributeViReal64(1150168)
     '''Type: float
@@ -399,12 +399,12 @@ class _SessionBase(object):
 
     `Phase Modulation <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/ni_5654_5696_phase_modulation.html>`_
     '''
-    analog_modulation_type = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.AnlgModType, 1150032)
-    '''Type: enums.AnlgModType
+    analog_modulation_type = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.AnalogModulationType, 1150032)
+    '''Type: enums.AnalogModulationType
 
     Specifies the analog modulation format to use.
 
-    **Default Value:** AnlgModType.NONE
+    **Default Value:** AnalogModulationType.NONE
 
     **Supported Devices:** PXI/PXIe-5650/5651/5652, PXIe-5654/5654 with PXIe-5696
 
@@ -418,17 +418,17 @@ class _SessionBase(object):
 
     **Defined Values**:
 
-    +------------------+--------------+--------------------------------------------------+
-    | Name             | Value        | Description                                      |
-    +==================+==============+==================================================+
-    | AnlgModType.AM   | 2002 (0x7d2) | Specifies that the analog modulation type is AM. |
-    +------------------+--------------+--------------------------------------------------+
-    | AnlgModType.FM   | 2000 (0x7d0) | Specifies that the analog modulation type is FM. |
-    +------------------+--------------+--------------------------------------------------+
-    | AnlgModType.NONE | 0 (0x0)      | Disables analog modulation.                      |
-    +------------------+--------------+--------------------------------------------------+
-    | AnlgModType.PM   | 2001 (0x7d1) | Specifies that the analog modulation type is PM. |
-    +------------------+--------------+--------------------------------------------------+
+    +---------------------------+--------------+--------------------------------------------------+
+    | Name                      | Value        | Description                                      |
+    +===========================+==============+==================================================+
+    | AnalogModulationType.AM   | 2002 (0x7d2) | Specifies that the analog modulation type is AM. |
+    +---------------------------+--------------+--------------------------------------------------+
+    | AnalogModulationType.FM   | 2000 (0x7d0) | Specifies that the analog modulation type is FM. |
+    +---------------------------+--------------+--------------------------------------------------+
+    | AnalogModulationType.NONE | 0 (0x0)      | Disables analog modulation.                      |
+    +---------------------------+--------------+--------------------------------------------------+
+    | AnalogModulationType.PM   | 2001 (0x7d1) | Specifies that the analog modulation type is PM. |
+    +---------------------------+--------------+--------------------------------------------------+
 
     Note:
     One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
@@ -448,12 +448,12 @@ class _SessionBase(object):
 
     `Modulation Schemes <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/modulation_modes.html>`_
     '''
-    analog_modulation_waveform_type = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.AnlgModWfmType, 1150033)
-    '''Type: enums.AnlgModWfmType
+    analog_modulation_waveform_type = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.AnalogModulationWaveformType, 1150033)
+    '''Type: enums.AnalogModulationWaveformType
 
     Specifies the type of waveform to use as the message signal for analog modulation.
 
-    **Default Value:** AnlgModWfmType.SINE
+    **Default Value:** AnalogModulationWaveformType.SINE
 
     **Supported Devices:** PXI/PXIe-5650/5651/5652
 
@@ -463,15 +463,15 @@ class _SessionBase(object):
 
     **Defined Values**:
 
-    +-------------------------+--------------+-----------------------------------------------------------------+
-    | Name                    | Value        | Description                                                     |
-    +=========================+==============+=================================================================+
-    | AnlgModWfmType.SINE     | 3000 (0xbb8) | Specifies that the analog modulation waveform type is sine.     |
-    +-------------------------+--------------+-----------------------------------------------------------------+
-    | AnlgModWfmType.SQUARE   | 3001 (0xbb9) | Specifies that the analog modulation waveform type is square.   |
-    +-------------------------+--------------+-----------------------------------------------------------------+
-    | AnlgModWfmType.TRIANGLE | 3002 (0xbba) | Specifies that the analog modulation waveform type is triangle. |
-    +-------------------------+--------------+-----------------------------------------------------------------+
+    +---------------------------------------+--------------+-----------------------------------------------------------------+
+    | Name                                  | Value        | Description                                                     |
+    +=======================================+==============+=================================================================+
+    | AnalogModulationWaveformType.SINE     | 3000 (0xbb8) | Specifies that the analog modulation waveform type is sine.     |
+    +---------------------------------------+--------------+-----------------------------------------------------------------+
+    | AnalogModulationWaveformType.SQUARE   | 3001 (0xbb9) | Specifies that the analog modulation waveform type is square.   |
+    +---------------------------------------+--------------+-----------------------------------------------------------------+
+    | AnalogModulationWaveformType.TRIANGLE | 3002 (0xbba) | Specifies that the analog modulation waveform type is triangle. |
+    +---------------------------------------+--------------+-----------------------------------------------------------------+
     '''
     arb_carrier_frequency = _attributes.AttributeViReal64(1150015)
     '''Type: float
@@ -1063,12 +1063,12 @@ class _SessionBase(object):
     **Supported Devices**: PXIe-5830/5831/5832/5840/5841/5842/5860
 
     Tip:
-    This property can be set/get on specific deembedding_port within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container deembedding_port to specify a subset.
+    This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container port to specify a subset.
 
-    Example: :py:attr:`my_session.deembedding_port[ ... ].deembedding_compensation_gain`
+    Example: :py:attr:`my_session.port[ ... ].deembedding_compensation_gain`
 
-    To set/get on all deembedding_port, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.deembedding_compensation_gain`
     '''
@@ -1086,12 +1086,12 @@ class _SessionBase(object):
     **Supported Devices**: PXIe-5830/5831/5832/5840/5841/5842/5860
 
     Tip:
-    This property can be set/get on specific deembedding_port within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container deembedding_port to specify a subset.
+    This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container port to specify a subset.
 
-    Example: :py:attr:`my_session.deembedding_port[ ... ].deembedding_selected_table`
+    Example: :py:attr:`my_session.port[ ... ].deembedding_selected_table`
 
-    To set/get on all deembedding_port, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.deembedding_selected_table`
     '''
@@ -1125,12 +1125,12 @@ class _SessionBase(object):
     +--------------------------------+----------------+------------------------------------------------------------------------+
 
     Tip:
-    This property can be set/get on specific deembedding_port within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container deembedding_port to specify a subset.
+    This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container port to specify a subset.
 
-    Example: :py:attr:`my_session.deembedding_port[ ... ].deembedding_type`
+    Example: :py:attr:`my_session.port[ ... ].deembedding_type`
 
-    To set/get on all deembedding_port, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.deembedding_type`
     '''
@@ -1195,13 +1195,23 @@ class _SessionBase(object):
     +----------------------------+--------------------------+-------------------------+
     | Second connected mmRH-5582 | SWITCHED TRX PORTS [0-7] | rf1switch1              |
     +----------------------------+--------------------------+-------------------------+
+
+    Tip:
+    This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container port to specify a subset.
+
+    Example: :py:attr:`my_session.port[ ... ].device_temperature`
+
+    To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+    Example: :py:attr:`my_session.device_temperature`
     '''
-    digital_edge_script_trigger_edge = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.ScriptTrigDigEdgeEdge, 1150021)
-    '''Type: enums.ScriptTrigDigEdgeEdge
+    digital_edge_script_trigger_edge = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.ScriptTriggerDigitalEdgeEdge, 1150021)
+    '''Type: enums.ScriptTriggerDigitalEdgeEdge
 
     Specifies the active edge for the Script Trigger. This property is used when the script_trigger_type property is set to digital edge. To set the digital_edge_script_trigger_edge property, the NI-RFSG device must be in the Configuration state.
 
-    **Default Value:** ScriptTrigDigEdgeEdge.RISING
+    **Default Value:** ScriptTriggerDigitalEdgeEdge.RISING
 
     **Supported Devices:** PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 
@@ -1217,13 +1227,13 @@ class _SessionBase(object):
 
     **Defined Values**:
 
-    +-------------------------------+---------+-------------------------------------------------------------------------------+
-    | Name                          | Value   | Description                                                                   |
-    +===============================+=========+===============================================================================+
-    | ScriptTrigDigEdgeEdge.FALLING | 1 (0x1) | Asserts the trigger when the signal transitions from high level to low level. |
-    +-------------------------------+---------+-------------------------------------------------------------------------------+
-    | ScriptTrigDigEdgeEdge.RISING  | 0 (0x0) | Asserts the trigger when the signal transitions from low level to high level. |
-    +-------------------------------+---------+-------------------------------------------------------------------------------+
+    +--------------------------------------+---------+-------------------------------------------------------------------------------+
+    | Name                                 | Value   | Description                                                                   |
+    +======================================+=========+===============================================================================+
+    | ScriptTriggerDigitalEdgeEdge.FALLING | 1 (0x1) | Asserts the trigger when the signal transitions from high level to low level. |
+    +--------------------------------------+---------+-------------------------------------------------------------------------------+
+    | ScriptTriggerDigitalEdgeEdge.RISING  | 0 (0x0) | Asserts the trigger when the signal transitions from low level to high level. |
+    +--------------------------------------+---------+-------------------------------------------------------------------------------+
 
     Note:
     One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
@@ -1321,14 +1331,14 @@ class _SessionBase(object):
 
     Example: :py:attr:`my_session.digital_edge_script_trigger_source`
     '''
-    digital_edge_start_trigger_edge = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.StartTrigDigEdgeEdge, 1250459)
-    '''Type: enums.StartTrigDigEdgeEdge
+    digital_edge_start_trigger_edge = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.StartTriggerDigitalEdgeEdge, 1250459)
+    '''Type: enums.StartTriggerDigitalEdgeEdge
 
     Specifies the active edge for the Start Trigger. This property is used when the start_trigger_type property is set to digital edge. To set the digital_edge_start_trigger_edge property, the NI-RFSG device must be in the Configuration state.
 
     PXIe-5654/5654 with PXIe-5696: The Start Trigger is valid only with a timer-based list when RF list mode is enabled.
 
-    **Default Value:** StartTrigDigEdgeEdge.RISING
+    **Default Value:** StartTriggerDigitalEdgeEdge.RISING
 
     **Supported Devices:** PXIe-5644/5645/5646, PXIe-5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 
@@ -1344,13 +1354,13 @@ class _SessionBase(object):
 
     **Defined Values**:
 
-    +------------------------------+---------+------------------------------------------------------------------+
-    | Name                         | Value   | Description                                                      |
-    +==============================+=========+==================================================================+
-    | StartTrigDigEdgeEdge.FALLING | 1 (0x1) | Occurs when the signal transitions from high level to low level. |
-    +------------------------------+---------+------------------------------------------------------------------+
-    | StartTrigDigEdgeEdge.RISING  | 0 (0x0) | Occurs when the signal transitions from low level to high level. |
-    +------------------------------+---------+------------------------------------------------------------------+
+    +-------------------------------------+---------+------------------------------------------------------------------+
+    | Name                                | Value   | Description                                                      |
+    +=====================================+=========+==================================================================+
+    | StartTriggerDigitalEdgeEdge.FALLING | 1 (0x1) | Occurs when the signal transitions from high level to low level. |
+    +-------------------------------------+---------+------------------------------------------------------------------+
+    | StartTriggerDigitalEdgeEdge.RISING  | 0 (0x0) | Occurs when the signal transitions from low level to high level. |
+    +-------------------------------------+---------+------------------------------------------------------------------+
 
     Note:
     One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
@@ -1468,12 +1478,12 @@ class _SessionBase(object):
     Note:
     One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
     '''
-    digital_level_script_trigger_active_level = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.ScriptTrigDigLevelActiveLevel, 1150055)
-    '''Type: enums.ScriptTrigDigLevelActiveLevel
+    digital_level_script_trigger_active_level = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.ScriptTriggerDigitalLevelActiveLevel, 1150055)
+    '''Type: enums.ScriptTriggerDigitalLevelActiveLevel
 
-    Specifies the active level for the Script Trigger. This property is used when the script_trigger_type property is set to ScriptTrigType.DIGITAL_LEVEL.
+    Specifies the active level for the Script Trigger. This property is used when the script_trigger_type property is set to ScriptTriggerType.DIGITAL_LEVEL.
 
-    **Default Value:** ScriptTrigDigLevelActiveLevel.HIGH
+    **Default Value:** ScriptTriggerDigitalLevelActiveLevel.HIGH
 
     **Supported Devices:** PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 
@@ -1485,13 +1495,13 @@ class _SessionBase(object):
 
     **Defined Values**:
 
-    +------------------------------------+---------------+--------------------------------------------------+
-    | Name                               | Value         | Description                                      |
-    +====================================+===============+==================================================+
-    | ScriptTrigDigLevelActiveLevel.HIGH | 9000 (0x2328) | Trigger when the digital trigger signal is high. |
-    +------------------------------------+---------------+--------------------------------------------------+
-    | ScriptTrigDigLevelActiveLevel.LOW  | 9001 (0x2329) | Trigger when the digital trigger signal is low.  |
-    +------------------------------------+---------------+--------------------------------------------------+
+    +-------------------------------------------+---------------+--------------------------------------------------+
+    | Name                                      | Value         | Description                                      |
+    +===========================================+===============+==================================================+
+    | ScriptTriggerDigitalLevelActiveLevel.HIGH | 9000 (0x2328) | Trigger when the digital trigger signal is high. |
+    +-------------------------------------------+---------------+--------------------------------------------------+
+    | ScriptTriggerDigitalLevelActiveLevel.LOW  | 9001 (0x2329) | Trigger when the digital trigger signal is low.  |
+    +-------------------------------------------+---------------+--------------------------------------------------+
 
     Tip:
     This property can be set/get on specific script_triggers within your :py:class:`nirfsg.Session` instance.
@@ -1506,7 +1516,7 @@ class _SessionBase(object):
     digital_level_script_trigger_source = _attributes.AttributeViString(1150054)
     '''Type: str
 
-    Specifies the source terminal for the Script Trigger. This property is used when the script_trigger_type property is set to ScriptTrigType.DIGITAL_LEVEL. The digital_level_script_trigger_source property is not case-sensitive.
+    Specifies the source terminal for the Script Trigger. This property is used when the script_trigger_type property is set to ScriptTriggerType.DIGITAL_LEVEL. The digital_level_script_trigger_source property is not case-sensitive.
 
     To set the digital_level_script_trigger_source property, the NI-RFSG device must be in the Configuration state.
 
@@ -1638,12 +1648,12 @@ class _SessionBase(object):
 
     `Modulation Schemes <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/modulation_modes.html>`_
     '''
-    digital_modulation_type = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.DigModType, 1150036)
-    '''Type: enums.DigModType
+    digital_modulation_type = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.DigitalModulationType, 1150036)
+    '''Type: enums.DigitalModulationType
 
     Specifies the digital modulation format to use.
 
-    **Default Value:** DigModType.NONE
+    **Default Value:** DigitalModulationType.NONE
 
     **Supported Devices:** PXI/PXIe-5650/5651/5652
 
@@ -1653,27 +1663,27 @@ class _SessionBase(object):
 
     **Defined Values**:
 
-    +-----------------+--------------+-----------------------------------------------------------------------------+
-    | Name            | Value        | Description                                                                 |
-    +=================+==============+=============================================================================+
-    | DigModType.FSK  | 4000 (0xfa0) | Specifies that the digital modulation type is frequency-shift keying (FSK). |
-    +-----------------+--------------+-----------------------------------------------------------------------------+
-    | DigModType.NONE | 0 (0x0)      | Disables digital modulation.                                                |
-    +-----------------+--------------+-----------------------------------------------------------------------------+
-    | DigModType.OOK  | 4001 (0xfa1) | Specifies that the digital modulation type is on-off keying (OOK).          |
-    +-----------------+--------------+-----------------------------------------------------------------------------+
-    | DigModType.PSK  | 4002 (0xfa2) | Specifies that the digital modulation type is phase-shift keying (PSK).     |
-    +-----------------+--------------+-----------------------------------------------------------------------------+
+    +----------------------------+--------------+-----------------------------------------------------------------------------+
+    | Name                       | Value        | Description                                                                 |
+    +============================+==============+=============================================================================+
+    | DigitalModulationType.FSK  | 4000 (0xfa0) | Specifies that the digital modulation type is frequency-shift keying (FSK). |
+    +----------------------------+--------------+-----------------------------------------------------------------------------+
+    | DigitalModulationType.NONE | 0 (0x0)      | Disables digital modulation.                                                |
+    +----------------------------+--------------+-----------------------------------------------------------------------------+
+    | DigitalModulationType.OOK  | 4001 (0xfa1) | Specifies that the digital modulation type is on-off keying (OOK).          |
+    +----------------------------+--------------+-----------------------------------------------------------------------------+
+    | DigitalModulationType.PSK  | 4002 (0xfa2) | Specifies that the digital modulation type is phase-shift keying (PSK).     |
+    +----------------------------+--------------+-----------------------------------------------------------------------------+
 
     Note:
     One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
     '''
-    digital_modulation_waveform_type = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.DigModWfmType, 1150038)
-    '''Type: enums.DigModWfmType
+    digital_modulation_waveform_type = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.DigitalModulationWaveformType, 1150038)
+    '''Type: enums.DigitalModulationWaveformType
 
     Specifies the type of waveform to use as the message signal in digital modulation.
 
-    **Default Value:** DigModWfmType.PRBS
+    **Default Value:** DigitalModulationWaveformType.PRBS
 
     **Supported Devices:** PXI/PXIe-5650/5651/5652
 
@@ -1683,13 +1693,13 @@ class _SessionBase(object):
 
     **Defined Values**:
 
-    +----------------------------+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-    | Name                       | Value         | Description                                                                                                                                                                    |
-    +============================+===============+================================================================================================================================================================================+
-    | DigModWfmType.PRBS         | 5000 (0x1388) | Specifies that the digital modulation waveform type is pseudorandom bit sequence (PRBS).                                                                                       |
-    +----------------------------+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-    | DigModWfmType.USER_DEFINED | 5001 (0x1389) | Specifies that the digital modulation waveform type is user defined. To specify the user-defined waveform, call the configure_digital_modulation_user_defined_waveform method. |
-    +----------------------------+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    +--------------------------------------------+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | Name                                       | Value         | Description                                                                                                                                                                    |
+    +============================================+===============+================================================================================================================================================================================+
+    | DigitalModulationWaveformType.PRBS         | 5000 (0x1388) | Specifies that the digital modulation waveform type is pseudorandom bit sequence (PRBS).                                                                                       |
+    +--------------------------------------------+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | DigitalModulationWaveformType.USER_DEFINED | 5001 (0x1389) | Specifies that the digital modulation waveform type is user defined. To specify the user-defined waveform, call the configure_digital_modulation_user_defined_waveform method. |
+    +--------------------------------------------+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
     Note:
     One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
@@ -1992,24 +2002,24 @@ class _SessionBase(object):
 
     Example: :py:attr:`my_session.exported_marker_event_output_terminal`
     '''
-    exported_pulse_modulation_event_active_level = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.ScriptTrigDigLevelActiveLevel, 1150310)
-    '''Type: enums.ScriptTrigDigLevelActiveLevel
+    exported_pulse_modulation_event_active_level = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.ScriptTriggerDigitalLevelActiveLevel, 1150310)
+    '''Type: enums.ScriptTriggerDigitalLevelActiveLevel
 
     Specifies the active level of the exported Pulse Modulation Event. When `property pulse modulation enabled` is Enabled, `pulse modulation active level` is `active high`, `exported pulse modulation event output terminal` is `PulseOut`, and this property is `active high`, then the Pulse Modulation Event will transition from Low to High after the the Pulse In signal is set to logic high, and the RF Output has settled. To set this property, the NI-RFSG device must be in the Configuration state.
 
-    **Default Value:** ScriptTrigDigLevelActiveLevel.HIGH
+    **Default Value:** ScriptTriggerDigitalLevelActiveLevel.HIGH
 
     **Supported Devices:**  PXIe-5842
 
     **Defined Values**:
 
-    +------------------------------------+---------------+--------------------------------------------------+
-    | Name                               | Value         | Description                                      |
-    +====================================+===============+==================================================+
-    | ScriptTrigDigLevelActiveLevel.HIGH | 9000 (0x2328) | Trigger when the digital trigger signal is high. |
-    +------------------------------------+---------------+--------------------------------------------------+
-    | ScriptTrigDigLevelActiveLevel.LOW  | 9001 (0x2329) | Trigger when the digital trigger signal is low.  |
-    +------------------------------------+---------------+--------------------------------------------------+
+    +-------------------------------------------+---------------+--------------------------------------------------+
+    | Name                                      | Value         | Description                                      |
+    +===========================================+===============+==================================================+
+    | ScriptTriggerDigitalLevelActiveLevel.HIGH | 9000 (0x2328) | Trigger when the digital trigger signal is high. |
+    +-------------------------------------------+---------------+--------------------------------------------------+
+    | ScriptTriggerDigitalLevelActiveLevel.LOW  | 9001 (0x2329) | Trigger when the digital trigger signal is low.  |
+    +-------------------------------------------+---------------+--------------------------------------------------+
     '''
     exported_pulse_modulation_event_output_terminal = _attributes.AttributeViString(1150309)
     '''Type: str
@@ -2535,10 +2545,6 @@ class _SessionBase(object):
 
     `Scripting Instructions <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/scripting_instructions.html>`_—Refer to this topic for more information about scripting.
 
-    **High-Level Methods**:
-
-    - configure_generation_mode
-
     **Defined Values**:
 
     +-----------------------------+--------------+------------------------------------------------------------------------------------------------------------------------+
@@ -2763,6 +2769,16 @@ class _SessionBase(object):
     Note: - For the PXIe-5645, this property is ignored if you are using the RF ports.
 
      - The valid range is dependent on the load impedance.
+
+    Tip:
+    This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container port to specify a subset.
+
+    Example: :py:attr:`my_session.port[ ... ].iq_out_port_common_mode_offset`
+
+    To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+    Example: :py:attr:`my_session.iq_out_port_common_mode_offset`
     '''
     iq_out_port_level = _attributes.AttributeViReal64(1150147)
     '''Type: float
@@ -2794,6 +2810,16 @@ class _SessionBase(object):
     Note: - For the PXIe-5645, this property is ignored if you are using the RF ports.
 
      - The valid values are only applicable when you set the iq_out_port_load_impedance property to 50 Ω and when you set the iq_out_port_offset property to 0.
+
+    Tip:
+    This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container port to specify a subset.
+
+    Example: :py:attr:`my_session.port[ ... ].iq_out_port_level`
+
+    To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+    Example: :py:attr:`my_session.iq_out_port_level`
     '''
     iq_out_port_load_impedance = _attributes.AttributeViReal64(1150163)
     '''Type: float
@@ -2811,6 +2837,16 @@ class _SessionBase(object):
     **Supported Devices:** PXIe-5645, PXIe-5820
 
     Note: For the PXIe-5645, this property is ignored if you are using the RF ports.
+
+    Tip:
+    This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container port to specify a subset.
+
+    Example: :py:attr:`my_session.port[ ... ].iq_out_port_load_impedance`
+
+    To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+    Example: :py:attr:`my_session.iq_out_port_load_impedance`
     '''
     iq_out_port_offset = _attributes.AttributeViReal64(1150149)
     '''Type: float
@@ -2828,6 +2864,16 @@ class _SessionBase(object):
     **Supported Devices:** PXIe-5645, PXIe-5820
 
     Note: For the PXIe-5645, this property is ignored if you are using the RF ports.
+
+    Tip:
+    This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container port to specify a subset.
+
+    Example: :py:attr:`my_session.port[ ... ].iq_out_port_offset`
+
+    To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+    Example: :py:attr:`my_session.iq_out_port_offset`
     '''
     iq_out_port_temperature = _attributes.AttributeViReal64(1150161)
     '''Type: float
@@ -2872,6 +2918,16 @@ class _SessionBase(object):
     +-------------------------------+----------------+--------------------------------------------------+
 
     Note: For the PXIe-5645, this property is ignored if you are using the RF ports.
+
+    Tip:
+    This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container port to specify a subset.
+
+    Example: :py:attr:`my_session.port[ ... ].iq_out_port_terminal_configuration`
+
+    To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+    Example: :py:attr:`my_session.iq_out_port_terminal_configuration`
     '''
     iq_q_offset = _attributes.AttributeViReal64(1150071)
     '''Type: float
@@ -3070,6 +3126,16 @@ class _SessionBase(object):
 
     Note:
     One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
+
+    Tip:
+    This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container lo to specify a subset.
+
+    Example: :py:attr:`my_session.lo[ ... ].loop_bandwidth`
+
+    To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+    Example: :py:attr:`my_session.loop_bandwidth`
     '''
     lo_frequency = _attributes.AttributeViReal64(1150199)
     '''Type: float
@@ -3087,6 +3153,16 @@ class _SessionBase(object):
     `PXIe-5831/5832 Frequency and Bandwidth Configuration <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/frequency_and_bandwidth_configuration.html>`_
 
     Note: This property is read/write if you are using an external LO. Otherwise, this property is read-only.
+
+    Tip:
+    This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container lo to specify a subset.
+
+    Example: :py:attr:`my_session.lo[ ... ].lo_frequency`
+
+    To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+    Example: :py:attr:`my_session.lo_frequency`
     '''
     lo_frequency_step_size = _attributes.AttributeViReal64(1150151)
     '''Type: float
@@ -3160,6 +3236,16 @@ class _SessionBase(object):
     Note: - This property is read/write if you are using an external LO. Otherwise, this property is read-only.
 
      - For the PXIe-5644/5645/5646, this property is always read-only.
+
+    Tip:
+    This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container lo to specify a subset.
+
+    Example: :py:attr:`my_session.lo[ ... ].lo_in_power`
+
+    To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+    Example: :py:attr:`my_session.lo_in_power`
     '''
     lo_out_enabled = _attributes.AttributeViBoolean(1150013)
     '''Type: bool
@@ -3188,6 +3274,16 @@ class _SessionBase(object):
 
     Note:
     One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
+
+    Tip:
+    This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container lo to specify a subset.
+
+    Example: :py:attr:`my_session.lo[ ... ].lo_out_enabled`
+
+    To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+    Example: :py:attr:`my_session.lo_out_enabled`
     '''
     lo_out_export_configure_from_rfsa = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.LoOutExportConfigureFromRFSaEnable, 1150242)
     '''Type: enums.LoOutExportConfigureFromRFSaEnable
@@ -3229,6 +3325,16 @@ class _SessionBase(object):
     `LO OUT <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/loout.html>`_
 
     Note: For the PXIe-5644/5645/5646 and PXIe-5673/5673E, this property is always read-only.
+
+    Tip:
+    This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container lo to specify a subset.
+
+    Example: :py:attr:`my_session.lo[ ... ].lo_out_power`
+
+    To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+    Example: :py:attr:`my_session.lo_out_power`
     '''
     lo_pll_fractional_mode_enabled = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.LoPlLfractionalModeEnabled, 1150152)
     '''Type: enums.LoPlLfractionalModeEnabled
@@ -3261,6 +3367,16 @@ class _SessionBase(object):
 
     Note:
     One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
+
+    Tip:
+    This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container lo to specify a subset.
+
+    Example: :py:attr:`my_session.lo[ ... ].lo_pll_fractional_mode_enabled`
+
+    To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+    Example: :py:attr:`my_session.lo_pll_fractional_mode_enabled`
     '''
     lo_source = _attributes.AttributeViString(1150150)
     '''Type: str
@@ -3296,6 +3412,16 @@ class _SessionBase(object):
     +--------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
     Note: For the PXIe-5841 with PXIe-5655, RF list mode is not supported when this property is set to SG_SA_Shared.
+
+    Tip:
+    This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container lo to specify a subset.
+
+    Example: :py:attr:`my_session.lo[ ... ].lo_source`
+
+    To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+
+    Example: :py:attr:`my_session.lo_source`
     '''
     lo_temperature = _attributes.AttributeViReal64(1150075)
     '''Type: float
@@ -3540,10 +3666,6 @@ class _SessionBase(object):
 
     `NI-RFSG Instrument Driver Programming Flow <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/progflow.html>`_
 
-    **High-Level Methods**:
-
-    - configure_output_enabled
-
     **Defined Values**:
 
     +-------+-------------------------+
@@ -3612,167 +3734,6 @@ class _SessionBase(object):
     +---------------------------------+--------------+----------------------------------------------------------------------------+
     | OverflowErrorReporting.WARNING  | 1301 (0x515) | NI-RFSG returns a warning when an OSP overflow occurs.                     |
     +---------------------------------+--------------+----------------------------------------------------------------------------+
-    '''
-    p2p_data_transfer_permission_initial_credits = _attributes.AttributeViInt64(1150135)
-    '''Type: int
-
-    Specifies the initial amount of data that the writer peer can transfer over the bus into the configured endpoint when the peer-to-peer data stream is enabled. If this property is not set and the endpoint is empty, credits equal to the full endpoint size are issued to the writer peer. If data is written to the endpoint using the WriteP2pEndpointI16 method prior to enabling the stream, credits equal to the remaining space available in the endpoint are issued to the writer peer. This property is coerced up by NI-RFSG to 8-byte boundaries. This property is endpoint-based.
-
-    **Units**: samples per channel
-
-    **Default Value:** 1,024
-
-    **Supported Devices:** PXIe-5673E
-
-    **Related Topics**
-
-    `Configuring a Peer-to-Peer Endpoint <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_configuring_an_endpoint.html>`_
-
-    `Configuring Flow Control <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_flow_control.html>`_
-    '''
-    p2p_data_transfer_permission_interval = _attributes.AttributeViInt64(1150134)
-    '''Type: int
-
-    Specifies the interval at which the RF signal generator issues credits to allow the writer peer to transfer data over the bus into the configured endpoint. This property is coerced up by NI-RFSG to the nearest 128-byte boundary. This property is endpoint-based.
-
-    **Units**: samples per channel
-
-    **Supported Devices:** PXIe-5673E
-
-    **Related Topics**
-
-    `Configuring a Peer-to-Peer Endpoint <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_configuring_an_endpoint.html>`_
-
-    `Configuring Flow Control <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_flow_control.html>`_
-    '''
-    p2p_enabled = _attributes.AttributeViBoolean(1150123)
-    '''Type: bool
-
-    Specifies whether the RF signal generator reads data from the peer-to-peer endpoint. This property is endpoint-based.
-
-    **Default Value**: False
-
-    **Supported Devices:** PXIe-5673E, PXIe-5820/5830/5831/5832/5840/5841/5842
-
-    **Related Topics**
-
-    `Configuring a Peer-to-Peer Endpoint <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_configuring_an_endpoint.html>`_
-
-    **Defined Values**:
-
-    +-------+------------------------------------------+
-    | Value | Description                              |
-    +=======+==========================================+
-    | True  | Peer-to-peer data streaming is enabled.  |
-    +-------+------------------------------------------+
-    | False | Peer-to-peer data streaming is disabled. |
-    +-------+------------------------------------------+
-    '''
-    p2p_endpoint_count = _attributes.AttributeViInt32(1150127)
-    '''Type: int
-
-    Returns the number of peer-to-peer FIFO endpoints supported by the device.
-
-    **Supported Devices:** PXIe-5673E, PXIe-5820/5830/5831/5832/5840/5841/5842
-
-    **Related Topics**
-
-    `Configuring a Peer-to-Peer Endpoint <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_configuring_an_endpoint.html>`_
-    '''
-    p2p_endpoint_fullness_start_trigger_level = _attributes.AttributeViInt64(1150128)
-    '''Type: int
-
-    Specifies the number of samples the endpoint must receive before the device starts generation. If no level is specified, NI-RFSG automatically sets this value to -1. This property applies only when the start_trigger_type property is set to StartTrigType.P2P_ENDPOINT_FULLNESS
-
-    **Default Value:** -1, which allows NI-RFSG to select the appropriate fullness value.
-
-    **Supported Devices:** PXIe-5673E, PXIe-5820/5830/5831/5832/5840/5841/5842
-
-    **Related Topics**
-
-    `Start Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/start_triggers.html>`_
-
-    Note: Due to an additional internal FIFO in the RF signal generator, the writer peer actually needs to write 2,304 bytes more than the quantity of data specified by this property to satisfy the trigger level.
-    '''
-    p2p_endpoint_size = _attributes.AttributeViInt64(1150124)
-    '''Type: int
-
-    Returns the size, in samples, of the device endpoint. This property is endpoint-based.
-
-    **Units**: samples (s)
-
-    **Supported Devices:** PXIe-5673E, PXIe-5820/5830/5831/5832/5840/5841/5842
-
-    **Related Topics**
-
-    `Configuring a Peer-to-Peer Endpoint <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_configuring_an_endpoint.html>`_
-    '''
-    p2p_generation_fifo_sample_quantum = _attributes.AttributeViInt64(1150219)
-    '''Type: int
-
-    Returns how many samples NI-RFSG pulls from the peer-to-peer FIFO per read. You can use this property to determine how many samples to send across the peer-to-peer bus to ensure that no samples are ignored. If you send a number of samples that is not a multiple of this value, the remaining samples are not read from the FIFO during generation. This property is endpoint-based.
-
-    **Supported Devices:** PXIe-5820/5830/5831/5832/5840/5841/5842
-    '''
-    p2p_is_finite_generation = _attributes.AttributeViBoolean(1150217)
-    '''Type: bool
-
-    Specifies whether peer-to-peer should continuously generate data from the peer-to-peer stream or from only a finite number of samples, according to the p2p_number_of_samples_to_generate property. To use this property, peer-to-peer must be enabled. This property is endpoint-based.
-
-    **Default Value**: False
-
-    **Supported Devices:** PXIe-5820/5830/5831/5832/5840/5841/5842
-
-    **Defined Values**:
-
-    +-------+--------------------------------------------------------------+
-    | Value | Description                                                  |
-    +=======+==============================================================+
-    | True  | Data is generated from only a finite number of samples.      |
-    +-------+--------------------------------------------------------------+
-    | False | Data is continuously generated from the peer-to-peer stream. |
-    +-------+--------------------------------------------------------------+
-    '''
-    p2p_most_space_available_in_endpoint = _attributes.AttributeViInt64(1150126)
-    '''Type: int
-
-    Returns the largest number of samples per channel available in the endpoint since this property was last read. You can use this property to determine how much endpoint space to use as a buffer against bus traffic latencies by reading the property and keeping track of the largest value returned. This property is endpoint-based.
-
-    If you want to minimize the latency for data to move through the endpoint and be generated by the RF signal generator, use the p2p_data_transfer_permission_initial_credits property to grant fewer initial credits than the default of the entire endpoint size.
-
-    **Units**: samples per channel
-
-    **Supported Devices:** PXIe-5673E, PXIe-5820/5830/5831/5832/5840/5841/5842
-
-    **Related Topics**
-
-    `Configuring a Peer-to-Peer Endpoint <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_configuring_an_endpoint.html>`_
-    '''
-    p2p_number_of_samples_to_generate = _attributes.AttributeViInt64(1150218)
-    '''Type: int
-
-    Specifies how many samples are generated from the peer-to-peer subsystem when it is enabled. To use this property, peer-to-peer must be enabled and set to finite generation. This property is endpoint-based.
-
-    **Supported Devices:** PXIe-5820/5830/5831/5832/5840/5841/5842
-
-    **Related Topics**
-
-    `Configuring a Peer-to-Peer Endpoint <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_configuring_an_endpoint.html>`_
-    '''
-    p2p_space_available_in_endpoint = _attributes.AttributeViInt64(1150125)
-    '''Type: int
-
-    Returns the current space available in the endpoint. You can use this property when priming the endpoint with initial data using the WriteP2pEndpointI16 method to determine how many samples you can write. You also can use this property to characterize the performance and measure the latency of the peer-to-peer stream as data moves across the bus. This property is endpoint-based.
-
-    **Units**: samples per channel
-
-    **Supported Devices:** PXIe-5673E, PXIe-5820/5830/5831/5832/5840/5841/5842
-
-    **Related Topics**
-
-    `Configuring a Peer-to-Peer Endpoint <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_configuring_an_endpoint.html>`_
-
-    `Starting Peer-to-Peer Generation <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_starting_generation.html>`_
     '''
     peak_envelope_power = _attributes.AttributeViReal64(1150011)
     '''Type: float
@@ -3937,10 +3898,6 @@ class _SessionBase(object):
 
     `Optimizing for Low Power Generation <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/optimizing_for_low_power_generation.html>`_
 
-    **High-Level Methods**:
-
-    - configure_power_level_type
-
     **Defined Values**:
 
     +------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -3951,24 +3908,24 @@ class _SessionBase(object):
     | PowerLevelType.PEAK    | Indicates the maximum power level of the RF signal averaged over one period of the RF carrier frequency (the peak envelope power). This setting requires that the magnitude of the I/Q waveform must always be less than or equal to one. When using peak power, the power level of the RF signal matches the specified power level at moments when the magnitude of the I/Q waveform equals one. If you write more than one waveform, the relative scaling between waveforms is preserved. In peak power mode, waveforms are scaled according to the arb_waveform_software_scaling_factor property. You can use the peak_power_adjustment property in conjunction with the power_level property when the power_level_type property is set to PowerLevelType.PEAK. |
     +------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
     '''
-    pulse_modulation_active_level = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.ScriptTrigDigLevelActiveLevel, 1150307)
-    '''Type: enums.ScriptTrigDigLevelActiveLevel
+    pulse_modulation_active_level = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.ScriptTriggerDigitalLevelActiveLevel, 1150307)
+    '''Type: enums.ScriptTriggerDigitalLevelActiveLevel
 
     Specifies the active level of the pulse modulation signal when pulse modulation is enabled. To set this property, the NI-RFSG device must be in the Configuration state.
 
-    **Default Value:** ScriptTrigDigLevelActiveLevel.HIGH
+    **Default Value:** ScriptTriggerDigitalLevelActiveLevel.HIGH
 
     **Supported Devices:**  PXIe-5842
 
     **Defined Values**:
 
-    +------------------------------------+---------------+--------------------------------------------------+
-    | Name                               | Value         | Description                                      |
-    +====================================+===============+==================================================+
-    | ScriptTrigDigLevelActiveLevel.HIGH | 9000 (0x2328) | Trigger when the digital trigger signal is high. |
-    +------------------------------------+---------------+--------------------------------------------------+
-    | ScriptTrigDigLevelActiveLevel.LOW  | 9001 (0x2329) | Trigger when the digital trigger signal is low.  |
-    +------------------------------------+---------------+--------------------------------------------------+
+    +-------------------------------------------+---------------+--------------------------------------------------+
+    | Name                                      | Value         | Description                                      |
+    +===========================================+===============+==================================================+
+    | ScriptTriggerDigitalLevelActiveLevel.HIGH | 9000 (0x2328) | Trigger when the digital trigger signal is high. |
+    +-------------------------------------------+---------------+--------------------------------------------------+
+    | ScriptTriggerDigitalLevelActiveLevel.LOW  | 9001 (0x2329) | Trigger when the digital trigger signal is low.  |
+    +-------------------------------------------+---------------+--------------------------------------------------+
     '''
     pulse_modulation_enabled = _attributes.AttributeViBoolean(1250051)
     '''Type: bool
@@ -4242,12 +4199,12 @@ class _SessionBase(object):
 
     Note: The PXI-5670/5671 and PXIe-5672 devices also allow you to drive the PXI 10 MHz backplane clock on PXI chassis *only* using the pxi_chassis_clk10_source property.
     '''
-    ref_pll_bandwidth = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.RefPllBandwidth, 1150133)
-    '''Type: enums.RefPllBandwidth
+    ref_pll_bandwidth = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.ReferencePllBandwidth, 1150133)
+    '''Type: enums.ReferencePllBandwidth
 
     Configures the loop bandwidth of the reference PLL.
 
-    **Default Value:** RefPllBandwidth.NARROW
+    **Default Value:** ReferencePllBandwidth.NARROW
 
     **Supported Devices:** PXIe-5653
 
@@ -4257,15 +4214,15 @@ class _SessionBase(object):
 
     **Defined Values**:
 
-    +------------------------+--------------------------------------------------------+
-    | Value                  | Description                                            |
-    +========================+========================================================+
-    | RefPllBandwidth.NARROW | Uses the narrowest loop bandwidth setting for the PLL. |
-    +------------------------+--------------------------------------------------------+
-    | RefPllBandwidth.MEDIUM | Uses the medium loop bandwidth setting for the PLL.    |
-    +------------------------+--------------------------------------------------------+
-    | RefPllBandwidth.WIDE   | Uses the widest loop bandwidth setting for the PLL.    |
-    +------------------------+--------------------------------------------------------+
+    +------------------------------+--------------------------------------------------------+
+    | Value                        | Description                                            |
+    +==============================+========================================================+
+    | ReferencePllBandwidth.NARROW | Uses the narrowest loop bandwidth setting for the PLL. |
+    +------------------------------+--------------------------------------------------------+
+    | ReferencePllBandwidth.MEDIUM | Uses the medium loop bandwidth setting for the PLL.    |
+    +------------------------------+--------------------------------------------------------+
+    | ReferencePllBandwidth.WIDE   | Uses the widest loop bandwidth setting for the PLL.    |
+    +------------------------------+--------------------------------------------------------+
 
     Note:
     One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
@@ -4310,7 +4267,7 @@ class _SessionBase(object):
 
     PXIe-5840/5841: RF blanking does not occur for frequencies below 120MHz.
 
-    For PXIe-5830/5831/5832: The RF Blanking reserves a PXI trigger line. If you are calling any Reset or `niRFSA_reset <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/cvinirfsa_reset.html>`_ on the same device, NI recommends calling it before committing blanking properties. Alternatively, you can call ResetWithOptions or `niRFSA_ResetWithOptions <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/cvinirfsa_resetwithoptions.html>`_. Select **Routes** in the **steps to omit** parameter.
+    For PXIe-5830/5831/5832: The RF Blanking reserves a PXI trigger line. If you are calling any Reset or `niRFSA_reset <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/cvinirfsa_reset.html>`_ on the same device, NI recommends calling it before committing blanking properties. Alternatively, you can call reset_with_options or `niRFSA_ResetWithOptions <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/cvinirfsa_resetwithoptions.html>`_. Select **Routes** in the **steps to omit** parameter.
 
     **Default Value:** "" (empty string)
 
@@ -4403,12 +4360,12 @@ class _SessionBase(object):
 
     Example: :py:attr:`my_session.script_trigger_terminal_name`
     '''
-    script_trigger_type = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.ScriptTrigType, 1150019)
-    '''Type: enums.ScriptTrigType
+    script_trigger_type = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.ScriptTriggerType, 1150019)
+    '''Type: enums.ScriptTriggerType
 
     Specifies the Script Trigger type. Depending upon the value of this property, more properties may be needed to fully configure the trigger. To set this property, the NI-RFSG device must be in the Configuration state.
 
-    **Default Value:** ScriptTrigType.NONE
+    **Default Value:** ScriptTriggerType.NONE
 
     **Supported Devices:** PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 
@@ -4424,17 +4381,17 @@ class _SessionBase(object):
 
     **Defined Values**:
 
-    +------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-    | Value                        | Description                                                                                                                                                                                                                                                           |
-    +==============================+=======================================================================================================================================================================================================================================================================+
-    | ScriptTrigType.NONE          | No trigger is configured. Signal generation starts immediately.                                                                                                                                                                                                       |
-    +------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-    | ScriptTrigType.DIGITAL_EDGE  | The data operation does not start until a digital edge is detected. The source of the digital edge is specified with the digital_edge_start_trigger_source property, and the active edge is specified with the digital_edge_start_trigger_edge property.              |
-    +------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-    | ScriptTrigType.DIGITAL_LEVEL | The data operation does not start until the digital level is detected. The source of the digital level is specified in the digital_level_script_trigger_source property, and the active level is specified in the digital_level_script_trigger_active_level property. |
-    +------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-    | ScriptTrigType.SOFTWARE      | The data operation does not start until a software trigger occurs. You can create a software event by calling the send_software_edge_trigger method.                                                                                                                  |
-    +------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    +---------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | Value                           | Description                                                                                                                                                                                                                                                           |
+    +=================================+=======================================================================================================================================================================================================================================================================+
+    | ScriptTriggerType.NONE          | No trigger is configured. Signal generation starts immediately.                                                                                                                                                                                                       |
+    +---------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | ScriptTriggerType.DIGITAL_EDGE  | The data operation does not start until a digital edge is detected. The source of the digital edge is specified with the digital_edge_start_trigger_source property, and the active edge is specified with the digital_edge_start_trigger_edge property.              |
+    +---------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | ScriptTriggerType.DIGITAL_LEVEL | The data operation does not start until the digital level is detected. The source of the digital level is specified in the digital_level_script_trigger_source property, and the active level is specified in the digital_level_script_trigger_active_level property. |
+    +---------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | ScriptTriggerType.SOFTWARE      | The data operation does not start until a software trigger occurs. You can create a software event by calling the send_software_edge_trigger method.                                                                                                                  |
+    +---------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
     Note:
     One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
@@ -4664,12 +4621,12 @@ class _SessionBase(object):
 
     - get_terminal_name
     '''
-    start_trigger_type = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.StartTrigType, 1250458)
-    '''Type: enums.StartTrigType
+    start_trigger_type = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.StartTriggerType, 1250458)
+    '''Type: enums.StartTriggerType
 
     Specifies the Start Trigger type. Depending upon the value of this property, more properties may be needed to fully configure the trigger. To set this property, the NI-RFSG device must be in the Configuration state.
 
-    **Default Value:** StartTrigType.NONE
+    **Default Value:** StartTriggerType.NONE
 
     **Supported Devices:** PXIe-5644/5645/5646, PXIe-5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 
@@ -4687,17 +4644,20 @@ class _SessionBase(object):
 
     **Defined Values**:
 
-    +-------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-    | Value                               | Description                                                                                                                                                                                                                                            |
-    +=====================================+========================================================================================================================================================================================================================================================+
-    | StartTrigType.NONE                  | No trigger is configured.                                                                                                                                                                                                                              |
-    +-------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-    | StartTrigType.DIGITAL_EDGE          | The data operation does not start until a digital edge is detected. The source of the digital edge is specified with the digital_edge_start_trigger_source property, and the active edge is specified in the digital_edge_start_trigger_edge property. |
-    +-------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-    | StartTrigType.SOFTWARE              | The data operation does not start until a software event occurs. You may create a software trigger by calling the send_software_edge_trigger method.                                                                                                   |
-    +-------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-    | StartTrigType.P2P_ENDPOINT_FULLNESS | The data operation does not start until the endpoint reaches the threshold specified in the p2p_endpoint_fullness_start_trigger_level property.                                                                                                        |
-    +-------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    +----------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | Value                                  | Description                                                                                                                                                                                                                                            |
+    +========================================+========================================================================================================================================================================================================================================================+
+    | StartTriggerType.NONE                  | No trigger is configured.                                                                                                                                                                                                                              |
+    +----------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | StartTriggerType.DIGITAL_EDGE          | The data operation does not start until a digital edge is detected. The source of the digital edge is specified with the digital_edge_start_trigger_source property, and the active edge is specified in the digital_edge_start_trigger_edge property. |
+    +----------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | StartTriggerType.SOFTWARE              | The data operation does not start until a software event occurs. You may create a software trigger by calling the send_software_edge_trigger method.                                                                                                   |
+    +----------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | StartTriggerType.P2P_ENDPOINT_FULLNESS | The data operation does not start until the endpoint reaches the threshold specified in the P2P_ENDPOINT_FULLNESS_START_TRIGGER_LEVEL property.                                                                                                        |
+    +----------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+    Note:
+    One or more of the referenced properties are not in the Python API for this driver.
 
     Note:
     One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
@@ -5163,7 +5123,7 @@ class _SessionBase(object):
     | NIRFSG_VAL_MARKER0, NIRFSG_VAL_MARKER1, NIRFSG_VAL_MARKER2, or NIRFSG_VAL_MARKER3 | RFBlanking.ENABLE    | Error is shown.                                                                                           |
     +-----------------------------------------------------------------------------------+----------------------+-----------------------------------------------------------------------------------------------------------+
 
-    Note: For PXIe-5830/5831/5832: The RF Blanking reserves a PXI trigger line. If you are calling any Reset or `niRFSA_reset <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/cvinirfsa_reset.html>`_ on the same device, NI recommends calling it before committing blanking properties. Alternatively, you can call ResetWithOptions or `niRFSA_ResetWithOptions <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/cvinirfsa_resetwithoptions.html>`_. Select **Routes** in the **steps to omit** parameter.
+    Note: For PXIe-5830/5831/5832: The RF Blanking reserves a PXI trigger line. If you are calling any Reset or `niRFSA_reset <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/cvinirfsa_reset.html>`_ on the same device, NI recommends calling it before committing blanking properties. Alternatively, you can call reset_with_options or `niRFSA_ResetWithOptions <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/cvinirfsa_resetwithoptions.html>`_. Select **Routes** in the **steps to omit** parameter.
 
     Note:
     One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
@@ -5254,7 +5214,7 @@ class _SessionBase(object):
 
     Note: - When you download a waveform using ReadAndDownloadWaveformFromFileTdms method and if waveform_rf_blanking property is enabled, you must set the write_waveform_burst_detection property to WriteWaveformBurstDetection.DISABLE.
 
-     - For PXIe-5830/5831/5832: The RF Blanking reserves a PXI trigger line. If you are calling any Reset or `niRFSA_reset <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/cvinirfsa_reset.html>`_ on the same device, NI recommends calling it before committing blanking properties. Alternatively, you can call ResetWithOptions or `niRFSA_ResetWithOptions <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/cvinirfsa_resetwithoptions.html>`_. Select **Routes** in the **steps to omit** parameter.
+     - For PXIe-5830/5831/5832: The RF Blanking reserves a PXI trigger line. If you are calling any Reset or `niRFSA_reset <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/cvinirfsa_reset.html>`_ on the same device, NI recommends calling it before committing blanking properties. Alternatively, you can call reset_with_options or `niRFSA_ResetWithOptions <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/cvinirfsa_resetwithoptions.html>`_. Select **Routes** in the **steps to omit** parameter.
 
     Note:
     One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
@@ -5360,7 +5320,8 @@ class _SessionBase(object):
         self.markers = _RepeatedCapabilities(self, 'marker', repeated_capability_list)
         self.script_triggers = _RepeatedCapabilities(self, 'scripttrigger', repeated_capability_list)
         self.waveform = _RepeatedCapabilities(self, 'waveform::', repeated_capability_list)
-        self.deembedding_port = _RepeatedCapabilities(self, '', repeated_capability_list)
+        self.port = _RepeatedCapabilities(self, '', repeated_capability_list)
+        self.lo = _RepeatedCapabilities(self, 'LO', repeated_capability_list)
 
         # Finally, set _is_frozen to True which is used to prevent clients from accidentally adding
         # members when trying to set a property with a typo.
@@ -5533,6 +5494,99 @@ class _SessionBase(object):
 
         '''
         self._interpreter.check_attribute_vi_string(self._repeated_capability, attribute, value)
+
+    @ivi_synchronized
+    def configure_digital_edge_script_trigger(self, source, edge):
+        r'''configure_digital_edge_script_trigger
+
+        Configures the specified Script Trigger for digital edge triggering.
+
+        The NI-RFSG device must be in the Configuration state before calling this method.
+
+        **Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
+
+        **Related Topics**
+
+        `Script Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/script_triggers.html>`_
+
+        `Digital Edge Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/trigger_edge.html>`_
+
+        Tip:
+        This method can be called on specific script_triggers within your :py:class:`nirfsg.Session` instance.
+        Use Python index notation on the repeated capabilities container script_triggers to specify a subset,
+        and then call this method on the result.
+
+        Example: :py:meth:`my_session.script_triggers[ ... ].configure_digital_edge_script_trigger`
+
+        To call the method on all script_triggers, you can call it directly on the :py:class:`nirfsg.Session`.
+
+        Example: :py:meth:`my_session.configure_digital_edge_script_trigger`
+
+        Args:
+            source (str): Specifies the source terminal for the digital edge Script Trigger. NI-RFSG sets the digital_edge_script_trigger_source property to this value.
+
+            edge (enums.ScriptTriggerDigitalEdgeEdge): Specifies the active edge for the digital edge Script Trigger. NI-RFSG sets the digital_edge_script_trigger_edge property to this value.
+
+        '''
+        if type(edge) is not enums.ScriptTriggerDigitalEdgeEdge:
+            raise TypeError('Parameter edge must be of type ' + str(enums.ScriptTriggerDigitalEdgeEdge))
+        self._interpreter.configure_digital_edge_script_trigger(self._repeated_capability, source, edge)
+
+    @ivi_synchronized
+    def configure_software_script_trigger(self):
+        r'''configure_software_script_trigger
+
+        Configures the Script Trigger for software triggering.
+
+        Refer to the send_software_edge_trigger method for more information about using the software Script Trigger. The NI-RFSG device must be in the Configuration state before calling this method.
+
+        **Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
+
+        **Related Topics**
+
+        `Script Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/script_triggers.html>`_
+
+        `Trigger Types <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/trigger_types.html>`_
+
+        Tip:
+        This method can be called on specific script_triggers within your :py:class:`nirfsg.Session` instance.
+        Use Python index notation on the repeated capabilities container script_triggers to specify a subset,
+        and then call this method on the result.
+
+        Example: :py:meth:`my_session.script_triggers[ ... ].configure_software_script_trigger`
+
+        To call the method on all script_triggers, you can call it directly on the :py:class:`nirfsg.Session`.
+
+        Example: :py:meth:`my_session.configure_software_script_trigger`
+        '''
+        self._interpreter.configure_software_script_trigger(self._repeated_capability)
+
+    @ivi_synchronized
+    def disable_script_trigger(self):
+        r'''disable_script_trigger
+
+        Configures the device not to wait for the specified Script Trigger.
+
+        Call this method only if you previously configured a Script Trigger and now want it disabled. The NI-RFSG device must be in the Configuration state before you call this method.
+
+        **Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
+
+        **Related Topics**
+
+        `Script Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/script_triggers.html>`_
+
+        Tip:
+        This method can be called on specific script_triggers within your :py:class:`nirfsg.Session` instance.
+        Use Python index notation on the repeated capabilities container script_triggers to specify a subset,
+        and then call this method on the result.
+
+        Example: :py:meth:`my_session.script_triggers[ ... ].disable_script_trigger`
+
+        To call the method on all script_triggers, you can call it directly on the :py:class:`nirfsg.Session`.
+
+        Example: :py:meth:`my_session.disable_script_trigger`
+        '''
+        self._interpreter.disable_script_trigger(self._repeated_capability)
 
     def error_message(self, error_code, error_message):
         r'''error_message
@@ -6791,34 +6845,6 @@ class Session(_SessionBase):
         self._interpreter.configure_deembedding_table_interpolation_spline(port, table_name)
 
     @ivi_synchronized
-    def configure_digital_edge_script_trigger(self, trigger_id, source, edge):
-        r'''configure_digital_edge_script_trigger
-
-        Configures the specified Script Trigger for digital edge triggering.
-
-        The NI-RFSG device must be in the Configuration state before calling this method.
-
-        **Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
-
-        **Related Topics**
-
-        `Script Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/script_triggers.html>`_
-
-        `Digital Edge Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/trigger_edge.html>`_
-
-        Args:
-            trigger_id (str): Specifies the Script Trigger to configure.
-
-            source (str): Specifies the source terminal for the digital edge Script Trigger. NI-RFSG sets the digital_edge_script_trigger_source property to this value.
-
-            edge (enums.ScriptTrigDigEdgeEdge): Specifies the active edge for the digital edge Script Trigger. NI-RFSG sets the digital_edge_script_trigger_edge property to this value.
-
-        '''
-        if type(edge) is not enums.ScriptTrigDigEdgeEdge:
-            raise TypeError('Parameter edge must be of type ' + str(enums.ScriptTrigDigEdgeEdge))
-        self._interpreter.configure_digital_edge_script_trigger(trigger_id, source, edge)
-
-    @ivi_synchronized
     def configure_digital_edge_start_trigger(self, source, edge):
         r'''configure_digital_edge_start_trigger
 
@@ -6839,11 +6865,11 @@ class Session(_SessionBase):
         Args:
             source (str): Specifies the source terminal for the digital edge trigger. NI-RFSG sets the digital_edge_start_trigger_source property to this value.
 
-            edge (enums.StartTrigDigEdgeEdge): Specifies the active edge for the Start Trigger. NI-RFSG sets the digital_edge_start_trigger_edge property to this value.
+            edge (enums.StartTriggerDigitalEdgeEdge): Specifies the active edge for the Start Trigger. NI-RFSG sets the digital_edge_start_trigger_edge property to this value.
 
         '''
-        if type(edge) is not enums.StartTrigDigEdgeEdge:
-            raise TypeError('Parameter edge must be of type ' + str(enums.StartTrigDigEdgeEdge))
+        if type(edge) is not enums.StartTriggerDigitalEdgeEdge:
+            raise TypeError('Parameter edge must be of type ' + str(enums.StartTriggerDigitalEdgeEdge))
         self._interpreter.configure_digital_edge_start_trigger(source, edge)
 
     @ivi_synchronized
@@ -6890,129 +6916,6 @@ class Session(_SessionBase):
 
         '''
         self._interpreter.configure_digital_modulation_user_defined_waveform(number_of_samples, user_defined_waveform)
-
-    @ivi_synchronized
-    def configure_generation_mode(self, generation_mode):
-        r'''configure_generation_mode
-
-        Configures the NI-RFSG device to generate a continuous sine tone (CW), apply I/Q (vector) modulation to the RF output signal, or generate arbitrary waveforms according to scripts.
-
-        The NI-RFSG device must be in the Configuration state before you call this method.
-
-        **Supported Devices** : PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
-
-        **Related Topics**
-
-        `Assigning Properties or Properties to a Waveform <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/assigning_properties_or_attributes_to_a_waveform.html>`_
-
-        `Scripting Instructions <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/scripting_instructions.html>`_--Refer to this topic for more information about VST restrictions on scripts.
-
-        Args:
-            generation_mode (enums.GenerationMode): Specifies the mode used by NI-RFSG for generating an RF output signal.
-
-                        **Default Value** : GenerationMode.CW
-
-                        **Defined Values** :
-
-                +-----------------------------+--------------+------------------------------------------------------------------------------------------------------------------------+
-                | Name                        | Value        | Description                                                                                                            |
-                +=============================+==============+========================================================================================================================+
-                | GenerationMode.CW           | 1000 (0x3e8) | Configures the RF signal generator to generate a CW signal.                                                            |
-                +-----------------------------+--------------+------------------------------------------------------------------------------------------------------------------------+
-                | GenerationMode.ARB_WAVEFORM | 1001 (0x3e9) | Configures the RF signal generator to generate the arbitrary waveform specified by the arb_selected_waveform property. |
-                +-----------------------------+--------------+------------------------------------------------------------------------------------------------------------------------+
-                | GenerationMode.SCRIPT       | 1002 (0x3ea) | Configures the RF signal generator to generate arbitrary waveforms as directed by the selected_script property.        |
-                +-----------------------------+--------------+------------------------------------------------------------------------------------------------------------------------+
-
-                Note: - For the PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696, only GenerationMode.CW is supported.
-
-                 - If you are using an RF vector signal transceiver (VST) device, some script instructions may not be supported.
-
-        '''
-        if type(generation_mode) is not enums.GenerationMode:
-            raise TypeError('Parameter generation_mode must be of type ' + str(enums.GenerationMode))
-        self._interpreter.configure_generation_mode(generation_mode)
-
-    @ivi_synchronized
-    def configure_output_enabled(self, output_enabled):
-        r'''configure_output_enabled
-
-        Enables or disables signal output.
-
-        Setting output_enabled to False while in the Generation state attenuates the generated signal so that no signal is output.
-
-        **Supported Devices** : PXI-5610, PXIe-5611, PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
-
-        **Related Topics**
-
-        `Output Enabled <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/outputenable.html>`_
-
-        `NI-RFSG Instrument Driver Programming Flow <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/progflow.html>`_
-
-        `RF List Mode <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/rf_list_mode_overview.html>`_
-
-        Args:
-            output_enabled (bool): Specifies whether you want to enable or disable the output.
-
-        '''
-        self._interpreter.configure_output_enabled(output_enabled)
-
-    @ivi_synchronized
-    def configure_p2p_endpoint_fullness_start_trigger(self, p2p_endpoint_fullness_level):
-        r'''configure_p2p_endpoint_fullness_start_trigger
-
-        Configures the Start Trigger to detect peer-to-peer endpoint fullness.
-
-        Generation begins when the number of samples in the peer-to-peer endpoint reaches the threshold specified by the P2P_ENDPOINT_FULLNESS_LEVEL parameter. The NI-RFSG device must be in the Configuration state before calling this method.
-
-        **Supported Devices** : PXIe-5673E, PXIe-5820/5830/5831/5832/5840/5841/5842
-
-        **Related Topics**
-
-        `Start Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/start_triggers.html>`_
-
-        Note: Due to an additional internal FIFO in the RF signal generator, the writer peer actually writes 2,304 bytes more than the quantity of data specified by this method to satisfy the trigger level.
-
-        Note:
-        One or more of the referenced properties are not in the Python API for this driver.
-
-        Args:
-            p2p_endpoint_fullness_level (int): Specifies the quantity of data in the FIFO endpoint that asserts the trigger. Units are samples per channel. The default value is -1, which allows NI-RFSG to select the appropriate fullness value.
-
-        '''
-        self._interpreter.configure_p2p_endpoint_fullness_start_trigger(p2p_endpoint_fullness_level)
-
-    @ivi_synchronized
-    def configure_power_level_type(self, power_level_type):
-        r'''configure_power_level_type
-
-        Specifies the way the driver interprets the power_level property.
-
-        In average power mode, NI-RFSG automatically scales waveform data to use the maximum dynamic range. In peak power mode, waveforms are scaled according to the arb_waveform_software_scaling_factor property.
-
-        **Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
-
-        **Related Topics**
-
-        `Spurious Performance <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/spurious_performance.html>`_
-
-        `Optimizing for Low Power Generation <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/optimizing_for_low_power_generation.html>`_
-
-        Args:
-            power_level_type (enums.PowerLevelType): Specifies the way the driver interprets the value of the power_level property. NI-RFSG sets the power_level_type property to this value.
-
-                +-------------------------+-------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-                | Name                    | Value | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-                +=========================+=======+========================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================+
-                | Average Power (default) | 7000  | Indicates the desired power averaged in time. The driver maximizes the dynamic range by scaling the I/Q waveform so that its peak magnitude is equal to one. If you write more than one waveform, NI-RFSG scales each waveform without preserving the power level ratio between the waveforms. This value is not valid for the PXIe-5820.                                                                                                                                                                                                                                              |
-                +-------------------------+-------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-                | Peak Power              | 7001  | Indicates the maximum power level of the RF signal averaged over one period of the RF carrier frequency (the peak envelope power). This setting requires the magnitude of the I/Q waveform to be less than or equal to one. When using peak power, the power level of the RF signal matches the specified power level at moments when the magnitude of the I/Q waveform equals one. If you write more than one waveform, the relative scaling between waveforms is preserved. In peak power mode, waveforms are scaled according to the arb_waveform_software_scaling_factor property. |
-                +-------------------------+-------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-        '''
-        if type(power_level_type) is not enums.PowerLevelType:
-            raise TypeError('Parameter power_level_type must be of type ' + str(enums.PowerLevelType))
-        self._interpreter.configure_power_level_type(power_level_type)
 
     @ivi_synchronized
     def configure_pxi_chassis_clk10(self, pxi_clk10_source):
@@ -7112,48 +7015,6 @@ class Session(_SessionBase):
         self._interpreter.configure_ref_clock(ref_clock_source, ref_clock_rate)
 
     @ivi_synchronized
-    def configure_signal_bandwidth(self, signal_bandwidth):
-        r'''configure_signal_bandwidth
-
-        Configures the signal bandwidth of the arbitrary waveform.
-
-        The NI-RFSG device must be in the Configuration state before you call this method.
-
-        NI-RFSG defines *signal bandwidth* as twice the maximum baseband signal deviation from 0 Hz. Usually, the baseband signal center frequency is 0Hz. In such cases, the signal bandwidth is simply the baseband signal minimum frequency subtracted from its maximum frequency, or *f* <sub>max</sub> minus *f* <sub>min</sub>. NI-RFSG uses this value to optimally configure the center frequency of the upconverter to help minimize phase noise. The generated signal is not filtered to achieve the set bandwidth. However, specifying a bandwidth smaller than the actual bandwidth of the signal could potentially result in spectral distortion.
-
-        **Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
-
-        Note: Based on your signal bandwidth, NI-RFSG decides whether to configure the upconverter center frequency on the PXI-5670/5671 or PXIe-5672 in increments of 1MHz or 5MHz. Failure to configure signal bandwidth may result in the signal being placed outside the upconverter passband.
-
-        Args:
-            signal_bandwidth (float): Specifies the signal bandwidth used by NI-RFSG to generate an RF output signal. NI-RFSG sets the signal_bandwidth property to this value.
-
-        '''
-        self._interpreter.configure_signal_bandwidth(signal_bandwidth)
-
-    @ivi_synchronized
-    def configure_software_script_trigger(self, trigger_id):
-        r'''configure_software_script_trigger
-
-        Configures the Script Trigger for software triggering.
-
-        Refer to the send_software_edge_trigger method for more information about using the software Script Trigger. The NI-RFSG device must be in the Configuration state before calling this method.
-
-        **Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
-
-        **Related Topics**
-
-        `Script Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/script_triggers.html>`_
-
-        `Trigger Types <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/trigger_types.html>`_
-
-        Args:
-            trigger_id (str): Specifies the Script Trigger to configure.
-
-        '''
-        self._interpreter.configure_software_script_trigger(trigger_id)
-
-    @ivi_synchronized
     def configure_software_start_trigger(self):
         r'''configure_software_start_trigger
 
@@ -7244,26 +7105,6 @@ class Session(_SessionBase):
         **Supported Devices** : PXI-5610, PXIe-5611, PXI/PXIe-5650/5651/5652, PXI-5670/5671, PXIe-5672/5673/5673E
         '''
         self._interpreter.disable()
-
-    @ivi_synchronized
-    def disable_script_trigger(self, trigger_id):
-        r'''disable_script_trigger
-
-        Configures the device not to wait for the specified Script Trigger.
-
-        Call this method only if you previously configured a Script Trigger and now want it disabled. The NI-RFSG device must be in the Configuration state before you call this method.
-
-        **Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
-
-        **Related Topics**
-
-        `Script Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/script_triggers.html>`_
-
-        Args:
-            trigger_id (str): Specifies the Script trigger to configure.
-
-        '''
-        self._interpreter.disable_script_trigger(trigger_id)
 
     @ivi_synchronized
     def disable_start_trigger(self):
@@ -7625,31 +7466,6 @@ class Session(_SessionBase):
         return temperature
 
     @ivi_synchronized
-    def get_stream_endpoint_handle(self, stream_endpoint):
-        r'''get_stream_endpoint_handle
-
-        Returns a reader endpoint handle that can be used with NI-P2P to configure a peer-to-peer stream with an RF signal generator endpoint.
-
-        **Supported Devices** : PXIe-5673E, PXIe-5820/5830/5831/5832/5840/5841/5842
-
-        **Related Topics**
-
-        `Configuring a Peer-to-Peer Stream <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/configuring_a_p2p_stream.html>`_
-
-        `Configuring Flow Control <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_flow_control.html>`_
-
-        Args:
-            stream_endpoint (str): Specifies the stream endpoint FIFO to configure.
-
-
-        Returns:
-            reader_handle (int): Returns the reader endpoint handle that is used with NI-P2P to create a stream with the NI-RFSG device as an endpoint.
-
-        '''
-        reader_handle = self._interpreter.get_stream_endpoint_handle(stream_endpoint)
-        return reader_handle
-
-    @ivi_synchronized
     def get_terminal_name(self, signal, signal_identifier):
         r'''get_terminal_name
 
@@ -7969,6 +7785,52 @@ class Session(_SessionBase):
         self._interpreter.reset_with_defaults()
 
     @ivi_synchronized
+    def reset_with_options(self, steps_to_omit):
+        r'''reset_with_options
+
+        Resets all properties to default values and specifies steps to omit during the reset process, such as signal routes.
+
+        By default, this method exhibits the same behavior as Reset. You can specify steps to omit using the steps to omit parameter. For example, if you specify ResetWithOptionsStepsToOmit.ROUTES for the STEPS_TO_OMIT parameter, this method does not release signal routes during the reset process.
+
+        When routes of signals between two devices are released, they are released regardless of which device created the route.
+
+        To avoid resetting routes on PXIe-5820/5830/5831/5832/5840/5841/5842/5860 that are in use by NI-RFSA sessions, NI recommends using this method instead of Reset, with STEPS_TO_OMIT set to ResetWithOptionsStepsToOmit.ROUTES.
+
+        **Supported Devices** : PXIe-5644/5645/5646, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
+
+        **Related Topics**
+
+        `Triggers <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/triggers.html>``Events <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/events.html>`_
+
+        Note:
+        One or more of the referenced properties are not in the Python API for this driver.
+
+        Args:
+            steps_to_omit (Bitwise combination of enums.ResetWithOptionsStepsToOmit flags): Specifies a list of steps to skip during the reset process. The default value is ResetWithOptionsStepsToOmit.NONE, which specifies that no step is omitted during reset. **Defined Values** :
+
+                +------------------------------------------------+---------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+                | Name                                           | Value   | Description                                                                                                                                                                                                |
+                +================================================+=========+============================================================================================================================================================================================================+
+                | ResetWithOptionsStepsToOmit.NONE               | 0 (0x0) | No step is omitted during reset.                                                                                                                                                                           |
+                +------------------------------------------------+---------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+                | ResetWithOptionsStepsToOmit.WAVEFORMS          | 1 (0x1) | Omits clearing waveforms.                                                                                                                                                                                  |
+                +------------------------------------------------+---------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+                | ResetWithOptionsStepsToOmit.SCRIPTS            | 2 (0x2) | Omits clearing scripts.                                                                                                                                                                                    |
+                +------------------------------------------------+---------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+                | ResetWithOptionsStepsToOmit.ROUTES             | 4 (0x4) | Omits the routing reset step. Routing is preserved after a reset. However, routing related properties are reset to default, and routing is released if the default properties are committed after a reset. |
+                +------------------------------------------------+---------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+                | ResetWithOptionsStepsToOmit.DEEMBEDDING_TABLES | 8 (0x8) | Omits deleting de-embedding tables. This step is valid only for the PXIe-5830/5831/5832/5840.                                                                                                              |
+                +------------------------------------------------+---------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+                Note: ResetWithOptionsStepsToOmit.ROUTES is not supported in external calibration or alignment sessions.
+                You can combine multiple enums.ResetWithOptionsStepsToOmit flags using the bitwise OR (|) operator.
+
+        '''
+        if type(steps_to_omit) is not enums.ResetWithOptionsStepsToOmit:
+            raise TypeError('Parameter steps_to_omit must be of type ' + str(enums.ResetWithOptionsStepsToOmit))
+        self._interpreter.reset_with_options(steps_to_omit)
+
+    @ivi_synchronized
     def revision_query(self):
         r'''revision_query
 
@@ -7993,7 +7855,7 @@ class Session(_SessionBase):
     def select_arb_waveform(self, name):
         r'''select_arb_waveform
 
-        Specifies the waveform that is generated upon a call to the _initiate method when the **generationMode** parameter of the configure_generation_mode method is set to GenerationMode.ARB_WAVEFORM.
+        Specifies the waveform that is generated upon a call to the _initiate method when the **generationMode** parameter of the ConfigureGenerationMode method is set to GenerationMode.ARB_WAVEFORM.
 
         You must specify a waveform using the NAME parameter if you have written multiple waveforms. The NI-RFSG device must be in the Configuration state before you call this method.
 
@@ -8049,7 +7911,7 @@ class Session(_SessionBase):
          - If there is an existing NI-RFSA session open for the same PXIe-5820/5830/5831/5832/5840/5841/5842 while this method runs, it may remain open but cannot be used for operations that access the hardware, for example niRFSA_Commit or niRFSA_Initiate.
 
         Args:
-            steps_to_omit (enums.SelfCalibrateRangeStepsToOmit): Specifies which calibration steps to skip during the self-calibration process. The default value is an empty array, which indicates that no calibration steps are omitted.
+            steps_to_omit (Bitwise combination of enums.SelfCalibrateRangeStepsToOmit flags): Specifies which calibration steps to skip during the self-calibration process. The default value is an empty array, which indicates that no calibration steps are omitted.
 
                 **Default Value** : SelfCalibrateRangeStepsToOmit.OMIT_NONE
 
@@ -8070,6 +7932,8 @@ class Session(_SessionBase):
                 +-----------------------------------------------------+-----------+---------------------------------------------------------------------------------------------------------------------+
                 | SelfCalibrateRangeStepsToOmit.SYNTHESIZER_ALIGNMENT | 16 (0x10) | Omits the Voltage Controlled Oscillator (VCO) Alignment step. If you omit this step, the LO PLL is not adjusted.    |
                 +-----------------------------------------------------+-----------+---------------------------------------------------------------------------------------------------------------------+
+
+                Note: You can combine multiple enums.SelfCalibrateRangeStepsToOmit flags using the bitwise OR (|) operator.
 
             min_frequency (float): Specifies the minimum frequency to calibrate.
 
@@ -8337,42 +8201,12 @@ class Session(_SessionBase):
         return self._write_arb_waveform_complex_f64(waveform_name, waveform_data_array, more_data_pending)
 
     @ivi_synchronized
-    def write_p2p_endpoint_i16(self, stream_endpoint, number_of_samples, endpoint_data):
-        r'''write_p2p_endpoint_i16
-
-        Writes an array of 16-bit integer data to the peer-to-peer endpoint.
-
-        Use this method to write initial data from the host to the endpoint before starting generation to avoid an underflow when you start the generation.
-
-        **Supported Devices** : PXIe-5673E
-
-        **Related Topics**
-
-        `Peer-to-Peer Data Streaming <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_streaming.html>`_--Refer to this topic for more information about configuring a stream.
-
-        `Configuring Flow Control <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_flow_control.html>`_
-
-        `Starting Peer-to-Peer Generation <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_starting_generation.html>`_
-
-        `Reconfiguring a Stream <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_reconfiguring_stream.html>`_
-
-        Args:
-            stream_endpoint (str): Specifies the stream endpoint FIFO to configure.
-
-            number_of_samples (int): Specifies the number of samples to write into the endpoint FIFO.
-
-            endpoint_data (array.array("h")): Specifies the array of data to write into the endpoint FIFO. The binary data is left-justified.
-
-        '''
-        self._interpreter.write_p2p_endpoint_i16(stream_endpoint, number_of_samples, endpoint_data)
-
-    @ivi_synchronized
     def write_script(self, script):
         r'''write_script
 
         Writes a script to the device to control waveform generation in Script mode.
 
-        First, configure your device for Script mode by calling the configure_generation_mode method. The NI-RFSG device must be in the Configuration state before calling the write_script method.
+        First, configure your device for Script mode by calling the ConfigureGenerationMode method. The NI-RFSG device must be in the Configuration state before calling the write_script method.
 
         **Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 
@@ -8415,7 +8249,7 @@ class Session(_SessionBase):
 
         Generally, calling this method instead of the reset_device method is acceptable. The Reset method executes faster than the reset_device method.
 
-        To avoid resetting routes on the PXIe-5644/5645/5646 and PXIe-5820/5830/5831/5832/5840/5841/5842/5860 that are in use by NI-RFSA sessions, NI recommends using the ResetWithOptions method, with **stepsToOmit** set to ResetWithOptionsStepsToOmit.ROUTES .
+        To avoid resetting routes on the PXIe-5644/5645/5646 and PXIe-5820/5830/5831/5832/5840/5841/5842/5860 that are in use by NI-RFSA sessions, NI recommends using the reset_with_options method, with **stepsToOmit** set to ResetWithOptionsStepsToOmit.ROUTES .
 
         **Supported Devices** : PXI-5610, PXIe-5611, PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 

--- a/generated/nirfsg/nirfsg/session.py
+++ b/generated/nirfsg/nirfsg/session.py
@@ -1063,12 +1063,12 @@ class _SessionBase(object):
     **Supported Devices**: PXIe-5830/5831/5832/5840/5841/5842/5860
 
     Tip:
-    This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container port to specify a subset.
+    This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container ports to specify a subset.
 
-    Example: :py:attr:`my_session.port[ ... ].deembedding_compensation_gain`
+    Example: :py:attr:`my_session.ports[ ... ].deembedding_compensation_gain`
 
-    To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.deembedding_compensation_gain`
     '''
@@ -1086,51 +1086,51 @@ class _SessionBase(object):
     **Supported Devices**: PXIe-5830/5831/5832/5840/5841/5842/5860
 
     Tip:
-    This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container port to specify a subset.
+    This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container ports to specify a subset.
 
-    Example: :py:attr:`my_session.port[ ... ].deembedding_selected_table`
+    Example: :py:attr:`my_session.ports[ ... ].deembedding_selected_table`
 
-    To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.deembedding_selected_table`
     '''
-    deembedding_type = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.DeembeddingTypeAttrVals, 1150252)
-    '''Type: enums.DeembeddingTypeAttrVals
+    deembedding_type = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.DeembeddingType, 1150252)
+    '''Type: enums.DeembeddingType
 
     Specifies the type of de-embedding to apply to measurements on the specified port.
 
     To use this property, you must use the channelName parameter of the _set_attribute_vi_int32 method to specify the name of the port to configure for de-embedding.
 
-    If you set this property to DeembeddingTypeAttrVals.SCALAR or DeembeddingTypeAttrVals.VECTOR, NI-RFSG adjusts the instrument settings and the returned data to remove the effects of the external network between the instrument and the DUT.
+    If you set this property to DeembeddingType.SCALAR or DeembeddingType.VECTOR, NI-RFSG adjusts the instrument settings and the returned data to remove the effects of the external network between the instrument and the DUT.
 
-    **Default Value**: DeembeddingTypeAttrVals.SCALAR
+    **Default Value**: DeembeddingType.SCALAR
 
-    **Valid Values for PXIe-5830/5832/5840/5841/5842/5860** : DeembeddingTypeAttrVals.SCALAR or DeembeddingTypeAttrVals.NONE
+    **Valid Values for PXIe-5830/5832/5840/5841/5842/5860** : DeembeddingType.SCALAR or DeembeddingType.NONE
 
-    **Valid Values for PXIe-5831** DeembeddingTypeAttrVals.SCALAR, DeembeddingTypeAttrVals.VECTOR, or DeembeddingTypeAttrVals.NONE. DeembeddingTypeAttrVals.VECTOR is only supported for TRX Ports in a Semiconductor Test System (STS).
+    **Valid Values for PXIe-5831** DeembeddingType.SCALAR, DeembeddingType.VECTOR, or DeembeddingType.NONE. DeembeddingType.VECTOR is only supported for TRX Ports in a Semiconductor Test System (STS).
 
     **Supported Devices**: PXIe-5830/5831/5832/5840/5841/5842/5860
 
     **Defined Values**:
 
-    +--------------------------------+----------------+------------------------------------------------------------------------+
-    | Name                           | Value          | Description                                                            |
-    +================================+================+========================================================================+
-    | DeembeddingTypeAttrVals.NONE   | 25000 (0x61a8) | De-embedding is not applied to the measurement.                        |
-    +--------------------------------+----------------+------------------------------------------------------------------------+
-    | DeembeddingTypeAttrVals.SCALAR | 25001 (0x61a9) | De-embeds the measurement using only the gain term.                    |
-    +--------------------------------+----------------+------------------------------------------------------------------------+
-    | DeembeddingTypeAttrVals.VECTOR | 25002 (0x61aa) | De-embeds the measurement using the gain term and the reflection term. |
-    +--------------------------------+----------------+------------------------------------------------------------------------+
+    +------------------------+----------------+------------------------------------------------------------------------+
+    | Name                   | Value          | Description                                                            |
+    +========================+================+========================================================================+
+    | DeembeddingType.NONE   | 25000 (0x61a8) | De-embedding is not applied to the measurement.                        |
+    +------------------------+----------------+------------------------------------------------------------------------+
+    | DeembeddingType.SCALAR | 25001 (0x61a9) | De-embeds the measurement using only the gain term.                    |
+    +------------------------+----------------+------------------------------------------------------------------------+
+    | DeembeddingType.VECTOR | 25002 (0x61aa) | De-embeds the measurement using the gain term and the reflection term. |
+    +------------------------+----------------+------------------------------------------------------------------------+
 
     Tip:
-    This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container port to specify a subset.
+    This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container ports to specify a subset.
 
-    Example: :py:attr:`my_session.port[ ... ].deembedding_type`
+    Example: :py:attr:`my_session.ports[ ... ].deembedding_type`
 
-    To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.deembedding_type`
     '''
@@ -1197,12 +1197,12 @@ class _SessionBase(object):
     +----------------------------+--------------------------+-------------------------+
 
     Tip:
-    This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container port to specify a subset.
+    This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container ports to specify a subset.
 
-    Example: :py:attr:`my_session.port[ ... ].device_temperature`
+    Example: :py:attr:`my_session.ports[ ... ].device_temperature`
 
-    To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.device_temperature`
     '''
@@ -2771,12 +2771,12 @@ class _SessionBase(object):
      - The valid range is dependent on the load impedance.
 
     Tip:
-    This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container port to specify a subset.
+    This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container ports to specify a subset.
 
-    Example: :py:attr:`my_session.port[ ... ].iq_out_port_common_mode_offset`
+    Example: :py:attr:`my_session.ports[ ... ].iq_out_port_common_mode_offset`
 
-    To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.iq_out_port_common_mode_offset`
     '''
@@ -2812,12 +2812,12 @@ class _SessionBase(object):
      - The valid values are only applicable when you set the iq_out_port_load_impedance property to 50 Ω and when you set the iq_out_port_offset property to 0.
 
     Tip:
-    This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container port to specify a subset.
+    This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container ports to specify a subset.
 
-    Example: :py:attr:`my_session.port[ ... ].iq_out_port_level`
+    Example: :py:attr:`my_session.ports[ ... ].iq_out_port_level`
 
-    To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.iq_out_port_level`
     '''
@@ -2839,12 +2839,12 @@ class _SessionBase(object):
     Note: For the PXIe-5645, this property is ignored if you are using the RF ports.
 
     Tip:
-    This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container port to specify a subset.
+    This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container ports to specify a subset.
 
-    Example: :py:attr:`my_session.port[ ... ].iq_out_port_load_impedance`
+    Example: :py:attr:`my_session.ports[ ... ].iq_out_port_load_impedance`
 
-    To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.iq_out_port_load_impedance`
     '''
@@ -2866,12 +2866,12 @@ class _SessionBase(object):
     Note: For the PXIe-5645, this property is ignored if you are using the RF ports.
 
     Tip:
-    This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container port to specify a subset.
+    This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container ports to specify a subset.
 
-    Example: :py:attr:`my_session.port[ ... ].iq_out_port_offset`
+    Example: :py:attr:`my_session.ports[ ... ].iq_out_port_offset`
 
-    To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.iq_out_port_offset`
     '''
@@ -2920,12 +2920,12 @@ class _SessionBase(object):
     Note: For the PXIe-5645, this property is ignored if you are using the RF ports.
 
     Tip:
-    This property can be set/get on specific port within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container port to specify a subset.
+    This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container ports to specify a subset.
 
-    Example: :py:attr:`my_session.port[ ... ].iq_out_port_terminal_configuration`
+    Example: :py:attr:`my_session.ports[ ... ].iq_out_port_terminal_configuration`
 
-    To set/get on all port, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.iq_out_port_terminal_configuration`
     '''
@@ -3128,12 +3128,12 @@ class _SessionBase(object):
     One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
     Tip:
-    This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container lo to specify a subset.
+    This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
 
-    Example: :py:attr:`my_session.lo[ ... ].loop_bandwidth`
+    Example: :py:attr:`my_session.lo_channels[ ... ].loop_bandwidth`
 
-    To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.loop_bandwidth`
     '''
@@ -3155,12 +3155,12 @@ class _SessionBase(object):
     Note: This property is read/write if you are using an external LO. Otherwise, this property is read-only.
 
     Tip:
-    This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container lo to specify a subset.
+    This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
 
-    Example: :py:attr:`my_session.lo[ ... ].lo_frequency`
+    Example: :py:attr:`my_session.lo_channels[ ... ].lo_frequency`
 
-    To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.lo_frequency`
     '''
@@ -3238,12 +3238,12 @@ class _SessionBase(object):
      - For the PXIe-5644/5645/5646, this property is always read-only.
 
     Tip:
-    This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container lo to specify a subset.
+    This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
 
-    Example: :py:attr:`my_session.lo[ ... ].lo_in_power`
+    Example: :py:attr:`my_session.lo_channels[ ... ].lo_in_power`
 
-    To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.lo_in_power`
     '''
@@ -3276,12 +3276,12 @@ class _SessionBase(object):
     One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
     Tip:
-    This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container lo to specify a subset.
+    This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
 
-    Example: :py:attr:`my_session.lo[ ... ].lo_out_enabled`
+    Example: :py:attr:`my_session.lo_channels[ ... ].lo_out_enabled`
 
-    To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.lo_out_enabled`
     '''
@@ -3327,12 +3327,12 @@ class _SessionBase(object):
     Note: For the PXIe-5644/5645/5646 and PXIe-5673/5673E, this property is always read-only.
 
     Tip:
-    This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container lo to specify a subset.
+    This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
 
-    Example: :py:attr:`my_session.lo[ ... ].lo_out_power`
+    Example: :py:attr:`my_session.lo_channels[ ... ].lo_out_power`
 
-    To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.lo_out_power`
     '''
@@ -3369,12 +3369,12 @@ class _SessionBase(object):
     One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
     Tip:
-    This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container lo to specify a subset.
+    This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
 
-    Example: :py:attr:`my_session.lo[ ... ].lo_pll_fractional_mode_enabled`
+    Example: :py:attr:`my_session.lo_channels[ ... ].lo_pll_fractional_mode_enabled`
 
-    To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.lo_pll_fractional_mode_enabled`
     '''
@@ -3414,12 +3414,12 @@ class _SessionBase(object):
     Note: For the PXIe-5841 with PXIe-5655, RF list mode is not supported when this property is set to SG_SA_Shared.
 
     Tip:
-    This property can be set/get on specific lo within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container lo to specify a subset.
+    This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
 
-    Example: :py:attr:`my_session.lo[ ... ].lo_source`
+    Example: :py:attr:`my_session.lo_channels[ ... ].lo_source`
 
-    To set/get on all lo, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.lo_source`
     '''
@@ -4644,20 +4644,15 @@ class _SessionBase(object):
 
     **Defined Values**:
 
-    +----------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-    | Value                                  | Description                                                                                                                                                                                                                                            |
-    +========================================+========================================================================================================================================================================================================================================================+
-    | StartTriggerType.NONE                  | No trigger is configured.                                                                                                                                                                                                                              |
-    +----------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-    | StartTriggerType.DIGITAL_EDGE          | The data operation does not start until a digital edge is detected. The source of the digital edge is specified with the digital_edge_start_trigger_source property, and the active edge is specified in the digital_edge_start_trigger_edge property. |
-    +----------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-    | StartTriggerType.SOFTWARE              | The data operation does not start until a software event occurs. You may create a software trigger by calling the send_software_edge_trigger method.                                                                                                   |
-    +----------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-    | StartTriggerType.P2P_ENDPOINT_FULLNESS | The data operation does not start until the endpoint reaches the threshold specified in the P2P_ENDPOINT_FULLNESS_START_TRIGGER_LEVEL property.                                                                                                        |
-    +----------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-    Note:
-    One or more of the referenced properties are not in the Python API for this driver.
+    +-------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | Value                         | Description                                                                                                                                                                                                                                            |
+    +===============================+========================================================================================================================================================================================================================================================+
+    | StartTriggerType.NONE         | No trigger is configured.                                                                                                                                                                                                                              |
+    +-------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | StartTriggerType.DIGITAL_EDGE | The data operation does not start until a digital edge is detected. The source of the digital edge is specified with the digital_edge_start_trigger_source property, and the active edge is specified in the digital_edge_start_trigger_edge property. |
+    +-------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | StartTriggerType.SOFTWARE     | The data operation does not start until a software event occurs. You may create a software trigger by calling the send_software_edge_trigger method.                                                                                                   |
+    +-------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
     Note:
     One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
@@ -5064,12 +5059,12 @@ class _SessionBase(object):
     `Digital Upconverter <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/duc.html>`_
 
     Tip:
-    This property can be set/get on specific waveform within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container waveform to specify a subset.
+    This property can be set/get on specific waveforms within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container waveforms to specify a subset.
 
-    Example: :py:attr:`my_session.waveform[ ... ].waveform_iq_rate`
+    Example: :py:attr:`my_session.waveforms[ ... ].waveform_iq_rate`
 
-    To set/get on all waveform, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all waveforms, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.waveform_iq_rate`
     '''
@@ -5081,12 +5076,12 @@ class _SessionBase(object):
     **Supported Devices:** PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 
     Tip:
-    This property can be set/get on specific waveform within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container waveform to specify a subset.
+    This property can be set/get on specific waveforms within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container waveforms to specify a subset.
 
-    Example: :py:attr:`my_session.waveform[ ... ].waveform_papr`
+    Example: :py:attr:`my_session.waveforms[ ... ].waveform_papr`
 
-    To set/get on all waveform, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all waveforms, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.waveform_papr`
     '''
@@ -5129,12 +5124,12 @@ class _SessionBase(object):
     One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
     Tip:
-    This property can be set/get on specific waveform within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container waveform to specify a subset.
+    This property can be set/get on specific waveforms within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container waveforms to specify a subset.
 
-    Example: :py:attr:`my_session.waveform[ ... ].waveform_rf_blanking`
+    Example: :py:attr:`my_session.waveforms[ ... ].waveform_rf_blanking`
 
-    To set/get on all waveform, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all waveforms, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.waveform_rf_blanking`
     '''
@@ -5148,12 +5143,12 @@ class _SessionBase(object):
     **Supported Devices:** PXIe-5820/5830/5831/5832/5840/5841/5842/5860, PXIe-5841 with PXIe-5655
 
     Tip:
-    This property can be set/get on specific waveform within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container waveform to specify a subset.
+    This property can be set/get on specific waveforms within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container waveforms to specify a subset.
 
-    Example: :py:attr:`my_session.waveform[ ... ].waveform_runtime_scaling`
+    Example: :py:attr:`my_session.waveforms[ ... ].waveform_runtime_scaling`
 
-    To set/get on all waveform, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all waveforms, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.waveform_runtime_scaling`
     '''
@@ -5167,12 +5162,12 @@ class _SessionBase(object):
     **Supported Devices:** PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 
     Tip:
-    This property can be set/get on specific waveform within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container waveform to specify a subset.
+    This property can be set/get on specific waveforms within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container waveforms to specify a subset.
 
-    Example: :py:attr:`my_session.waveform[ ... ].waveform_signal_bandwidth`
+    Example: :py:attr:`my_session.waveforms[ ... ].waveform_signal_bandwidth`
 
-    To set/get on all waveform, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all waveforms, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.waveform_signal_bandwidth`
     '''
@@ -5184,12 +5179,12 @@ class _SessionBase(object):
     **Supported Devices:** PXIe-5820/5830/5831/5832/5840/5841/5841 with PXIe-5655/5842/5860
 
     Tip:
-    This property can be set/get on specific waveform within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container waveform to specify a subset.
+    This property can be set/get on specific waveforms within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container waveforms to specify a subset.
 
-    Example: :py:attr:`my_session.waveform[ ... ].waveform_waveform_size`
+    Example: :py:attr:`my_session.waveforms[ ... ].waveform_waveform_size`
 
-    To set/get on all waveform, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all waveforms, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.waveform_waveform_size`
     '''
@@ -5319,9 +5314,9 @@ class _SessionBase(object):
         # Instantiate any repeated capability objects
         self.markers = _RepeatedCapabilities(self, 'marker', repeated_capability_list)
         self.script_triggers = _RepeatedCapabilities(self, 'scripttrigger', repeated_capability_list)
-        self.waveform = _RepeatedCapabilities(self, 'waveform::', repeated_capability_list)
-        self.port = _RepeatedCapabilities(self, '', repeated_capability_list)
-        self.lo = _RepeatedCapabilities(self, 'LO', repeated_capability_list)
+        self.waveforms = _RepeatedCapabilities(self, 'waveform::', repeated_capability_list)
+        self.ports = _RepeatedCapabilities(self, '', repeated_capability_list)
+        self.lo_channels = _RepeatedCapabilities(self, 'LO', repeated_capability_list)
 
         # Finally, set _is_frozen to True which is used to prevent clients from accidentally adding
         # members when trying to set a property with a typo.
@@ -5820,13 +5815,13 @@ class _SessionBase(object):
         **Supported Devices** : PXIe-5820/5830/5831/5832/5840/5841/5842
 
         Tip:
-        This method can be called on specific waveform within your :py:class:`nirfsg.Session` instance.
-        Use Python index notation on the repeated capabilities container waveform to specify a subset,
+        This method can be called on specific waveforms within your :py:class:`nirfsg.Session` instance.
+        Use Python index notation on the repeated capabilities container waveforms to specify a subset,
         and then call this method on the result.
 
-        Example: :py:meth:`my_session.waveform[ ... ].get_waveform_burst_start_locations`
+        Example: :py:meth:`my_session.waveforms[ ... ].get_waveform_burst_start_locations`
 
-        To call the method on all waveform, you can call it directly on the :py:class:`nirfsg.Session`.
+        To call the method on all waveforms, you can call it directly on the :py:class:`nirfsg.Session`.
 
         Example: :py:meth:`my_session.get_waveform_burst_start_locations`
 
@@ -5849,13 +5844,13 @@ class _SessionBase(object):
         **Supported Devices** : PXIe-5820/5830/5831/5832/5840/5841/5842
 
         Tip:
-        This method can be called on specific waveform within your :py:class:`nirfsg.Session` instance.
-        Use Python index notation on the repeated capabilities container waveform to specify a subset,
+        This method can be called on specific waveforms within your :py:class:`nirfsg.Session` instance.
+        Use Python index notation on the repeated capabilities container waveforms to specify a subset,
         and then call this method on the result.
 
-        Example: :py:meth:`my_session.waveform[ ... ].get_waveform_burst_stop_locations`
+        Example: :py:meth:`my_session.waveforms[ ... ].get_waveform_burst_stop_locations`
 
-        To call the method on all waveform, you can call it directly on the :py:class:`nirfsg.Session`.
+        To call the method on all waveforms, you can call it directly on the :py:class:`nirfsg.Session`.
 
         Example: :py:meth:`my_session.get_waveform_burst_stop_locations`
 
@@ -6296,13 +6291,13 @@ class _SessionBase(object):
         **Supported Devices** : PXIe-5820/5830/5831/5832/5840/5841/5842
 
         Tip:
-        This method can be called on specific waveform within your :py:class:`nirfsg.Session` instance.
-        Use Python index notation on the repeated capabilities container waveform to specify a subset,
+        This method can be called on specific waveforms within your :py:class:`nirfsg.Session` instance.
+        Use Python index notation on the repeated capabilities container waveforms to specify a subset,
         and then call this method on the result.
 
-        Example: :py:meth:`my_session.waveform[ ... ].set_waveform_burst_start_locations`
+        Example: :py:meth:`my_session.waveforms[ ... ].set_waveform_burst_start_locations`
 
-        To call the method on all waveform, you can call it directly on the :py:class:`nirfsg.Session`.
+        To call the method on all waveforms, you can call it directly on the :py:class:`nirfsg.Session`.
 
         Example: :py:meth:`my_session.set_waveform_burst_start_locations`
 
@@ -6324,13 +6319,13 @@ class _SessionBase(object):
         **Supported Devices** : PXIe-5820/5830/5831/5832/5840/5841/5842
 
         Tip:
-        This method can be called on specific waveform within your :py:class:`nirfsg.Session` instance.
-        Use Python index notation on the repeated capabilities container waveform to specify a subset,
+        This method can be called on specific waveforms within your :py:class:`nirfsg.Session` instance.
+        Use Python index notation on the repeated capabilities container waveforms to specify a subset,
         and then call this method on the result.
 
-        Example: :py:meth:`my_session.waveform[ ... ].set_waveform_burst_stop_locations`
+        Example: :py:meth:`my_session.waveforms[ ... ].set_waveform_burst_stop_locations`
 
-        To call the method on all waveform, you can call it directly on the :py:class:`nirfsg.Session`.
+        To call the method on all waveforms, you can call it directly on the :py:class:`nirfsg.Session`.
 
         Example: :py:meth:`my_session.set_waveform_burst_stop_locations`
 
@@ -6618,9 +6613,7 @@ class Session(_SessionBase):
 
         **Related Topics**
 
-        `NI-RFSG Instrument Driver Programming Flow <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/progflow.html>`_
-
-        `Stopping Pear-to-Peer Generation <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_stopping_generation.html>`_
+        `NI-RFSG Instrument Driver Programming Flow <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/progflow.html>`
 
         Returns:
             is_done (bool): Returns information about the completion of signal generation.
@@ -7855,7 +7848,7 @@ class Session(_SessionBase):
     def select_arb_waveform(self, name):
         r'''select_arb_waveform
 
-        Specifies the waveform that is generated upon a call to the _initiate method when the **generationMode** parameter of the ConfigureGenerationMode method is set to GenerationMode.ARB_WAVEFORM.
+        Specifies the waveform that is generated upon a call to the _initiate method when the generation_mode property is set to GenerationMode.ARB_WAVEFORM.
 
         You must specify a waveform using the NAME parameter if you have written multiple waveforms. The NI-RFSG device must be in the Configuration state before you call this method.
 
@@ -8206,7 +8199,7 @@ class Session(_SessionBase):
 
         Writes a script to the device to control waveform generation in Script mode.
 
-        First, configure your device for Script mode by calling the ConfigureGenerationMode method. The NI-RFSG device must be in the Configuration state before calling the write_script method.
+        First, configure your device for Script mode by setting the generation_mode property. The NI-RFSG device must be in the Configuration state before calling the write_script method.
 
         **Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 

--- a/generated/nirfsg/nirfsg/session.py
+++ b/generated/nirfsg/nirfsg/session.py
@@ -311,7 +311,7 @@ class _SessionBase(object):
 
     This property is valid only when you set the analog_modulation_type property to AnalogModulationType.FM and the analog_modulation_fm_band property to AnalogModulationFmBand.NARROWBAND.
 
-    **Default Value:** AnalogModulationFmNarrowbandIntegrator._100Hzto1kHz
+    **Default Value:** AnalogModulationFmNarrowbandIntegrator.RANGE_100_HERTZ_TO_1_KILOHERTZ
 
     **Supported Devices:** PXIe-5654/5654 with PXIe-5696
 
@@ -321,15 +321,15 @@ class _SessionBase(object):
 
     **Defined Values**:
 
-    +-------------------------------------------------------+----------------+---------------------------------------------+
-    | Name                                                  | Value          | Description                                 |
-    +=======================================================+================+=============================================+
-    | AnalogModulationFmNarrowbandIntegrator._100Hzto1kHz   | 18000 (0x4650) | Specifies a range from 100Â Hz to 1Â kHz.   |
-    +-------------------------------------------------------+----------------+---------------------------------------------+
-    | AnalogModulationFmNarrowbandIntegrator._10kHzto100kHz | 18002 (0x4652) | Specifies a range from 10Â kHz to 100Â kHz. |
-    +-------------------------------------------------------+----------------+---------------------------------------------+
-    | AnalogModulationFmNarrowbandIntegrator._1kHzto10kHz   | 18001 (0x4651) | Specifies a range from 1Â kHz to 10Â kHz.   |
-    +-------------------------------------------------------+----------------+---------------------------------------------+
+    +----------------------------------------------------------------------------+----------------+---------------------------------------------+
+    | Name                                                                       | Value          | Description                                 |
+    +============================================================================+================+=============================================+
+    | AnalogModulationFmNarrowbandIntegrator.RANGE_100_HERTZ_TO_1_KILOHERTZ      | 18000 (0x4650) | Specifies a range from 100Â Hz to 1Â kHz.   |
+    +----------------------------------------------------------------------------+----------------+---------------------------------------------+
+    | AnalogModulationFmNarrowbandIntegrator.RANGE_10_KILOHERTZ_TO_100_KILOHERTZ | 18002 (0x4652) | Specifies a range from 10Â kHz to 100Â kHz. |
+    +----------------------------------------------------------------------------+----------------+---------------------------------------------+
+    | AnalogModulationFmNarrowbandIntegrator.RANGE_1_KILOHERTZ_TO_10_KILOHERTZ   | 18001 (0x4651) | Specifies a range from 1Â kHz to 10Â kHz.   |
+    +----------------------------------------------------------------------------+----------------+---------------------------------------------+
     '''
     analog_modulation_fm_sensitivity = _attributes.AttributeViReal64(1150166)
     '''Type: float
@@ -2084,21 +2084,21 @@ class _SessionBase(object):
 
     Specifies the Reference Clock Rate, in Hz, of the signal sent to the Reference Clock Export Output Terminal. To set this property, the NI-RFSG device must be in the Configuration state.
 
-    **Default Value:** ReferenceClockExportedRate._10MHz
+    **Default Value:** ReferenceClockExportedRate.CLOCK_RATE_10_MEGAHERTZ
 
     **Supported Devices:** PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 
     **Defined Values**:
 
-    +------------------------------------+--------------+-------------------------------------+
-    | Name                               | Value        | Description                         |
-    +====================================+==============+=====================================+
-    | ReferenceClockExportedRate._10MHz  | 10000000.0   | Uses a 10MHz Reference Clock rate.  |
-    +------------------------------------+--------------+-------------------------------------+
-    | ReferenceClockExportedRate._100MHz | 100000000.0  | Uses a 100MHz Reference Clock rate. |
-    +------------------------------------+--------------+-------------------------------------+
-    | ReferenceClockExportedRate._1GHz   | 1000000000.0 | Uses a 1GHz Reference Clock rate.   |
-    +------------------------------------+--------------+-------------------------------------+
+    +-----------------------------------------------------+--------------+-------------------------------------+
+    | Name                                                | Value        | Description                         |
+    +=====================================================+==============+=====================================+
+    | ReferenceClockExportedRate.CLOCK_RATE_10_MEGAHERTZ  | 10000000.0   | Uses a 10MHz Reference Clock rate.  |
+    +-----------------------------------------------------+--------------+-------------------------------------+
+    | ReferenceClockExportedRate.CLOCK_RATE_100_MEGAHERTZ | 100000000.0  | Uses a 100MHz Reference Clock rate. |
+    +-----------------------------------------------------+--------------+-------------------------------------+
+    | ReferenceClockExportedRate.CLOCK_RATE_1_GIGAHERTZ   | 1000000000.0 | Uses a 1GHz Reference Clock rate.   |
+    +-----------------------------------------------------+--------------+-------------------------------------+
 
     Note:
     One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
@@ -4123,7 +4123,7 @@ class _SessionBase(object):
 
     **Valid Values:**
 
-    PXIe-5654/5654 with PXIe-5696: Values between 1MHz to 20MHz in 1MHz steps are supported in addition to the ReferenceClockRate.AUTO and ReferenceClockRate._10MHz values.
+    PXIe-5654/5654 with PXIe-5696: Values between 1MHz to 20MHz in 1MHz steps are supported in addition to the ReferenceClockRate.AUTO and ReferenceClockRate.CLOCK_RATE_10_MEGAHERTZ values.
 
     PXIe-5841 with PXIe-5655, PXIe-5842: 10 MHz, 100 MHz, 270 MHz, and 3.84 MHz
 
@@ -4149,13 +4149,13 @@ class _SessionBase(object):
 
     **Defined Values**:
 
-    +---------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
-    | Value                     | Description                                                                                                                       |
-    +===========================+===================================================================================================================================+
-    | ReferenceClockRate.AUTO   | Uses the default Reference Clock rate for the device or automatically detects the Reference Clock rate if the device supports it. |
-    +---------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
-    | ReferenceClockRate._10MHz | Uses a 10 MHz Reference Clock rate.                                                                                               |
-    +---------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
+    +--------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
+    | Value                                      | Description                                                                                                                       |
+    +============================================+===================================================================================================================================+
+    | ReferenceClockRate.AUTO                    | Uses the default Reference Clock rate for the device or automatically detects the Reference Clock rate if the device supports it. |
+    +--------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
+    | ReferenceClockRate.CLOCK_RATE_10_MEGAHERTZ | Uses a 10 MHz Reference Clock rate.                                                                                               |
+    +--------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
 
     Note: Automatic detection of the Reference Clock rate is supported on only the PXIe-5654/5654 with PXIe-5696. For all other supported devices, NI-RFSG uses the default Reference Clock rate of 10MHz.
 
@@ -7050,13 +7050,13 @@ class Session(_SessionBase):
 
             sparameter_orientation (enums.SparameterOrientation): Specifies the orientation of the data in the S2P file relative to the port on the DUT port. **Defined Values** :
 
-                +-----------------------------+----------------+-----------------------------------------------------+
-                | Name                        | Value          | Description                                         |
-                +=============================+================+=====================================================+
-                | SparameterOrientation.PORT1 | 24000 (0x5dc0) | Port 1 of the S2P is oriented towards the DUT port. |
-                +-----------------------------+----------------+-----------------------------------------------------+
-                | SparameterOrientation.PORT2 | 24001 (0x5dc1) | Port 2 of the S2P is oriented towards the DUT port. |
-                +-----------------------------+----------------+-----------------------------------------------------+
+                +-----------------------------------------+----------------+-----------------------------------------------------+
+                | Name                                    | Value          | Description                                         |
+                +=========================================+================+=====================================================+
+                | SparameterOrientation.PORT1_TOWARDS_DUT | 24000 (0x5dc0) | Port 1 of the S2P is oriented towards the DUT port. |
+                +-----------------------------------------+----------------+-----------------------------------------------------+
+                | SparameterOrientation.PORT2_TOWARDS_DUT | 24001 (0x5dc1) | Port 2 of the S2P is oriented towards the DUT port. |
+                +-----------------------------------------+----------------+-----------------------------------------------------+
 
         '''
         if type(sparameter_orientation) is not enums.SparameterOrientation:
@@ -7161,25 +7161,25 @@ class Session(_SessionBase):
 
                  **Defined Values** :
 
-                +----------------------------------------+---------+--------------------------------------------+
-                | Name                                   | Value   | Description                                |
-                +========================================+=========+============================================+
-                | Signal.START_TRIGGER                   | 0 (0x0) | Exports a Start Trigger.                   |
-                +----------------------------------------+---------+--------------------------------------------+
-                | Signal.SCRIPT_TRIGGER                  | 1 (0x1) | Exports a Script Trigger.                  |
-                +----------------------------------------+---------+--------------------------------------------+
-                | Signal.MARKER_EVENT                    | 2 (0x2) | Exports a Marker Event.                    |
-                +----------------------------------------+---------+--------------------------------------------+
-                | Signal.REF_CLOCK                       | 3 (0x3) | Exports the Reference Clock.               |
-                +----------------------------------------+---------+--------------------------------------------+
-                | Signal.STARTED_EVENT                   | 4 (0x4) | Exports a Started Event.                   |
-                +----------------------------------------+---------+--------------------------------------------+
-                | Signal.DONE_EVENT                      | 5 (0x5) | Exports a Done Event.                      |
-                +----------------------------------------+---------+--------------------------------------------+
-                | Signal.CONFIGURATION_LIST_STEP_TRIGGER | 6 (0x6) | Exports a Configuration List Step Trigger. |
-                +----------------------------------------+---------+--------------------------------------------+
-                | Signal.CONFIGURATION_SETTLED_EVENT     | 7 (0x7) | Exports a Configuration Settled Event.     |
-                +----------------------------------------+---------+--------------------------------------------+
+                +--------------------------------------------+---------+--------------------------------------------+
+                | Name                                       | Value   | Description                                |
+                +============================================+=========+============================================+
+                | Signal.START_TRIGGER                       | 0 (0x0) | Exports a Start Trigger.                   |
+                +--------------------------------------------+---------+--------------------------------------------+
+                | Signal.SCRIPT_TRIGGER                      | 1 (0x1) | Exports a Script Trigger.                  |
+                +--------------------------------------------+---------+--------------------------------------------+
+                | Signal.MARKER_EVENT                        | 2 (0x2) | Exports a Marker Event.                    |
+                +--------------------------------------------+---------+--------------------------------------------+
+                | Signal.REF_CLOCK                           | 3 (0x3) | Exports the Reference Clock.               |
+                +--------------------------------------------+---------+--------------------------------------------+
+                | Signal.STARTED_EVENT                       | 4 (0x4) | Exports a Started Event.                   |
+                +--------------------------------------------+---------+--------------------------------------------+
+                | Signal.DONE_EVENT                          | 5 (0x5) | Exports a Done Event.                      |
+                +--------------------------------------------+---------+--------------------------------------------+
+                | NIRFSG_VAL_CONFIGURATION_LIST_STEP_TRIGGER | 6 (0x6) | Exports a Configuration List Step Trigger. |
+                +--------------------------------------------+---------+--------------------------------------------+
+                | NIRFSG_VAL_CONFIGURATION_SETTLED_EVENT     | 7 (0x7) | Exports a Configuration Settled Event.     |
+                +--------------------------------------------+---------+--------------------------------------------+
 
                 Note:
                 One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
@@ -7479,25 +7479,25 @@ class Session(_SessionBase):
         Args:
             signal (enums.Signal): Specifies the signal to query. **Defined Values** :
 
-                +----------------------------------------+---------+--------------------------------------------+
-                | Name                                   | Value   | Description                                |
-                +========================================+=========+============================================+
-                | Signal.START_TRIGGER                   | 0 (0x0) | Exports a Start Trigger.                   |
-                +----------------------------------------+---------+--------------------------------------------+
-                | Signal.SCRIPT_TRIGGER                  | 1 (0x1) | Exports a Script Trigger.                  |
-                +----------------------------------------+---------+--------------------------------------------+
-                | Signal.MARKER_EVENT                    | 2 (0x2) | Exports a Marker Event.                    |
-                +----------------------------------------+---------+--------------------------------------------+
-                | Signal.REF_CLOCK                       | 3 (0x3) | Exports the Reference Clock.               |
-                +----------------------------------------+---------+--------------------------------------------+
-                | Signal.STARTED_EVENT                   | 4 (0x4) | Exports a Started Event.                   |
-                +----------------------------------------+---------+--------------------------------------------+
-                | Signal.DONE_EVENT                      | 5 (0x5) | Exports a Done Event.                      |
-                +----------------------------------------+---------+--------------------------------------------+
-                | Signal.CONFIGURATION_LIST_STEP_TRIGGER | 6 (0x6) | Exports a Configuration List Step Trigger. |
-                +----------------------------------------+---------+--------------------------------------------+
-                | Signal.CONFIGURATION_SETTLED_EVENT     | 7 (0x7) | Exports a Configuration Settled Event.     |
-                +----------------------------------------+---------+--------------------------------------------+
+                +--------------------------------------------+---------+--------------------------------------------+
+                | Name                                       | Value   | Description                                |
+                +============================================+=========+============================================+
+                | Signal.START_TRIGGER                       | 0 (0x0) | Exports a Start Trigger.                   |
+                +--------------------------------------------+---------+--------------------------------------------+
+                | Signal.SCRIPT_TRIGGER                      | 1 (0x1) | Exports a Script Trigger.                  |
+                +--------------------------------------------+---------+--------------------------------------------+
+                | Signal.MARKER_EVENT                        | 2 (0x2) | Exports a Marker Event.                    |
+                +--------------------------------------------+---------+--------------------------------------------+
+                | Signal.REF_CLOCK                           | 3 (0x3) | Exports the Reference Clock.               |
+                +--------------------------------------------+---------+--------------------------------------------+
+                | Signal.STARTED_EVENT                       | 4 (0x4) | Exports a Started Event.                   |
+                +--------------------------------------------+---------+--------------------------------------------+
+                | Signal.DONE_EVENT                          | 5 (0x5) | Exports a Done Event.                      |
+                +--------------------------------------------+---------+--------------------------------------------+
+                | NIRFSG_VAL_CONFIGURATION_LIST_STEP_TRIGGER | 6 (0x6) | Exports a Configuration List Step Trigger. |
+                +--------------------------------------------+---------+--------------------------------------------+
+                | NIRFSG_VAL_CONFIGURATION_SETTLED_EVENT     | 7 (0x7) | Exports a Configuration Settled Event.     |
+                +--------------------------------------------+---------+--------------------------------------------+
 
                 Note:
                 One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.

--- a/generated/nirfsg/nirfsg/unit_tests/_mock_helper.py
+++ b/generated/nirfsg/nirfsg/unit_tests/_mock_helper.py
@@ -67,22 +67,12 @@ class SideEffectsHelper(object):
         self._defaults['ConfigureDigitalLevelScriptTrigger']['return'] = 0
         self._defaults['ConfigureDigitalModulationUserDefinedWaveform'] = {}
         self._defaults['ConfigureDigitalModulationUserDefinedWaveform']['return'] = 0
-        self._defaults['ConfigureGenerationMode'] = {}
-        self._defaults['ConfigureGenerationMode']['return'] = 0
-        self._defaults['ConfigureOutputEnabled'] = {}
-        self._defaults['ConfigureOutputEnabled']['return'] = 0
-        self._defaults['ConfigureP2PEndpointFullnessStartTrigger'] = {}
-        self._defaults['ConfigureP2PEndpointFullnessStartTrigger']['return'] = 0
-        self._defaults['ConfigurePowerLevelType'] = {}
-        self._defaults['ConfigurePowerLevelType']['return'] = 0
         self._defaults['ConfigurePxiChassisClk10'] = {}
         self._defaults['ConfigurePxiChassisClk10']['return'] = 0
         self._defaults['ConfigureRF'] = {}
         self._defaults['ConfigureRF']['return'] = 0
         self._defaults['ConfigureRefClock'] = {}
         self._defaults['ConfigureRefClock']['return'] = 0
-        self._defaults['ConfigureSignalBandwidth'] = {}
-        self._defaults['ConfigureSignalBandwidth']['return'] = 0
         self._defaults['ConfigureSoftwareScriptTrigger'] = {}
         self._defaults['ConfigureSoftwareScriptTrigger']['return'] = 0
         self._defaults['ConfigureSoftwareStartTrigger'] = {}
@@ -162,9 +152,6 @@ class SideEffectsHelper(object):
         self._defaults['GetSelfCalibrationTemperature'] = {}
         self._defaults['GetSelfCalibrationTemperature']['return'] = 0
         self._defaults['GetSelfCalibrationTemperature']['temperature'] = None
-        self._defaults['GetStreamEndpointHandle'] = {}
-        self._defaults['GetStreamEndpointHandle']['return'] = 0
-        self._defaults['GetStreamEndpointHandle']['readerHandle'] = None
         self._defaults['GetTerminalName'] = {}
         self._defaults['GetTerminalName']['return'] = 0
         self._defaults['GetTerminalName']['terminalName'] = None
@@ -208,6 +195,8 @@ class SideEffectsHelper(object):
         self._defaults['ResetDevice']['return'] = 0
         self._defaults['ResetWithDefaults'] = {}
         self._defaults['ResetWithDefaults']['return'] = 0
+        self._defaults['ResetWithOptions'] = {}
+        self._defaults['ResetWithOptions']['return'] = 0
         self._defaults['RevisionQuery'] = {}
         self._defaults['RevisionQuery']['return'] = 0
         self._defaults['RevisionQuery']['instrumentDriverRevision'] = None
@@ -256,8 +245,6 @@ class SideEffectsHelper(object):
         self._defaults['WriteArbWaveformComplexF64']['return'] = 0
         self._defaults['WriteArbWaveformComplexI16'] = {}
         self._defaults['WriteArbWaveformComplexI16']['return'] = 0
-        self._defaults['WriteP2PEndpointI16'] = {}
-        self._defaults['WriteP2PEndpointI16']['return'] = 0
         self._defaults['WriteScript'] = {}
         self._defaults['WriteScript']['return'] = 0
         self._defaults['close'] = {}
@@ -406,26 +393,6 @@ class SideEffectsHelper(object):
             return self._defaults['ConfigureDigitalModulationUserDefinedWaveform']['return']
         return self._defaults['ConfigureDigitalModulationUserDefinedWaveform']['return']
 
-    def niRFSG_ConfigureGenerationMode(self, vi, generation_mode):  # noqa: N802
-        if self._defaults['ConfigureGenerationMode']['return'] != 0:
-            return self._defaults['ConfigureGenerationMode']['return']
-        return self._defaults['ConfigureGenerationMode']['return']
-
-    def niRFSG_ConfigureOutputEnabled(self, vi, output_enabled):  # noqa: N802
-        if self._defaults['ConfigureOutputEnabled']['return'] != 0:
-            return self._defaults['ConfigureOutputEnabled']['return']
-        return self._defaults['ConfigureOutputEnabled']['return']
-
-    def niRFSG_ConfigureP2PEndpointFullnessStartTrigger(self, vi, p2p_endpoint_fullness_level):  # noqa: N802
-        if self._defaults['ConfigureP2PEndpointFullnessStartTrigger']['return'] != 0:
-            return self._defaults['ConfigureP2PEndpointFullnessStartTrigger']['return']
-        return self._defaults['ConfigureP2PEndpointFullnessStartTrigger']['return']
-
-    def niRFSG_ConfigurePowerLevelType(self, vi, power_level_type):  # noqa: N802
-        if self._defaults['ConfigurePowerLevelType']['return'] != 0:
-            return self._defaults['ConfigurePowerLevelType']['return']
-        return self._defaults['ConfigurePowerLevelType']['return']
-
     def niRFSG_ConfigurePxiChassisClk10(self, vi, pxi_clk10_source):  # noqa: N802
         if self._defaults['ConfigurePxiChassisClk10']['return'] != 0:
             return self._defaults['ConfigurePxiChassisClk10']['return']
@@ -440,11 +407,6 @@ class SideEffectsHelper(object):
         if self._defaults['ConfigureRefClock']['return'] != 0:
             return self._defaults['ConfigureRefClock']['return']
         return self._defaults['ConfigureRefClock']['return']
-
-    def niRFSG_ConfigureSignalBandwidth(self, vi, signal_bandwidth):  # noqa: N802
-        if self._defaults['ConfigureSignalBandwidth']['return'] != 0:
-            return self._defaults['ConfigureSignalBandwidth']['return']
-        return self._defaults['ConfigureSignalBandwidth']['return']
 
     def niRFSG_ConfigureSoftwareScriptTrigger(self, vi, trigger_id):  # noqa: N802
         if self._defaults['ConfigureSoftwareScriptTrigger']['return'] != 0:
@@ -725,16 +687,6 @@ class SideEffectsHelper(object):
             temperature.contents.value = self._defaults['GetSelfCalibrationTemperature']['temperature']
         return self._defaults['GetSelfCalibrationTemperature']['return']
 
-    def niRFSG_GetStreamEndpointHandle(self, vi, stream_endpoint, reader_handle):  # noqa: N802
-        if self._defaults['GetStreamEndpointHandle']['return'] != 0:
-            return self._defaults['GetStreamEndpointHandle']['return']
-        # reader_handle
-        if self._defaults['GetStreamEndpointHandle']['readerHandle'] is None:
-            raise MockFunctionCallError("niRFSG_GetStreamEndpointHandle", param='readerHandle')
-        if reader_handle is not None:
-            reader_handle.contents.value = self._defaults['GetStreamEndpointHandle']['readerHandle']
-        return self._defaults['GetStreamEndpointHandle']['return']
-
     def niRFSG_GetTerminalName(self, vi, signal, signal_identifier, buffer_size, terminal_name):  # noqa: N802
         if self._defaults['GetTerminalName']['return'] != 0:
             return self._defaults['GetTerminalName']['return']
@@ -894,6 +846,11 @@ class SideEffectsHelper(object):
             return self._defaults['ResetWithDefaults']['return']
         return self._defaults['ResetWithDefaults']['return']
 
+    def niRFSG_ResetWithOptions(self, vi, steps_to_omit):  # noqa: N802
+        if self._defaults['ResetWithOptions']['return'] != 0:
+            return self._defaults['ResetWithOptions']['return']
+        return self._defaults['ResetWithOptions']['return']
+
     def niRFSG_RevisionQuery(self, vi, instrument_driver_revision, firmware_revision):  # noqa: N802
         if self._defaults['RevisionQuery']['return'] != 0:
             return self._defaults['RevisionQuery']['return']
@@ -1032,11 +989,6 @@ class SideEffectsHelper(object):
             return self._defaults['WriteArbWaveformComplexI16']['return']
         return self._defaults['WriteArbWaveformComplexI16']['return']
 
-    def niRFSG_WriteP2PEndpointI16(self, vi, stream_endpoint, number_of_samples, endpoint_data):  # noqa: N802
-        if self._defaults['WriteP2PEndpointI16']['return'] != 0:
-            return self._defaults['WriteP2PEndpointI16']['return']
-        return self._defaults['WriteP2PEndpointI16']['return']
-
     def niRFSG_WriteScript(self, vi, script):  # noqa: N802
         if self._defaults['WriteScript']['return'] != 0:
             return self._defaults['WriteScript']['return']
@@ -1102,22 +1054,12 @@ class SideEffectsHelper(object):
         mock_library.niRFSG_ConfigureDigitalLevelScriptTrigger.return_value = 0
         mock_library.niRFSG_ConfigureDigitalModulationUserDefinedWaveform.side_effect = MockFunctionCallError("niRFSG_ConfigureDigitalModulationUserDefinedWaveform")
         mock_library.niRFSG_ConfigureDigitalModulationUserDefinedWaveform.return_value = 0
-        mock_library.niRFSG_ConfigureGenerationMode.side_effect = MockFunctionCallError("niRFSG_ConfigureGenerationMode")
-        mock_library.niRFSG_ConfigureGenerationMode.return_value = 0
-        mock_library.niRFSG_ConfigureOutputEnabled.side_effect = MockFunctionCallError("niRFSG_ConfigureOutputEnabled")
-        mock_library.niRFSG_ConfigureOutputEnabled.return_value = 0
-        mock_library.niRFSG_ConfigureP2PEndpointFullnessStartTrigger.side_effect = MockFunctionCallError("niRFSG_ConfigureP2PEndpointFullnessStartTrigger")
-        mock_library.niRFSG_ConfigureP2PEndpointFullnessStartTrigger.return_value = 0
-        mock_library.niRFSG_ConfigurePowerLevelType.side_effect = MockFunctionCallError("niRFSG_ConfigurePowerLevelType")
-        mock_library.niRFSG_ConfigurePowerLevelType.return_value = 0
         mock_library.niRFSG_ConfigurePxiChassisClk10.side_effect = MockFunctionCallError("niRFSG_ConfigurePxiChassisClk10")
         mock_library.niRFSG_ConfigurePxiChassisClk10.return_value = 0
         mock_library.niRFSG_ConfigureRF.side_effect = MockFunctionCallError("niRFSG_ConfigureRF")
         mock_library.niRFSG_ConfigureRF.return_value = 0
         mock_library.niRFSG_ConfigureRefClock.side_effect = MockFunctionCallError("niRFSG_ConfigureRefClock")
         mock_library.niRFSG_ConfigureRefClock.return_value = 0
-        mock_library.niRFSG_ConfigureSignalBandwidth.side_effect = MockFunctionCallError("niRFSG_ConfigureSignalBandwidth")
-        mock_library.niRFSG_ConfigureSignalBandwidth.return_value = 0
         mock_library.niRFSG_ConfigureSoftwareScriptTrigger.side_effect = MockFunctionCallError("niRFSG_ConfigureSoftwareScriptTrigger")
         mock_library.niRFSG_ConfigureSoftwareScriptTrigger.return_value = 0
         mock_library.niRFSG_ConfigureSoftwareStartTrigger.side_effect = MockFunctionCallError("niRFSG_ConfigureSoftwareStartTrigger")
@@ -1168,8 +1110,6 @@ class SideEffectsHelper(object):
         mock_library.niRFSG_GetSelfCalibrationDateAndTime.return_value = 0
         mock_library.niRFSG_GetSelfCalibrationTemperature.side_effect = MockFunctionCallError("niRFSG_GetSelfCalibrationTemperature")
         mock_library.niRFSG_GetSelfCalibrationTemperature.return_value = 0
-        mock_library.niRFSG_GetStreamEndpointHandle.side_effect = MockFunctionCallError("niRFSG_GetStreamEndpointHandle")
-        mock_library.niRFSG_GetStreamEndpointHandle.return_value = 0
         mock_library.niRFSG_GetTerminalName.side_effect = MockFunctionCallError("niRFSG_GetTerminalName")
         mock_library.niRFSG_GetTerminalName.return_value = 0
         mock_library.niRFSG_GetWaveformBurstStartLocations.side_effect = MockFunctionCallError("niRFSG_GetWaveformBurstStartLocations")
@@ -1200,6 +1140,8 @@ class SideEffectsHelper(object):
         mock_library.niRFSG_ResetDevice.return_value = 0
         mock_library.niRFSG_ResetWithDefaults.side_effect = MockFunctionCallError("niRFSG_ResetWithDefaults")
         mock_library.niRFSG_ResetWithDefaults.return_value = 0
+        mock_library.niRFSG_ResetWithOptions.side_effect = MockFunctionCallError("niRFSG_ResetWithOptions")
+        mock_library.niRFSG_ResetWithOptions.return_value = 0
         mock_library.niRFSG_RevisionQuery.side_effect = MockFunctionCallError("niRFSG_RevisionQuery")
         mock_library.niRFSG_RevisionQuery.return_value = 0
         mock_library.niRFSG_SaveConfigurationsToFile.side_effect = MockFunctionCallError("niRFSG_SaveConfigurationsToFile")
@@ -1244,8 +1186,6 @@ class SideEffectsHelper(object):
         mock_library.niRFSG_WriteArbWaveformComplexF64.return_value = 0
         mock_library.niRFSG_WriteArbWaveformComplexI16.side_effect = MockFunctionCallError("niRFSG_WriteArbWaveformComplexI16")
         mock_library.niRFSG_WriteArbWaveformComplexI16.return_value = 0
-        mock_library.niRFSG_WriteP2PEndpointI16.side_effect = MockFunctionCallError("niRFSG_WriteP2PEndpointI16")
-        mock_library.niRFSG_WriteP2PEndpointI16.return_value = 0
         mock_library.niRFSG_WriteScript.side_effect = MockFunctionCallError("niRFSG_WriteScript")
         mock_library.niRFSG_WriteScript.return_value = 0
         mock_library.niRFSG_close.side_effect = MockFunctionCallError("niRFSG_close")

--- a/src/nirfsg/metadata/attributes.py
+++ b/src/nirfsg/metadata/attributes.py
@@ -739,6 +739,9 @@ attributes = {
         },
         'lv_property': 'RF:LO Out Enabled',
         'name': 'LO_OUT_ENABLED',
+        'supported_rep_caps': [
+            'lo'
+        ],
         'type': 'ViBoolean'
     },
     1150014: {
@@ -860,13 +863,16 @@ attributes = {
         },
         'lv_property': 'Device Characteristics:Device Temperature (Degrees C)',
         'name': 'DEVICE_TEMPERATURE',
+        'supported_rep_caps': [
+            'port'
+        ],
         'type': 'ViReal64'
     },
     1150018: {
         'access': 'read-write',
         'codegen_method': 'public',
         'documentation': {
-            'description': 'Specifies whether to generate a continuous wave (CW) signal, the arbitrary waveform specified by the NIRFSG_ATTR_ARB_SELECTED_WAVEFORM attribute, or the script specified by the NIRFSG_ATTR_SELECTED_SCRIPT attribute, upon calling the nirfsg_Initiate function.\n\nTo set this attribute, the NI-RFSG device must be in the Configuration state.\n\n**Default Value:** NIRFSG_VAL_CW\n\n**Supported Devices:** PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696 (CW support only), PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Assigning Properties or Attributes to a Waveform <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/assigning_properties_or_attributes_to_a_waveform.html>`_\n\n`Scripting Instructions <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/scripting_instructions.html>`_—Refer to this topic for more information about scripting.\n\n**High-Level Functions**:\n\n- nirfsg_ConfigureGenerationMode\n\n**Defined Values**:',
+            'description': 'Specifies whether to generate a continuous wave (CW) signal, the arbitrary waveform specified by the NIRFSG_ATTR_ARB_SELECTED_WAVEFORM attribute, or the script specified by the NIRFSG_ATTR_SELECTED_SCRIPT attribute, upon calling the nirfsg_Initiate function.\n\nTo set this attribute, the NI-RFSG device must be in the Configuration state.\n\n**Default Value:** NIRFSG_VAL_CW\n\n**Supported Devices:** PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696 (CW support only), PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Assigning Properties or Attributes to a Waveform <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/assigning_properties_or_attributes_to_a_waveform.html>`_\n\n`Scripting Instructions <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/scripting_instructions.html>`_—Refer to this topic for more information about scripting.\n\n**Defined Values**:',
             'table_body': [
                 [
                     'NIRFSG_VAL_ARB_WAVEFORM',
@@ -923,7 +929,7 @@ attributes = {
                 'Description'
             ]
         },
-        'enum': 'ScriptTrigType',
+        'enum': 'ScriptTriggerType',
         'lv_property': 'Triggers:Script:Type',
         'name': 'SCRIPT_TRIGGER_TYPE',
         'supported_rep_caps': [
@@ -1069,7 +1075,7 @@ attributes = {
                 'Description'
             ]
         },
-        'enum': 'ScriptTrigDigEdgeEdge',
+        'enum': 'ScriptTriggerDigitalEdgeEdge',
         'lv_property': 'Triggers:Script:Digital Edge:Edge',
         'name': 'DIGITAL_EDGE_SCRIPT_TRIGGER_EDGE',
         'supported_rep_caps': [
@@ -1252,6 +1258,9 @@ attributes = {
         'enum': 'LoopBandwidth',
         'lv_property': 'RF:Loop Bandwidth',
         'name': 'LOOP_BANDWIDTH',
+        'supported_rep_caps': [
+            'lo'
+        ],
         'type': 'ViInt32'
     },
     1150029: {
@@ -1347,7 +1356,7 @@ attributes = {
                 'Description'
             ]
         },
-        'enum': 'AnlgModType',
+        'enum': 'AnalogModulationType',
         'lv_property': 'Modulation:Analog:Modulation Type',
         'name': 'ANALOG_MODULATION_TYPE',
         'type': 'ViInt32'
@@ -1380,7 +1389,7 @@ attributes = {
                 'Description'
             ]
         },
-        'enum': 'AnlgModWfmType',
+        'enum': 'AnalogModulationWaveformType',
         'lv_property': 'Modulation:Analog:Waveform Type',
         'name': 'ANALOG_MODULATION_WAVEFORM_TYPE',
         'type': 'ViInt32'
@@ -1438,7 +1447,7 @@ attributes = {
                 'Description'
             ]
         },
-        'enum': 'DigModType',
+        'enum': 'DigitalModulationType',
         'lv_property': 'Modulation:Digital:Modulation Type',
         'name': 'DIGITAL_MODULATION_TYPE',
         'type': 'ViInt32'
@@ -1476,7 +1485,7 @@ attributes = {
                 'Description'
             ]
         },
-        'enum': 'DigModWfmType',
+        'enum': 'DigitalModulationWaveformType',
         'lv_property': 'Modulation:Digital:Waveform Type',
         'name': 'DIGITAL_MODULATION_WAVEFORM_TYPE',
         'type': 'ViInt32'
@@ -1548,7 +1557,7 @@ attributes = {
         'access': 'read-write',
         'codegen_method': 'public',
         'documentation': {
-            'description': 'Specifies how NI-RFSG interprets the value of the NIRFSG_ATTR_POWER_LEVEL attribute. The NIRFSG_ATTR_POWER_LEVEL_TYPE attribute also affects how waveforms are scaled.\n\nPXI-5670/5671: While in Script generation mode, if this attribute is set to NIRFSG_VAL_AVERAGE_POWER, NI-RFSG scales each waveform so that all waveforms have the same average power. The average power level of each waveform matches the value set with the NIRFSG_ATTR_POWER_LEVEL attribute. You can disable this scaling operation by setting the NIRFSG_ATTR_POWER_LEVEL_TYPE attribute to NIRFSG_VAL_PEAK_POWER.\n\nPXIe-5644/5645/5646, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860: While in Script generation mode, this attribute must be set to NIRFSG_VAL_PEAK_POWER.\n\nConverting from Average Power to Peak Power\n\nTypically, this attribute is set to NIRFSG_VAL_AVERAGE_POWER. However, some instrument modes require this attribute to be set to NIRFSG_VAL_PEAK_POWER. Use the following equations to calculate the equivalent peak power given the desired average power for your waveform:\n\nWhere 1 is the highest possible magnitude in the waveform.\n\n**Default Value:**\n\nPXIe-5820: NIRFSG_VAL_PEAK_POWER\n\nAll other devices: NIRFSG_VAL_AVERAGE_POWER\n\n**Supported Devices:** PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Spurious Performance <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/spurious_performance.html>`_\n\n`Optimizing for Low Power Generation <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/optimizing_for_low_power_generation.html>`_\n\n**High-Level Functions**:\n\n- nirfsg_ConfigurePowerLevelType   \n\n**Defined Values**:',
+            'description': 'Specifies how NI-RFSG interprets the value of the NIRFSG_ATTR_POWER_LEVEL attribute. The NIRFSG_ATTR_POWER_LEVEL_TYPE attribute also affects how waveforms are scaled.\n\nPXI-5670/5671: While in Script generation mode, if this attribute is set to NIRFSG_VAL_AVERAGE_POWER, NI-RFSG scales each waveform so that all waveforms have the same average power. The average power level of each waveform matches the value set with the NIRFSG_ATTR_POWER_LEVEL attribute. You can disable this scaling operation by setting the NIRFSG_ATTR_POWER_LEVEL_TYPE attribute to NIRFSG_VAL_PEAK_POWER.\n\nPXIe-5644/5645/5646, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860: While in Script generation mode, this attribute must be set to NIRFSG_VAL_PEAK_POWER.\n\nConverting from Average Power to Peak Power\n\nTypically, this attribute is set to NIRFSG_VAL_AVERAGE_POWER. However, some instrument modes require this attribute to be set to NIRFSG_VAL_PEAK_POWER. Use the following equations to calculate the equivalent peak power given the desired average power for your waveform:\n\nWhere 1 is the highest possible magnitude in the waveform.\n\n**Default Value:**\n\nPXIe-5820: NIRFSG_VAL_PEAK_POWER\n\nAll other devices: NIRFSG_VAL_AVERAGE_POWER\n\n**Supported Devices:** PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Spurious Performance <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/spurious_performance.html>`_\n\n`Optimizing for Low Power Generation <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/optimizing_for_low_power_generation.html>`_\n\n**Defined Values**:',
             'table_body': [
                 [
                     'NIRFSG_VAL_AVERAGE_POWER',
@@ -1829,7 +1838,7 @@ attributes = {
                 'Description'
             ]
         },
-        'enum': 'ScriptTrigDigLevelActiveLevel',
+        'enum': 'ScriptTriggerDigitalLevelActiveLevel',
         'lv_property': 'Triggers:Script:Digital Level:Active Level',
         'name': 'DIGITAL_LEVEL_SCRIPT_TRIGGER_ACTIVE_LEVEL',
         'supported_rep_caps': [
@@ -2109,7 +2118,6 @@ attributes = {
         },
         'lv_property': 'Events:Marker:Output Terminal',
         'name': 'EXPORTED_MARKER_EVENT_OUTPUT_TERMINAL',
-        'repeated_capability_type': 'markers',
         'supported_rep_caps': [
             'markers'
         ],
@@ -2224,6 +2232,9 @@ attributes = {
         },
         'lv_property': 'RF:LO Out Power (dBm)',
         'name': 'LO_OUT_POWER',
+        'supported_rep_caps': [
+            'lo'
+        ],
         'type': 'ViReal64'
     },
     1150067: {
@@ -2235,6 +2246,9 @@ attributes = {
         },
         'lv_property': 'RF:LO In Power (dBm)',
         'name': 'LO_IN_POWER',
+        'supported_rep_caps': [
+            'lo'
+        ],
         'type': 'ViReal64'
     },
     1150068: {
@@ -2533,7 +2547,6 @@ attributes = {
         },
         'lv_property': 'Events:Marker:Terminal Name',
         'name': 'MARKER_EVENT_TERMINAL_NAME',
-        'repeated_capability_type': 'markers',
         'supported_rep_caps': [
             'markers'
         ],
@@ -2577,81 +2590,6 @@ attributes = {
         'lv_property': 'RF:Advanced:YIG Main Coil Drive',
         'name': 'YIG_MAIN_COIL_DRIVE',
         'type': 'ViInt32'
-    },
-    1150123: {
-        'access': 'read-write',
-        'codegen_method': 'public',
-        'documentation': {
-            'description': 'Specifies whether the RF signal generator reads data from the peer-to-peer endpoint. This attribute is endpoint-based.\n\n**Default Value**: VI_FALSE\n\n**Supported Devices:** PXIe-5673E, PXIe-5820/5830/5831/5832/5840/5841/5842\n\n**Related Topics**\n\n`Configuring a Peer-to-Peer Endpoint <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_configuring_an_endpoint.html>`_\n\n**Defined Values**:',
-            'table_body': [
-                [
-                    'VI_TRUE',
-                    'Peer-to-peer data streaming is enabled.'
-                ],
-                [
-                    'VI_FALSE',
-                    'Peer-to-peer data streaming is disabled.'
-                ]
-            ],
-            'table_header': [
-                'Value',
-                'Description'
-            ]
-        },
-        'lv_property': 'Peer-to-Peer:Enabled',
-        'name': 'P2P_ENABLED',
-        'type': 'ViBoolean'
-    },
-    1150124: {
-        'access': 'read only',
-        'codegen_method': 'public',
-        'documentation': {
-            'description': 'Returns the size, in samples, of the device endpoint. This attribute is endpoint-based.\n\n**Units**: samples (s)\n\n**Supported Devices:** PXIe-5673E, PXIe-5820/5830/5831/5832/5840/5841/5842\n\n**Related Topics**\n\n`Configuring a Peer-to-Peer Endpoint <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_configuring_an_endpoint.html>`_'
-        },
-        'lv_property': 'Peer-to-Peer:Endpoint Size',
-        'name': 'P2P_ENDPOINT_SIZE',
-        'type': 'ViInt64'
-    },
-    1150125: {
-        'access': 'read only',
-        'codegen_method': 'public',
-        'documentation': {
-            'description': 'Returns the current space available in the endpoint. You can use this attribute when priming the endpoint with initial data using the nirfsg_WriteP2pEndpointI16 function to determine how many samples you can write. You also can use this attribute to characterize the performance and measure the latency of the peer-to-peer stream as data moves across the bus. This attribute is endpoint-based.\n\n**Units**: samples per channel\n\n**Supported Devices:** PXIe-5673E, PXIe-5820/5830/5831/5832/5840/5841/5842\n\n**Related Topics**\n\n`Configuring a Peer-to-Peer Endpoint <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_configuring_an_endpoint.html>`_\n\n`Starting Peer-to-Peer Generation <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_starting_generation.html>`_'
-        },
-        'lv_property': 'Peer-to-Peer:Space Available In Endpoint',
-        'name': 'P2P_SPACE_AVAILABLE_IN_ENDPOINT',
-        'type': 'ViInt64'
-    },
-    1150126: {
-        'access': 'read only',
-        'codegen_method': 'public',
-        'documentation': {
-            'description': 'Returns the largest number of samples per channel available in the endpoint since this attribute was last read. You can use this attribute to determine how much endpoint space to use as a buffer against bus traffic latencies by reading the attribute and keeping track of the largest value returned. This attribute is endpoint-based.\n\nIf you want to minimize the latency for data to move through the endpoint and be generated by the RF signal generator, use the NIRFSG_ATTR_P2P_DATA_TRANSFER_PERMISSION_INITIAL_CREDITS attribute to grant fewer initial credits than the default of the entire endpoint size.\n\n**Units**: samples per channel\n\n**Supported Devices:** PXIe-5673E, PXIe-5820/5830/5831/5832/5840/5841/5842\n\n**Related Topics**\n\n`Configuring a Peer-to-Peer Endpoint <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_configuring_an_endpoint.html>`_'
-        },
-        'lv_property': 'Peer-to-Peer:Most Space Available in Endpoint',
-        'name': 'P2P_MOST_SPACE_AVAILABLE_IN_ENDPOINT',
-        'type': 'ViInt64'
-    },
-    1150127: {
-        'access': 'read only',
-        'codegen_method': 'public',
-        'documentation': {
-            'description': 'Returns the number of peer-to-peer FIFO endpoints supported by the device.\n\n**Supported Devices:** PXIe-5673E, PXIe-5820/5830/5831/5832/5840/5841/5842\n\n**Related Topics**\n\n`Configuring a Peer-to-Peer Endpoint <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_configuring_an_endpoint.html>`_'
-        },
-        'lv_property': 'Peer-to-Peer:Endpoint Count',
-        'name': 'P2P_ENDPOINT_COUNT',
-        'type': 'ViInt32'
-    },
-    1150128: {
-        'access': 'read-write',
-        'codegen_method': 'public',
-        'documentation': {
-            'description': 'Specifies the number of samples the endpoint must receive before the device starts generation. If no level is specified, NI-RFSG automatically sets this value to -1. This attribute applies only when the NIRFSG_ATTR_START_TRIGGER_TYPE attribute is set to NIRFSG_VAL_P2P_ENDPOINT_FULLNESS\n\n**Default Value:** -1, which allows NI-RFSG to select the appropriate fullness value.\n\n**Supported Devices:** PXIe-5673E, PXIe-5820/5830/5831/5832/5840/5841/5842\n\n**Related Topics**\n\n`Start Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/start_triggers.html>`_',
-            'note': 'Due to an additional internal FIFO in the RF signal generator, the writer peer actually needs to write 2,304 bytes more than the quantity of data specified by this attribute to satisfy the trigger level.'
-        },
-        'lv_property': 'Triggers:Start:P2P Endpoint Fullness:Level',
-        'name': 'P2P_ENDPOINT_FULLNESS_START_TRIGGER_LEVEL',
-        'type': 'ViInt64'
     },
     1150129: {
         'access': 'read-write',
@@ -2744,30 +2682,10 @@ attributes = {
                 'Description'
             ]
         },
-        'enum': 'RefPllBandwidth',
+        'enum': 'ReferencePllBandwidth',
         'lv_property': 'RF:Advanced:Ref PLL Bandwidth',
         'name': 'REF_PLL_BANDWIDTH',
         'type': 'ViInt32'
-    },
-    1150134: {
-        'access': 'read-write',
-        'codegen_method': 'public',
-        'documentation': {
-            'description': 'Specifies the interval at which the RF signal generator issues credits to allow the writer peer to transfer data over the bus into the configured endpoint. This attribute is coerced up by NI-RFSG to the nearest 128-byte boundary. This attribute is endpoint-based.\n\n**Units**: samples per channel\n\n**Supported Devices:** PXIe-5673E\n\n**Related Topics**\n\n`Configuring a Peer-to-Peer Endpoint <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_configuring_an_endpoint.html>`_\n\n`Configuring Flow Control <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_flow_control.html>`_'
-        },
-        'lv_property': 'Peer-to-Peer:Data Transfer Permission Interval',
-        'name': 'P2P_DATA_TRANSFER_PERMISSION_INTERVAL',
-        'type': 'ViInt64'
-    },
-    1150135: {
-        'access': 'read-write',
-        'codegen_method': 'public',
-        'documentation': {
-            'description': 'Specifies the initial amount of data that the writer peer can transfer over the bus into the configured endpoint when the peer-to-peer data stream is enabled. If this attribute is not set and the endpoint is empty, credits equal to the full endpoint size are issued to the writer peer. If data is written to the endpoint using the nirfsg_WriteP2pEndpointI16 function prior to enabling the stream, credits equal to the remaining space available in the endpoint are issued to the writer peer. This attribute is coerced up by NI-RFSG to 8-byte boundaries. This attribute is endpoint-based.\n\n**Units**: samples per channel\n\n**Default Value:** 1,024\n\n**Supported Devices:** PXIe-5673E\n\n**Related Topics**\n\n`Configuring a Peer-to-Peer Endpoint <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_configuring_an_endpoint.html>`_\n\n`Configuring Flow Control <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_flow_control.html>`_'
-        },
-        'lv_property': 'Peer-to-Peer:Data Transfer Permission Initial Credits',
-        'name': 'P2P_DATA_TRANSFER_PERMISSION_INITIAL_CREDITS',
-        'type': 'ViInt64'
     },
     1150136: {
         'access': 'read only',
@@ -2936,6 +2854,9 @@ attributes = {
         'enum': 'IQOutPortTermCfg',
         'lv_property': 'Device Specific:Vector Signal Transceiver:IQ Out Port:Terminal Configuration',
         'name': 'IQ_OUT_PORT_TERMINAL_CONFIGURATION',
+        'supported_rep_caps': [
+            'port'
+        ],
         'type': 'ViInt32'
     },
     1150147: {
@@ -2947,6 +2868,9 @@ attributes = {
         },
         'lv_property': 'Device Specific:Vector Signal Transceiver:IQ Out Port:Level',
         'name': 'IQ_OUT_PORT_LEVEL',
+        'supported_rep_caps': [
+            'port'
+        ],
         'type': 'ViReal64'
     },
     1150148: {
@@ -2958,6 +2882,9 @@ attributes = {
         },
         'lv_property': 'Device Specific:Vector Signal Transceiver:IQ Out Port:Common Mode Offset',
         'name': 'IQ_OUT_PORT_COMMON_MODE_OFFSET',
+        'supported_rep_caps': [
+            'port'
+        ],
         'type': 'ViReal64'
     },
     1150149: {
@@ -2969,6 +2896,9 @@ attributes = {
         },
         'lv_property': 'Device Specific:Vector Signal Transceiver:IQ Out Port:Offset',
         'name': 'IQ_OUT_PORT_OFFSET',
+        'supported_rep_caps': [
+            'port'
+        ],
         'type': 'ViReal64'
     },
     1150150: {
@@ -3006,6 +2936,9 @@ attributes = {
         },
         'lv_property': 'Device Specific:Vector Signal Transceiver:Signal Path:LO Source',
         'name': 'LO_SOURCE',
+        'supported_rep_caps': [
+            'lo'
+        ],
         'type': 'ViString'
     },
     1150151: {
@@ -3083,6 +3016,9 @@ attributes = {
         'enum': 'LoPlLfractionalModeEnabled',
         'lv_property': 'Device Specific:Vector Signal Transceiver:Signal Path:LO PLL Fractional Mode Enabled',
         'name': 'LO_PLL_FRACTIONAL_MODE_ENABLED',
+        'supported_rep_caps': [
+            'lo'
+        ],
         'type': 'ViInt32'
     },
     1150153: {
@@ -3244,6 +3180,9 @@ attributes = {
         },
         'lv_property': 'Device Specific:Vector Signal Transceiver:IQ Out Port:Load Impedance',
         'name': 'IQ_OUT_PORT_LOAD_IMPEDANCE',
+        'supported_rep_caps': [
+            'port'
+        ],
         'type': 'ViReal64'
     },
     1150165: {
@@ -3274,7 +3213,7 @@ attributes = {
                 'Description'
             ]
         },
-        'enum': 'AnlgModFmNarrowbandIntegrator',
+        'enum': 'AnalogModulationFmNarrowbandIntegrator',
         'lv_property': 'Modulation:Analog:FM Narrowband Integrator',
         'name': 'ANALOG_MODULATION_FM_NARROWBAND_INTEGRATOR',
         'type': 'ViInt32'
@@ -3483,7 +3422,7 @@ attributes = {
                 'Description'
             ]
         },
-        'enum': 'AnlgModFmBand',
+        'enum': 'AnalogModulationFmBand',
         'lv_property': 'Modulation:Analog:FM Band',
         'name': 'ANALOG_MODULATION_FM_BAND',
         'type': 'ViInt32'
@@ -3511,7 +3450,7 @@ attributes = {
                 'Description'
             ]
         },
-        'enum': 'AnlgModPmMode',
+        'enum': 'AnalogModulationPmMode',
         'lv_property': 'Modulation:Analog:PM Mode',
         'name': 'ANALOG_MODULATION_PM_MODE',
         'type': 'ViInt32'
@@ -3591,6 +3530,9 @@ attributes = {
         },
         'lv_property': 'RF:LO Frequency (Hz)',
         'name': 'LO_FREQUENCY',
+        'supported_rep_caps': [
+            'lo'
+        ],
         'type': 'ViReal64'
     },
     1150204: {
@@ -3628,7 +3570,6 @@ attributes = {
         'enum': 'MarkerEventOutputBehavior',
         'lv_property': 'Events:Marker:Output Behavior',
         'name': 'MARKER_EVENT_OUTPUT_BEHAVIOR',
-        'repeated_capability_type': 'markers',
         'supported_rep_caps': [
             'markers'
         ],
@@ -3642,7 +3583,6 @@ attributes = {
         },
         'lv_property': 'Events:Marker:Pulse:Width Value',
         'name': 'MARKER_EVENT_PULSE_WIDTH',
-        'repeated_capability_type': 'markers',
         'supported_rep_caps': [
             'markers'
         ],
@@ -3674,7 +3614,6 @@ attributes = {
         'enum': 'MarkerEventPulseWidthUnits',
         'lv_property': 'Events:Marker:Pulse:Width Units',
         'name': 'MARKER_EVENT_PULSE_WIDTH_UNITS',
-        'repeated_capability_type': 'markers',
         'supported_rep_caps': [
             'markers'
         ],
@@ -3706,7 +3645,6 @@ attributes = {
         'enum': 'MarkerEventToggleInitialState',
         'lv_property': 'Events:Marker:Toggle:Initial State',
         'name': 'MARKER_EVENT_TOGGLE_INITIAL_STATE',
-        'repeated_capability_type': 'markers',
         'supported_rep_caps': [
             'markers'
         ],
@@ -3745,50 +3683,6 @@ attributes = {
         'name': 'TEMPERATURE_READ_INTERVAL',
         'type': 'ViReal64',
         'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
-    },
-    1150217: {
-        'access': 'read-write',
-        'codegen_method': 'public',
-        'documentation': {
-            'description': 'Specifies whether peer-to-peer should continuously generate data from the peer-to-peer stream or from only a finite number of samples, according to the NIRFSG_ATTR_P2P_NUMBER_OF_SAMPLES_TO_GENERATE attribute. To use this attribute, peer-to-peer must be enabled. This attribute is endpoint-based.\n\n**Default Value**: VI_FALSE\n\n**Supported Devices:** PXIe-5820/5830/5831/5832/5840/5841/5842\n\n**Defined Values**:',
-            'table_body': [
-                [
-                    'VI_TRUE',
-                    'Data is generated from only a finite number of samples.'
-                ],
-                [
-                    'VI_FALSE',
-                    'Data is continuously generated from the peer-to-peer stream.'
-                ]
-            ],
-            'table_header': [
-                'Value',
-                'Description'
-            ]
-        },
-        'lv_property': 'Peer-to-Peer:Is Finite Generation',
-        'name': 'P2P_IS_FINITE_GENERATION',
-        'type': 'ViBoolean'
-    },
-    1150218: {
-        'access': 'read-write',
-        'codegen_method': 'public',
-        'documentation': {
-            'description': 'Specifies how many samples are generated from the peer-to-peer subsystem when it is enabled. To use this attribute, peer-to-peer must be enabled and set to finite generation. This attribute is endpoint-based.\n\n**Supported Devices:** PXIe-5820/5830/5831/5832/5840/5841/5842\n\n**Related Topics**\n\n`Configuring a Peer-to-Peer Endpoint <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_configuring_an_endpoint.html>`_'
-        },
-        'lv_property': 'Peer-to-Peer:Number Of Samples To Generate',
-        'name': 'P2P_NUMBER_OF_SAMPLES_TO_GENERATE',
-        'type': 'ViInt64'
-    },
-    1150219: {
-        'access': 'read only',
-        'codegen_method': 'public',
-        'documentation': {
-            'description': 'Returns how many samples NI-RFSG pulls from the peer-to-peer FIFO per read. You can use this attribute to determine how many samples to send across the peer-to-peer bus to ensure that no samples are ignored. If you send a number of samples that is not a multiple of this value, the remaining samples are not read from the FIFO during generation. This attribute is endpoint-based.\n\n**Supported Devices:** PXIe-5820/5830/5831/5832/5840/5841/5842'
-        },
-        'lv_property': 'Peer-to-Peer:Generation FIFO Sample Quantum',
-        'name': 'P2P_GENERATION_FIFO_SAMPLE_QUANTUM',
-        'type': 'ViInt64'
     },
     1150220: {
         'access': 'read-write',
@@ -4022,7 +3916,7 @@ attributes = {
         'lv_property': 'De-embedding:Type',
         'name': 'DEEMBEDDING_TYPE',
         'supported_rep_caps': [
-            'deembedding_port'
+            'port'
         ],
         'type': 'ViInt32'
     },
@@ -4035,7 +3929,7 @@ attributes = {
         'lv_property': 'De-embedding:Selected Table',
         'name': 'DEEMBEDDING_SELECTED_TABLE',
         'supported_rep_caps': [
-            'deembedding_port'
+            'port'
         ],
         'type': 'ViString'
     },
@@ -4233,7 +4127,7 @@ attributes = {
         'lv_property': 'De-embedding:Compensation Gain',
         'name': 'DEEMBEDDING_COMPENSATION_GAIN',
         'supported_rep_caps': [
-            'deembedding_port'
+            'port'
         ],
         'type': 'ViReal64'
     },
@@ -4390,7 +4284,7 @@ attributes = {
                 'Description'
             ]
         },
-        'enum': 'ScriptTrigDigLevelActiveLevel',
+        'enum': 'ScriptTriggerDigitalLevelActiveLevel',
         'lv_property': 'RF:Advanced:Pulse Modulation Active Level',
         'name': 'PULSE_MODULATION_ACTIVE_LEVEL',
         'type': 'ViInt32'
@@ -4478,7 +4372,7 @@ attributes = {
                 'Description'
             ]
         },
-        'enum': 'ScriptTrigDigLevelActiveLevel',
+        'enum': 'ScriptTriggerDigitalLevelActiveLevel',
         'lv_property': 'Events:Pulse Modulation:Exported Pulse Modulation Event Active Level',
         'name': 'EXPORTED_PULSE_MODULATION_EVENT_ACTIVE_LEVEL',
         'type': 'ViInt32'
@@ -4575,7 +4469,7 @@ attributes = {
         'access': 'read-write',
         'codegen_method': 'public',
         'documentation': {
-            'description': 'Specifies whether signal output is enabled. Setting the NIRFSG_ATTR_OUTPUT_ENABLED attribute to VI_FALSE while in the Generation state stops signal output, although generation continues internally. For the PXI-5610, PXIe-5611, PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653, PXI-5670/5671, and PXIe-5672/5673/5673E, setting the NIRFSG_ATTR_OUTPUT_ENABLED attribute while in the Committed state does not transition the device to the Configuration state, but output changes immediately.\n\n**Default Value:** VI_TRUE\n\n**Supported Devices:** PXI-5610, PXIe-5611, PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Output Enabled <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/outputenable.html>`_\n\n`NI-RFSG Instrument Driver Programming Flow <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/progflow.html>`_\n\n**High-Level Functions**:\n\n- nirfsg_ConfigureOutputEnabled\n\n**Defined Values**:',
+            'description': 'Specifies whether signal output is enabled. Setting the NIRFSG_ATTR_OUTPUT_ENABLED attribute to VI_FALSE while in the Generation state stops signal output, although generation continues internally. For the PXI-5610, PXIe-5611, PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653, PXI-5670/5671, and PXIe-5672/5673/5673E, setting the NIRFSG_ATTR_OUTPUT_ENABLED attribute while in the Committed state does not transition the device to the Configuration state, but output changes immediately.\n\n**Default Value:** VI_TRUE\n\n**Supported Devices:** PXI-5610, PXIe-5611, PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Output Enabled <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/outputenable.html>`_\n\n`NI-RFSG Instrument Driver Programming Flow <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/progflow.html>`_\n\n**Defined Values**:',
             'note': '- For the PXIe-5653, this attribute controls only the LO1 terminal.\n\n - For the PXIe-5645, this attribute is ignored if you are using the I/Q ports.\n\n - When the NIRFSG_ATTR_ACTIVE_CONFIGURATION_LIST attribute is set to a valid list name, setting the NIRFSG_ATTR_OUTPUT_ENABLED attribute transitions the device to the Configuration state.',
             'table_body': [
                 [
@@ -4813,7 +4707,7 @@ attributes = {
                 'Description'
             ]
         },
-        'enum': 'StartTrigType',
+        'enum': 'StartTriggerType',
         'lv_property': 'Triggers:Start:Type',
         'name': 'START_TRIGGER_TYPE',
         'type': 'ViInt32'
@@ -4841,7 +4735,7 @@ attributes = {
                 'Description'
             ]
         },
-        'enum': 'StartTrigDigEdgeEdge',
+        'enum': 'StartTriggerDigitalEdgeEdge',
         'lv_property': 'Triggers:Start:Digital Edge',
         'name': 'DIGITAL_EDGE_START_TRIGGER_EDGE',
         'type': 'ViInt32'

--- a/src/nirfsg/metadata/attributes.py
+++ b/src/nirfsg/metadata/attributes.py
@@ -740,7 +740,7 @@ attributes = {
         'lv_property': 'RF:LO Out Enabled',
         'name': 'LO_OUT_ENABLED',
         'supported_rep_caps': [
-            'lo'
+            'lo_channels'
         ],
         'type': 'ViBoolean'
     },
@@ -864,7 +864,7 @@ attributes = {
         'lv_property': 'Device Characteristics:Device Temperature (Degrees C)',
         'name': 'DEVICE_TEMPERATURE',
         'supported_rep_caps': [
-            'port'
+            'ports'
         ],
         'type': 'ViReal64'
     },
@@ -1259,7 +1259,7 @@ attributes = {
         'lv_property': 'RF:Loop Bandwidth',
         'name': 'LOOP_BANDWIDTH',
         'supported_rep_caps': [
-            'lo'
+            'lo_channels'
         ],
         'type': 'ViInt32'
     },
@@ -2233,7 +2233,7 @@ attributes = {
         'lv_property': 'RF:LO Out Power (dBm)',
         'name': 'LO_OUT_POWER',
         'supported_rep_caps': [
-            'lo'
+            'lo_channels'
         ],
         'type': 'ViReal64'
     },
@@ -2247,7 +2247,7 @@ attributes = {
         'lv_property': 'RF:LO In Power (dBm)',
         'name': 'LO_IN_POWER',
         'supported_rep_caps': [
-            'lo'
+            'lo_channels'
         ],
         'type': 'ViReal64'
     },
@@ -2855,7 +2855,7 @@ attributes = {
         'lv_property': 'Device Specific:Vector Signal Transceiver:IQ Out Port:Terminal Configuration',
         'name': 'IQ_OUT_PORT_TERMINAL_CONFIGURATION',
         'supported_rep_caps': [
-            'port'
+            'ports'
         ],
         'type': 'ViInt32'
     },
@@ -2869,7 +2869,7 @@ attributes = {
         'lv_property': 'Device Specific:Vector Signal Transceiver:IQ Out Port:Level',
         'name': 'IQ_OUT_PORT_LEVEL',
         'supported_rep_caps': [
-            'port'
+            'ports'
         ],
         'type': 'ViReal64'
     },
@@ -2883,7 +2883,7 @@ attributes = {
         'lv_property': 'Device Specific:Vector Signal Transceiver:IQ Out Port:Common Mode Offset',
         'name': 'IQ_OUT_PORT_COMMON_MODE_OFFSET',
         'supported_rep_caps': [
-            'port'
+            'ports'
         ],
         'type': 'ViReal64'
     },
@@ -2897,7 +2897,7 @@ attributes = {
         'lv_property': 'Device Specific:Vector Signal Transceiver:IQ Out Port:Offset',
         'name': 'IQ_OUT_PORT_OFFSET',
         'supported_rep_caps': [
-            'port'
+            'ports'
         ],
         'type': 'ViReal64'
     },
@@ -2937,7 +2937,7 @@ attributes = {
         'lv_property': 'Device Specific:Vector Signal Transceiver:Signal Path:LO Source',
         'name': 'LO_SOURCE',
         'supported_rep_caps': [
-            'lo'
+            'lo_channels'
         ],
         'type': 'ViString'
     },
@@ -3017,7 +3017,7 @@ attributes = {
         'lv_property': 'Device Specific:Vector Signal Transceiver:Signal Path:LO PLL Fractional Mode Enabled',
         'name': 'LO_PLL_FRACTIONAL_MODE_ENABLED',
         'supported_rep_caps': [
-            'lo'
+            'lo_channels'
         ],
         'type': 'ViInt32'
     },
@@ -3181,7 +3181,7 @@ attributes = {
         'lv_property': 'Device Specific:Vector Signal Transceiver:IQ Out Port:Load Impedance',
         'name': 'IQ_OUT_PORT_LOAD_IMPEDANCE',
         'supported_rep_caps': [
-            'port'
+            'ports'
         ],
         'type': 'ViReal64'
     },
@@ -3531,7 +3531,7 @@ attributes = {
         'lv_property': 'RF:LO Frequency (Hz)',
         'name': 'LO_FREQUENCY',
         'supported_rep_caps': [
-            'lo'
+            'lo_channels'
         ],
         'type': 'ViReal64'
     },
@@ -3912,11 +3912,11 @@ attributes = {
                 'Description'
             ]
         },
-        'enum': 'DeembeddingTypeAttrVals',
+        'enum': 'DeembeddingType',
         'lv_property': 'De-embedding:Type',
         'name': 'DEEMBEDDING_TYPE',
         'supported_rep_caps': [
-            'port'
+            'ports'
         ],
         'type': 'ViInt32'
     },
@@ -3929,7 +3929,7 @@ attributes = {
         'lv_property': 'De-embedding:Selected Table',
         'name': 'DEEMBEDDING_SELECTED_TABLE',
         'supported_rep_caps': [
-            'port'
+            'ports'
         ],
         'type': 'ViString'
     },
@@ -3962,7 +3962,7 @@ attributes = {
         'lv_property': 'Arb:Waveform Attributes:Waveform IQ Rate (S/s)',
         'name': 'WAVEFORM_IQ_RATE',
         'supported_rep_caps': [
-            'waveform'
+            'waveforms'
         ],
         'type': 'ViReal64'
     },
@@ -3975,7 +3975,7 @@ attributes = {
         'lv_property': 'Arb:Waveform Attributes:Waveform Signal Bandwidth (Hz)',
         'name': 'WAVEFORM_SIGNAL_BANDWIDTH',
         'supported_rep_caps': [
-            'waveform'
+            'waveforms'
         ],
         'type': 'ViReal64'
     },
@@ -3988,7 +3988,7 @@ attributes = {
         'lv_property': 'Arb:Waveform Attributes:Waveform Runtime Scaling',
         'name': 'WAVEFORM_RUNTIME_SCALING',
         'supported_rep_caps': [
-            'waveform'
+            'waveforms'
         ],
         'type': 'ViReal64'
     },
@@ -4001,7 +4001,7 @@ attributes = {
         'lv_property': 'Arb:Waveform Attributes:Waveform PAPR (dB)',
         'name': 'WAVEFORM_PAPR',
         'supported_rep_caps': [
-            'waveform'
+            'waveforms'
         ],
         'type': 'ViReal64'
     },
@@ -4114,7 +4114,7 @@ attributes = {
         'lv_property': 'Arb:Waveform Attributes:Waveform RF Blanking',
         'name': 'WAVEFORM_RF_BLANKING',
         'supported_rep_caps': [
-            'waveform'
+            'waveforms'
         ],
         'type': 'ViInt32'
     },
@@ -4127,7 +4127,7 @@ attributes = {
         'lv_property': 'De-embedding:Compensation Gain',
         'name': 'DEEMBEDDING_COMPENSATION_GAIN',
         'supported_rep_caps': [
-            'port'
+            'ports'
         ],
         'type': 'ViReal64'
     },
@@ -4257,7 +4257,7 @@ attributes = {
         'lv_property': 'Arb:Waveform Attributes:Waveform Size',
         'name': 'WAVEFORM_WAVEFORM_SIZE',
         'supported_rep_caps': [
-            'waveform'
+            'waveforms'
         ],
         'type': 'ViInt32'
     },
@@ -4696,10 +4696,6 @@ attributes = {
                 [
                     'NIRFSG_VAL_SOFTWARE',
                     'The data operation does not start until a software event occurs. You may create a software trigger by calling the niRFSG_SendSoftwareEdgeTrigger function.'
-                ],
-                [
-                    'NIRFSG_VAL_P2P_ENDPOINT_FULLNESS',
-                    'The data operation does not start until the endpoint reaches the threshold specified in the NIRFSG_ATTR_P2P_ENDPOINT_FULLNESS_START_TRIGGER_LEVEL attribute.'
                 ]
             ],
             'table_header': [

--- a/src/nirfsg/metadata/config.py
+++ b/src/nirfsg/metadata/config.py
@@ -39,6 +39,17 @@ config = {
         }
     },
     'module_name': 'nirfsg',
+    'enum_whitelist_prefix': [
+        'RANGE_',
+        'CLOCK_RATE_'
+    ],
+    'enum_whitelist_suffix': [
+        '_HERTZ',
+        '_KILOHERTZ',
+        '_MEGAHERTZ',
+        '_GIGAHERTZ',
+        '_TOWARDS_DUT'
+    ],
     'repeated_capabilities': [
         {
             'prefix': 'marker',

--- a/src/nirfsg/metadata/config.py
+++ b/src/nirfsg/metadata/config.py
@@ -50,15 +50,15 @@ config = {
         },
         {
             'prefix': 'waveform::',
-            'python_name': 'waveform'
+            'python_name': 'waveforms'
         },
         {
             'prefix': '',
-            'python_name': 'port'
+            'python_name': 'ports'
         },
         {
             'prefix': 'LO',
-            'python_name': 'lo'
+            'python_name': 'lo_channels'
         }
     ],
     'session_class_description': 'An NI-RFSG session to the NI-RFSG driver',

--- a/src/nirfsg/metadata/config.py
+++ b/src/nirfsg/metadata/config.py
@@ -54,7 +54,11 @@ config = {
         },
         {
             'prefix': '',
-            'python_name': 'deembedding_port'
+            'python_name': 'port'
+        },
+        {
+            'prefix': 'LO',
+            'python_name': 'lo'
         }
     ],
     'session_class_description': 'An NI-RFSG session to the NI-RFSG driver',

--- a/src/nirfsg/metadata/enums.py
+++ b/src/nirfsg/metadata/enums.py
@@ -99,7 +99,7 @@ enums = {
             }
         ]
     },
-    'AnlgModFmBand': {
+    'AnalogModulationFmBand': {
         'codegen_method': 'public',
         'values': [
             {
@@ -118,7 +118,7 @@ enums = {
             }
         ]
     },
-    'AnlgModFmNarrowbandIntegrator': {
+    'AnalogModulationFmNarrowbandIntegrator': {
         'codegen_method': 'public',
         'values': [
             {
@@ -147,7 +147,7 @@ enums = {
             }
         ]
     },
-    'AnlgModPmMode': {
+    'AnalogModulationPmMode': {
         'codegen_method': 'public',
         'values': [
             {
@@ -166,7 +166,7 @@ enums = {
             }
         ]
     },
-    'AnlgModType': {
+    'AnalogModulationType': {
         'codegen_method': 'public',
         'values': [
             {
@@ -199,7 +199,7 @@ enums = {
             }
         ]
     },
-    'AnlgModWfmType': {
+    'AnalogModulationWaveformType': {
         'codegen_method': 'public',
         'values': [
             {
@@ -325,64 +325,6 @@ enums = {
             }
         ]
     },
-    'ConfigListTrigDigEdgeEdge': {
-        'codegen_method': 'public',
-        'values': [
-            {
-                'documentation': {
-                    'description': 'Specifies the rising edge as the active edge. The rising edge occurs when the signal transitions from low level to high level.'
-                },
-                'name': 'NIRFSG_VAL_RISING_EDGE',
-                'value': 0
-            }
-        ]
-    },
-    'ConfigListTrigType': {
-        'codegen_method': 'public',
-        'values': [
-            {
-                'documentation': {
-                    'description': 'Generation starts immediately, but the list does not advance.'
-                },
-                'name': 'NIRFSG_VAL_NONE',
-                'value': 0
-            },
-            {
-                'documentation': {
-                    'description': 'Data operation does not start until a digital edge is detected. The source of the digital edge is specified in the NIRFSG_ATTR_DIGITAL_EDGE_CONFIGURATION_LIST_STEP_TRIGGER_SOURCE attribute, and the active edge is always rising.'
-                },
-                'name': 'NIRFSG_VAL_DIGITAL_EDGE',
-                'value': 1
-            }
-        ]
-    },
-    'ConfigurationListRepeat': {
-        'codegen_method': 'public',
-        'values': [
-            {
-                'documentation': {
-                    'description': 'NI-RFSG runs the configuration list continuously.'
-                },
-                'name': 'NIRFSG_VAL_CONFIGURATION_LIST_REPEAT_CONTINUOUS',
-                'value': 0
-            },
-            {
-                'name': 'NIRFSG_VAL_MANUAL',
-                'value': 0
-            },
-            {
-                'documentation': {
-                    'description': 'NI-RFSG runs the configuration list only once.'
-                },
-                'name': 'NIRFSG_VAL_CONFIGURATION_LIST_REPEAT_SINGLE',
-                'value': 1
-            },
-            {
-                'name': 'NIRFSG_VAL_SCRIPT_TRIGGER',
-                'value': 1
-            }
-        ]
-    },
     'DacDecoderMode': {
         'values': [
             {
@@ -433,7 +375,7 @@ enums = {
             }
         ]
     },
-    'DigModType': {
+    'DigitalModulationType': {
         'codegen_method': 'public',
         'values': [
             {
@@ -466,7 +408,7 @@ enums = {
             }
         ]
     },
-    'DigModWfmType': {
+    'DigitalModulationWaveformType': {
         'codegen_method': 'public',
         'values': [
             {
@@ -696,14 +638,14 @@ enums = {
                 'documentation': {
                     'description': 'yet to be defined'
                 },
-                'name': 'NIRFSG_VAL_MANUAL',
+                'name': 'NIRFSG_VAL_5.5GHz_HIGH_PASS',
                 'value': 0
             },
             {
                 'documentation': {
                     'description': 'yet to be defined'
                 },
-                'name': 'NIRFSG_VAL_SCRIPT_TRIGGER',
+                'name': 'NIRFSG_VAL_5.5GHz_LOW_PASS',
                 'value': 1
             }
         ]
@@ -719,18 +661,10 @@ enums = {
                 'value': 0
             },
             {
-                'name': 'NIRFSG_VAL_MANUAL',
-                'value': 0
-            },
-            {
                 'documentation': {
                     'description': 'The local oscillator signal is  not present at the LO OUT front panel connector..'
                 },
                 'name': 'NIRFSG_VAL_ENABLE',
-                'value': 1
-            },
-            {
-                'name': 'NIRFSG_VAL_SCRIPT_TRIGGER',
                 'value': 1
             }
         ]
@@ -746,18 +680,10 @@ enums = {
                 'value': 0
             },
             {
-                'name': 'NIRFSG_VAL_MANUAL',
-                'value': 0
-            },
-            {
                 'documentation': {
                     'description': 'Allow NI-RFSA to control the NI-RFSG local oscillator export.'
                 },
                 'name': 'NIRFSG_VAL_ENABLE',
-                'value': 1
-            },
-            {
-                'name': 'NIRFSG_VAL_SCRIPT_TRIGGER',
                 'value': 1
             }
         ]
@@ -785,18 +711,10 @@ enums = {
                 'value': 0
             },
             {
-                'name': 'NIRFSG_VAL_MANUAL',
-                'value': 0
-            },
-            {
                 'documentation': {
                     'description': 'Enables fractional mode for the LO PLL.'
                 },
                 'name': 'NIRFSG_VAL_ENABLE',
-                'value': 1
-            },
-            {
-                'name': 'NIRFSG_VAL_SCRIPT_TRIGGER',
                 'value': 1
             }
         ]
@@ -1275,7 +1193,7 @@ enums = {
             }
         ]
     },
-    'RefPllBandwidth': {
+    'ReferencePllBandwidth': {
         'codegen_method': 'public',
         'values': [
             {
@@ -1371,6 +1289,7 @@ enums = {
     },
     'ResetWithOptionsStepsToOmit': {
         'codegen_method': 'public',
+        'enum_class': 'IntFlag',
         'values': [
             {
                 'documentation': {
@@ -1409,7 +1328,7 @@ enums = {
             }
         ]
     },
-    'ScriptTrigDigEdgeEdge': {
+    'ScriptTriggerDigitalEdgeEdge': {
         'codegen_method': 'public',
         'values': [
             {
@@ -1428,7 +1347,7 @@ enums = {
             }
         ]
     },
-    'ScriptTrigDigLevelActiveLevel': {
+    'ScriptTriggerDigitalLevelActiveLevel': {
         'codegen_method': 'public',
         'values': [
             {
@@ -1447,7 +1366,7 @@ enums = {
             }
         ]
     },
-    'ScriptTrigType': {
+    'ScriptTriggerType': {
         'codegen_method': 'public',
         'values': [
             {
@@ -1482,6 +1401,7 @@ enums = {
     },
     'SelfCalibrateRangeStepsToOmit': {
         'codegen_method': 'public',
+        'enum_class': 'IntFlag',
         'values': [
             {
                 'documentation': {
@@ -1626,7 +1546,7 @@ enums = {
             }
         ]
     },
-    'StartTrigDigEdgeEdge': {
+    'StartTriggerDigitalEdgeEdge': {
         'codegen_method': 'public',
         'values': [
             {
@@ -1645,7 +1565,7 @@ enums = {
             }
         ]
     },
-    'StartTrigType': {
+    'StartTriggerType': {
         'codegen_method': 'public',
         'values': [
             {

--- a/src/nirfsg/metadata/enums.py
+++ b/src/nirfsg/metadata/enums.py
@@ -2,7 +2,6 @@
 # This file is generated from NI-RFSG API metadata version 25.5.0d9999
 enums = {
     'AllowOutOfSpecificationUserSettings': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -21,7 +20,6 @@ enums = {
         ]
     },
     'AmpPath': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -40,7 +38,6 @@ enums = {
         ]
     },
     'AnalogModulationFmBand': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -59,14 +56,13 @@ enums = {
         ]
     },
     'AnalogModulationFmNarrowbandIntegrator': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
                     'description': 'Specifies a range from 100Hz to 1kHz.'
                 },
                 'name': 'NIRFSG_VAL_100HZ_TO_1KHZ',
-                'python_name': '_100Hzto1kHz',
+                'python_name': 'RANGE_100_HERTZ_TO_1_KILOHERTZ',
                 'value': 18000
             },
             {
@@ -74,7 +70,7 @@ enums = {
                     'description': 'Specifies a range from 1kHz to 10kHz.'
                 },
                 'name': 'NIRFSG_VAL_1KHZ_TO_10KHZ',
-                'python_name': '_1kHzto10kHz',
+                'python_name': 'RANGE_1_KILOHERTZ_TO_10_KILOHERTZ',
                 'value': 18001
             },
             {
@@ -82,13 +78,12 @@ enums = {
                     'description': 'Specifies a range from 10kHz to 100kHz.'
                 },
                 'name': 'NIRFSG_VAL_10KHZ_TO_100KHZ',
-                'python_name': '_10kHzto100kHz',
+                'python_name': 'RANGE_10_KILOHERTZ_TO_100_KILOHERTZ',
                 'value': 18002
             }
         ]
     },
     'AnalogModulationPmMode': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -107,7 +102,6 @@ enums = {
         ]
     },
     'AnalogModulationType': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -140,7 +134,6 @@ enums = {
         ]
     },
     'AnalogModulationWaveformType': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -165,20 +158,7 @@ enums = {
             }
         ]
     },
-    'ArbAmplitudeCorrectionMethod': {
-        'values': [
-            {
-                'name': 'NIRFSG_VAL_ANALOG',
-                'value': 98000
-            },
-            {
-                'name': 'NIRFSG_VAL_DIGITAL',
-                'value': 98001
-            }
-        ]
-    },
     'ArbOnboardSampleClockMode': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -197,7 +177,6 @@ enums = {
         ]
     },
     'AutomaticLevelControl': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -216,7 +195,6 @@ enums = {
         ]
     },
     'AutomaticPowerSearch': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -235,7 +213,6 @@ enums = {
         ]
     },
     'AutomaticThermalCorrection': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -253,44 +230,7 @@ enums = {
             }
         ]
     },
-    'CoercePowerLevelToMaxPower': {
-        'values': [
-            {
-                'name': 'NIRFSG_VAL_DISABLED',
-                'value': 0
-            },
-            {
-                'name': 'NIRFSG_VAL_ENABLED',
-                'value': 1
-            }
-        ]
-    },
-    'DacDecoderMode': {
-        'values': [
-            {
-                'name': 'NIRFSG_VAL_MAX_SNR',
-                'value': 28001
-            },
-            {
-                'name': 'NIRFSG_VAL_MAX_LINEARITY',
-                'value': 28002
-            }
-        ]
-    },
-    'DebuggingOptions': {
-        'values': [
-            {
-                'name': 'NIRFSG_VAL_PLL_LOCK_COUNT',
-                'value': 1
-            },
-            {
-                'name': 'NIRFSG_VAL_MEASURE_IO_TIME',
-                'value': 2
-            }
-        ]
-    },
     'DeembeddingType': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -316,7 +256,6 @@ enums = {
         ]
     },
     'DigitalModulationType': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -349,7 +288,6 @@ enums = {
         ]
     },
     'DigitalModulationWaveformType': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -368,7 +306,6 @@ enums = {
         ]
     },
     'DigitalEqualizationEnabled': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -387,7 +324,6 @@ enums = {
         ]
     },
     'DirectDownload': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -413,7 +349,6 @@ enums = {
         ]
     },
     'FilterType': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -439,7 +374,6 @@ enums = {
         ]
     },
     'Format': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -464,20 +398,7 @@ enums = {
             }
         ]
     },
-    'FrequencyResponseFilterEnabled': {
-        'values': [
-            {
-                'name': 'NIRFSG_VAL_DISABLED',
-                'value': 0
-            },
-            {
-                'name': 'NIRFSG_VAL_ENABLED',
-                'value': 1
-            }
-        ]
-    },
     'FrequencySettlingUnits': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -502,20 +423,7 @@ enums = {
             }
         ]
     },
-    'GainStateFromSelfCal': {
-        'values': [
-            {
-                'name': 'NIRFSG_VAL_DISABLED',
-                'value': 0
-            },
-            {
-                'name': 'NIRFSG_VAL_ENABLED',
-                'value': 1
-            }
-        ]
-    },
     'GenerationMode': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -541,7 +449,6 @@ enums = {
         ]
     },
     'IQOutPortTermCfg': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -559,20 +466,7 @@ enums = {
             }
         ]
     },
-    'ImpairmentsFilterEnabled': {
-        'values': [
-            {
-                'name': 'NIRFSG_VAL_DISABLED',
-                'value': 0
-            },
-            {
-                'name': 'NIRFSG_VAL_ENABLED',
-                'value': 1
-            }
-        ]
-    },
     'LoOutExportConfigureFromRFSaEnable': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -590,20 +484,7 @@ enums = {
             }
         ]
     },
-    'LoOutSource': {
-        'values': [
-            {
-                'name': 'NIRFSG_VAL_INTERNAL_LO',
-                'value': 'Internal_LO'
-            },
-            {
-                'name': 'NIRFSG_VAL_ONBOARD',
-                'value': 'Onboard'
-            }
-        ]
-    },
     'LoPlLfractionalModeEnabled': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -622,7 +503,6 @@ enums = {
         ]
     },
     'LoadConfigurationResetOptions': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -655,7 +535,6 @@ enums = {
         ]
     },
     'LoadOptions': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -674,7 +553,6 @@ enums = {
         ]
     },
     'LoopBandwidth': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -700,7 +578,6 @@ enums = {
         ]
     },
     'MarkerEventOutputBehavior': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -719,7 +596,6 @@ enums = {
         ]
     },
     'MarkerEventPulseWidthUnits': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -738,7 +614,6 @@ enums = {
         ]
     },
     'MarkerEventToggleInitialState': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -756,20 +631,7 @@ enums = {
             }
         ]
     },
-    'MismatchCorrectionEnabled': {
-        'values': [
-            {
-                'name': 'NIRFSG_VAL_DISABLED',
-                'value': 0
-            },
-            {
-                'name': 'NIRFSG_VAL_ENABLED',
-                'value': 1
-            }
-        ]
-    },
     'Module': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -795,7 +657,6 @@ enums = {
         ]
     },
     'OffsetUnits': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -813,20 +674,7 @@ enums = {
             }
         ]
     },
-    'OptimizePathForSignalBandwidth': {
-        'values': [
-            {
-                'name': 'NIRFSG_VAL_DISABLED',
-                'value': 0
-            },
-            {
-                'name': 'NIRFSG_VAL_ENABLED',
-                'value': 1
-            }
-        ]
-    },
     'OutputPort': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -859,7 +707,6 @@ enums = {
         ]
     },
     'OverflowErrorReporting': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -878,7 +725,6 @@ enums = {
         ]
     },
     'PhaseContinuityEnabled': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -904,7 +750,6 @@ enums = {
         ]
     },
     'PowerLevelType': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -923,7 +768,6 @@ enums = {
         ]
     },
     'PpaInheritance': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -949,7 +793,6 @@ enums = {
         ]
     },
     'PulseModulationMode': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -982,7 +825,6 @@ enums = {
         ]
     },
     'RFBlanking': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -1001,7 +843,6 @@ enums = {
         ]
     },
     'RFInLoExportEnabled': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -1026,32 +867,7 @@ enums = {
             }
         ]
     },
-    'RFPowerMeterEnabled': {
-        'values': [
-            {
-                'name': 'NIRFSG_VAL_DISABLED',
-                'value': 0
-            },
-            {
-                'name': 'NIRFSG_VAL_ENABLED',
-                'value': 1
-            }
-        ]
-    },
-    'RFPowerProtectionEnabled': {
-        'values': [
-            {
-                'name': 'NIRFSG_VAL_DISABLED',
-                'value': 0
-            },
-            {
-                'name': 'NIRFSG_VAL_ENABLED',
-                'value': 1
-            }
-        ]
-    },
     'ReferencePllBandwidth': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -1077,14 +893,13 @@ enums = {
         ]
     },
     'ReferenceClockExportedRate': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
                     'description': 'Uses a 10MHz Reference Clock rate.'
                 },
                 'name': 'NIRFSG_VAL_10MHZ',
-                'python_name': '_10MHz',
+                'python_name': 'CLOCK_RATE_10_MEGAHERTZ',
                 'value': 10000000
             },
             {
@@ -1092,7 +907,7 @@ enums = {
                     'description': 'Uses a 100MHz Reference Clock rate.'
                 },
                 'name': 'NIRFSG_VAL_100MHZ',
-                'python_name': '_100MHz',
+                'python_name': 'CLOCK_RATE_100_MEGAHERTZ',
                 'value': 100000000.0
             },
             {
@@ -1100,13 +915,12 @@ enums = {
                     'description': 'Uses a 1GHz Reference Clock rate.'
                 },
                 'name': 'NIRFSG_VAL_1GHZ',
-                'python_name': '_1GHz',
+                'python_name': 'CLOCK_RATE_1_GIGAHERTZ',
                 'value': 1000000000.0
             }
         ]
     },
     'ReferenceClockRate': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -1120,13 +934,12 @@ enums = {
                     'description': 'Uses a 10MHz Reference Clock rate.'
                 },
                 'name': 'NIRFSG_VAL_10MHZ',
-                'python_name': '_10MHz',
+                'python_name': 'CLOCK_RATE_10_MEGAHERTZ',
                 'value': 10000000
             }
         ]
     },
     'RelativeTo': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -1145,7 +958,6 @@ enums = {
         ]
     },
     'ResetWithOptionsStepsToOmit': {
-        'codegen_method': 'public',
         'enum_class': 'IntFlag',
         'values': [
             {
@@ -1186,7 +998,6 @@ enums = {
         ]
     },
     'ScriptTriggerDigitalEdgeEdge': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -1205,7 +1016,6 @@ enums = {
         ]
     },
     'ScriptTriggerDigitalLevelActiveLevel': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -1224,7 +1034,6 @@ enums = {
         ]
     },
     'ScriptTriggerType': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -1257,7 +1066,6 @@ enums = {
         ]
     },
     'SelfCalibrateRangeStepsToOmit': {
-        'codegen_method': 'public',
         'enum_class': 'IntFlag',
         'values': [
             {
@@ -1305,15 +1113,7 @@ enums = {
         ]
     },
     'Signal': {
-        'codegen_method': 'public',
         'values': [
-            {
-                'documentation': {
-                    'description': 'Exports a Configuration Settled Event.'
-                },
-                'name': 'NIRFSG_VAL_CONFIGURATION_SETTLED_EVENT',
-                'value': 7
-            },
             {
                 'documentation': {
                     'description': 'Exports a Start Trigger.'
@@ -1355,18 +1155,10 @@ enums = {
                 },
                 'name': 'NIRFSG_VAL_DONE_EVENT',
                 'value': 5
-            },
-            {
-                'documentation': {
-                    'description': 'Exports a Configuration List Step Trigger.'
-                },
-                'name': 'NIRFSG_VAL_CONFIGURATION_LIST_STEP_TRIGGER',
-                'value': 6
             }
         ]
     },
     'SoftwareTriggerType': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -1385,7 +1177,6 @@ enums = {
         ]
     },
     'SparameterOrientation': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -1404,7 +1195,6 @@ enums = {
         ]
     },
     'StartTriggerDigitalEdgeEdge': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -1423,7 +1213,6 @@ enums = {
         ]
     },
     'StartTriggerType': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -1448,64 +1237,7 @@ enums = {
             }
         ]
     },
-    'StatusChecksDisabled': {
-        'values': [
-            {
-                'name': 'NIRFSG_VAL_NONE',
-                'value': 0
-            },
-            {
-                'name': 'NIRFSG_VAL_POWER_PROTECTION',
-                'value': 1
-            },
-            {
-                'name': 'NIRFSG_VAL_DSP',
-                'value': 2
-            },
-            {
-                'name': 'NIRFSG_VAL_LO_PLL',
-                'value': 4
-            },
-            {
-                'name': 'NIRFSG_VAL_ALL',
-                'value': -1
-            }
-        ]
-    },
-    'Sts5532SignalPath': {
-        'values': [
-            {
-                'name': 'NIRFSG_VAL_DIRECT',
-                'value': 0
-            },
-            {
-                'name': 'NIRFSG_VAL_GAIN',
-                'value': 1
-            },
-            {
-                'name': 'NIRFSG_VAL_LOOP',
-                'value': 2
-            },
-            {
-                'name': 'NIRFSG_VAL_AUTO',
-                'value': -1
-            }
-        ]
-    },
-    'TimerStartSource': {
-        'values': [
-            {
-                'name': 'NIRFSG_VAL_STARTTRIGGER',
-                'value': 'StartTrigger'
-            },
-            {
-                'name': 'NIRFSG_VAL_SCRIPTTRIGGER0',
-                'value': 'ScriptTrigger0'
-            }
-        ]
-    },
     'UpconverterFrequencyOffsetMode': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -1530,48 +1262,7 @@ enums = {
             }
         ]
     },
-    'UseCalibration': {
-        'values': [
-            {
-                'name': 'NIRFSG_VAL_DISABLE',
-                'value': 0
-            },
-            {
-                'name': 'NIRFSG_VAL_ENABLE',
-                'value': 1
-            }
-        ]
-    },
-    'VcoSelfCalEnabled': {
-        'values': [
-            {
-                'name': 'NIRFSG_VAL_DISABLED',
-                'value': 0
-            },
-            {
-                'name': 'NIRFSG_VAL_ENABLED',
-                'value': 1
-            }
-        ]
-    },
-    'WaveformSource': {
-        'values': [
-            {
-                'name': 'NIRFSG_VAL_NONE',
-                'value': 0
-            },
-            {
-                'name': 'NIRFSG_VAL_WGEN',
-                'value': 27000
-            },
-            {
-                'name': 'NIRFSG_VAL_USER',
-                'value': 27002
-            }
-        ]
-    },
     'WriteWaveformBurstDetection': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -1590,7 +1281,6 @@ enums = {
         ]
     },
     'WriteWaveformBurstDetectionMode': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -1609,7 +1299,6 @@ enums = {
         ]
     },
     'WriteWaveformNormalization': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {
@@ -1628,7 +1317,6 @@ enums = {
         ]
     },
     'YigMainCoilDrive': {
-        'codegen_method': 'public',
         'values': [
             {
                 'documentation': {

--- a/src/nirfsg/metadata/enums.py
+++ b/src/nirfsg/metadata/enums.py
@@ -1,66 +1,6 @@
 # -*- coding: utf-8 -*-
 # This file is generated from NI-RFSG API metadata version 25.5.0d9999
 enums = {
-    '5696AmpBand': {
-        'values': [
-            {
-                'name': 'NIRFSG_VAL_250_KHZ_-_250_MHZ',
-                'value': 96000
-            },
-            {
-                'name': 'NIRFSG_VAL_250_MHZ_-_1_GHZ',
-                'value': 96001
-            },
-            {
-                'name': 'NIRFSG_VAL_1_GHZ_-_2.4_GHZ',
-                'value': 96002
-            },
-            {
-                'name': 'NIRFSG_VAL_2.4_GHZ_-_3.86_GHZ',
-                'value': 96003
-            },
-            {
-                'name': 'NIRFSG_VAL_3.86_GHZ_-_5.37_GHZ',
-                'value': 96004
-            },
-            {
-                'name': 'NIRFSG_VAL_5.37_GHZ_-_7.45_GHZ',
-                'value': 96005
-            },
-            {
-                'name': 'NIRFSG_VAL_7.45_GHZ_-_10.4_GHZ',
-                'value': 96006
-            },
-            {
-                'name': 'NIRFSG_VAL_10.4_GHZ_-_14.4_GHZ',
-                'value': 96007
-            },
-            {
-                'name': 'NIRFSG_VAL_14.4GHZ_-_20_GHZ',
-                'value': 96008
-            },
-            {
-                'name': 'NIRFSG_VAL_LOW_GROUP_DELAY_14.4_GHZ_-_17_GHZ',
-                'value': 96009
-            },
-            {
-                'name': 'NIRFSG_VAL_LOW_GROUP_DELAY_17_GHZ_-_20_GHZ',
-                'value': 96010
-            }
-        ]
-    },
-    '5840Modulator': {
-        'values': [
-            {
-                'name': 'NIRFSG_VAL_BYPASS',
-                'value': 95000
-            },
-            {
-                'name': 'NIRFSG_VAL_ENABLED',
-                'value': 95001
-            }
-        ]
-    },
     'AllowOutOfSpecificationUserSettings': {
         'codegen_method': 'public',
         'values': [
@@ -126,7 +66,7 @@ enums = {
                     'description': 'Specifies a range from 100Hz to 1kHz.'
                 },
                 'name': 'NIRFSG_VAL_100HZ_TO_1KHZ',
-                'python_name': '_100hzto1khz',
+                'python_name': '_100Hzto1kHz',
                 'value': 18000
             },
             {
@@ -134,7 +74,7 @@ enums = {
                     'description': 'Specifies a range from 1kHz to 10kHz.'
                 },
                 'name': 'NIRFSG_VAL_1KHZ_TO_10KHZ',
-                'python_name': '_1khzto10khz',
+                'python_name': '_1kHzto10kHz',
                 'value': 18001
             },
             {
@@ -142,7 +82,7 @@ enums = {
                     'description': 'Specifies a range from 10kHz to 100kHz.'
                 },
                 'name': 'NIRFSG_VAL_10KHZ_TO_100KHZ',
-                'python_name': '_10khzto100khz',
+                'python_name': '_10kHzto100kHz',
                 'value': 18002
             }
         ]
@@ -631,44 +571,6 @@ enums = {
             }
         ]
     },
-    'Lo1OutputFilter': {
-        'codegen_method': 'public',
-        'values': [
-            {
-                'documentation': {
-                    'description': 'yet to be defined'
-                },
-                'name': 'NIRFSG_VAL_5.5GHz_HIGH_PASS',
-                'value': 0
-            },
-            {
-                'documentation': {
-                    'description': 'yet to be defined'
-                },
-                'name': 'NIRFSG_VAL_5.5GHz_LOW_PASS',
-                'value': 1
-            }
-        ]
-    },
-    'LoOutEnabled': {
-        'codegen_method': 'public',
-        'values': [
-            {
-                'documentation': {
-                    'description': 'The local oscillator signal is present at the LO OUT front panel connector.'
-                },
-                'name': 'NIRFSG_VAL_DISABLE',
-                'value': 0
-            },
-            {
-                'documentation': {
-                    'description': 'The local oscillator signal is  not present at the LO OUT front panel connector..'
-                },
-                'name': 'NIRFSG_VAL_ENABLE',
-                'value': 1
-            }
-        ]
-    },
     'LoOutExportConfigureFromRFSaEnable': {
         'codegen_method': 'public',
         'values': [
@@ -1001,25 +903,6 @@ enums = {
             }
         ]
     },
-    'PortTypes': {
-        'codegen_method': 'public',
-        'values': [
-            {
-                'documentation': {
-                    'description': 'Specifies the PXIe-5840 RF OUT port.'
-                },
-                'name': 'NIRFSG_VAL_PORT_RF_OUT',
-                'value': 14501
-            },
-            {
-                'documentation': {
-                    'description': 'Specifies the PXIe-5840 RF IN port. This value is not supported as the first element of an array.'
-                },
-                'name': 'NIRFSG_VAL_PORT_RF_IN',
-                'value': 14500
-            }
-        ]
-    },
     'PowerLevelType': {
         'codegen_method': 'public',
         'values': [
@@ -1117,32 +1000,6 @@ enums = {
             }
         ]
     },
-    'RFFilter': {
-        'codegen_method': 'public',
-        'values': [
-            {
-                'documentation': {
-                    'description': 'yet to be defined'
-                },
-                'name': 'NIRFSG_VAL_HI_FREQ_MOD',
-                'value': '0'
-            },
-            {
-                'documentation': {
-                    'description': 'yet to be defined'
-                },
-                'name': 'NIRFSG_VAL_LO_FREQ_MOD_4000',
-                'value': '1'
-            },
-            {
-                'documentation': {
-                    'description': 'yet to be defined'
-                },
-                'name': 'NIRFSG_VAL_LO_FREQ_MOD_2500',
-                'value': '2'
-            }
-        ]
-    },
     'RFInLoExportEnabled': {
         'codegen_method': 'public',
         'values': [
@@ -1227,7 +1084,7 @@ enums = {
                     'description': 'Uses a 10MHz Reference Clock rate.'
                 },
                 'name': 'NIRFSG_VAL_10MHZ',
-                'python_name': '_10mhz',
+                'python_name': '_10MHz',
                 'value': 10000000
             },
             {
@@ -1235,7 +1092,7 @@ enums = {
                     'description': 'Uses a 100MHz Reference Clock rate.'
                 },
                 'name': 'NIRFSG_VAL_100MHZ',
-                'python_name': '_100mhz',
+                'python_name': '_100MHz',
                 'value': 100000000.0
             },
             {
@@ -1243,7 +1100,7 @@ enums = {
                     'description': 'Uses a 1GHz Reference Clock rate.'
                 },
                 'name': 'NIRFSG_VAL_1GHZ',
-                'python_name': '_1ghz',
+                'python_name': '_1GHz',
                 'value': 1000000000.0
             }
         ]
@@ -1263,7 +1120,7 @@ enums = {
                     'description': 'Uses a 10MHz Reference Clock rate.'
                 },
                 'name': 'NIRFSG_VAL_10MHZ',
-                'python_name': '_10mhz',
+                'python_name': '_10MHz',
                 'value': 10000000
             }
         ]

--- a/src/nirfsg/metadata/enums.py
+++ b/src/nirfsg/metadata/enums.py
@@ -349,7 +349,7 @@ enums = {
             }
         ]
     },
-    'DeembeddingTypeAttrVals': {
+    'DeembeddingType': {
         'codegen_method': 'public',
         'values': [
             {
@@ -1588,13 +1588,6 @@ enums = {
                 },
                 'name': 'NIRFSG_VAL_SOFTWARE',
                 'value': 2
-            },
-            {
-                'documentation': {
-                    'description': 'The data operation does not start until the endpoint reaches the threshold specified in the NIRFSG_ATTR_P2P_ENDPOINT_FULLNESS_START_TRIGGER_LEVEL attribute.'
-                },
-                'name': 'NIRFSG_VAL_P2P_ENDPOINT_FULLNESS',
-                'value': 3
             }
         ]
     },
@@ -1713,10 +1706,6 @@ enums = {
             {
                 'name': 'NIRFSG_VAL_WGEN',
                 'value': 27000
-            },
-            {
-                'name': 'NIRFSG_VAL_P2P',
-                'value': 27001
             },
             {
                 'name': 'NIRFSG_VAL_USER',

--- a/src/nirfsg/metadata/functions.py
+++ b/src/nirfsg/metadata/functions.py
@@ -486,7 +486,7 @@ functions = {
     'CheckGenerationStatus': {
         'codegen_method': 'public',
         'documentation': {
-            'description': '\nChecks the status of the generation.\n\nCall this function to check for any errors that might occur during the signal generation or to check whether the device has finished generating.\n\n**Supported Devices** : PXIe-5611, PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`NI-RFSG Instrument Driver Programming Flow <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/progflow.html>`_\n\n`Stopping Pear-to-Peer Generation <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_stopping_generation.html>`_'
+            'description': '\nChecks the status of the generation.\n\nCall this function to check for any errors that might occur during the signal generation or to check whether the device has finished generating.\n\n**Supported Devices** : PXIe-5611, PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`NI-RFSG Instrument Driver Programming Flow <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/progflow.html>`'
         },
         'included_in_proto': True,
         'method_templates': [
@@ -3128,7 +3128,7 @@ functions = {
                 },
                 'name': 'channelName',
                 'is_repeated_capability': True,
-                'repeated_capability_type': 'waveform',
+                'repeated_capability_type': 'waveforms',
                 'type': 'ViConstString',
                 'use_array': False,
                 'use_in_python_api': True
@@ -3202,7 +3202,7 @@ functions = {
                 },
                 'name': 'channelName',
                 'is_repeated_capability': True,
-                'repeated_capability_type': 'waveform',
+                'repeated_capability_type': 'waveforms',
                 'type': 'ViConstString',
                 'use_array': False,
                 'use_in_python_api': True
@@ -4053,7 +4053,7 @@ functions = {
     'SelectArbWaveform': {
         'codegen_method': 'public',
         'documentation': {
-            'description': '\nSpecifies the waveform that is generated upon a call to the nirfsg_Initiate function when the **generationMode** parameter of the nirfsg_ConfigureGenerationMode function is set to NIRFSG_VAL_ARB_WAVEFORM.\n\nYou must specify a waveform using the NIRFSG_ATTR_NAME parameter if you have written multiple waveforms. The NI-RFSG device must be in the Configuration state before you call this function.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Assigning Properties or Attributes to a Waveform <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/assigning_properties_or_attributes_to_a_waveform.html>`_'
+            'description': '\nSpecifies the waveform that is generated upon a call to the nirfsg_Initiate function when the generation_mode property is set to NIRFSG_VAL_ARB_WAVEFORM.\n\nYou must specify a waveform using the NIRFSG_ATTR_NAME parameter if you have written multiple waveforms. The NI-RFSG device must be in the Configuration state before you call this function.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Assigning Properties or Attributes to a Waveform <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/assigning_properties_or_attributes_to_a_waveform.html>`_'
         },
         'included_in_proto': True,
         'method_templates': [
@@ -4847,7 +4847,7 @@ functions = {
                 },
                 'name': 'channelName',
                 'is_repeated_capability': True,
-                'repeated_capability_type': 'waveform',
+                'repeated_capability_type': 'waveforms',
                 'type': 'ViConstString',
                 'use_array': False,
                 'use_in_python_api': True
@@ -4910,7 +4910,7 @@ functions = {
                 },
                 'name': 'channelName',
                 'is_repeated_capability': True,
-                'repeated_capability_type': 'waveform',
+                'repeated_capability_type': 'waveforms',
                 'type': 'ViConstString',
                 'use_array': False,
                 'use_in_python_api': True
@@ -5390,7 +5390,7 @@ functions = {
     'WriteScript': {
         'codegen_method': 'public',
         'documentation': {
-            'description': '\nWrites a script to the device to control waveform generation in Script mode.\n\nFirst, configure your device for Script mode by calling the nirfsg_ConfigureGenerationMode function. The NI-RFSG device must be in the Configuration state before calling the nirfsg_WriteScript function.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Scripting Instructions <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/scripting_instructions.html>`_--Refer to this topic for more information about VST restrictions on scripts.\n\n`Common Scripting Use Cases <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/scripting_use_cases.html>`_',
+            'description': '\nWrites a script to the device to control waveform generation in Script mode.\n\nFirst, configure your device for Script mode by setting the generation_mode property. The NI-RFSG device must be in the Configuration state before calling the nirfsg_WriteScript function.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Scripting Instructions <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/scripting_instructions.html>`_--Refer to this topic for more information about VST restrictions on scripts.\n\n`Common Scripting Use Cases <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/scripting_use_cases.html>`_',
             'note': 'If you are using an RF vector signal transceiver (VST) device, some script instructions may not be supported.'
         },
         'included_in_proto': True,

--- a/src/nirfsg/metadata/functions.py
+++ b/src/nirfsg/metadata/functions.py
@@ -4,7 +4,7 @@ functions = {
     'Abort': {
         'codegen_method': 'public',
         'documentation': {
-            'description': 'Stops signal generation.\n\n**Supported Devices** : PXI-5610, PXIe-5611, PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`NI-RFSG Programming State Model <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/ni_5670_programming_state_model.html>`_'
+            'description': '\nStops signal generation.\n\n**Supported Devices** : PXI-5610, PXIe-5611, PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`NI-RFSG Programming State Model <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/ni_5670_programming_state_model.html>`_'
         },
         'included_in_proto': True,
         'method_templates': [
@@ -32,7 +32,7 @@ functions = {
     'AllocateArbWaveform': {
         'codegen_method': 'public',
         'documentation': {
-            'description': 'Allocates onboard memory space for the arbitrary waveform.\n\nUse this function to specify the total size of a waveform before writing the data. Use this function only if you are calling the nirfsg_WriteArbWaveform function multiple times to write a large waveform in smaller blocks.\n\nThe NI-RFSG device must be in the Configuration state before you call this function.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Streaming Waveform Data <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/streaming_waveform_data.html>`_'
+            'description': '\nAllocates onboard memory space for the arbitrary waveform.\n\nUse this function to specify the total size of a waveform before writing the data. Use this function only if you are calling the nirfsg_WriteArbWaveform function multiple times to write a large waveform in smaller blocks.\n\nThe NI-RFSG device must be in the Configuration state before you call this function.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Streaming Waveform Data <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/streaming_waveform_data.html>`_'
         },
         'included_in_proto': True,
         'method_templates': [
@@ -80,7 +80,7 @@ functions = {
     'ChangeExternalCalibrationPassword': {
         'codegen_method': 'public',
         'documentation': {
-            'description': 'Changes the external calibration password of the device.\n\n**Supported Devices:** PXIe-5611, PXIe-5653/5654, PXIe-5673/5673E, PXIe-5696, PXIe-5820/5830/5831/5832/5840/5841/5842/5860'
+            'description': '\nChanges the external calibration password of the device.\n\n**Supported Devices:** PXIe-5611, PXIe-5653/5654, PXIe-5673/5673E, PXIe-5696, PXIe-5820/5830/5831/5832/5840/5841/5842/5860'
         },
         'included_in_proto': True,
         'method_templates': [
@@ -187,7 +187,7 @@ functions = {
     'CheckAttributeViInt32': {
         'codegen_method': 'public',
         'documentation': {
-            'description': 'Checks the validity of a value you specify for a ViInt32 attribute.'
+            'description': '\nChecks the validity of a value you specify for a ViInt32 attribute.'
         },
         'included_in_proto': True,
         'method_templates': [
@@ -813,7 +813,7 @@ functions = {
     'ConfigureDeembeddingTableInterpolationLinear': {
         'codegen_method': 'public',
         'documentation': {
-            'description': 'Selects the linear interpolation method.\n\nIf the carrier frequency does not match a row in the de-embedding table, NI-RFSG performs a linear interpolation based on the entries in the de-embedding table to determine the parameters to use for de-embedding.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860'
+            'description': '\nSelects the linear interpolation method.\n\nIf the carrier frequency does not match a row in the de-embedding table, NI-RFSG performs a linear interpolation based on the entries in the de-embedding table to determine the parameters to use for de-embedding.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860'
         },
         'included_in_proto': True,
         'method_templates': [
@@ -894,7 +894,7 @@ functions = {
     'ConfigureDeembeddingTableInterpolationNearest': {
         'codegen_method': 'public',
         'documentation': {
-            'description': 'Selects the nearest interpolation method.\n\nNI-RFSG uses the parameters of the table nearest to the carrier frequency for de-embedding.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860'
+            'description': '\nSelects the nearest interpolation method.\n\nNI-RFSG uses the parameters of the table nearest to the carrier frequency for de-embedding.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860'
         },
         'included_in_proto': True,
         'method_templates': [
@@ -942,7 +942,7 @@ functions = {
     'ConfigureDeembeddingTableInterpolationSpline': {
         'codegen_method': 'public',
         'documentation': {
-            'description': 'Selects the spline interpolation method.\n\nIf the carrier frequency does not match a row in the de-embedding table, NI-RFSG performs a spline interpolation based on the entries in the de-embedding table to determine the parameters to use for de-embedding.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860'
+            'description': '\nSelects the spline interpolation method.\n\nIf the carrier frequency does not match a row in the de-embedding table, NI-RFSG performs a spline interpolation based on the entries in the de-embedding table to determine the parameters to use for de-embedding.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860'
         },
         'included_in_proto': True,
         'method_templates': [
@@ -1019,6 +1019,8 @@ functions = {
                 },
                 'name': 'triggerId',
                 'type': 'ViConstString',
+                'is_repeated_capability': True,
+                'repeated_capability_type': 'script_triggers',
                 'use_array': False,
                 'use_in_python_api': True
             },
@@ -1038,7 +1040,7 @@ functions = {
                     'description': 'Specifies the active edge for the digital edge Script Trigger. NI-RFSG sets the NIRFSG_ATTR_DIGITAL_EDGE_SCRIPT_TRIGGER_EDGE attribute to this value.'
                 },
                 'name': 'edge',
-                'enum': 'ScriptTrigDigEdgeEdge',
+                'enum': 'ScriptTriggerDigitalEdgeEdge',
                 'type': 'ViInt32',
                 'use_array': False,
                 'use_in_python_api': True
@@ -1088,7 +1090,7 @@ functions = {
                     'description': 'Specifies the active edge for the Start Trigger. NI-RFSG sets the NIRFSG_ATTR_DIGITAL_EDGE_START_TRIGGER_EDGE attribute to this value.'
                 },
                 'name': 'edge',
-                'enum': 'StartTrigDigEdgeEdge',
+                'enum': 'StartTriggerDigitalEdgeEdge',
                 'type': 'ViInt32',
                 'use_array': False,
                 'use_in_python_api': True
@@ -1200,201 +1202,6 @@ functions = {
                     'value': 'numberOfSamples'
                 },
                 'type': 'ViInt8[]',
-                'use_array': False,
-                'use_in_python_api': True
-            }
-        ],
-        'returns': 'ViStatus'
-    },
-    'ConfigureGenerationMode': {
-        'codegen_method': 'public',
-        'documentation': {
-            'description': '\nConfigures the NI-RFSG device to generate a continuous sine tone (CW), apply I/Q (vector) modulation to the RF output signal, or generate arbitrary waveforms according to scripts.\n\nThe NI-RFSG device must be in the Configuration state before you call this function.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Assigning Properties or Attributes to a Waveform <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/assigning_properties_or_attributes_to_a_waveform.html>`_\n\n`Scripting Instructions <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/scripting_instructions.html>`_--Refer to this topic for more information about VST restrictions on scripts.'
-        },
-        'included_in_proto': True,
-        'method_templates': [
-            {
-                'documentation_filename': 'default_method',
-                'library_interpreter_filename': 'default_method',
-                'method_python_name_suffix': '',
-                'session_filename': 'default_method'
-            }
-        ],
-        'parameters': [
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies your instrument session. The ViSession handle is obtained from the nirfsg_Init function or the nirfsg_InitWithOptions function and identifies a particular instrument session.'
-                },
-                'name': 'vi',
-                'type': 'ViSession',
-                'use_array': False,
-                'use_in_python_api': True
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Specifies the mode used by NI-RFSG for generating an RF output signal.\n\n        **Default Value** : NIRFSG_VAL_CW\n\n        **Defined Values** :    ',
-                    'note': '- For the PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696, only NIRFSG_VAL_CW is supported.\n\n - If you are using an RF vector signal transceiver (VST) device, some script instructions may not be supported.',
-                    'table_body': [
-                        [
-                            'NIRFSG_VAL_CW',
-                            '1000 (0x3e8)',
-                            'Configures the RF signal generator to generate a CW signal.'
-                        ],
-                        [
-                            'NIRFSG_VAL_ARB_WAVEFORM',
-                            '1001 (0x3e9)',
-                            'Configures the RF signal generator to generate the arbitrary waveform specified by the NIRFSG_ATTR_ARB_SELECTED_WAVEFORM attribute.'
-                        ],
-                        [
-                            'NIRFSG_VAL_SCRIPT',
-                            '1002 (0x3ea)',
-                            'Configures the RF signal generator to generate arbitrary waveforms as directed by the NIRFSG_ATTR_SELECTED_SCRIPT attribute.'
-                        ]
-                    ],
-                    'table_header': [
-                        'Name',
-                        'Value',
-                        'Description'
-                    ]
-                },
-                'enum': 'GenerationMode',
-                'name': 'generationMode',
-                'type': 'ViInt32',
-                'use_array': False,
-                'use_in_python_api': True
-            }
-        ],
-        'returns': 'ViStatus'
-    },
-    'ConfigureOutputEnabled': {
-        'codegen_method': 'public',
-        'documentation': {
-            'description': '\nEnables or disables signal output.\n\nSetting NIRFSG_ATTR_OUTPUT_ENABLED to VI_FALSE while in the Generation state attenuates the generated signal so that no signal is output.\n\n**Supported Devices** : PXI-5610, PXIe-5611, PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Output Enabled <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/outputenable.html>`_\n\n`NI-RFSG Instrument Driver Programming Flow <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/progflow.html>`_\n\n`RF List Mode <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/rf_list_mode_overview.html>`_'
-        },
-        'included_in_proto': True,
-        'method_templates': [
-            {
-                'documentation_filename': 'default_method',
-                'library_interpreter_filename': 'default_method',
-                'method_python_name_suffix': '',
-                'session_filename': 'default_method'
-            }
-        ],
-        'parameters': [
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies your instrument session. The ViSession handle is obtained from the nirfsg_Init function or the nirfsg_InitWithOptions function and identifies a particular instrument session.'
-                },
-                'name': 'vi',
-                'type': 'ViSession',
-                'use_array': False,
-                'use_in_python_api': True
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Specifies whether you want to enable or disable the output.'
-                },
-                'name': 'outputEnabled',
-                'type': 'ViBoolean',
-                'use_array': False,
-                'use_in_python_api': True
-            }
-        ],
-        'returns': 'ViStatus'
-    },
-    'ConfigureP2PEndpointFullnessStartTrigger': {
-        'codegen_method': 'public',
-        'documentation': {
-            'description': '\nConfigures the Start Trigger to detect peer-to-peer endpoint fullness.\n\nGeneration begins when the number of samples in the peer-to-peer endpoint reaches the threshold specified by the NIRFSG_ATTR_P2P_ENDPOINT_FULLNESS_LEVEL parameter. The NI-RFSG device must be in the Configuration state before calling this function.\n\n**Supported Devices** : PXIe-5673E, PXIe-5820/5830/5831/5832/5840/5841/5842\n\n**Related Topics**\n\n`Start Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/start_triggers.html>`_',
-            'note': 'Due to an additional internal FIFO in the RF signal generator, the writer peer actually writes 2,304 bytes more than the quantity of data specified by this function to satisfy the trigger level.'
-        },
-        'included_in_proto': True,
-        'method_templates': [
-            {
-                'documentation_filename': 'default_method',
-                'library_interpreter_filename': 'default_method',
-                'method_python_name_suffix': '',
-                'session_filename': 'default_method'
-            }
-        ],
-        'parameters': [
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies your instrument session. The ViSession handle is obtained from the nirfsg_Init function or the nirfsg_InitWithOptions function and identifies a particular instrument session.'
-                },
-                'name': 'vi',
-                'type': 'ViSession',
-                'use_array': False,
-                'use_in_python_api': True
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Specifies the quantity of data in the FIFO endpoint that asserts the trigger. Units are samples per channel. The default value is -1, which allows NI-RFSG to select the appropriate fullness value.'
-                },
-                'name': 'p2pEndpointFullnessLevel',
-                'type': 'ViInt64',
-                'use_array': False,
-                'use_in_python_api': True
-            }
-        ],
-        'returns': 'ViStatus'
-    },
-    'ConfigurePowerLevelType': {
-        'codegen_method': 'public',
-        'documentation': {
-            'description': '\nSpecifies the way the driver interprets the NIRFSG_ATTR_POWER_LEVEL attribute.\n\nIn average power mode, NI-RFSG automatically scales waveform data to use the maximum dynamic range. In peak power mode, waveforms are scaled according to the NIRFSG_ATTR_ARB_WAVEFORM_SOFTWARE_SCALING_FACTOR attribute.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Spurious Performance <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/spurious_performance.html>`_\n\n`Optimizing for Low Power Generation <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/optimizing_for_low_power_generation.html>`_'
-        },
-        'included_in_proto': True,
-        'method_templates': [
-            {
-                'documentation_filename': 'default_method',
-                'library_interpreter_filename': 'default_method',
-                'method_python_name_suffix': '',
-                'session_filename': 'default_method'
-            }
-        ],
-        'parameters': [
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies your instrument session. The ViSession handle is obtained from the nirfsg_Init function or the nirfsg_InitWithOptions function and identifies a particular instrument session.'
-                },
-                'name': 'vi',
-                'type': 'ViSession',
-                'use_array': False,
-                'use_in_python_api': True
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Specifies the way the driver interprets the value of the NIRFSG_ATTR_POWER_LEVEL attribute. NI-RFSG sets the NIRFSG_ATTR_POWER_LEVEL_TYPE attribute to this value.',
-                    'table_body': [
-                        [
-                            'Average Power (default)',
-                            '7000',
-                            'Indicates the desired power averaged in time. The driver maximizes the dynamic range by scaling the I/Q waveform so that its peak magnitude is equal to one. If you write more than one waveform, NI-RFSG scales each waveform without preserving the power level ratio between the waveforms. This value is not valid for the PXIe-5820.'
-                        ],
-                        [
-                            'Peak Power',
-                            '7001',
-                            'Indicates the maximum power level of the RF signal averaged over one period of the RF carrier frequency (the peak envelope power). This setting requires the magnitude of the I/Q waveform to be less than or equal to one. When using peak power, the power level of the RF signal matches the specified power level at moments when the magnitude of the I/Q waveform equals one. If you write more than one waveform, the relative scaling between waveforms is preserved. In peak power mode, waveforms are scaled according to the NIRFSG_ATTR_ARB_WAVEFORM_SOFTWARE_SCALING_FACTOR attribute.'
-                        ]
-                    ],
-                    'table_header': [
-                        'Name',
-                        'Value',
-                        'Description'
-                    ]
-                },
-                'name': 'powerLevelType',
-                'enum': 'PowerLevelType',
-                'type': 'ViInt32',
                 'use_array': False,
                 'use_in_python_api': True
             }
@@ -1565,45 +1372,6 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
-    'ConfigureSignalBandwidth': {
-        'codegen_method': 'public',
-        'documentation': {
-            'description': 'Configures the signal bandwidth of the arbitrary waveform.\n\nThe NI-RFSG device must be in the Configuration state before you call this function.\n\nNI-RFSG defines *signal bandwidth* as twice the maximum baseband signal deviation from 0 Hz. Usually, the baseband signal center frequency is 0Hz. In such cases, the signal bandwidth is simply the baseband signal minimum frequency subtracted from its maximum frequency, or *f* <sub>max</sub> minus *f* <sub>min</sub>. NI-RFSG uses this value to optimally configure the center frequency of the upconverter to help minimize phase noise. The generated signal is not filtered to achieve the set bandwidth. However, specifying a bandwidth smaller than the actual bandwidth of the signal could potentially result in spectral distortion.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860',
-            'note': 'Based on your signal bandwidth, NI-RFSG decides whether to configure the upconverter center frequency on the PXI-5670/5671 or PXIe-5672 in increments of 1MHz or 5MHz. Failure to configure signal bandwidth may result in the signal being placed outside the upconverter passband.'
-        },
-        'included_in_proto': True,
-        'method_templates': [
-            {
-                'documentation_filename': 'default_method',
-                'library_interpreter_filename': 'default_method',
-                'method_python_name_suffix': '',
-                'session_filename': 'default_method'
-            }
-        ],
-        'parameters': [
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies your instrument session. The ViSession handle is obtained from the nirfsg_Init function or the nirfsg_InitWithOptions function and identifies a particular instrument session.'
-                },
-                'name': 'vi',
-                'type': 'ViSession',
-                'use_array': False,
-                'use_in_python_api': True
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Specifies the signal bandwidth used by NI-RFSG to generate an RF output signal. NI-RFSG sets the NIRFSG_ATTR_SIGNAL_BANDWIDTH attribute to this value.'
-                },
-                'name': 'signalBandwidth',
-                'type': 'ViReal64',
-                'use_array': False,
-                'use_in_python_api': True
-            }
-        ],
-        'returns': 'ViStatus'
-    },
     'ConfigureSoftwareScriptTrigger': {
         'codegen_method': 'public',
         'documentation': {
@@ -1636,6 +1404,8 @@ functions = {
                 },
                 'name': 'triggerId',
                 'type': 'ViConstString',
+                'is_repeated_capability': True,
+                'repeated_capability_type': 'script_triggers',
                 'use_array': False,
                 'use_in_python_api': True
             }
@@ -1673,7 +1443,7 @@ functions = {
     'CreateDeembeddingSparameterTableS2PFile': {
         'codegen_method': 'public',
         'documentation': {
-            'description': 'Creates an S-parameter de-embedding table for the port based on the specified S2P file.\n\nIf you only create one table for a port, NI-RFSG automatically selects that table to de-embed the measurement.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`De-embedding Overview <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/de_embedding_overview.html>`_\n\n`S-parameters <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/s_parameters.html>`_'
+            'description': '\nCreates an S-parameter de-embedding table for the port based on the specified S2P file.\n\nIf you only create one table for a port, NI-RFSG automatically selects that table to de-embed the measurement.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`De-embedding Overview <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/de_embedding_overview.html>`_\n\n`S-parameters <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/s_parameters.html>`_'
         },
         'included_in_proto': True,
         'method_templates': [
@@ -1759,7 +1529,7 @@ functions = {
     'DeleteAllDeembeddingTables': {
         'codegen_method': 'public',
         'documentation': {
-            'description': 'Deletes all configured de-embedding tables for the session.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860'
+            'description': '\nDeletes all configured de-embedding tables for the session.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860'
         },
         'included_in_proto': True,
         'method_templates': [
@@ -1787,7 +1557,7 @@ functions = {
     'DeleteDeembeddingTable': {
         'codegen_method': 'public',
         'documentation': {
-            'description': 'Deletes the selected de-embedding table for a given port.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860'
+            'description': '\nDeletes the selected de-embedding table for a given port.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860'
         },
         'included_in_proto': True,
         'method_templates': [
@@ -1892,6 +1662,8 @@ functions = {
                 },
                 'name': 'triggerId',
                 'type': 'ViConstString',
+                'is_repeated_capability': True,
+                'repeated_capability_type': 'script_triggers',
                 'use_array': False,
                 'use_in_python_api': True
             }
@@ -2688,7 +2460,7 @@ functions = {
     'GetChannelName': {
         'codegen_method': 'public',
         'documentation': {
-            'description': 'Returns the channel string that is in the channel table at an index you specify.\n\n**Supported Devices** : PXI-5670/5671, PXIe-5672/5673/5673E'
+            'description': '\nReturns the channel string that is in the channel table at an index you specify.\n\n**Supported Devices** : PXI-5670/5671, PXIe-5672/5673/5673E'
         },
         'included_in_proto': True,
         'method_templates': [
@@ -3166,54 +2938,6 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
-    'GetStreamEndpointHandle': {
-        'codegen_method': 'public',
-        'documentation': {
-            'description': '\nReturns a reader endpoint handle that can be used with NI-P2P to configure a peer-to-peer stream with an RF signal generator endpoint.\n\n**Supported Devices** : PXIe-5673E, PXIe-5820/5830/5831/5832/5840/5841/5842\n\n**Related Topics**\n\n`Configuring a Peer-to-Peer Stream <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/configuring_a_p2p_stream.html>`_\n\n`Configuring Flow Control <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_flow_control.html>`_'
-        },
-        'included_in_proto': True,
-        'method_templates': [
-            {
-                'documentation_filename': 'default_method',
-                'library_interpreter_filename': 'default_method',
-                'method_python_name_suffix': '',
-                'session_filename': 'default_method'
-            }
-        ],
-        'parameters': [
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies your instrument session. The ViSession handle is obtained from the nirfsg_Init function or the nirfsg_InitWithOptions function and identifies a particular instrument session.'
-                },
-                'name': 'vi',
-                'type': 'ViSession',
-                'use_array': False,
-                'use_in_python_api': True
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Specifies the stream endpoint FIFO to configure.'
-                },
-                'name': 'streamEndpoint',
-                'type': 'ViConstString',
-                'use_array': False,
-                'use_in_python_api': True
-            },
-            {
-                'direction': 'out',
-                'documentation': {
-                    'description': 'Returns the reader endpoint handle that is used with NI-P2P to create a stream with the NI-RFSG device as an endpoint.'
-                },
-                'name': 'readerHandle',
-                'type': 'ViUInt32',
-                'use_array': False,
-                'use_in_python_api': True
-            }
-        ],
-        'returns': 'ViStatus'
-    },
     'GetTerminalName': {
         'codegen_method': 'public',
         'documentation': {
@@ -3523,7 +3247,7 @@ functions = {
     'GetWaveformMarkerEventLocations': {
         'codegen_method': 'public',
         'documentation': {
-            'description': 'Returns the marker locations associated with the waveform and the marker stored in the NI-RFSG session.\n\n**Supported Devices** : PXIe-5820/5830/5831/5832/5840/5841/5842'
+            'description': '\nReturns the marker locations associated with the waveform and the marker stored in the NI-RFSG session.\n\n**Supported Devices** : PXIe-5820/5830/5831/5832/5840/5841/5842'
         },
         'included_in_proto': True,
         'method_templates': [
@@ -4205,6 +3929,79 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
+    'ResetWithOptions': {
+        'codegen_method': 'public',
+        'documentation': {
+            'description': '\nResets all properties to default values and specifies steps to omit during the reset process, such as signal routes.\n\nBy default, this function exhibits the same behavior as nirfsg_Reset. You can specify steps to omit using the steps to omit parameter. For example, if you specify NIRFSG_VAL_RESET_WITH_OPTIONS_ROUTES for the NIRFSG_ATTR_STEPS_TO_OMIT parameter, this function does not release signal routes during the reset process.\n\nWhen routes of signals between two devices are released, they are released regardless of which device created the route.\n\nTo avoid resetting routes on PXIe-5820/5830/5831/5832/5840/5841/5842/5860 that are in use by NI-RFSA sessions, NI recommends using this function instead of nirfsg_Reset, with NIRFSG_ATTR_STEPS_TO_OMIT set to NIRFSG_VAL_RESET_WITH_OPTIONS_ROUTES.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Triggers <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/triggers.html>``Events <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/events.html>`_'
+        },
+        'included_in_proto': True,
+        'method_templates': [
+            {
+                'documentation_filename': 'default_method',
+                'library_interpreter_filename': 'default_method',
+                'method_python_name_suffix': '',
+                'session_filename': 'default_method'
+            }
+        ],
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Identifies your instrument session. The ViSession handle is obtained from the nirfsg_Init function or the nirfsg_InitWithOptions function and identifies a particular instrument session.'
+                },
+                'name': 'vi',
+                'type': 'ViSession',
+                'use_array': False,
+                'use_in_python_api': True
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Specifies a list of steps to skip during the reset process. The default value is NIRFSG_VAL_RESET_WITH_OPTIONS_NONE, which specifies that no step is omitted during reset. **Defined Values** :',
+                    'note': 'NIRFSG_VAL_RESET_WITH_OPTIONS_ROUTES is not supported in external calibration or alignment sessions.\nYou can combine multiple enums.ResetWithOptionsStepsToOmit flags using the bitwise OR (|) operator.',
+                    'table_body': [
+                        [
+                            'NIRFSG_VAL_RESET_WITH_OPTIONS_NONE',
+                            '0 (0x0)',
+                            'No step is omitted during reset.'
+                        ],
+                        [
+                            'NIRFSG_VAL_RESET_WITH_OPTIONS_WAVEFORMS',
+                            '1 (0x1)',
+                            'Omits clearing waveforms.'
+                        ],
+                        [
+                            'NIRFSG_VAL_RESET_WITH_OPTIONS_SCRIPTS',
+                            '2 (0x2)',
+                            'Omits clearing scripts.'
+                        ],
+                        [
+                            'NIRFSG_VAL_RESET_WITH_OPTIONS_ROUTES',
+                            '4 (0x4)',
+                            'Omits the routing reset step. Routing is preserved after a reset. However, routing related properties are reset to default, and routing is released if the default properties are committed after a reset.'
+                        ],
+                        [
+                            'NIRFSG_VAL_RESET_WITH_OPTIONS_DEEMBEDDING_TABLES',
+                            '8 (0x8)',
+                            'Omits deleting de-embedding tables. This step is valid only for the PXIe-5830/5831/5832/5840.'
+                        ]
+                    ],
+                    'table_header': [
+                        'Name',
+                        'Value',
+                        'Description'
+                    ]
+                },
+                'type_in_documentation': 'Bitwise combination of enums.ResetWithOptionsStepsToOmit flags',
+                'enum': 'ResetWithOptionsStepsToOmit',
+                'name': 'stepsToOmit',
+                'type': 'ViUInt64',
+                'use_array': False,
+                'use_in_python_api': True
+            }
+        ],
+        'returns': 'ViStatus'
+    },
     'SaveConfigurationsToFile': {
         'codegen_method': 'public',
         'documentation': {
@@ -4350,6 +4147,7 @@ functions = {
                 'direction': 'in',
                 'documentation': {
                     'description': 'Specifies which calibration steps to skip during the self-calibration process. The default value is an empty array, which indicates that no calibration steps are omitted.\n\n**Default Value** : NIRFSG_VAL_SELF_CAL_OMIT_NONE\n\n**Defined Values:**',
+                    'note': 'You can combine multiple enums.SelfCalibrateRangeStepsToOmit flags using the bitwise OR (|) operator.',
                     'table_body': [
                         [
                             'NIRFSG_VAL_SELF_CAL_OMIT_NONE',
@@ -4388,6 +4186,7 @@ functions = {
                         'Description'
                     ]
                 },
+                'type_in_documentation': 'Bitwise combination of enums.SelfCalibrateRangeStepsToOmit flags',
                 'enum': 'SelfCalibrateRangeStepsToOmit',
                 'name': 'stepsToOmit',
                 'type': 'ViInt64',
@@ -5019,7 +4818,7 @@ functions = {
     'SetWaveformBurstStartLocations': {
         'codegen_method': 'public',
         'documentation': {
-            'description': 'Configures the start location of the burst in samples where the burst refers to the active portion of a waveform.\n\n**Supported Devices** : PXIe-5820/5830/5831/5832/5840/5841/5842'
+            'description': '\nConfigures the start location of the burst in samples where the burst refers to the active portion of a waveform.\n\n**Supported Devices** : PXIe-5820/5830/5831/5832/5840/5841/5842'
         },
         'included_in_proto': True,
         'method_templates': [
@@ -5279,69 +5078,6 @@ functions = {
                 'name': 'maxTimeMilliseconds',
                 'type': 'ViInt32',
                 'use_array': False,
-                'use_in_python_api': True
-            }
-        ],
-        'returns': 'ViStatus'
-    },
-    'WriteP2PEndpointI16': {
-        'codegen_method': 'public',
-        'documentation': {
-            'description': '\nWrites an array of 16-bit integer data to the peer-to-peer endpoint.\n\nUse this function to write initial data from the host to the endpoint before starting generation to avoid an underflow when you start the generation.\n\n**Supported Devices** : PXIe-5673E\n\n**Related Topics**\n\n`Peer-to-Peer Data Streaming <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_streaming.html>`_--Refer to this topic for more information about configuring a stream.\n\n`Configuring Flow Control <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_flow_control.html>`_\n\n`Starting Peer-to-Peer Generation <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_starting_generation.html>`_\n\n`Reconfiguring a Stream <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/p2p_reconfiguring_stream.html>`_'
-        },
-        'included_in_proto': True,
-        'method_templates': [
-            {
-                'documentation_filename': 'default_method',
-                'library_interpreter_filename': 'default_method',
-                'method_python_name_suffix': '',
-                'session_filename': 'default_method'
-            }
-        ],
-        'parameters': [
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies your instrument session. The ViSession handle is obtained from the nirfsg_Init function or the nirfsg_InitWithOptions function and identifies a particular instrument session.'
-                },
-                'name': 'vi',
-                'type': 'ViSession',
-                'use_array': False,
-                'use_in_python_api': True
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Specifies the stream endpoint FIFO to configure.'
-                },
-                'name': 'streamEndpoint',
-                'type': 'ViConstString',
-                'use_array': False,
-                'use_in_python_api': True
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Specifies the number of samples to write into the endpoint FIFO.'
-                },
-                'name': 'numberOfSamples',
-                'type': 'ViInt32',
-                'use_array': False,
-                'use_in_python_api': True
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Specifies the array of data to write into the endpoint FIFO. The binary data is left-justified.'
-                },
-                'name': 'endpointData',
-                'numpy': True,
-                'size': {
-                    'mechanism': 'passed-in',
-                    'value': 'numberOfSamples'
-                },
-                'type': 'ViInt16[]',
-                'use_array': True,
                 'use_in_python_api': True
             }
         ],

--- a/src/nirfsg/system_tests/test_system_nirfsg.py
+++ b/src/nirfsg/system_tests/test_system_nirfsg.py
@@ -164,7 +164,7 @@ class SystemTests:
         trigger.exported_script_trigger_output_terminal = requested_terminal_name
         assert trigger.exported_script_trigger_output_terminal == requested_terminal_name
 
-    def test_waveform_rep_cap(self, rfsg_device_session):
+    def test_waveforms_rep_cap(self, rfsg_device_session):
         rfsg_device_session.generation_mode = nirfsg.GenerationMode.ARB_WAVEFORM
         waveform_data = np.full(1000, 1 + 0j, dtype=np.complex128)
         rfsg_device_session.write_arb_waveform('mywaveform', waveform_data, False)
@@ -172,12 +172,12 @@ class SystemTests:
         rfsg_device_session.waveforms['mywaveform'].waveform_iq_rate = requested_waveform_iq_rate
         assert rfsg_device_session.waveforms['mywaveform'].waveform_iq_rate == requested_waveform_iq_rate
 
-    def test_port_rep_cap(self, simulated_5831_device_session):
+    def test_ports_rep_cap(self, simulated_5831_device_session):
         requested_deembedding_type = nirfsg.DeembeddingType.SCALAR
         simulated_5831_device_session.ports['if1'].deembedding_type = requested_deembedding_type
         assert simulated_5831_device_session.ports['if1'].deembedding_type == requested_deembedding_type
 
-    def test_lo_rep_cap(self, simulated_5831_device_session):
+    def test_lo_channels_rep_cap(self, simulated_5831_device_session):
         requested_lo_source = "SG_SA_Shared"
         simulated_5831_device_session.lo_channels[2].lo_source = requested_lo_source
         assert simulated_5831_device_session.lo_channels[2].lo_source == requested_lo_source

--- a/src/nirfsg/system_tests/test_system_nirfsg.py
+++ b/src/nirfsg/system_tests/test_system_nirfsg.py
@@ -537,8 +537,8 @@ class SystemTests:
 
     @pytest.mark.skipif(sys.platform == "linux", reason="Function not supported on Linux OS")
     def test_deembedding_table_with_s2p_file(self, rfsg_device_session):
-        rfsg_device_session.create_deembedding_sparameter_table_s2p_file('', 'myTable1', get_test_file_path('samples2pfile.s2p'), nirfsg.SparameterOrientation.PORT2)
-        rfsg_device_session.create_deembedding_sparameter_table_s2p_file('', 'myTable2', get_test_file_path('samples2pfile.s2p'), nirfsg.SparameterOrientation.PORT1)
+        rfsg_device_session.create_deembedding_sparameter_table_s2p_file('', 'myTable1', get_test_file_path('samples2pfile.s2p'), nirfsg.SparameterOrientation.PORT2_TOWARDS_DUT)
+        rfsg_device_session.create_deembedding_sparameter_table_s2p_file('', 'myTable2', get_test_file_path('samples2pfile.s2p'), nirfsg.SparameterOrientation.PORT1_TOWARDS_DUT)
         rfsg_device_session.configure_deembedding_table_interpolation_linear('', 'myTable1', nirfsg.Format.MAGNITUDE_AND_PHASE)
         rfsg_device_session.ports[''].deembedding_selected_table = 'myTable1'
         with rfsg_device_session.initiate():

--- a/src/nirfsg/system_tests/test_system_nirfsg.py
+++ b/src/nirfsg/system_tests/test_system_nirfsg.py
@@ -169,18 +169,18 @@ class SystemTests:
         waveform_data = np.full(1000, 1 + 0j, dtype=np.complex128)
         rfsg_device_session.write_arb_waveform('mywaveform', waveform_data, False)
         requested_waveform_iq_rate = 1e6
-        rfsg_device_session.waveform['mywaveform'].waveform_iq_rate = requested_waveform_iq_rate
-        assert rfsg_device_session.waveform['mywaveform'].waveform_iq_rate == requested_waveform_iq_rate
+        rfsg_device_session.waveforms['mywaveform'].waveform_iq_rate = requested_waveform_iq_rate
+        assert rfsg_device_session.waveforms['mywaveform'].waveform_iq_rate == requested_waveform_iq_rate
 
     def test_port_rep_cap(self, simulated_5831_device_session):
-        requested_deembedding_type = nirfsg.DeembeddingTypeAttrVals.SCALAR
-        simulated_5831_device_session.port['if1'].deembedding_type = requested_deembedding_type
-        assert simulated_5831_device_session.port['if1'].deembedding_type == requested_deembedding_type
+        requested_deembedding_type = nirfsg.DeembeddingType.SCALAR
+        simulated_5831_device_session.ports['if1'].deembedding_type = requested_deembedding_type
+        assert simulated_5831_device_session.ports['if1'].deembedding_type == requested_deembedding_type
 
     def test_lo_rep_cap(self, simulated_5831_device_session):
         requested_lo_source = "SG_SA_Shared"
-        simulated_5831_device_session.lo[2].lo_source = requested_lo_source
-        assert simulated_5831_device_session.lo[2].lo_source == requested_lo_source
+        simulated_5831_device_session.lo_channels[2].lo_source = requested_lo_source
+        assert simulated_5831_device_session.lo_channels[2].lo_source == requested_lo_source
 
 # Configuration methods related tests
     def test_configure_rf(self, rfsg_device_session):
@@ -279,10 +279,10 @@ class SystemTests:
         rfsg_device_session.write_arb_waveform('mywaveform1', waveform_data, False)
         startlocations = [1, 100, 200]
         stoplocations = [50, 175, 750]
-        rfsg_device_session.waveform['mywaveform1'].set_waveform_burst_start_locations(startlocations)
-        rfsg_device_session.waveform['mywaveform1'].set_waveform_burst_stop_locations(stoplocations)
-        startlocations_out = rfsg_device_session.waveform['mywaveform1'].get_waveform_burst_start_locations()
-        stoplocations_out = rfsg_device_session.waveform['mywaveform1'].get_waveform_burst_stop_locations()
+        rfsg_device_session.waveforms['mywaveform1'].set_waveform_burst_start_locations(startlocations)
+        rfsg_device_session.waveforms['mywaveform1'].set_waveform_burst_stop_locations(stoplocations)
+        startlocations_out = rfsg_device_session.waveforms['mywaveform1'].get_waveform_burst_start_locations()
+        stoplocations_out = rfsg_device_session.waveforms['mywaveform1'].get_waveform_burst_stop_locations()
         assert startlocations_out == startlocations
         assert stoplocations_out == stoplocations
 
@@ -291,8 +291,8 @@ class SystemTests:
         waveform_data = np.full(1000, 1 + 0j, dtype=np.complex128)
         rfsg_device_session.write_arb_waveform('mywaveform1', waveform_data, False)
         markerlocations = [1, 100, 200]
-        rfsg_device_session.waveform['mywaveform1'].markers[0].set_waveform_marker_event_locations(markerlocations)
-        markerlocations_out = rfsg_device_session.waveform['mywaveform1'].markers[0].get_waveform_marker_event_locations()
+        rfsg_device_session.waveforms['mywaveform1'].markers[0].set_waveform_marker_event_locations(markerlocations)
+        markerlocations_out = rfsg_device_session.waveforms['mywaveform1'].markers[0].get_waveform_marker_event_locations()
         assert markerlocations_out == markerlocations
 
     def test_write_script(self, rfsg_device_session):
@@ -540,11 +540,11 @@ class SystemTests:
         rfsg_device_session.create_deembedding_sparameter_table_s2p_file('', 'myTable1', get_test_file_path('samples2pfile.s2p'), nirfsg.SparameterOrientation.PORT2)
         rfsg_device_session.create_deembedding_sparameter_table_s2p_file('', 'myTable2', get_test_file_path('samples2pfile.s2p'), nirfsg.SparameterOrientation.PORT1)
         rfsg_device_session.configure_deembedding_table_interpolation_linear('', 'myTable1', nirfsg.Format.MAGNITUDE_AND_PHASE)
-        rfsg_device_session.port[''].deembedding_selected_table = 'myTable1'
+        rfsg_device_session.ports[''].deembedding_selected_table = 'myTable1'
         with rfsg_device_session.initiate():
             rfsg_device_session.check_generation_status()
         rfsg_device_session.delete_deembedding_table('', 'myTable1')
-        rfsg_device_session.port[''].deembedding_selected_table = 'myTable2'
+        rfsg_device_session.ports[''].deembedding_selected_table = 'myTable2'
         with rfsg_device_session.initiate():
             rfsg_device_session.check_generation_status()
         rfsg_device_session.delete_all_deembedding_tables()
@@ -554,7 +554,7 @@ class SystemTests:
         except nirfsg.Error as e:
             assert e.code == -1074097772
             assert 'The specified de-embedding table cannot be found' in e.description
-        rfsg_device_session.port[''].deembedding_selected_table = ''
+        rfsg_device_session.ports[''].deembedding_selected_table = ''
         with rfsg_device_session.initiate():
             rfsg_device_session.check_generation_status()
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [ ] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?
- Enables intflag parameter for self_calibrate_range and adds reset_with_options method
  - Overriding doc_tip for stepsToOmit parameter to call out Bitwise input (this should be done in codegen itself in the future)
- Expands shortened terms in enum names to full terms
- Adds lo_channels repeated capability and changed deembedding_port into ports repcap since ports is used by API other then deembedding as well
  - Marks relevant attributes with the same
- Makes waveform repcap name plural to align with repcap naming policy
- Fixes few enum values and documentation snippets
- Removes few enums that are not used by any attribute or function
- Ensures all method description start with \n consistently
- Removes p2p related methods, enums, enum values and attributes
- Removes leftover configuration list related enum values
- Removes few missed configuration list related enums (list mode API will not be supported for 1st release)
- Makes script trigger configuration methods to have triggerID as repeated capability
- Removes methods which are configuring just one attribute
  - Removes references to these in documentation

### List issues fixed by this Pull Request below, if any.
None

### What testing has been done?
System tests for newly added API and updated enum names all pass on simulated and real hardware.
