### PR TITLE
Enable deembedding methods and more misc changes

### DIFF
--- a/docs/nirfsg/class.rst
+++ b/docs/nirfsg/class.rst
@@ -1223,6 +1223,81 @@ configure_software_start_trigger
 
 
 
+create_deembedding_sparameter_table_array
+-----------------------------------------
+
+    .. py:currentmodule:: nirfsg.Session
+
+    .. py:method:: create_deembedding_sparameter_table_array(port, table_name, frequencies, sparameter_table, sparameter_orientation)
+
+            Creates an s-parameter de-embedding table for the port from the input data.
+
+            If you only create one table for a port, NI-RFSA automatically selects that table to de-embed the measurement.
+
+            **Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860
+
+            **Related Topics**
+
+            `De-embedding Overview <https://www.ni.com/docs/en-US/bundle/pxie-5840/page/de-embedding-overview.html>`_
+
+            
+
+
+
+            :param port:
+
+
+                Specifies the name of the port. The only valid value for the PXIe-5840/5841/5842/5860 is "" (empty string).
+
+                
+
+
+            :type port: str
+            :param table_name:
+
+
+                Specifies the name of the table. The name must be unique for a given port, but not across ports. If you use the same name as an existing table, the table is replaced.
+
+                
+
+
+            :type table_name: str
+            :param frequencies:
+
+
+                Specifies the frequencies for the :py:attr:`nirfsg.Session.SPARAMETER_TABLE` rows. Frequencies must be unique and in ascending order.
+
+                
+
+                .. note:: One or more of the referenced properties are not in the Python API for this driver.
+
+
+            :type frequencies: numpy.array(dtype=numpy.float64)
+            :param sparameter_table:
+
+
+                Specifies the S-parameters for each frequency. S-parameters for each frequency are placed in the array in the following order: s11, s12, s21, s22.
+
+                
+
+
+            :type sparameter_table: numpy.array(dtype=numpy.complex128)
+            :param sparameter_orientation:
+
+
+                Specifies the orientation of the input data relative to the port on the DUT port. **Defined Values** :
+
+                +------------------------------------------------------------+----------------+-----------------------------------------------------+
+                | Name                                                       | Value          | Description                                         |
+                +============================================================+================+=====================================================+
+                | :py:data:`~nirfsg.SparameterOrientation.PORT1_TOWARDS_DUT` | 24000 (0x5dc0) | Port 1 of the S2P is oriented towards the DUT port. |
+                +------------------------------------------------------------+----------------+-----------------------------------------------------+
+                | :py:data:`~nirfsg.SparameterOrientation.PORT2_TOWARDS_DUT` | 24001 (0x5dc1) | Port 2 of the S2P is oriented towards the DUT port. |
+                +------------------------------------------------------------+----------------+-----------------------------------------------------+
+
+
+            :type sparameter_orientation: :py:data:`nirfsg.SparameterOrientation`
+
 create_deembedding_sparameter_table_s2p_file
 --------------------------------------------
 
@@ -1481,121 +1556,6 @@ error_query
 
 
 
-export_signal
--------------
-
-    .. py:currentmodule:: nirfsg.Session
-
-    .. py:method:: export_signal(signal, signal_identifier, output_terminal)
-
-            Routes signals (triggers, clocks, and events) to a specified output terminal.
-
-            The NI-RFSG device must be in the Configuration state before you call this method.
-
-            You can clear a previously routed signal by exporting the signal to "" (empty string).
-
-            **Supported Devices** :PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
-
-            **Related Topics**
-
-            `Triggers <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/triggers.html>`_
-
-            `Events <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/events.html>`_
-
-            `PFI Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pfi_lines.html>`_
-
-            `PXI Trigger Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pxi_trigger.html>`_
-
-            
-
-
-
-            :param signal:
-
-
-                Specifies the type of signal to route.
-
-                 **Defined Values** :
-
-                +---------------------------------------------------------------+---------+--------------------------------------------+
-                | Name                                                          | Value   | Description                                |
-                +===============================================================+=========+============================================+
-                | :py:data:`~nirfsg.Signal.START_TRIGGER`                       | 0 (0x0) | Exports a Start Trigger.                   |
-                +---------------------------------------------------------------+---------+--------------------------------------------+
-                | :py:data:`~nirfsg.Signal.SCRIPT_TRIGGER`                      | 1 (0x1) | Exports a Script Trigger.                  |
-                +---------------------------------------------------------------+---------+--------------------------------------------+
-                | :py:data:`~nirfsg.Signal.MARKER_EVENT`                        | 2 (0x2) | Exports a Marker Event.                    |
-                +---------------------------------------------------------------+---------+--------------------------------------------+
-                | :py:data:`~nirfsg.Signal.REF_CLOCK`                           | 3 (0x3) | Exports the Reference Clock.               |
-                +---------------------------------------------------------------+---------+--------------------------------------------+
-                | :py:data:`~nirfsg.Signal.STARTED_EVENT`                       | 4 (0x4) | Exports a Started Event.                   |
-                +---------------------------------------------------------------+---------+--------------------------------------------+
-                | :py:data:`~nirfsg.Signal.DONE_EVENT`                          | 5 (0x5) | Exports a Done Event.                      |
-                +---------------------------------------------------------------+---------+--------------------------------------------+
-                | :py:data:`~nirfsg.NIRFSG_VAL_CONFIGURATION_LIST_STEP_TRIGGER` | 6 (0x6) | Exports a Configuration List Step Trigger. |
-                +---------------------------------------------------------------+---------+--------------------------------------------+
-                | :py:data:`~nirfsg.NIRFSG_VAL_CONFIGURATION_SETTLED_EVENT`     | 7 (0x7) | Exports a Configuration Settled Event.     |
-                +---------------------------------------------------------------+---------+--------------------------------------------+
-
-                .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
-
-
-            :type signal: :py:data:`nirfsg.Signal`
-            :param signal_identifier:
-
-
-                Specifies which instance of the selected signal to export. This parameter is useful when you set the :py:attr:`nirfsg.Session.SIGNAL` parameter to :py:data:`~nirfsg.NIRFSG_VAL_SCRIPT_TRIGGER` or :py:data:`~nirfsg.Signal.MARKER_EVENT`. Otherwise, set the :py:attr:`nirfsg.Session.SIGNAL_IDENTIFIER` parameter to "".
-
-                **Possible Values** :
-
-                +------------------+-----------------------------+
-                | Possible Value   | Description                 |
-                +==================+=============================+
-                | "marker0"        | Specifies Marker 0.         |
-                +------------------+-----------------------------+
-                | "marker1"        | Specifies Marker 1.         |
-                +------------------+-----------------------------+
-                | "marker2"        | Specifies Marker 2.         |
-                +------------------+-----------------------------+
-                | "marker3"        | Specifies Marker 3.         |
-                +------------------+-----------------------------+
-                | "scriptTrigger0" | Specifies Script Trigger 0. |
-                +------------------+-----------------------------+
-                | "scriptTrigger1" | Specifies Script Trigger 1. |
-                +------------------+-----------------------------+
-                | "scriptTrigger2" | Specifies Script Trigger 2. |
-                +------------------+-----------------------------+
-                | "scriptTrigger3" | Specifies Script Trigger 3. |
-                +------------------+-----------------------------+
-
-                .. note:: One or more of the referenced properties are not in the Python API for this driver.
-
-                .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
-
-
-            :type signal_identifier: str
-            :param output_terminal:
-
-
-                Specifies the terminal where the signal is exported. You can choose not to export any signal. For the PXIe-5841 with PXIe-5655, the signal is exported to the terminal on the PXIe-5841.
-
-                 **Possible Values** :
-
-                +----------------+--------------------------------------------------------------------------------------------+
-                | Possible Value | Description                                                                                |
-                +================+============================================================================================+
-                | "ClkOut"       | Exports the Reference Clock signal to the CLK OUT connector of the device.                 |
-                +----------------+--------------------------------------------------------------------------------------------+
-                | ""             | The Reference Clock signal is not exported.                                                |
-                +----------------+--------------------------------------------------------------------------------------------+
-                | "RefOut"       | Exports the Reference Clock signal to the REF OUT connector of the device.                 |
-                +----------------+--------------------------------------------------------------------------------------------+
-                | "RefOut2"      | Exports the Reference Clock signal to the REF OUT2 connector of the device, if applicable. |
-                +----------------+--------------------------------------------------------------------------------------------+
-
-
-            :type output_terminal: str
-
 get_all_named_waveform_names
 ----------------------------
 
@@ -1706,6 +1666,60 @@ get_channel_name
 
 
                     Returns a channel string from the channel table at the index you specify in the Index parameter. Do not modify the contents of the channel string.
+
+                    
+
+
+
+get_deembedding_sparameters
+---------------------------
+
+    .. py:currentmodule:: nirfsg.Session
+
+    .. py:method:: get_deembedding_sparameters(sparameter_array_size)
+
+            Returns the S-parameters used for de-embedding a measurement on the selected port.
+
+            This includes interpolation of the parameters based on the configured carrier frequency. This method returns an empty array if no de-embedding is done.
+
+            If you want to call this method just to get the required buffer size, you can pass 0 for **S-parameter Size** and VI_NULL for the **S-parameters** buffer.
+
+            **Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860
+
+            **Note**: The port orientation for the returned S-parameters is normalized to :py:data:`~nirfsg.SparameterOrientation.PORT1_TOWARDS_DUT`.
+
+            
+
+
+
+            :param sparameter_array_size:
+
+
+                Specifies the size of the array that is returned by the :py:attr:`nirfsg.Session.SPARAMETERS` output.
+
+                
+
+                .. note:: One or more of the referenced properties are not in the Python API for this driver.
+
+
+            :type sparameter_array_size: int
+
+            :rtype: tuple (sparameters, number_of_ports)
+
+                WHERE
+
+                sparameters (list of NIComplexNumber): 
+
+
+                    Returns an array of S-parameters. The S-parameters are returned in the following order: s11, s12, s21, s22.
+
+                    
+
+
+                number_of_ports (int): 
+
+
+                    Returns the number of S-parameter ports. The **sparameter** array is always *n* x *n*, where span *n* is the number of ports.
 
                     
 
@@ -5405,26 +5419,26 @@ device_temperature
         +----------------------------+--------------------------+-------------------------+
 
 
-        .. tip:: This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container ports to specify a subset.
+        .. tip:: This property can be set/get on specific device_temperatures within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container device_temperatures to specify a subset.
 
-            Example: :py:attr:`my_session.ports[ ... ].device_temperature`
+            Example: :py:attr:`my_session.device_temperatures[ ... ].device_temperature`
 
-            To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all device_temperatures, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.device_temperature`
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+-----------+
-            | Characteristic        | Value     |
-            +=======================+===========+
-            | Datatype              | float     |
-            +-----------------------+-----------+
-            | Permissions           | read only |
-            +-----------------------+-----------+
-            | Repeated Capabilities | ports     |
-            +-----------------------+-----------+
+            +-----------------------+---------------------+
+            | Characteristic        | Value               |
+            +=======================+=====================+
+            | Datatype              | float               |
+            +-----------------------+---------------------+
+            | Permissions           | read only           |
+            +-----------------------+---------------------+
+            | Repeated Capabilities | device_temperatures |
+            +-----------------------+---------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -6457,10 +6471,6 @@ exported_done_event_output_terminal
 
         `PXI Trigger Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pxi_trigger.html>`_
 
-        **High-Level Methods**:
-
-        - :py:meth:`nirfsg.Session.export_signal`
-
         **Possible Values**:
 
         +---------------+---------------------------------------------------------------------------------------------------------------------------------+
@@ -6543,10 +6553,6 @@ exported_marker_event_output_terminal
         `PFI Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pfi_lines.html>`_
 
         `PXI Trigger Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pxi_trigger.html>`_
-
-        **High-Level Methods**:
-
-        - :py:meth:`nirfsg.Session.export_signal`
 
         **Possible Values**:
 
@@ -6821,10 +6827,6 @@ exported_script_trigger_output_terminal
 
         `PXI Trigger Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pxi_trigger.html>`_
 
-        **High-Level Methods**:
-
-        - :py:meth:`nirfsg.Session.export_signal`
-
         **Possible Values**:
 
         +----------------+---------------------------------------------------------------------------------------------------------------------------------+
@@ -6917,10 +6919,6 @@ exported_started_event_output_terminal
         `PFI Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pfi_lines.html>`_
 
         `PXI Trigger Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pxi_trigger.html>`_
-
-        **High-Level Methods**:
-
-        - :py:meth:`nirfsg.Session.export_signal`
 
         **Possible Values**:
 
@@ -8041,7 +8039,7 @@ iq_out_port_common_mode_offset
 
     .. py:attribute:: iq_out_port_common_mode_offset
 
-        Specifies the common-mode offset applied to the signals generated at each differential output terminal. This property applies only when you set the :py:attr:`nirfsg.Session.iq_out_port_terminal_configuration` property to :py:data:`~nirfsg.IQOutPortTermCfg.DIFFERENTIAL`. Common-mode offset shifts both positive and negative terminals in the same direction.
+        Specifies the common-mode offset applied to the signals generated at each differential output terminal. This property applies only when you set the :py:attr:`nirfsg.Session.iq_out_port_terminal_configuration` property to :py:data:`~nirfsg.IQOutPortTerminalConfiguration.DIFFERENTIAL`. Common-mode offset shifts both positive and negative terminals in the same direction.
 
         To use this property, you must use the channelName parameter of the :py:meth:`nirfsg.Session._set_attribute_vi_real64` method to specify the name of the channel you are configuring. For the PXIe-5645, you can configure the I and Q channels by using I or Q as the channel string, or set the channel string to "" (empty string) to configure both channels. For the PXIe-5820, the only valid value for the channel string is "" (empty string).
 
@@ -8064,12 +8062,12 @@ iq_out_port_common_mode_offset
              - The valid range is dependent on the load impedance.
 
 
-        .. tip:: This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container ports to specify a subset.
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
 
-            Example: :py:attr:`my_session.ports[ ... ].iq_out_port_common_mode_offset`
+            Example: :py:attr:`my_session.channels[ ... ].iq_out_port_common_mode_offset`
 
-            To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all channels, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.iq_out_port_common_mode_offset`
 
@@ -8082,7 +8080,7 @@ iq_out_port_common_mode_offset
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | ports      |
+            | Repeated Capabilities | channels   |
             +-----------------------+------------+
 
         .. tip::
@@ -8108,9 +8106,9 @@ iq_out_port_level
 
         **Valid Values:**
 
-        PXIe-5645: 1V :sub:`pk-pk`  maximum if you set the :py:attr:`nirfsg.Session.iq_out_port_terminal_configuration` property to :py:data:`~nirfsg.IQOutPortTermCfg.DIFFERENTIAL`, and 0.5V :sub:`pk-pk`
+        PXIe-5645: 1V :sub:`pk-pk`  maximum if you set the :py:attr:`nirfsg.Session.iq_out_port_terminal_configuration` property to :py:data:`~nirfsg.IQOutPortTerminalConfiguration.DIFFERENTIAL`, and 0.5V :sub:`pk-pk`
 
-        maximum if you set the :py:attr:`nirfsg.Session.iq_out_port_terminal_configuration` property to :py:data:`~nirfsg.IQOutPortTermCfg.SINGLE_ENDED`.
+        maximum if you set the :py:attr:`nirfsg.Session.iq_out_port_terminal_configuration` property to :py:data:`~nirfsg.IQOutPortTerminalConfiguration.SINGLE_ENDED`.
 
         PXIe-5820: 3.4V :sub:`pk-pk` maximum for signal bandwidth less than 160MHz, and 2V :sub:`pk-pk`
 
@@ -8127,12 +8125,12 @@ iq_out_port_level
              - The valid values are only applicable when you set the :py:attr:`nirfsg.Session.iq_out_port_load_impedance` property to 50 Ω and when you set the :py:attr:`nirfsg.Session.iq_out_port_offset` property to 0.
 
 
-        .. tip:: This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container ports to specify a subset.
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
 
-            Example: :py:attr:`my_session.ports[ ... ].iq_out_port_level`
+            Example: :py:attr:`my_session.channels[ ... ].iq_out_port_level`
 
-            To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all channels, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.iq_out_port_level`
 
@@ -8145,7 +8143,7 @@ iq_out_port_level
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | ports      |
+            | Repeated Capabilities | channels   |
             +-----------------------+------------+
 
         .. tip::
@@ -8167,7 +8165,7 @@ iq_out_port_load_impedance
 
         **Valid Values:** Any value greater than 0. Values greater than or equal to 1 megaohms (MΩ) are interpreted as high impedance.
 
-        **Default Value:** 50 Ω if you set the :py:attr:`nirfsg.Session.iq_out_port_terminal_configuration` property to :py:data:`~nirfsg.IQOutPortTermCfg.SINGLE_ENDED`, and 100 Ω if you set the :py:attr:`nirfsg.Session.iq_out_port_terminal_configuration` property to :py:data:`~nirfsg.IQOutPortTermCfg.DIFFERENTIAL`.
+        **Default Value:** 50 Ω if you set the :py:attr:`nirfsg.Session.iq_out_port_terminal_configuration` property to :py:data:`~nirfsg.IQOutPortTerminalConfiguration.SINGLE_ENDED`, and 100 Ω if you set the :py:attr:`nirfsg.Session.iq_out_port_terminal_configuration` property to :py:data:`~nirfsg.IQOutPortTerminalConfiguration.DIFFERENTIAL`.
 
         **Supported Devices:** PXIe-5645, PXIe-5820
 
@@ -8176,12 +8174,12 @@ iq_out_port_load_impedance
         .. note:: For the PXIe-5645, this property is ignored if you are using the RF ports.
 
 
-        .. tip:: This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container ports to specify a subset.
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
 
-            Example: :py:attr:`my_session.ports[ ... ].iq_out_port_load_impedance`
+            Example: :py:attr:`my_session.channels[ ... ].iq_out_port_load_impedance`
 
-            To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all channels, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.iq_out_port_load_impedance`
 
@@ -8194,7 +8192,7 @@ iq_out_port_load_impedance
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | ports      |
+            | Repeated Capabilities | channels   |
             +-----------------------+------------+
 
         .. tip::
@@ -8225,12 +8223,12 @@ iq_out_port_offset
         .. note:: For the PXIe-5645, this property is ignored if you are using the RF ports.
 
 
-        .. tip:: This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container ports to specify a subset.
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
 
-            Example: :py:attr:`my_session.ports[ ... ].iq_out_port_offset`
+            Example: :py:attr:`my_session.channels[ ... ].iq_out_port_offset`
 
-            To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all channels, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.iq_out_port_offset`
 
@@ -8243,7 +8241,7 @@ iq_out_port_offset
             +-----------------------+------------+
             | Permissions           | read-write |
             +-----------------------+------------+
-            | Repeated Capabilities | ports      |
+            | Repeated Capabilities | channels   |
             +-----------------------+------------+
 
         .. tip::
@@ -8290,17 +8288,17 @@ iq_out_port_terminal_configuration
 
     .. py:attribute:: iq_out_port_terminal_configuration
 
-        Specifies whether to use the I/Q OUT port for differential configuration or single-ended configuration. If you set this property to :py:data:`~nirfsg.IQOutPortTermCfg.SINGLE_ENDED`, you must terminate the negative I and Q output connectors with a 50 Ohm termination.
+        Specifies whether to use the I/Q OUT port for differential configuration or single-ended configuration. If you set this property to :py:data:`~nirfsg.IQOutPortTerminalConfiguration.SINGLE_ENDED`, you must terminate the negative I and Q output connectors with a 50 Ohm termination.
 
-        If you set this property to :py:data:`~nirfsg.IQOutPortTermCfg.SINGLE_ENDED`, the positive I and Q connectors generate the resulting waveform. If you set this property to :py:data:`~nirfsg.IQOutPortTermCfg.DIFFERENTIAL`, both the positive and negative I and Q connectors generate the resulting waveform.
+        If you set this property to :py:data:`~nirfsg.IQOutPortTerminalConfiguration.SINGLE_ENDED`, the positive I and Q connectors generate the resulting waveform. If you set this property to :py:data:`~nirfsg.IQOutPortTerminalConfiguration.DIFFERENTIAL`, both the positive and negative I and Q connectors generate the resulting waveform.
 
         To use this property, you must use the channelName parameter of the :py:meth:`nirfsg.Session._set_attribute_vi_int32` method to specify the name of the channel you are configuring. For the PXIe-5645, you can configure the I and Q channels by using I or Q as the channel string, or set the channel string to "" (empty string) to configure both channels. For the PXIe-5820, the only valid value for the channel string is "" (empty string).
 
         To set this property, the NI-RFSG device must be in the Configuration state.
 
-        **Default Value:** :py:data:`~nirfsg.IQOutPortTermCfg.DIFFERENTIAL`
+        **Default Value:** :py:data:`~nirfsg.IQOutPortTerminalConfiguration.DIFFERENTIAL`
 
-        PXIe-5820: The only valid value for this property is :py:data:`~nirfsg.IQOutPortTermCfg.DIFFERENTIAL`.
+        PXIe-5820: The only valid value for this property is :py:data:`~nirfsg.IQOutPortTerminalConfiguration.DIFFERENTIAL`.
 
         **Supported Devices:** PXIe-5645, PXIe-5820
 
@@ -8310,37 +8308,37 @@ iq_out_port_terminal_configuration
 
         **Defined Values**:
 
-        +--------------------------------------------------+----------------+--------------------------------------------------+
-        | Name                                             | Value          | Description                                      |
-        +==================================================+================+==================================================+
-        | :py:data:`~nirfsg.IQOutPortTermCfg.DIFFERENTIAL` | 15000 (0x3a98) | Sets the terminal configuration to differential. |
-        +--------------------------------------------------+----------------+--------------------------------------------------+
-        | :py:data:`~nirfsg.IQOutPortTermCfg.SINGLE_ENDED` | 15001 (0x3a99) | Sets the terminal configuration to single-ended. |
-        +--------------------------------------------------+----------------+--------------------------------------------------+
+        +----------------------------------------------------------------+----------------+--------------------------------------------------+
+        | Name                                                           | Value          | Description                                      |
+        +================================================================+================+==================================================+
+        | :py:data:`~nirfsg.IQOutPortTerminalConfiguration.DIFFERENTIAL` | 15000 (0x3a98) | Sets the terminal configuration to differential. |
+        +----------------------------------------------------------------+----------------+--------------------------------------------------+
+        | :py:data:`~nirfsg.IQOutPortTerminalConfiguration.SINGLE_ENDED` | 15001 (0x3a99) | Sets the terminal configuration to single-ended. |
+        +----------------------------------------------------------------+----------------+--------------------------------------------------+
 
         .. note:: For the PXIe-5645, this property is ignored if you are using the RF ports.
 
 
-        .. tip:: This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container ports to specify a subset.
+        .. tip:: This property can be set/get on specific channels within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container channels to specify a subset.
 
-            Example: :py:attr:`my_session.ports[ ... ].iq_out_port_terminal_configuration`
+            Example: :py:attr:`my_session.channels[ ... ].iq_out_port_terminal_configuration`
 
-            To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all channels, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.iq_out_port_terminal_configuration`
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+------------------------+
-            | Characteristic        | Value                  |
-            +=======================+========================+
-            | Datatype              | enums.IQOutPortTermCfg |
-            +-----------------------+------------------------+
-            | Permissions           | read-write             |
-            +-----------------------+------------------------+
-            | Repeated Capabilities | ports                  |
-            +-----------------------+------------------------+
+            +-----------------------+--------------------------------------+
+            | Characteristic        | Value                                |
+            +=======================+======================================+
+            | Datatype              | enums.IQOutPortTerminalConfiguration |
+            +-----------------------+--------------------------------------+
+            | Permissions           | read-write                           |
+            +-----------------------+--------------------------------------+
+            | Repeated Capabilities | channels                             |
+            +-----------------------+--------------------------------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -8685,12 +8683,12 @@ loop_bandwidth
         .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
 
-        .. tip:: This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
+        .. tip:: This property can be set/get on specific los within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container los to specify a subset.
 
-            Example: :py:attr:`my_session.lo_channels[ ... ].loop_bandwidth`
+            Example: :py:attr:`my_session.los[ ... ].loop_bandwidth`
 
-            To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all los, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.loop_bandwidth`
 
@@ -8703,7 +8701,7 @@ loop_bandwidth
             +-----------------------+---------------------+
             | Permissions           | read-write          |
             +-----------------------+---------------------+
-            | Repeated Capabilities | lo_channels         |
+            | Repeated Capabilities | los                 |
             +-----------------------+---------------------+
 
         .. tip::
@@ -8734,26 +8732,26 @@ lo_frequency
         .. note:: This property is read/write if you are using an external LO. Otherwise, this property is read-only.
 
 
-        .. tip:: This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
+        .. tip:: This property can be set/get on specific los within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container los to specify a subset.
 
-            Example: :py:attr:`my_session.lo_channels[ ... ].lo_frequency`
+            Example: :py:attr:`my_session.los[ ... ].lo_frequency`
 
-            To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all los, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.lo_frequency`
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+-------------+
-            | Characteristic        | Value       |
-            +=======================+=============+
-            | Datatype              | float       |
-            +-----------------------+-------------+
-            | Permissions           | read-write  |
-            +-----------------------+-------------+
-            | Repeated Capabilities | lo_channels |
-            +-----------------------+-------------+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | los        |
+            +-----------------------+------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -8859,26 +8857,26 @@ lo_in_power
              - For the PXIe-5644/5645/5646, this property is always read-only.
 
 
-        .. tip:: This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
+        .. tip:: This property can be set/get on specific los within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container los to specify a subset.
 
-            Example: :py:attr:`my_session.lo_channels[ ... ].lo_in_power`
+            Example: :py:attr:`my_session.los[ ... ].lo_in_power`
 
-            To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all los, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.lo_in_power`
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+-------------+
-            | Characteristic        | Value       |
-            +=======================+=============+
-            | Datatype              | float       |
-            +-----------------------+-------------+
-            | Permissions           | read-write  |
-            +-----------------------+-------------+
-            | Repeated Capabilities | lo_channels |
-            +-----------------------+-------------+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | los        |
+            +-----------------------+------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -8916,26 +8914,26 @@ lo_out_enabled
         .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
 
-        .. tip:: This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
+        .. tip:: This property can be set/get on specific los within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container los to specify a subset.
 
-            Example: :py:attr:`my_session.lo_channels[ ... ].lo_out_enabled`
+            Example: :py:attr:`my_session.los[ ... ].lo_out_enabled`
 
-            To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all los, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.lo_out_enabled`
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+-------------+
-            | Characteristic        | Value       |
-            +=======================+=============+
-            | Datatype              | bool        |
-            +-----------------------+-------------+
-            | Permissions           | read-write  |
-            +-----------------------+-------------+
-            | Repeated Capabilities | lo_channels |
-            +-----------------------+-------------+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | bool       |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | los        |
+            +-----------------------+------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -9008,26 +9006,26 @@ lo_out_power
         .. note:: For the PXIe-5644/5645/5646 and PXIe-5673/5673E, this property is always read-only.
 
 
-        .. tip:: This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
+        .. tip:: This property can be set/get on specific los within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container los to specify a subset.
 
-            Example: :py:attr:`my_session.lo_channels[ ... ].lo_out_power`
+            Example: :py:attr:`my_session.los[ ... ].lo_out_power`
 
-            To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all los, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.lo_out_power`
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+-------------+
-            | Characteristic        | Value       |
-            +=======================+=============+
-            | Datatype              | float       |
-            +-----------------------+-------------+
-            | Permissions           | read-write  |
-            +-----------------------+-------------+
-            | Repeated Capabilities | lo_channels |
-            +-----------------------+-------------+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | float      |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | los        |
+            +-----------------------+------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:
@@ -9069,12 +9067,12 @@ lo_pll_fractional_mode_enabled
         .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
 
-        .. tip:: This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
+        .. tip:: This property can be set/get on specific los within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container los to specify a subset.
 
-            Example: :py:attr:`my_session.lo_channels[ ... ].lo_pll_fractional_mode_enabled`
+            Example: :py:attr:`my_session.los[ ... ].lo_pll_fractional_mode_enabled`
 
-            To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all los, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.lo_pll_fractional_mode_enabled`
 
@@ -9087,7 +9085,7 @@ lo_pll_fractional_mode_enabled
             +-----------------------+----------------------------------+
             | Permissions           | read-write                       |
             +-----------------------+----------------------------------+
-            | Repeated Capabilities | lo_channels                      |
+            | Repeated Capabilities | los                              |
             +-----------------------+----------------------------------+
 
         .. tip::
@@ -9134,26 +9132,26 @@ lo_source
         .. note:: For the PXIe-5841 with PXIe-5655, RF list mode is not supported when this property is set to SG_SA_Shared.
 
 
-        .. tip:: This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
-            Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
+        .. tip:: This property can be set/get on specific los within your :py:class:`nirfsg.Session` instance.
+            Use Python index notation on the repeated capabilities container los to specify a subset.
 
-            Example: :py:attr:`my_session.lo_channels[ ... ].lo_source`
+            Example: :py:attr:`my_session.los[ ... ].lo_source`
 
-            To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
+            To set/get on all los, you can call the property directly on the :py:class:`nirfsg.Session`.
 
             Example: :py:attr:`my_session.lo_source`
 
         The following table lists the characteristics of this property.
 
-            +-----------------------+-------------+
-            | Characteristic        | Value       |
-            +=======================+=============+
-            | Datatype              | str         |
-            +-----------------------+-------------+
-            | Permissions           | read-write  |
-            +-----------------------+-------------+
-            | Repeated Capabilities | lo_channels |
-            +-----------------------+-------------+
+            +-----------------------+------------+
+            | Characteristic        | Value      |
+            +=======================+============+
+            | Datatype              | str        |
+            +-----------------------+------------+
+            | Permissions           | read-write |
+            +-----------------------+------------+
+            | Repeated Capabilities | los        |
+            +-----------------------+------------+
 
         .. tip::
             This property corresponds to the following LabVIEW Property or C Attribute:

--- a/docs/nirfsg/class.rst
+++ b/docs/nirfsg/class.rst
@@ -1232,7 +1232,7 @@ create_deembedding_sparameter_table_array
 
             Creates an s-parameter de-embedding table for the port from the input data.
 
-            If you only create one table for a port, NI-RFSA automatically selects that table to de-embed the measurement.
+            If you only create one table for a port, NI-RFSG automatically selects that table to de-embed the measurement.
 
             **Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860
 

--- a/docs/nirfsg/enums.rst
+++ b/docs/nirfsg/enums.rst
@@ -626,12 +626,12 @@ GenerationMode
 
 
 
-IQOutPortTermCfg
-----------------
+IQOutPortTerminalConfiguration
+------------------------------
 
-.. py:class:: IQOutPortTermCfg
+.. py:class:: IQOutPortTerminalConfiguration
 
-    .. py:attribute:: IQOutPortTermCfg.DIFFERENTIAL
+    .. py:attribute:: IQOutPortTerminalConfiguration.DIFFERENTIAL
 
 
 
@@ -641,7 +641,7 @@ IQOutPortTermCfg
 
 
 
-    .. py:attribute:: IQOutPortTermCfg.SINGLE_ENDED
+    .. py:attribute:: IQOutPortTerminalConfiguration.SINGLE_ENDED
 
 
 

--- a/docs/nirfsg/rep_caps.rst
+++ b/docs/nirfsg/rep_caps.rst
@@ -113,17 +113,17 @@ ports
         passes a string of :python:`'0, 1, 2'` to the set attribute function.
 
 
-lo_channels
------------
+los
+---
 
-    .. py:attribute:: nirfsg.Session.lo_channels[]
+    .. py:attribute:: nirfsg.Session.los[]
 
         If no prefix is added to the items in the parameter, the correct prefix will be added when
         the driver function call is made.
 
         .. code:: python
 
-            session.lo_channels['0-2'].channel_enabled = True
+            session.los['0-2'].channel_enabled = True
 
         passes a string of :python:`'LO0, LO1, LO2'` to the set attribute function.
 
@@ -134,9 +134,33 @@ lo_channels
 
         .. code:: python
 
-            session.lo_channels['LO0-LO2'].channel_enabled = True
+            session.los['LO0-LO2'].channel_enabled = True
 
         passes a string of :python:`'LO0, LO1, LO2'` to the set attribute function.
+
+
+device_temperatures
+-------------------
+
+    .. py:attribute:: nirfsg.Session.device_temperatures[]
+
+        .. code:: python
+
+            session.device_temperatures['0-2'].channel_enabled = True
+
+        passes a string of :python:`'0, 1, 2'` to the set attribute function.
+
+
+channels
+--------
+
+    .. py:attribute:: nirfsg.Session.channels[]
+
+        .. code:: python
+
+            session.channels['0-2'].channel_enabled = True
+
+        passes a string of :python:`'0, 1, 2'` to the set attribute function.
 
 
 

--- a/generated/nirfsg/nirfsg/_library.py
+++ b/generated/nirfsg/nirfsg/_library.py
@@ -49,6 +49,7 @@ class Library(object):
         self.niRFSG_ConfigureRefClock_cfunc = None
         self.niRFSG_ConfigureSoftwareScriptTrigger_cfunc = None
         self.niRFSG_ConfigureSoftwareStartTrigger_cfunc = None
+        self.niRFSG_CreateDeembeddingSparameterTableArray_cfunc = None
         self.niRFSG_CreateDeembeddingSparameterTableS2PFile_cfunc = None
         self.niRFSG_DeleteAllDeembeddingTables_cfunc = None
         self.niRFSG_DeleteDeembeddingTable_cfunc = None
@@ -57,7 +58,6 @@ class Library(object):
         self.niRFSG_DisableStartTrigger_cfunc = None
         self.niRFSG_ErrorMessage_cfunc = None
         self.niRFSG_ErrorQuery_cfunc = None
-        self.niRFSG_ExportSignal_cfunc = None
         self.niRFSG_GetAllNamedWaveformNames_cfunc = None
         self.niRFSG_GetAllScriptNames_cfunc = None
         self.niRFSG_GetAttributeViBoolean_cfunc = None
@@ -67,6 +67,8 @@ class Library(object):
         self.niRFSG_GetAttributeViSession_cfunc = None
         self.niRFSG_GetAttributeViString_cfunc = None
         self.niRFSG_GetChannelName_cfunc = None
+        self.niRFSG_GetDeembeddingSparameters_cfunc = None
+        self.niRFSG_GetDeembeddingTableNumberOfPorts_cfunc = None
         self.niRFSG_GetError_cfunc = None
         self.niRFSG_GetExternalCalibrationLastDateAndTime_cfunc = None
         self.niRFSG_GetMaxSettablePower_cfunc = None
@@ -353,6 +355,14 @@ class Library(object):
                 self.niRFSG_ConfigureSoftwareStartTrigger_cfunc.restype = ViStatus  # noqa: F405
         return self.niRFSG_ConfigureSoftwareStartTrigger_cfunc(vi)
 
+    def niRFSG_CreateDeembeddingSparameterTableArray(self, vi, port, table_name, frequencies, frequencies_size, sparameter_table, sparameter_table_size, number_of_ports, sparameter_orientation):  # noqa: N802
+        with self._func_lock:
+            if self.niRFSG_CreateDeembeddingSparameterTableArray_cfunc is None:
+                self.niRFSG_CreateDeembeddingSparameterTableArray_cfunc = self._get_library_function('niRFSG_CreateDeembeddingSparameterTableArray')
+                self.niRFSG_CreateDeembeddingSparameterTableArray_cfunc.argtypes = [ViSession, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar), ctypes.POINTER(ViReal64), ViInt32, ctypes.POINTER(NIComplexNumber), ViInt32, ViInt32, ViInt32]  # noqa: F405
+                self.niRFSG_CreateDeembeddingSparameterTableArray_cfunc.restype = ViStatus  # noqa: F405
+        return self.niRFSG_CreateDeembeddingSparameterTableArray_cfunc(vi, port, table_name, frequencies, frequencies_size, sparameter_table, sparameter_table_size, number_of_ports, sparameter_orientation)
+
     def niRFSG_CreateDeembeddingSparameterTableS2PFile(self, vi, port, table_name, s2p_file_path, sparameter_orientation):  # noqa: N802
         with self._func_lock:
             if self.niRFSG_CreateDeembeddingSparameterTableS2PFile_cfunc is None:
@@ -416,14 +426,6 @@ class Library(object):
                 self.niRFSG_ErrorQuery_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32), ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niRFSG_ErrorQuery_cfunc.restype = ViStatus  # noqa: F405
         return self.niRFSG_ErrorQuery_cfunc(vi, error_code, error_message)
-
-    def niRFSG_ExportSignal(self, vi, signal, signal_identifier, output_terminal):  # noqa: N802
-        with self._func_lock:
-            if self.niRFSG_ExportSignal_cfunc is None:
-                self.niRFSG_ExportSignal_cfunc = self._get_library_function('niRFSG_ExportSignal')
-                self.niRFSG_ExportSignal_cfunc.argtypes = [ViSession, ViInt32, ctypes.POINTER(ViChar), ctypes.POINTER(ViChar)]  # noqa: F405
-                self.niRFSG_ExportSignal_cfunc.restype = ViStatus  # noqa: F405
-        return self.niRFSG_ExportSignal_cfunc(vi, signal, signal_identifier, output_terminal)
 
     def niRFSG_GetAllNamedWaveformNames(self, vi, waveform_names, buffer_size, actual_buffer_size):  # noqa: N802
         with self._func_lock:
@@ -496,6 +498,22 @@ class Library(object):
                 self.niRFSG_GetChannelName_cfunc.argtypes = [ViSession, ViInt32, ViInt32, ctypes.POINTER(ViChar)]  # noqa: F405
                 self.niRFSG_GetChannelName_cfunc.restype = ViStatus  # noqa: F405
         return self.niRFSG_GetChannelName_cfunc(vi, index, buffer_size, name)
+
+    def niRFSG_GetDeembeddingSparameters(self, vi, sparameters, sparameter_array_size, number_of_sparameters, number_of_ports):  # noqa: N802
+        with self._func_lock:
+            if self.niRFSG_GetDeembeddingSparameters_cfunc is None:
+                self.niRFSG_GetDeembeddingSparameters_cfunc = self._get_library_function('niRFSG_GetDeembeddingSparameters')
+                self.niRFSG_GetDeembeddingSparameters_cfunc.argtypes = [ViSession, ctypes.POINTER(NIComplexNumber), ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
+                self.niRFSG_GetDeembeddingSparameters_cfunc.restype = ViStatus  # noqa: F405
+        return self.niRFSG_GetDeembeddingSparameters_cfunc(vi, sparameters, sparameter_array_size, number_of_sparameters, number_of_ports)
+
+    def niRFSG_GetDeembeddingTableNumberOfPorts(self, vi, number_of_ports):  # noqa: N802
+        with self._func_lock:
+            if self.niRFSG_GetDeembeddingTableNumberOfPorts_cfunc is None:
+                self.niRFSG_GetDeembeddingTableNumberOfPorts_cfunc = self._get_library_function('niRFSG_GetDeembeddingTableNumberOfPorts')
+                self.niRFSG_GetDeembeddingTableNumberOfPorts_cfunc.argtypes = [ViSession, ctypes.POINTER(ViInt32)]  # noqa: F405
+                self.niRFSG_GetDeembeddingTableNumberOfPorts_cfunc.restype = ViStatus  # noqa: F405
+        return self.niRFSG_GetDeembeddingTableNumberOfPorts_cfunc(vi, number_of_ports)
 
     def niRFSG_GetError(self, vi, error_code, error_description_buffer_size, error_description):  # noqa: N802
         with self._func_lock:

--- a/generated/nirfsg/nirfsg/_library_interpreter.py
+++ b/generated/nirfsg/nirfsg/_library_interpreter.py
@@ -315,6 +315,20 @@ class LibraryInterpreter(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return
 
+    def create_deembedding_sparameter_table_array(self, port, table_name, frequencies, sparameter_table, sparameter_table_size, number_of_ports, sparameter_orientation):  # noqa: N802
+        vi_ctype = _visatype.ViSession(self._vi)  # case S110
+        port_ctype = ctypes.create_string_buffer(port.encode(self._encoding))  # case C020
+        table_name_ctype = ctypes.create_string_buffer(table_name.encode(self._encoding))  # case C020
+        frequencies_ctype = _get_ctypes_pointer_for_buffer(value=frequencies)  # case B510
+        frequencies_size_ctype = _visatype.ViInt32(0 if frequencies is None else len(frequencies))  # case S160
+        sparameter_table_ctype = _get_ctypes_pointer_for_buffer(value=sparameter_table, library_type=_complextype.NIComplexNumber)  # case B510
+        sparameter_table_size_ctype = _visatype.ViInt32(sparameter_table_size)  # case S150
+        number_of_ports_ctype = _visatype.ViInt32(number_of_ports)  # case S150
+        sparameter_orientation_ctype = _visatype.ViInt32(sparameter_orientation.value)  # case S130
+        error_code = self._library.niRFSG_CreateDeembeddingSparameterTableArray(vi_ctype, port_ctype, table_name_ctype, frequencies_ctype, frequencies_size_ctype, sparameter_table_ctype, sparameter_table_size_ctype, number_of_ports_ctype, sparameter_orientation_ctype)
+        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
+        return
+
     def create_deembedding_sparameter_table_s2p_file(self, port, table_name, s2p_file_path, sparameter_orientation):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         port_ctype = ctypes.create_string_buffer(port.encode(self._encoding))  # case C020
@@ -373,15 +387,6 @@ class LibraryInterpreter(object):
         error_code = self._library.niRFSG_ErrorQuery(vi_ctype, None if error_code_ctype is None else (ctypes.pointer(error_code_ctype)), error_message_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(error_code_ctype.value), error_message_ctype.value.decode(self._encoding)
-
-    def export_signal(self, signal, signal_identifier, output_terminal):  # noqa: N802
-        vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        signal_ctype = _visatype.ViInt32(signal.value)  # case S130
-        signal_identifier_ctype = ctypes.create_string_buffer(signal_identifier.encode(self._encoding))  # case C020
-        output_terminal_ctype = ctypes.create_string_buffer(output_terminal.encode(self._encoding))  # case C020
-        error_code = self._library.niRFSG_ExportSignal(vi_ctype, signal_ctype, signal_identifier_ctype, output_terminal_ctype)
-        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return
 
     def get_all_named_waveform_names(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
@@ -480,6 +485,23 @@ class LibraryInterpreter(object):
         error_code = self._library.niRFSG_GetChannelName(vi_ctype, index_ctype, buffer_size_ctype, name_ctype)
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return name_ctype.value.decode(self._encoding)
+
+    def get_deembedding_sparameters(self, sparameters, sparameter_array_size):  # noqa: N802
+        vi_ctype = _visatype.ViSession(self._vi)  # case S110
+        sparameters_ctype = _get_ctypes_pointer_for_buffer(value=sparameters, library_type=_complextype.NIComplexNumber)  # case B510
+        sparameter_array_size_ctype = _visatype.ViInt32(sparameter_array_size)  # case S150
+        number_of_sparameters_ctype = _visatype.ViInt32()  # case S220
+        number_of_ports_ctype = _visatype.ViInt32()  # case S220
+        error_code = self._library.niRFSG_GetDeembeddingSparameters(vi_ctype, sparameters_ctype, sparameter_array_size_ctype, None if number_of_sparameters_ctype is None else (ctypes.pointer(number_of_sparameters_ctype)), None if number_of_ports_ctype is None else (ctypes.pointer(number_of_ports_ctype)))
+        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
+        return int(number_of_ports_ctype.value)
+
+    def get_deembedding_table_number_of_ports(self):  # noqa: N802
+        vi_ctype = _visatype.ViSession(self._vi)  # case S110
+        number_of_ports_ctype = _visatype.ViInt32()  # case S220
+        error_code = self._library.niRFSG_GetDeembeddingTableNumberOfPorts(vi_ctype, None if number_of_ports_ctype is None else (ctypes.pointer(number_of_ports_ctype)))
+        errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
+        return int(number_of_ports_ctype.value)
 
     def get_error(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110

--- a/generated/nirfsg/nirfsg/enums.py
+++ b/generated/nirfsg/nirfsg/enums.py
@@ -273,7 +273,7 @@ class GenerationMode(Enum):
     '''
 
 
-class IQOutPortTermCfg(Enum):
+class IQOutPortTerminalConfiguration(Enum):
     DIFFERENTIAL = 15000
     r'''
     Sets the terminal configuration to differential.

--- a/generated/nirfsg/nirfsg/session.py
+++ b/generated/nirfsg/nirfsg/session.py
@@ -7017,7 +7017,7 @@ class Session(_SessionBase):
 
         Creates an s-parameter de-embedding table for the port from the input data.
 
-        If you only create one table for a port, NI-RFSA automatically selects that table to de-embed the measurement.
+        If you only create one table for a port, NI-RFSG automatically selects that table to de-embed the measurement.
 
         **Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860
 
@@ -7185,7 +7185,7 @@ class Session(_SessionBase):
 
         Creates an s-parameter de-embedding table for the port from the input data.
 
-        If you only create one table for a port, NI-RFSA automatically selects that table to de-embed the measurement.
+        If you only create one table for a port, NI-RFSG automatically selects that table to de-embed the measurement.
 
         **Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860
 
@@ -7224,11 +7224,11 @@ class Session(_SessionBase):
                         sparameter_table_size = sparameter_table.size
                         return self._create_deembedding_sparameter_table_array(port, table_name, frequencies, sparameter_table, sparameter_table_size, number_of_ports, sparameter_orientation)
                     else:
-                        raise IndexError("Row and column count of sparameters table should be equal. Table row count is {} and column count is {}.".format(sparameter_table.shape[1], sparameter_table.shape[2]))
+                        raise ValueError("Row and column count of sparameter table should be equal. Table row count is {} and column count is {}.".format(sparameter_table.shape[1], sparameter_table.shape[2]))
                 else:
-                    raise IndexError("Frequencies count does not match the sparameter table count. Frequencies count is {} and s parameter table count is {}.".format(frequencies.size, sparameter_table.shape[0]))
+                    raise ValueError("Frequencies count does not match the sparameter table count. Frequencies count is {} and sparameter table count is {}.".format(frequencies.size, sparameter_table.shape[0]))
             else:
-                raise IndexError("Unsupported array dimension. Is {}, expected 3".format(sparameter_table.ndim))
+                raise ValueError("Unsupported array dimension. Is {}, expected 3".format(sparameter_table.ndim))
         else:
             raise TypeError("Unsupported datatype. Expected numpy array.")
 

--- a/generated/nirfsg/nirfsg/session.py
+++ b/generated/nirfsg/nirfsg/session.py
@@ -1197,12 +1197,12 @@ class _SessionBase(object):
     +----------------------------+--------------------------+-------------------------+
 
     Tip:
-    This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container ports to specify a subset.
+    This property can be set/get on specific device_temperatures within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container device_temperatures to specify a subset.
 
-    Example: :py:attr:`my_session.ports[ ... ].device_temperature`
+    Example: :py:attr:`my_session.device_temperatures[ ... ].device_temperature`
 
-    To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all device_temperatures, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.device_temperature`
     '''
@@ -1873,10 +1873,6 @@ class _SessionBase(object):
 
     `PXI Trigger Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pxi_trigger.html>`_
 
-    **High-Level Methods**:
-
-    - export_signal
-
     **Possible Values**:
 
     +---------------+---------------------------------------------------------------------------------------------------------------------------------+
@@ -1939,10 +1935,6 @@ class _SessionBase(object):
     `PFI Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pfi_lines.html>`_
 
     `PXI Trigger Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pxi_trigger.html>`_
-
-    **High-Level Methods**:
-
-    - export_signal
 
     **Possible Values**:
 
@@ -2118,10 +2110,6 @@ class _SessionBase(object):
 
     `PXI Trigger Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pxi_trigger.html>`_
 
-    **High-Level Methods**:
-
-    - export_signal
-
     **Possible Values**:
 
     +----------------+---------------------------------------------------------------------------------------------------------------------------------+
@@ -2194,10 +2182,6 @@ class _SessionBase(object):
     `PFI Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pfi_lines.html>`_
 
     `PXI Trigger Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pxi_trigger.html>`_
-
-    **High-Level Methods**:
-
-    - export_signal
 
     **Possible Values**:
 
@@ -2750,7 +2734,7 @@ class _SessionBase(object):
     iq_out_port_common_mode_offset = _attributes.AttributeViReal64(1150148)
     '''Type: float
 
-    Specifies the common-mode offset applied to the signals generated at each differential output terminal. This property applies only when you set the iq_out_port_terminal_configuration property to IQOutPortTermCfg.DIFFERENTIAL. Common-mode offset shifts both positive and negative terminals in the same direction.
+    Specifies the common-mode offset applied to the signals generated at each differential output terminal. This property applies only when you set the iq_out_port_terminal_configuration property to IQOutPortTerminalConfiguration.DIFFERENTIAL. Common-mode offset shifts both positive and negative terminals in the same direction.
 
     To use this property, you must use the channelName parameter of the _set_attribute_vi_real64 method to specify the name of the channel you are configuring. For the PXIe-5645, you can configure the I and Q channels by using I or Q as the channel string, or set the channel string to "" (empty string) to configure both channels. For the PXIe-5820, the only valid value for the channel string is "" (empty string).
 
@@ -2771,12 +2755,12 @@ class _SessionBase(object):
      - The valid range is dependent on the load impedance.
 
     Tip:
-    This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container ports to specify a subset.
+    This property can be set/get on specific channels within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
 
-    Example: :py:attr:`my_session.ports[ ... ].iq_out_port_common_mode_offset`
+    Example: :py:attr:`my_session.channels[ ... ].iq_out_port_common_mode_offset`
 
-    To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all channels, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.iq_out_port_common_mode_offset`
     '''
@@ -2795,9 +2779,9 @@ class _SessionBase(object):
 
     **Valid Values:**
 
-    PXIe-5645: 1V :sub:`pk-pk`  maximum if you set the iq_out_port_terminal_configuration property to IQOutPortTermCfg.DIFFERENTIAL, and 0.5V :sub:`pk-pk`
+    PXIe-5645: 1V :sub:`pk-pk`  maximum if you set the iq_out_port_terminal_configuration property to IQOutPortTerminalConfiguration.DIFFERENTIAL, and 0.5V :sub:`pk-pk`
 
-    maximum if you set the iq_out_port_terminal_configuration property to IQOutPortTermCfg.SINGLE_ENDED.
+    maximum if you set the iq_out_port_terminal_configuration property to IQOutPortTerminalConfiguration.SINGLE_ENDED.
 
     PXIe-5820: 3.4V :sub:`pk-pk` maximum for signal bandwidth less than 160MHz, and 2V :sub:`pk-pk`
 
@@ -2812,12 +2796,12 @@ class _SessionBase(object):
      - The valid values are only applicable when you set the iq_out_port_load_impedance property to 50 Ω and when you set the iq_out_port_offset property to 0.
 
     Tip:
-    This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container ports to specify a subset.
+    This property can be set/get on specific channels within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
 
-    Example: :py:attr:`my_session.ports[ ... ].iq_out_port_level`
+    Example: :py:attr:`my_session.channels[ ... ].iq_out_port_level`
 
-    To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all channels, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.iq_out_port_level`
     '''
@@ -2832,19 +2816,19 @@ class _SessionBase(object):
 
     **Valid Values:** Any value greater than 0. Values greater than or equal to 1 megaohms (MΩ) are interpreted as high impedance.
 
-    **Default Value:** 50 Ω if you set the iq_out_port_terminal_configuration property to IQOutPortTermCfg.SINGLE_ENDED, and 100 Ω if you set the iq_out_port_terminal_configuration property to IQOutPortTermCfg.DIFFERENTIAL.
+    **Default Value:** 50 Ω if you set the iq_out_port_terminal_configuration property to IQOutPortTerminalConfiguration.SINGLE_ENDED, and 100 Ω if you set the iq_out_port_terminal_configuration property to IQOutPortTerminalConfiguration.DIFFERENTIAL.
 
     **Supported Devices:** PXIe-5645, PXIe-5820
 
     Note: For the PXIe-5645, this property is ignored if you are using the RF ports.
 
     Tip:
-    This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container ports to specify a subset.
+    This property can be set/get on specific channels within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
 
-    Example: :py:attr:`my_session.ports[ ... ].iq_out_port_load_impedance`
+    Example: :py:attr:`my_session.channels[ ... ].iq_out_port_load_impedance`
 
-    To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all channels, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.iq_out_port_load_impedance`
     '''
@@ -2866,12 +2850,12 @@ class _SessionBase(object):
     Note: For the PXIe-5645, this property is ignored if you are using the RF ports.
 
     Tip:
-    This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container ports to specify a subset.
+    This property can be set/get on specific channels within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
 
-    Example: :py:attr:`my_session.ports[ ... ].iq_out_port_offset`
+    Example: :py:attr:`my_session.channels[ ... ].iq_out_port_offset`
 
-    To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all channels, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.iq_out_port_offset`
     '''
@@ -2886,20 +2870,20 @@ class _SessionBase(object):
 
     Note: If you query this property during RF list mode, list steps may take longer to complete during list execution.
     '''
-    iq_out_port_terminal_configuration = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.IQOutPortTermCfg, 1150146)
-    '''Type: enums.IQOutPortTermCfg
+    iq_out_port_terminal_configuration = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.IQOutPortTerminalConfiguration, 1150146)
+    '''Type: enums.IQOutPortTerminalConfiguration
 
-    Specifies whether to use the I/Q OUT port for differential configuration or single-ended configuration. If you set this property to IQOutPortTermCfg.SINGLE_ENDED, you must terminate the negative I and Q output connectors with a 50 Ohm termination.
+    Specifies whether to use the I/Q OUT port for differential configuration or single-ended configuration. If you set this property to IQOutPortTerminalConfiguration.SINGLE_ENDED, you must terminate the negative I and Q output connectors with a 50 Ohm termination.
 
-    If you set this property to IQOutPortTermCfg.SINGLE_ENDED, the positive I and Q connectors generate the resulting waveform. If you set this property to IQOutPortTermCfg.DIFFERENTIAL, both the positive and negative I and Q connectors generate the resulting waveform.
+    If you set this property to IQOutPortTerminalConfiguration.SINGLE_ENDED, the positive I and Q connectors generate the resulting waveform. If you set this property to IQOutPortTerminalConfiguration.DIFFERENTIAL, both the positive and negative I and Q connectors generate the resulting waveform.
 
     To use this property, you must use the channelName parameter of the _set_attribute_vi_int32 method to specify the name of the channel you are configuring. For the PXIe-5645, you can configure the I and Q channels by using I or Q as the channel string, or set the channel string to "" (empty string) to configure both channels. For the PXIe-5820, the only valid value for the channel string is "" (empty string).
 
     To set this property, the NI-RFSG device must be in the Configuration state.
 
-    **Default Value:** IQOutPortTermCfg.DIFFERENTIAL
+    **Default Value:** IQOutPortTerminalConfiguration.DIFFERENTIAL
 
-    PXIe-5820: The only valid value for this property is IQOutPortTermCfg.DIFFERENTIAL.
+    PXIe-5820: The only valid value for this property is IQOutPortTerminalConfiguration.DIFFERENTIAL.
 
     **Supported Devices:** PXIe-5645, PXIe-5820
 
@@ -2909,23 +2893,23 @@ class _SessionBase(object):
 
     **Defined Values**:
 
-    +-------------------------------+----------------+--------------------------------------------------+
-    | Name                          | Value          | Description                                      |
-    +===============================+================+==================================================+
-    | IQOutPortTermCfg.DIFFERENTIAL | 15000 (0x3a98) | Sets the terminal configuration to differential. |
-    +-------------------------------+----------------+--------------------------------------------------+
-    | IQOutPortTermCfg.SINGLE_ENDED | 15001 (0x3a99) | Sets the terminal configuration to single-ended. |
-    +-------------------------------+----------------+--------------------------------------------------+
+    +---------------------------------------------+----------------+--------------------------------------------------+
+    | Name                                        | Value          | Description                                      |
+    +=============================================+================+==================================================+
+    | IQOutPortTerminalConfiguration.DIFFERENTIAL | 15000 (0x3a98) | Sets the terminal configuration to differential. |
+    +---------------------------------------------+----------------+--------------------------------------------------+
+    | IQOutPortTerminalConfiguration.SINGLE_ENDED | 15001 (0x3a99) | Sets the terminal configuration to single-ended. |
+    +---------------------------------------------+----------------+--------------------------------------------------+
 
     Note: For the PXIe-5645, this property is ignored if you are using the RF ports.
 
     Tip:
-    This property can be set/get on specific ports within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container ports to specify a subset.
+    This property can be set/get on specific channels within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container channels to specify a subset.
 
-    Example: :py:attr:`my_session.ports[ ... ].iq_out_port_terminal_configuration`
+    Example: :py:attr:`my_session.channels[ ... ].iq_out_port_terminal_configuration`
 
-    To set/get on all ports, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all channels, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.iq_out_port_terminal_configuration`
     '''
@@ -3128,12 +3112,12 @@ class _SessionBase(object):
     One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
     Tip:
-    This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
+    This property can be set/get on specific los within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container los to specify a subset.
 
-    Example: :py:attr:`my_session.lo_channels[ ... ].loop_bandwidth`
+    Example: :py:attr:`my_session.los[ ... ].loop_bandwidth`
 
-    To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all los, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.loop_bandwidth`
     '''
@@ -3155,12 +3139,12 @@ class _SessionBase(object):
     Note: This property is read/write if you are using an external LO. Otherwise, this property is read-only.
 
     Tip:
-    This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
+    This property can be set/get on specific los within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container los to specify a subset.
 
-    Example: :py:attr:`my_session.lo_channels[ ... ].lo_frequency`
+    Example: :py:attr:`my_session.los[ ... ].lo_frequency`
 
-    To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all los, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.lo_frequency`
     '''
@@ -3238,12 +3222,12 @@ class _SessionBase(object):
      - For the PXIe-5644/5645/5646, this property is always read-only.
 
     Tip:
-    This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
+    This property can be set/get on specific los within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container los to specify a subset.
 
-    Example: :py:attr:`my_session.lo_channels[ ... ].lo_in_power`
+    Example: :py:attr:`my_session.los[ ... ].lo_in_power`
 
-    To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all los, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.lo_in_power`
     '''
@@ -3276,12 +3260,12 @@ class _SessionBase(object):
     One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
     Tip:
-    This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
+    This property can be set/get on specific los within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container los to specify a subset.
 
-    Example: :py:attr:`my_session.lo_channels[ ... ].lo_out_enabled`
+    Example: :py:attr:`my_session.los[ ... ].lo_out_enabled`
 
-    To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all los, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.lo_out_enabled`
     '''
@@ -3327,12 +3311,12 @@ class _SessionBase(object):
     Note: For the PXIe-5644/5645/5646 and PXIe-5673/5673E, this property is always read-only.
 
     Tip:
-    This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
+    This property can be set/get on specific los within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container los to specify a subset.
 
-    Example: :py:attr:`my_session.lo_channels[ ... ].lo_out_power`
+    Example: :py:attr:`my_session.los[ ... ].lo_out_power`
 
-    To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all los, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.lo_out_power`
     '''
@@ -3369,12 +3353,12 @@ class _SessionBase(object):
     One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
 
     Tip:
-    This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
+    This property can be set/get on specific los within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container los to specify a subset.
 
-    Example: :py:attr:`my_session.lo_channels[ ... ].lo_pll_fractional_mode_enabled`
+    Example: :py:attr:`my_session.los[ ... ].lo_pll_fractional_mode_enabled`
 
-    To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all los, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.lo_pll_fractional_mode_enabled`
     '''
@@ -3414,12 +3398,12 @@ class _SessionBase(object):
     Note: For the PXIe-5841 with PXIe-5655, RF list mode is not supported when this property is set to SG_SA_Shared.
 
     Tip:
-    This property can be set/get on specific lo_channels within your :py:class:`nirfsg.Session` instance.
-    Use Python index notation on the repeated capabilities container lo_channels to specify a subset.
+    This property can be set/get on specific los within your :py:class:`nirfsg.Session` instance.
+    Use Python index notation on the repeated capabilities container los to specify a subset.
 
-    Example: :py:attr:`my_session.lo_channels[ ... ].lo_source`
+    Example: :py:attr:`my_session.los[ ... ].lo_source`
 
-    To set/get on all lo_channels, you can call the property directly on the :py:class:`nirfsg.Session`.
+    To set/get on all los, you can call the property directly on the :py:class:`nirfsg.Session`.
 
     Example: :py:attr:`my_session.lo_source`
     '''
@@ -5316,7 +5300,9 @@ class _SessionBase(object):
         self.script_triggers = _RepeatedCapabilities(self, 'scripttrigger', repeated_capability_list)
         self.waveforms = _RepeatedCapabilities(self, 'waveform::', repeated_capability_list)
         self.ports = _RepeatedCapabilities(self, '', repeated_capability_list)
-        self.lo_channels = _RepeatedCapabilities(self, 'LO', repeated_capability_list)
+        self.los = _RepeatedCapabilities(self, 'LO', repeated_capability_list)
+        self.device_temperatures = _RepeatedCapabilities(self, '', repeated_capability_list)
+        self.channels = _RepeatedCapabilities(self, '', repeated_capability_list)
 
         # Finally, set _is_frozen to True which is used to prevent clients from accidentally adding
         # members when trying to set a property with a typo.
@@ -7026,6 +7012,65 @@ class Session(_SessionBase):
         self._interpreter.configure_software_start_trigger()
 
     @ivi_synchronized
+    def _create_deembedding_sparameter_table_array(self, port, table_name, frequencies, sparameter_table, sparameter_table_size, number_of_ports, sparameter_orientation):
+        r'''_create_deembedding_sparameter_table_array
+
+        Creates an s-parameter de-embedding table for the port from the input data.
+
+        If you only create one table for a port, NI-RFSA automatically selects that table to de-embed the measurement.
+
+        **Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860
+
+        **Related Topics**
+
+        `De-embedding Overview <https://www.ni.com/docs/en-US/bundle/pxie-5840/page/de-embedding-overview.html>`_
+
+        Args:
+            port (str): Specifies the name of the port. The only valid value for the PXIe-5840/5841/5842/5860 is "" (empty string).
+
+            table_name (str): Specifies the name of the table. The name must be unique for a given port, but not across ports. If you use the same name as an existing table, the table is replaced.
+
+            frequencies (numpy.array(dtype=numpy.float64)): Specifies the frequencies for the SPARAMETER_TABLE rows. Frequencies must be unique and in ascending order.
+
+                Note:
+                One or more of the referenced properties are not in the Python API for this driver.
+
+            sparameter_table (numpy.array(dtype=numpy.complex128)): Specifies the S-parameters for each frequency. S-parameters for each frequency are placed in the array in the following order: s11, s12, s21, s22.
+
+            sparameter_orientation (enums.SparameterOrientation): Specifies the orientation of the input data relative to the port on the DUT port. **Defined Values** :
+
+                +-----------------------------------------+----------------+-----------------------------------------------------+
+                | Name                                    | Value          | Description                                         |
+                +=========================================+================+=====================================================+
+                | SparameterOrientation.PORT1_TOWARDS_DUT | 24000 (0x5dc0) | Port 1 of the S2P is oriented towards the DUT port. |
+                +-----------------------------------------+----------------+-----------------------------------------------------+
+                | SparameterOrientation.PORT2_TOWARDS_DUT | 24001 (0x5dc1) | Port 2 of the S2P is oriented towards the DUT port. |
+                +-----------------------------------------+----------------+-----------------------------------------------------+
+
+        '''
+        import numpy
+
+        if type(sparameter_orientation) is not enums.SparameterOrientation:
+            raise TypeError('Parameter sparameter_orientation must be of type ' + str(enums.SparameterOrientation))
+        if type(frequencies) is not numpy.ndarray:
+            raise TypeError('frequencies must be {0}, is {1}'.format(numpy.ndarray, type(frequencies)))
+        if numpy.isfortran(frequencies) is True:
+            raise TypeError('frequencies must be in C-order')
+        if frequencies.dtype is not numpy.dtype('float64'):
+            raise TypeError('frequencies must be numpy.ndarray of dtype=float64, is ' + str(frequencies.dtype))
+        if frequencies.ndim != 1:
+            raise TypeError('frequencies must be numpy.ndarray of dimension=1, is ' + str(frequencies.ndim))
+        if type(sparameter_table) is not numpy.ndarray:
+            raise TypeError('sparameter_table must be {0}, is {1}'.format(numpy.ndarray, type(sparameter_table)))
+        if numpy.isfortran(sparameter_table) is True:
+            raise TypeError('sparameter_table must be in C-order')
+        if sparameter_table.dtype is not numpy.dtype('complex128'):
+            raise TypeError('sparameter_table must be numpy.ndarray of dtype=complex128, is ' + str(sparameter_table.dtype))
+        if sparameter_table.ndim != 3:
+            raise TypeError('sparameter_table must be numpy.ndarray of dimension=3, is ' + str(sparameter_table.ndim))
+        self._interpreter.create_deembedding_sparameter_table_array(port, table_name, frequencies, sparameter_table, sparameter_table_size, number_of_ports, sparameter_orientation)
+
+    @ivi_synchronized
     def create_deembedding_sparameter_table_s2p_file(self, port, table_name, s2p_file_path, sparameter_orientation):
         r'''create_deembedding_sparameter_table_s2p_file
 
@@ -7135,105 +7180,57 @@ class Session(_SessionBase):
         return error_code, error_message
 
     @ivi_synchronized
-    def export_signal(self, signal, signal_identifier, output_terminal):
-        r'''export_signal
+    def create_deembedding_sparameter_table_array(self, port, table_name, frequencies, sparameter_table, sparameter_orientation):
+        '''create_deembedding_sparameter_table_array
 
-        Routes signals (triggers, clocks, and events) to a specified output terminal.
+        Creates an s-parameter de-embedding table for the port from the input data.
 
-        The NI-RFSG device must be in the Configuration state before you call this method.
+        If you only create one table for a port, NI-RFSA automatically selects that table to de-embed the measurement.
 
-        You can clear a previously routed signal by exporting the signal to "" (empty string).
-
-        **Supported Devices** :PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
+        **Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860
 
         **Related Topics**
 
-        `Triggers <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/triggers.html>`_
-
-        `Events <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/events.html>`_
-
-        `PFI Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pfi_lines.html>`_
-
-        `PXI Trigger Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pxi_trigger.html>`_
+        `De-embedding Overview <https://www.ni.com/docs/en-US/bundle/pxie-5840/page/de-embedding-overview.html>`_
 
         Args:
-            signal (enums.Signal): Specifies the type of signal to route.
+            port (str): Specifies the name of the port. The only valid value for the PXIe-5840/5841/5842/5860 is "" (empty string).
 
-                 **Defined Values** :
+            table_name (str): Specifies the name of the table. The name must be unique for a given port, but not across ports. If you use the same name as an existing table, the table is replaced.
 
-                +--------------------------------------------+---------+--------------------------------------------+
-                | Name                                       | Value   | Description                                |
-                +============================================+=========+============================================+
-                | Signal.START_TRIGGER                       | 0 (0x0) | Exports a Start Trigger.                   |
-                +--------------------------------------------+---------+--------------------------------------------+
-                | Signal.SCRIPT_TRIGGER                      | 1 (0x1) | Exports a Script Trigger.                  |
-                +--------------------------------------------+---------+--------------------------------------------+
-                | Signal.MARKER_EVENT                        | 2 (0x2) | Exports a Marker Event.                    |
-                +--------------------------------------------+---------+--------------------------------------------+
-                | Signal.REF_CLOCK                           | 3 (0x3) | Exports the Reference Clock.               |
-                +--------------------------------------------+---------+--------------------------------------------+
-                | Signal.STARTED_EVENT                       | 4 (0x4) | Exports a Started Event.                   |
-                +--------------------------------------------+---------+--------------------------------------------+
-                | Signal.DONE_EVENT                          | 5 (0x5) | Exports a Done Event.                      |
-                +--------------------------------------------+---------+--------------------------------------------+
-                | NIRFSG_VAL_CONFIGURATION_LIST_STEP_TRIGGER | 6 (0x6) | Exports a Configuration List Step Trigger. |
-                +--------------------------------------------+---------+--------------------------------------------+
-                | NIRFSG_VAL_CONFIGURATION_SETTLED_EVENT     | 7 (0x7) | Exports a Configuration Settled Event.     |
-                +--------------------------------------------+---------+--------------------------------------------+
-
-                Note:
-                One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
-
-            signal_identifier (str): Specifies which instance of the selected signal to export. This parameter is useful when you set the SIGNAL parameter to NIRFSG_VAL_SCRIPT_TRIGGER or Signal.MARKER_EVENT. Otherwise, set the SIGNAL_IDENTIFIER parameter to "".
-
-                **Possible Values** :
-
-                +------------------+-----------------------------+
-                | Possible Value   | Description                 |
-                +==================+=============================+
-                | "marker0"        | Specifies Marker 0.         |
-                +------------------+-----------------------------+
-                | "marker1"        | Specifies Marker 1.         |
-                +------------------+-----------------------------+
-                | "marker2"        | Specifies Marker 2.         |
-                +------------------+-----------------------------+
-                | "marker3"        | Specifies Marker 3.         |
-                +------------------+-----------------------------+
-                | "scriptTrigger0" | Specifies Script Trigger 0. |
-                +------------------+-----------------------------+
-                | "scriptTrigger1" | Specifies Script Trigger 1. |
-                +------------------+-----------------------------+
-                | "scriptTrigger2" | Specifies Script Trigger 2. |
-                +------------------+-----------------------------+
-                | "scriptTrigger3" | Specifies Script Trigger 3. |
-                +------------------+-----------------------------+
+            frequencies (numpy.array(dtype=numpy.float64)): Specifies the frequencies for the SPARAMETER_TABLE rows. Frequencies must be unique and in ascending order.
 
                 Note:
                 One or more of the referenced properties are not in the Python API for this driver.
 
-                Note:
-                One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
+            sparameter_table (numpy.array(dtype=numpy.complex128)): Specifies the S-parameters for each frequency. S-parameters for each frequency are placed in the array in the following order: s11, s12, s21, s22.
 
-            output_terminal (str): Specifies the terminal where the signal is exported. You can choose not to export any signal. For the PXIe-5841 with PXIe-5655, the signal is exported to the terminal on the PXIe-5841.
+            sparameter_orientation (enums.SparameterOrientation): Specifies the orientation of the input data relative to the port on the DUT port. **Defined Values** :
 
-                 **Possible Values** :
-
-                +----------------+--------------------------------------------------------------------------------------------+
-                | Possible Value | Description                                                                                |
-                +================+============================================================================================+
-                | "ClkOut"       | Exports the Reference Clock signal to the CLK OUT connector of the device.                 |
-                +----------------+--------------------------------------------------------------------------------------------+
-                | ""             | The Reference Clock signal is not exported.                                                |
-                +----------------+--------------------------------------------------------------------------------------------+
-                | "RefOut"       | Exports the Reference Clock signal to the REF OUT connector of the device.                 |
-                +----------------+--------------------------------------------------------------------------------------------+
-                | "RefOut2"      | Exports the Reference Clock signal to the REF OUT2 connector of the device, if applicable. |
-                +----------------+--------------------------------------------------------------------------------------------+
+                +-----------------------------------------+----------------+-----------------------------------------------------+
+                | Name                                    | Value          | Description                                         |
+                +=========================================+================+=====================================================+
+                | SparameterOrientation.PORT1_TOWARDS_DUT | 24000 (0x5dc0) | Port 1 of the S2P is oriented towards the DUT port. |
+                +-----------------------------------------+----------------+-----------------------------------------------------+
+                | SparameterOrientation.PORT2_TOWARDS_DUT | 24001 (0x5dc1) | Port 2 of the S2P is oriented towards the DUT port. |
+                +-----------------------------------------+----------------+-----------------------------------------------------+
 
         '''
-        if type(signal) is not enums.Signal:
-            raise TypeError('Parameter signal must be of type ' + str(enums.Signal))
-        self._interpreter.export_signal(signal, signal_identifier, output_terminal)
+        if (str(type(sparameter_table)).find("'numpy.ndarray'") != -1) or (str(type(frequencies)).find("'numpy.ndarray'") != -1):
+            if sparameter_table.ndim == 3:
+                if frequencies.size == sparameter_table.shape[0]:
+                    if sparameter_table.shape[1] == sparameter_table.shape[2]:
+                        number_of_ports = sparameter_table.shape[1]
+                        sparameter_table_size = sparameter_table.size
+                        return self._create_deembedding_sparameter_table_array(port, table_name, frequencies, sparameter_table, sparameter_table_size, number_of_ports, sparameter_orientation)
+                    else:
+                        raise IndexError("Row and column count of sparameters table should be equal. Table row count is {} and column count is {}.".format(sparameter_table.shape[1], sparameter_table.shape[2]))
+                else:
+                    raise IndexError("Frequencies count does not match the sparameter table count. Frequencies count is {} and s parameter table count is {}.".format(frequencies.size, sparameter_table.shape[0]))
+            else:
+                raise IndexError("Unsupported array dimension. Is {}, expected 3".format(sparameter_table.ndim))
+        else:
+            raise TypeError("Unsupported datatype. Expected numpy array.")
 
     @ivi_synchronized
     def get_all_named_waveform_names(self):
@@ -7297,6 +7294,54 @@ class Session(_SessionBase):
         '''
         name = self._interpreter.get_channel_name(index)
         return name
+
+    @ivi_synchronized
+    def get_deembedding_sparameters(self):
+        '''get_deembedding_sparameters
+
+        Returns the S-parameters used for de-embedding a measurement on the selected port.
+
+        This includes interpolation of the parameters based on the configured carrier frequency. This method returns an empty array if no de-embedding is done.
+
+        If you want to call this method just to get the required buffer size, you can pass 0 for **S-parameter Size** and VI_NULL for the **S-parameters** buffer.
+
+        **Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860
+
+        **Note**: The port orientation for the returned S-parameters is normalized to SparameterOrientation.PORT1_TOWARDS_DUT.
+
+        Args:
+            sparameter_array_size (int): Specifies the size of the array that is returned by the SPARAMETERS output.
+
+                Note:
+                One or more of the referenced properties are not in the Python API for this driver.
+
+
+        Returns:
+            sparameters (list of NIComplexNumber): Returns an array of S-parameters. The S-parameters are returned in the following order: s11, s12, s21, s22.
+
+            number_of_ports (int): Returns the number of S-parameter ports. The **sparameter** array is always *n* x *n*, where span *n* is the number of ports.
+
+        '''
+        import numpy as np
+        number_of_ports = self._get_deembedding_table_number_of_ports()
+        sparameter_table_size = number_of_ports ** 2
+        sparameters = np.full((number_of_ports, number_of_ports), 0 + 0j, dtype=np.complex128)
+        number_of_ports = self._interpreter.get_deembedding_sparameters(sparameters, sparameter_table_size)
+        sparameters = sparameters.reshape((number_of_ports, number_of_ports))
+        return sparameters, number_of_ports
+
+    @ivi_synchronized
+    def _get_deembedding_table_number_of_ports(self):
+        r'''_get_deembedding_table_number_of_ports
+
+        Returns the number of S-parameter ports.
+
+        Returns:
+            number_of_ports (int): Returns the number of S-parameter ports. The **sparameter** array is always *n* x *n*, where span *n* is the number of ports.
+
+        '''
+        number_of_ports = self._interpreter.get_deembedding_table_number_of_ports()
+        return number_of_ports
 
     @ivi_synchronized
     def _get_external_calibration_last_date_and_time(self):
@@ -8195,7 +8240,7 @@ class Session(_SessionBase):
             else:
                 raise TypeError("Unsupported datatype. Is {}, expected {} or {} or {}".format(waveform_data_array.dtype, numpy.complex128, numpy.complex64, numpy.int16))
         else:
-            raise TypeError("Unsupported datatype. Expected {} or {} or {}".format(numpy.complex128, numpy.complex64, numpy.int16))
+            raise TypeError("Unsupported datatype. Expected numpy array of {} or {} or {}".format(numpy.complex128, numpy.complex64, numpy.int16))
 
         return self._write_arb_waveform_complex_f64(waveform_name, waveform_data_array, more_data_pending)
 

--- a/generated/nirfsg/nirfsg/unit_tests/_mock_helper.py
+++ b/generated/nirfsg/nirfsg/unit_tests/_mock_helper.py
@@ -77,6 +77,8 @@ class SideEffectsHelper(object):
         self._defaults['ConfigureSoftwareScriptTrigger']['return'] = 0
         self._defaults['ConfigureSoftwareStartTrigger'] = {}
         self._defaults['ConfigureSoftwareStartTrigger']['return'] = 0
+        self._defaults['CreateDeembeddingSparameterTableArray'] = {}
+        self._defaults['CreateDeembeddingSparameterTableArray']['return'] = 0
         self._defaults['CreateDeembeddingSparameterTableS2PFile'] = {}
         self._defaults['CreateDeembeddingSparameterTableS2PFile']['return'] = 0
         self._defaults['DeleteAllDeembeddingTables'] = {}
@@ -95,8 +97,6 @@ class SideEffectsHelper(object):
         self._defaults['ErrorQuery']['return'] = 0
         self._defaults['ErrorQuery']['errorCode'] = None
         self._defaults['ErrorQuery']['errorMessage'] = None
-        self._defaults['ExportSignal'] = {}
-        self._defaults['ExportSignal']['return'] = 0
         self._defaults['GetAllNamedWaveformNames'] = {}
         self._defaults['GetAllNamedWaveformNames']['return'] = 0
         self._defaults['GetAllNamedWaveformNames']['actualBufferSize'] = None
@@ -126,6 +126,14 @@ class SideEffectsHelper(object):
         self._defaults['GetChannelName'] = {}
         self._defaults['GetChannelName']['return'] = 0
         self._defaults['GetChannelName']['name'] = None
+        self._defaults['GetDeembeddingSparameters'] = {}
+        self._defaults['GetDeembeddingSparameters']['return'] = 0
+        self._defaults['GetDeembeddingSparameters']['sparameters'] = None
+        self._defaults['GetDeembeddingSparameters']['numberOfSparameters'] = None
+        self._defaults['GetDeembeddingSparameters']['numberOfPorts'] = None
+        self._defaults['GetDeembeddingTableNumberOfPorts'] = {}
+        self._defaults['GetDeembeddingTableNumberOfPorts']['return'] = 0
+        self._defaults['GetDeembeddingTableNumberOfPorts']['numberOfPorts'] = None
         self._defaults['GetError'] = {}
         self._defaults['GetError']['return'] = 0
         self._defaults['GetError']['errorCode'] = None
@@ -418,6 +426,11 @@ class SideEffectsHelper(object):
             return self._defaults['ConfigureSoftwareStartTrigger']['return']
         return self._defaults['ConfigureSoftwareStartTrigger']['return']
 
+    def niRFSG_CreateDeembeddingSparameterTableArray(self, vi, port, table_name, frequencies, frequencies_size, sparameter_table, sparameter_table_size, number_of_ports, sparameter_orientation):  # noqa: N802
+        if self._defaults['CreateDeembeddingSparameterTableArray']['return'] != 0:
+            return self._defaults['CreateDeembeddingSparameterTableArray']['return']
+        return self._defaults['CreateDeembeddingSparameterTableArray']['return']
+
     def niRFSG_CreateDeembeddingSparameterTableS2PFile(self, vi, port, table_name, s2p_file_path, sparameter_orientation):  # noqa: N802
         if self._defaults['CreateDeembeddingSparameterTableS2PFile']['return'] != 0:
             return self._defaults['CreateDeembeddingSparameterTableS2PFile']['return']
@@ -471,11 +484,6 @@ class SideEffectsHelper(object):
         for i in range(len(test_value)):
             error_message[i] = test_value[i]
         return self._defaults['ErrorQuery']['return']
-
-    def niRFSG_ExportSignal(self, vi, signal, signal_identifier, output_terminal):  # noqa: N802
-        if self._defaults['ExportSignal']['return'] != 0:
-            return self._defaults['ExportSignal']['return']
-        return self._defaults['ExportSignal']['return']
 
     def niRFSG_GetAllNamedWaveformNames(self, vi, waveform_names, buffer_size, actual_buffer_size):  # noqa: N802
         if self._defaults['GetAllNamedWaveformNames']['return'] != 0:
@@ -580,6 +588,42 @@ class SideEffectsHelper(object):
             return len(self._defaults['GetChannelName']['name'])
         name.value = self._defaults['GetChannelName']['name'].encode('ascii')
         return self._defaults['GetChannelName']['return']
+
+    def niRFSG_GetDeembeddingSparameters(self, vi, sparameters, sparameter_array_size, number_of_sparameters, number_of_ports):  # noqa: N802
+        if self._defaults['GetDeembeddingSparameters']['return'] != 0:
+            return self._defaults['GetDeembeddingSparameters']['return']
+        # sparameters
+        if self._defaults['GetDeembeddingSparameters']['sparameters'] is None:
+            raise MockFunctionCallError("niRFSG_GetDeembeddingSparameters", param='sparameters')
+        test_value = self._defaults['GetDeembeddingSparameters']['sparameters']
+        try:
+            sparameters_ref = sparameters.contents
+        except AttributeError:
+            sparameters_ref = sparameters
+        assert len(sparameters_ref) >= len(test_value)
+        for i in range(len(test_value)):
+            sparameters_ref[i] = test_value[i]
+        # number_of_sparameters
+        if self._defaults['GetDeembeddingSparameters']['numberOfSparameters'] is None:
+            raise MockFunctionCallError("niRFSG_GetDeembeddingSparameters", param='numberOfSparameters')
+        if number_of_sparameters is not None:
+            number_of_sparameters.contents.value = self._defaults['GetDeembeddingSparameters']['numberOfSparameters']
+        # number_of_ports
+        if self._defaults['GetDeembeddingSparameters']['numberOfPorts'] is None:
+            raise MockFunctionCallError("niRFSG_GetDeembeddingSparameters", param='numberOfPorts')
+        if number_of_ports is not None:
+            number_of_ports.contents.value = self._defaults['GetDeembeddingSparameters']['numberOfPorts']
+        return self._defaults['GetDeembeddingSparameters']['return']
+
+    def niRFSG_GetDeembeddingTableNumberOfPorts(self, vi, number_of_ports):  # noqa: N802
+        if self._defaults['GetDeembeddingTableNumberOfPorts']['return'] != 0:
+            return self._defaults['GetDeembeddingTableNumberOfPorts']['return']
+        # number_of_ports
+        if self._defaults['GetDeembeddingTableNumberOfPorts']['numberOfPorts'] is None:
+            raise MockFunctionCallError("niRFSG_GetDeembeddingTableNumberOfPorts", param='numberOfPorts')
+        if number_of_ports is not None:
+            number_of_ports.contents.value = self._defaults['GetDeembeddingTableNumberOfPorts']['numberOfPorts']
+        return self._defaults['GetDeembeddingTableNumberOfPorts']['return']
 
     def niRFSG_GetError(self, vi, error_code, error_description_buffer_size, error_description):  # noqa: N802
         if self._defaults['GetError']['return'] != 0:
@@ -1064,6 +1108,8 @@ class SideEffectsHelper(object):
         mock_library.niRFSG_ConfigureSoftwareScriptTrigger.return_value = 0
         mock_library.niRFSG_ConfigureSoftwareStartTrigger.side_effect = MockFunctionCallError("niRFSG_ConfigureSoftwareStartTrigger")
         mock_library.niRFSG_ConfigureSoftwareStartTrigger.return_value = 0
+        mock_library.niRFSG_CreateDeembeddingSparameterTableArray.side_effect = MockFunctionCallError("niRFSG_CreateDeembeddingSparameterTableArray")
+        mock_library.niRFSG_CreateDeembeddingSparameterTableArray.return_value = 0
         mock_library.niRFSG_CreateDeembeddingSparameterTableS2PFile.side_effect = MockFunctionCallError("niRFSG_CreateDeembeddingSparameterTableS2PFile")
         mock_library.niRFSG_CreateDeembeddingSparameterTableS2PFile.return_value = 0
         mock_library.niRFSG_DeleteAllDeembeddingTables.side_effect = MockFunctionCallError("niRFSG_DeleteAllDeembeddingTables")
@@ -1080,8 +1126,6 @@ class SideEffectsHelper(object):
         mock_library.niRFSG_ErrorMessage.return_value = 0
         mock_library.niRFSG_ErrorQuery.side_effect = MockFunctionCallError("niRFSG_ErrorQuery")
         mock_library.niRFSG_ErrorQuery.return_value = 0
-        mock_library.niRFSG_ExportSignal.side_effect = MockFunctionCallError("niRFSG_ExportSignal")
-        mock_library.niRFSG_ExportSignal.return_value = 0
         mock_library.niRFSG_GetAllNamedWaveformNames.side_effect = MockFunctionCallError("niRFSG_GetAllNamedWaveformNames")
         mock_library.niRFSG_GetAllNamedWaveformNames.return_value = 0
         mock_library.niRFSG_GetAllScriptNames.side_effect = MockFunctionCallError("niRFSG_GetAllScriptNames")
@@ -1100,6 +1144,10 @@ class SideEffectsHelper(object):
         mock_library.niRFSG_GetAttributeViString.return_value = 0
         mock_library.niRFSG_GetChannelName.side_effect = MockFunctionCallError("niRFSG_GetChannelName")
         mock_library.niRFSG_GetChannelName.return_value = 0
+        mock_library.niRFSG_GetDeembeddingSparameters.side_effect = MockFunctionCallError("niRFSG_GetDeembeddingSparameters")
+        mock_library.niRFSG_GetDeembeddingSparameters.return_value = 0
+        mock_library.niRFSG_GetDeembeddingTableNumberOfPorts.side_effect = MockFunctionCallError("niRFSG_GetDeembeddingTableNumberOfPorts")
+        mock_library.niRFSG_GetDeembeddingTableNumberOfPorts.return_value = 0
         mock_library.niRFSG_GetError.side_effect = MockFunctionCallError("niRFSG_GetError")
         mock_library.niRFSG_GetError.return_value = 0
         mock_library.niRFSG_GetExternalCalibrationLastDateAndTime.side_effect = MockFunctionCallError("niRFSG_GetExternalCalibrationLastDateAndTime")

--- a/src/nirfsg/metadata/attributes.py
+++ b/src/nirfsg/metadata/attributes.py
@@ -740,7 +740,7 @@ attributes = {
         'lv_property': 'RF:LO Out Enabled',
         'name': 'LO_OUT_ENABLED',
         'supported_rep_caps': [
-            'lo_channels'
+            'los'
         ],
         'type': 'ViBoolean'
     },
@@ -864,7 +864,7 @@ attributes = {
         'lv_property': 'Device Characteristics:Device Temperature (Degrees C)',
         'name': 'DEVICE_TEMPERATURE',
         'supported_rep_caps': [
-            'ports'
+            'device_temperatures'
         ],
         'type': 'ViReal64'
     },
@@ -1087,7 +1087,7 @@ attributes = {
         'access': 'read-write',
         'codegen_method': 'public',
         'documentation': {
-            'description': 'Specifies the destination terminal for exporting the Script Trigger. To set this attribute, the NI-RFSG device must be in the Configuration state.\n\n**Supported Devices:** PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Script Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/script_triggers.html>`_ —Refer to this topic for information about trigger delay.\n\n`PFI Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pfi_lines.html>`_\n\n`PXI Trigger Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pxi_trigger.html>`_\n\n**High-Level Functions**:\n\n- nirfsg_ExportSignal\n\n**Possible Values**:',
+            'description': 'Specifies the destination terminal for exporting the Script Trigger. To set this attribute, the NI-RFSG device must be in the Configuration state.\n\n**Supported Devices:** PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Script Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/script_triggers.html>`_ —Refer to this topic for information about trigger delay.\n\n`PFI Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pfi_lines.html>`_\n\n`PXI Trigger Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pxi_trigger.html>`_\n\n**Possible Values**:',
             'table_body': [
                 [
                     '""',
@@ -1259,7 +1259,7 @@ attributes = {
         'lv_property': 'RF:Loop Bandwidth',
         'name': 'LOOP_BANDWIDTH',
         'supported_rep_caps': [
-            'lo_channels'
+            'los'
         ],
         'type': 'ViInt32'
     },
@@ -1924,7 +1924,7 @@ attributes = {
         'access': 'read-write',
         'codegen_method': 'public',
         'documentation': {
-            'description': 'Specifies the destination terminal for exporting the Done event. To set this attribute, the NI-RFSG device must be in the Configuration state.\n\n**Supported Devices:** PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Triggers <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/triggers.html>`_\n\n`Events <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/events.html>`_\n\n`PFI Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pfi_lines.html>`_\n\n`PXI Trigger Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pxi_trigger.html>`_\n\n**High-Level Functions**:\n\n- nirfsg_ExportSignal\n\n**Possible Values**:',
+            'description': 'Specifies the destination terminal for exporting the Done event. To set this attribute, the NI-RFSG device must be in the Configuration state.\n\n**Supported Devices:** PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Triggers <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/triggers.html>`_\n\n`Events <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/events.html>`_\n\n`PFI Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pfi_lines.html>`_\n\n`PXI Trigger Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pxi_trigger.html>`_\n\n**Possible Values**:',
             'table_body': [
                 [
                     '""',
@@ -2024,7 +2024,7 @@ attributes = {
         'access': 'read-write',
         'codegen_method': 'public',
         'documentation': {
-            'description': 'Specifies the destination terminal for exporting the Marker Event. To set this attribute, the NI-RFSG device must be in the Configuration state.\n\n**Supported Devices:** PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Marker Events <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/marker_events.html>`_\n\n`PFI Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pfi_lines.html>`_\n\n`PXI Trigger Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pxi_trigger.html>`_\n\n**High-Level Functions**:\n\n- nirfsg_ExportSignal\n\n**Possible Values**:',
+            'description': 'Specifies the destination terminal for exporting the Marker Event. To set this attribute, the NI-RFSG device must be in the Configuration state.\n\n**Supported Devices:** PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Marker Events <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/marker_events.html>`_\n\n`PFI Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pfi_lines.html>`_\n\n`PXI Trigger Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pxi_trigger.html>`_\n\n**Possible Values**:',
             'table_body': [
                 [
                     '""',
@@ -2127,7 +2127,7 @@ attributes = {
         'access': 'read-write',
         'codegen_method': 'public',
         'documentation': {
-            'description': 'Specifies the destination terminal for exporting the Started event. To set this attribute, the NI-RFSG device must be in the Configuration state.\n\n**Supported Devices:** PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Events <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/events.html>`_\n\n`PFI Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pfi_lines.html>`_\n\n`PXI Trigger Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pxi_trigger.html>`_\n\n**High-Level Functions**:\n\n- nirfsg_ExportSignal\n\n**Possible Values**:',
+            'description': 'Specifies the destination terminal for exporting the Started event. To set this attribute, the NI-RFSG device must be in the Configuration state.\n\n**Supported Devices:** PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Events <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/events.html>`_\n\n`PFI Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pfi_lines.html>`_\n\n`PXI Trigger Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pxi_trigger.html>`_\n\n**Possible Values**:',
             'table_body': [
                 [
                     '""',
@@ -2233,7 +2233,7 @@ attributes = {
         'lv_property': 'RF:LO Out Power (dBm)',
         'name': 'LO_OUT_POWER',
         'supported_rep_caps': [
-            'lo_channels'
+            'los'
         ],
         'type': 'ViReal64'
     },
@@ -2247,7 +2247,7 @@ attributes = {
         'lv_property': 'RF:LO In Power (dBm)',
         'name': 'LO_IN_POWER',
         'supported_rep_caps': [
-            'lo_channels'
+            'los'
         ],
         'type': 'ViReal64'
     },
@@ -2851,11 +2851,11 @@ attributes = {
                 'Description'
             ]
         },
-        'enum': 'IQOutPortTermCfg',
+        'enum': 'IQOutPortTerminalConfiguration',
         'lv_property': 'Device Specific:Vector Signal Transceiver:IQ Out Port:Terminal Configuration',
         'name': 'IQ_OUT_PORT_TERMINAL_CONFIGURATION',
         'supported_rep_caps': [
-            'ports'
+            'channels'
         ],
         'type': 'ViInt32'
     },
@@ -2869,7 +2869,7 @@ attributes = {
         'lv_property': 'Device Specific:Vector Signal Transceiver:IQ Out Port:Level',
         'name': 'IQ_OUT_PORT_LEVEL',
         'supported_rep_caps': [
-            'ports'
+            'channels'
         ],
         'type': 'ViReal64'
     },
@@ -2883,7 +2883,7 @@ attributes = {
         'lv_property': 'Device Specific:Vector Signal Transceiver:IQ Out Port:Common Mode Offset',
         'name': 'IQ_OUT_PORT_COMMON_MODE_OFFSET',
         'supported_rep_caps': [
-            'ports'
+            'channels'
         ],
         'type': 'ViReal64'
     },
@@ -2897,7 +2897,7 @@ attributes = {
         'lv_property': 'Device Specific:Vector Signal Transceiver:IQ Out Port:Offset',
         'name': 'IQ_OUT_PORT_OFFSET',
         'supported_rep_caps': [
-            'ports'
+            'channels'
         ],
         'type': 'ViReal64'
     },
@@ -2937,7 +2937,7 @@ attributes = {
         'lv_property': 'Device Specific:Vector Signal Transceiver:Signal Path:LO Source',
         'name': 'LO_SOURCE',
         'supported_rep_caps': [
-            'lo_channels'
+            'los'
         ],
         'type': 'ViString'
     },
@@ -3017,7 +3017,7 @@ attributes = {
         'lv_property': 'Device Specific:Vector Signal Transceiver:Signal Path:LO PLL Fractional Mode Enabled',
         'name': 'LO_PLL_FRACTIONAL_MODE_ENABLED',
         'supported_rep_caps': [
-            'lo_channels'
+            'los'
         ],
         'type': 'ViInt32'
     },
@@ -3181,7 +3181,7 @@ attributes = {
         'lv_property': 'Device Specific:Vector Signal Transceiver:IQ Out Port:Load Impedance',
         'name': 'IQ_OUT_PORT_LOAD_IMPEDANCE',
         'supported_rep_caps': [
-            'ports'
+            'channels'
         ],
         'type': 'ViReal64'
     },
@@ -3531,7 +3531,7 @@ attributes = {
         'lv_property': 'RF:LO Frequency (Hz)',
         'name': 'LO_FREQUENCY',
         'supported_rep_caps': [
-            'lo_channels'
+            'los'
         ],
         'type': 'ViReal64'
     },

--- a/src/nirfsg/metadata/config.py
+++ b/src/nirfsg/metadata/config.py
@@ -69,7 +69,15 @@ config = {
         },
         {
             'prefix': 'LO',
-            'python_name': 'lo_channels'
+            'python_name': 'los'
+        },
+        {
+            'prefix': '',
+            'python_name': 'device_temperatures'
+        },
+        {
+            'prefix': '',
+            'python_name': 'channels'
         }
     ],
     'session_class_description': 'An NI-RFSG session to the NI-RFSG driver',

--- a/src/nirfsg/metadata/enums.py
+++ b/src/nirfsg/metadata/enums.py
@@ -448,7 +448,7 @@ enums = {
             }
         ]
     },
-    'IQOutPortTermCfg': {
+    'IQOutPortTerminalConfiguration': {
         'values': [
             {
                 'documentation': {

--- a/src/nirfsg/metadata/functions.py
+++ b/src/nirfsg/metadata/functions.py
@@ -813,7 +813,7 @@ functions = {
     'CreateDeembeddingSparameterTableArray': {
         'codegen_method': 'private',
         'documentation': {
-        'description': '\nCreates an s-parameter de-embedding table for the port from the input data.\n                \nIf you only create one table for a port, NI-RFSA automatically selects that table to de-embed the measurement.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`De-embedding Overview <https://www.ni.com/docs/en-US/bundle/pxie-5840/page/de-embedding-overview.html>`_'
+        'description': '\nCreates an s-parameter de-embedding table for the port from the input data.\n\nIf you only create one table for a port, NI-RFSG automatically selects that table to de-embed the measurement.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`De-embedding Overview <https://www.ni.com/docs/en-US/bundle/pxie-5840/page/de-embedding-overview.html>`_'
         },
         'included_in_proto': True,
         'method_templates': [
@@ -945,7 +945,7 @@ functions = {
     'FancyCreateDeembeddingSparameterTableArray': {
         'codegen_method': 'python-only',
         'documentation': {
-        'description': '\nCreates an s-parameter de-embedding table for the port from the input data.\n                \nIf you only create one table for a port, NI-RFSA automatically selects that table to de-embed the measurement.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`De-embedding Overview <https://www.ni.com/docs/en-US/bundle/pxie-5840/page/de-embedding-overview.html>`_'
+        'description': '\nCreates an s-parameter de-embedding table for the port from the input data.\n\nIf you only create one table for a port, NI-RFSG automatically selects that table to de-embed the measurement.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`De-embedding Overview <https://www.ni.com/docs/en-US/bundle/pxie-5840/page/de-embedding-overview.html>`_'
         },
         'included_in_proto': True,
         'method_templates': [

--- a/src/nirfsg/metadata/functions.py
+++ b/src/nirfsg/metadata/functions.py
@@ -810,6 +810,240 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
+    'CreateDeembeddingSparameterTableArray': {
+        'codegen_method': 'private',
+        'documentation': {
+        'description': '\nCreates an s-parameter de-embedding table for the port from the input data.\n                \nIf you only create one table for a port, NI-RFSA automatically selects that table to de-embed the measurement.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`De-embedding Overview <https://www.ni.com/docs/en-US/bundle/pxie-5840/page/de-embedding-overview.html>`_'
+        },
+        'included_in_proto': True,
+        'method_templates': [
+            {
+                'documentation_filename': 'numpy_method',
+                'library_interpreter_filename': 'numpy_write_method',
+                'method_python_name_suffix': '',
+                'session_filename': 'numpy_write_method'
+            }
+        ],
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'vi',
+                'documentation': {
+                    'description': 'Identifies your instrument session. NIRFSG_ATTR_VI is obtained from the nirfsg_Init or nirfsg_InitWithOptions function.'
+                },
+                'type': 'ViSession',
+                'use_array': False,
+                'use_in_python_api': True
+            },
+            {
+                'direction': 'in',
+                'name': 'port',
+                'documentation': {
+                    'description': 'Specifies the name of the port. The only valid value for the PXIe-5840/5841/5842/5860 is \"\" (empty string).'
+                },
+                'type': 'ViConstString',
+                'use_array': False,
+                'use_in_python_api': True
+            },
+            {
+                'direction': 'in',
+                'name': 'tableName',
+                'documentation': {
+                    'description': 'Specifies the name of the table. The name must be unique for a given port, but not across ports. If you use the same name as an existing table, the table is replaced.'
+                },
+                'type': 'ViConstString',
+                'use_array': False,
+                'use_in_python_api': True
+            },
+            {
+                'direction': 'in',
+                'name': 'frequencies',
+                'documentation': {
+                    'description': 'Specifies the frequencies for the NIRFSG_ATTR_SPARAMETER_TABLE rows. Frequencies must be unique and in ascending order.'
+                },
+                'type': 'ViReal64[]',
+                'size': {
+                    'mechanism': 'len',
+                    'value': 'frequenciesSize'
+                },
+                'numpy': True,
+                'use_in_python_api': True
+            },
+            {
+                'direction': 'in',
+                'name': 'frequenciesSize',
+                'documentation': {
+                    'description': 'Specifies the size of the frequency array.'
+                },
+                'type': 'ViInt32',
+                'use_array': False,
+                'use_in_python_api': False
+            },
+            {
+                'complex_type': 'numpy',
+                'direction': 'in',
+                'name': 'sparameterTable',
+                'documentation': {
+                    'description': 'Specifies the S-parameters for each frequency. S-parameters for each frequency are placed in the array in the following order: s11, s12, s21, s22.'
+                },
+                'type': 'NIComplexNumber[]',
+                'numpy': True,
+                'use_in_python_api': True,
+                'array_dimension': 3
+            },
+            {
+                'direction': 'in',
+                'name': 'sparameterTableSize',
+                'documentation': {
+                    'description': 'Specifies the size of the S-parameter table array.'
+                },
+                'type': 'ViInt32',
+                'use_array': False,
+                'use_in_python_api': False
+            },
+            {
+                'direction': 'in',
+                'name': 'numberOfPorts',
+                'documentation': {
+                    'description': 'Specifies the number of DUT ports.'
+                },
+                'type': 'ViInt32',
+                'use_array': False,
+                'use_in_python_api': False
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': ' Specifies the orientation of the input data relative to the port on the DUT port. **Defined Values** :',
+                    'table_body': [
+                        [
+                            'NIRFSG_VAL_PORT1_TOWARDS_DUT',
+                            '24000 (0x5dc0)',
+                            'Port 1 of the S2P is oriented towards the DUT port.'
+                        ],
+                        [
+                            'NIRFSG_VAL_PORT2_TOWARDS_DUT',
+                            '24001 (0x5dc1)',
+                            'Port 2 of the S2P is oriented towards the DUT port.'
+                        ]
+                    ],
+                    'table_header': [
+                        'Name',
+                        'Value',
+                        'Description'
+                    ]
+                },
+                'enum': 'SparameterOrientation',
+                'name': 'sparameterOrientation',
+                'type': 'ViInt32',
+                'use_array': False,
+                'use_in_python_api': True
+            }
+        ],
+        'returns': 'ViStatus',
+    },
+    'FancyCreateDeembeddingSparameterTableArray': {
+        'codegen_method': 'python-only',
+        'documentation': {
+        'description': '\nCreates an s-parameter de-embedding table for the port from the input data.\n                \nIf you only create one table for a port, NI-RFSA automatically selects that table to de-embed the measurement.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`De-embedding Overview <https://www.ni.com/docs/en-US/bundle/pxie-5840/page/de-embedding-overview.html>`_'
+        },
+        'included_in_proto': True,
+        'method_templates': [
+            {
+                'documentation_filename': 'default_method',
+                'library_interpreter_filename': 'none',
+                'method_python_name_suffix': '',
+                'session_filename': 'create_deembedding_sparameter_table_array'
+            }
+        ],
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'vi',
+                'documentation': {
+                    'description': 'Identifies your instrument session. NIRFSG_ATTR_VI is obtained from the nirfsg_Init or nirfsg_InitWithOptions function.'
+                },
+                'type': 'ViSession',
+                'use_array': False,
+                'use_in_python_api': True
+            },
+            {
+                'direction': 'in',
+                'name': 'port',
+                'documentation': {
+                    'description': 'Specifies the name of the port. The only valid value for the PXIe-5840/5841/5842/5860 is \"\" (empty string).'
+                },
+                'type': 'ViConstString',
+                'use_array': False,
+                'use_in_python_api': True
+            },
+            {
+                'direction': 'in',
+                'name': 'tableName',
+                'documentation': {
+                    'description': 'Specifies the name of the table. The name must be unique for a given port, but not across ports. If you use the same name as an existing table, the table is replaced.'
+                },
+                'type': 'ViConstString',
+                'use_array': False,
+                'use_in_python_api': True
+            },
+            {
+                'complex_type': 'numpy',
+                'direction': 'in',
+                'name': 'frequencies',
+                'documentation': {
+                    'description': 'Specifies the frequencies for the NIRFSG_ATTR_SPARAMETER_TABLE rows. Frequencies must be unique and in ascending order.'
+                },
+                'type_in_documentation': 'numpy.array(dtype=numpy.float64)',
+                'type': 'ViReal64[]',
+                'numpy': True,
+                'use_in_python_api': True
+            },
+            {
+                'complex_type': 'numpy',
+                'direction': 'in',
+                'name': 'sparameterTable',
+                'documentation': {
+                    'description': 'Specifies the S-parameters for each frequency. S-parameters for each frequency are placed in the array in the following order: s11, s12, s21, s22.'
+                },
+                'type_in_documentation': 'numpy.array(dtype=numpy.complex128)',
+                'type': 'NIComplexNumber[]',
+                'numpy': True,
+                'use_in_python_api': True,
+                'array_dimension': 3
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': ' Specifies the orientation of the input data relative to the port on the DUT port. **Defined Values** :',
+                    'table_body': [
+                        [
+                            'NIRFSG_VAL_PORT1_TOWARDS_DUT',
+                            '24000 (0x5dc0)',
+                            'Port 1 of the S2P is oriented towards the DUT port.'
+                        ],
+                        [
+                            'NIRFSG_VAL_PORT2_TOWARDS_DUT',
+                            '24001 (0x5dc1)',
+                            'Port 2 of the S2P is oriented towards the DUT port.'
+                        ]
+                    ],
+                    'table_header': [
+                        'Name',
+                        'Value',
+                        'Description'
+                    ]
+                },
+                'enum': 'SparameterOrientation',
+                'name': 'sparameterOrientation',
+                'type': 'ViInt32',
+                'use_array': False,
+                'use_in_python_api': True
+            }
+        ],
+        'python_name': 'create_deembedding_sparameter_table_array',
+        'returns': 'ViStatus',
+    },
     'ConfigureDeembeddingTableInterpolationLinear': {
         'codegen_method': 'public',
         'documentation': {
@@ -985,6 +1219,121 @@ functions = {
                 'use_in_python_api': True
             }
         ],
+        'returns': 'ViStatus'
+    },
+    'GetDeembeddingTableNumberOfPorts': {
+        'codegen_method': 'private',
+        'documentation': {
+            'description': '\nReturns the number of S-parameter ports.'
+        },
+        'included_in_proto': False,
+        'is_error_handling': False,
+        'method_templates': [
+            {
+                'documentation_filename': 'default_method',
+                'library_interpreter_filename': 'default_method',
+                'method_python_name_suffix': '',
+                'session_filename': 'default_method'
+            }
+        ],
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Identifies your instrument session. The ViSession handle is obtained from the nirfsg_Init function or the nirfsg_InitWithOptions function and identifies a particular instrument session.'
+                },
+                'name': 'vi',
+                'type': 'ViSession',
+                'use_array': False,
+                'use_in_python_api': True
+            },
+            {
+                'direction': 'out',
+                'documentation': {
+                    'description': 'Returns the number of S-parameter ports. The **sparameter** array is always *n* x *n*, where span *n* is the number of ports.'
+                },
+                'name': 'numberOfPorts',
+                'type': 'ViInt32',
+                'use_array': False,
+                'use_in_python_api': True
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'GetDeembeddingSparameters': {
+        'codegen_method': 'public',
+        'documentation': {
+            'description': '\nReturns the S-parameters used for de-embedding a measurement on the selected port. \n\nThis includes interpolation of the parameters based on the configured carrier frequency. This function returns an empty array if no de-embedding is done.\n\nIf you want to call this function just to get the required buffer size, you can pass 0 for **S-parameter Size** and VI_NULL for the **S-parameters** buffer.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860\n\n**Note**: The port orientation for the returned S-parameters is normalized to NIRFSG_VAL_PORT1_TOWARDS_DUT.\n                '
+        },
+        'included_in_proto': False,
+        'is_error_handling': False,
+        'method_templates': [
+            {
+                'documentation_filename': 'default_method',
+                'library_interpreter_filename': 'numpy_read_method',
+                'method_python_name_suffix': '',
+                'session_filename': 'get_deembedding_sparameter'
+            }
+        ],
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Identifies your instrument session. The ViSession handle is obtained from the nirfsg_Init function or the nirfsg_InitWithOptions function and identifies a particular instrument session.'
+                },
+                'name': 'vi',
+                'type': 'ViSession',
+                'use_array': False,
+                'use_in_python_api': True
+            },
+            {
+                'direction': 'out',
+                'documentation': {
+                    'description': 'Returns an array of S-parameters. The S-parameters are returned in the following order: s11, s12, s21, s22.'
+                },
+                'name': 'sparameters',
+                'size': {
+                    'mechanism': 'pass',
+                    'value': 'numberOfSparameters'
+                },
+                'numpy': True,
+                'type': 'NIComplexNumber[]',
+                'complex_type': 'numpy',
+                'use_in_python_api': True,
+                'array_dimension': 3
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Specifies the size of the array that is returned by the NIRFSG_ATTR_SPARAMETERS output.'
+                },
+                'name': 'sparameterArraySize',
+                'type': 'ViInt32',
+                'use_array': False,
+                'use_in_python_api': True
+            },
+            {
+                'direction': 'out',
+                'name': 'numberOfSparameters',
+                'documentation': {
+                    'description': 'Returns the number of S-parameters.'
+                },
+                'type': 'ViInt32',
+                'use_array': False,
+                'use_in_python_api': False
+            },
+            {
+                'direction': 'out',
+                'name': 'numberOfPorts',
+                'documentation': {
+                    'description': 'Returns the number of S-parameter ports. The **sparameter** array is always *n* x *n*, where span *n* is the number of ports.'
+                },
+                'type': 'ViInt32',
+                'use_array': False,
+                'use_in_python_api': True
+            }
+        ],
+        'python_name': 'get_deembedding_sparameters',
         'returns': 'ViStatus'
     },
     'ConfigureDigitalEdgeScriptTrigger': {
@@ -1798,172 +2147,6 @@ functions = {
                     'value': 256
                 },
                 'type': 'ViChar[]',
-                'use_array': False,
-                'use_in_python_api': True
-            }
-        ],
-        'returns': 'ViStatus'
-    },
-    'ExportSignal': {
-        'codegen_method': 'public',
-        'documentation': {
-            'description': '\nRoutes signals (triggers, clocks, and events) to a specified output terminal.\n\nThe NI-RFSG device must be in the Configuration state before you call this function.\n\nYou can clear a previously routed signal by exporting the signal to "" (empty string).\n\n**Supported Devices** :PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Triggers <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/triggers.html>`_\n\n`Events <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/events.html>`_\n\n`PFI Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pfi_lines.html>`_\n\n`PXI Trigger Lines <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/integration_pxi_trigger.html>`_'
-        },
-        'included_in_proto': True,
-        'method_templates': [
-            {
-                'documentation_filename': 'default_method',
-                'library_interpreter_filename': 'default_method',
-                'method_python_name_suffix': '',
-                'session_filename': 'default_method'
-            }
-        ],
-        'parameters': [
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies your instrument session. The ViSession handle is obtained from the nirfsg_Init function or the nirfsg_InitWithOptions function and identifies a particular instrument session.'
-                },
-                'name': 'vi',
-                'type': 'ViSession',
-                'use_array': False,
-                'use_in_python_api': True
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': ' Specifies the type of signal to route.\n\n **Defined Values** :',
-                    'table_body': [
-                        [
-                            'NIRFSG_VAL_START_TRIGGER',
-                            '0 (0x0)',
-                            'Exports a Start Trigger.'
-                        ],
-                        [
-                            'NIRFSG_VAL_SCRIPT_TRIGGER',
-                            '1 (0x1)',
-                            'Exports a Script Trigger.'
-                        ],
-                        [
-                            'NIRFSG_VAL_MARKER_EVENT',
-                            '2 (0x2)',
-                            'Exports a Marker Event.'
-                        ],
-                        [
-                            'NIRFSG_VAL_REF_CLOCK',
-                            '3 (0x3)',
-                            'Exports the Reference Clock.'
-                        ],
-                        [
-                            'NIRFSG_VAL_STARTED_EVENT',
-                            '4 (0x4)',
-                            'Exports a Started Event.'
-                        ],
-                        [
-                            'NIRFSG_VAL_DONE_EVENT',
-                            '5 (0x5)',
-                            'Exports a Done Event.'
-                        ],
-                        [
-                            'NIRFSG_VAL_CONFIGURATION_LIST_STEP_TRIGGER',
-                            '6 (0x6)',
-                            'Exports a Configuration List Step Trigger.'
-                        ],
-                        [
-                            'NIRFSG_VAL_CONFIGURATION_SETTLED_EVENT',
-                            '7 (0x7)',
-                            'Exports a Configuration Settled Event.'
-                        ]
-                    ],
-                    'table_header': [
-                        'Name',
-                        'Value',
-                        'Description'
-                    ]
-                },
-                'enum': 'Signal',
-                'name': 'signal',
-                'type': 'ViInt32',
-                'use_array': False,
-                'use_in_python_api': True
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Specifies which instance of the selected signal to export. This parameter is useful when you set the NIRFSG_ATTR_SIGNAL parameter to NIRFSG_VAL_SCRIPT_TRIGGER or NIRFSG_VAL_MARKER_EVENT. Otherwise, set the NIRFSG_ATTR_SIGNAL_IDENTIFIER parameter to "".\n\n**Possible Values** :',
-                    'table_body': [
-                        [
-                            '"marker0"',
-                            'Specifies Marker 0.'
-                        ],
-                        [
-                            '"marker1"',
-                            'Specifies Marker 1.'
-                        ],
-                        [
-                            '"marker2"',
-                            'Specifies Marker 2.'
-                        ],
-                        [
-                            '"marker3"',
-                            'Specifies Marker 3.'
-                        ],
-                        [
-                            '"scriptTrigger0"',
-                            'Specifies Script Trigger 0.'
-                        ],
-                        [
-                            '"scriptTrigger1"',
-                            'Specifies Script Trigger 1.'
-                        ],
-                        [
-                            '"scriptTrigger2"',
-                            'Specifies Script Trigger 2.'
-                        ],
-                        [
-                            '"scriptTrigger3"',
-                            'Specifies Script Trigger 3.'
-                        ]
-                    ],
-                    'table_header': [
-                        'Possible Value',
-                        'Description'
-                    ]
-                },
-                'name': 'signalIdentifier',
-                'type': 'ViConstString',
-                'use_array': False,
-                'use_in_python_api': True
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Specifies the terminal where the signal is exported. You can choose not to export any signal. For the PXIe-5841 with PXIe-5655, the signal is exported to the terminal on the PXIe-5841.\n\n **Possible Values** :',
-                    'table_body': [
-                        [
-                            '"ClkOut"',
-                            'Exports the Reference Clock signal to the CLK OUT connector of the device.'
-                        ],
-                        [
-                            '""',
-                            'The Reference Clock signal is not exported.'
-                        ],
-                        [
-                            '"RefOut"',
-                            'Exports the Reference Clock signal to the REF OUT connector of the device.'
-                        ],
-                        [
-                            '"RefOut2"',
-                            'Exports the Reference Clock signal to the REF OUT2 connector of the device, if applicable.'
-                        ]
-                    ],
-                    'table_header': [
-                        'Possible Value',
-                        'Description'
-                    ]
-                },
-                'name': 'outputTerminal',
-                'type': 'ViConstString',
                 'use_array': False,
                 'use_in_python_api': True
             }
@@ -5145,7 +5328,7 @@ functions = {
                 },
                 'type': 'NIComplexNumberF32[]',
                 'use_in_python_api': True,
-                'use_numpy_array': True
+                'use_array': True
             },
             {
                 'direction': 'in',
@@ -5223,7 +5406,7 @@ functions = {
                 },
                 'type': 'NIComplexNumber[]',
                 'use_in_python_api': True,
-                'use_numpy_array': True
+                'use_array': True
             },
             {
                 'direction': 'in',
@@ -5301,7 +5484,7 @@ functions = {
                 },
                 'type': 'NIComplexI16[]',
                 'use_in_python_api': True,
-                'use_numpy_array': True
+                'use_array': True
             }
         ],
         'returns': 'ViStatus',
@@ -5369,7 +5552,7 @@ functions = {
                 },
                 'type': 'NIComplexNumber[]',
                 'use_in_python_api': True,
-                'use_numpy_array': True
+                'use_array': True
             },
             {
                 'direction': 'in',

--- a/src/nirfsg/system_tests/test_system_nirfsg.py
+++ b/src/nirfsg/system_tests/test_system_nirfsg.py
@@ -539,8 +539,8 @@ class SystemTests:
 
     def test_set_get_deembedding_table(self, rfsg_device_session):
         frequencies = np.array([1e9, 2e9, 3e9], dtype=np.float64)
-        sparameter_tables = np.array([[[1+1j, 2+2j], [3+3j, 4+4j]],[[5+5j, 6+6j], [7+7j, 8+8j]],[[9+9j, 10+10j], [11+11j, 12+12j]]], dtype=np.complex128)
-        expected_sparameter_table = np.array([[5+5j, 6+6j], [7+7j, 8+8j]], dtype=np.complex128)
+        sparameter_tables = np.array([[[1 + 1j, 2 + 2j], [3 + 3j, 4 + 4j]], [[5 + 5j, 6 + 6j], [7 + 7j, 8 + 8j]], [[9 + 9j, 10 + 10j], [11 + 11j, 12 + 12j]]], dtype=np.complex128)
+        expected_sparameter_table = np.array([[5 + 5j, 6 + 6j], [7 + 7j, 8 + 8j]], dtype=np.complex128)
         rfsg_device_session.create_deembedding_sparameter_table_array('', 'myTable1', frequencies, sparameter_tables, nirfsg.SparameterOrientation.PORT2_TOWARDS_DUT)
         rfsg_device_session.frequency = 2e9
         returned_sparameter_table, number_of_ports = rfsg_device_session.get_deembedding_sparameters()

--- a/src/nirfsg/system_tests/test_system_nirfsg.py
+++ b/src/nirfsg/system_tests/test_system_nirfsg.py
@@ -515,7 +515,7 @@ class SystemTests:
             rfsg_device_session.send_software_edge_trigger(nirfsg.SoftwareTriggerType.SCRIPT, 'scriptTrigger0')
 
     @pytest.mark.skipif(sys.platform == "linux", reason="Function not supported on Linux OS")
-    def test_deembedding_table_with_s2p_file(self, rfsg_device_session):
+    def test_create_deembedding_sparameter_table_s2p_file(self, rfsg_device_session):
         rfsg_device_session.create_deembedding_sparameter_table_s2p_file('', 'myTable1', get_test_file_path('samples2pfile.s2p'), nirfsg.SparameterOrientation.PORT2_TOWARDS_DUT)
         rfsg_device_session.create_deembedding_sparameter_table_s2p_file('', 'myTable2', get_test_file_path('samples2pfile.s2p'), nirfsg.SparameterOrientation.PORT1_TOWARDS_DUT)
         rfsg_device_session.configure_deembedding_table_interpolation_linear('', 'myTable1', nirfsg.Format.MAGNITUDE_AND_PHASE)
@@ -537,7 +537,7 @@ class SystemTests:
         with rfsg_device_session.initiate():
             rfsg_device_session.check_generation_status()
 
-    def test_set_get_deembedding_table(self, rfsg_device_session):
+    def test_set_get_deembedding_sparameters(self, rfsg_device_session):
         frequencies = np.array([1e9, 2e9, 3e9], dtype=np.float64)
         sparameter_tables = np.array([[[1 + 1j, 2 + 2j], [3 + 3j, 4 + 4j]], [[5 + 5j, 6 + 6j], [7 + 7j, 8 + 8j]], [[9 + 9j, 10 + 10j], [11 + 11j, 12 + 12j]]], dtype=np.complex128)
         expected_sparameter_table = np.array([[5 + 5j, 6 + 6j], [7 + 7j, 8 + 8j]], dtype=np.complex128)
@@ -547,7 +547,7 @@ class SystemTests:
         assert number_of_ports == 2
         assert returned_sparameter_table.all() == expected_sparameter_table.all()
 
-    def test_configure_deembedding_table_error_cases(self, rfsg_device_session):
+    def test_create_deembedding_sparameter_table_array_error_cases(self, rfsg_device_session):
         frequencies = np.array([1e9, 2e9, 3e9], dtype=np.float64)
         wrong_number_of_tables = np.full((2, 2, 2), 2.0 + 0.0j, dtype=np.complex128)
         wrong_table_size = np.full((3, 2, 3), 2.0 + 0.0j, dtype=np.complex128)
@@ -555,17 +555,17 @@ class SystemTests:
         try:
             rfsg_device_session.create_deembedding_sparameter_table_array('', 'myTable1', frequencies, wrong_number_of_tables, nirfsg.SparameterOrientation.PORT2_TOWARDS_DUT)
             assert False
-        except IndexError as e:
-            assert str(e) == 'Frequencies count does not match the sparameter table count. Frequencies count is 3 and s parameter table count is 2.'
+        except ValueError as e:
+            assert str(e) == 'Frequencies count does not match the sparameter table count. Frequencies count is 3 and sparameter table count is 2.'
         try:
             rfsg_device_session.create_deembedding_sparameter_table_array('', 'myTable1', frequencies, wrong_table_size, nirfsg.SparameterOrientation.PORT2_TOWARDS_DUT)
             assert False
-        except IndexError as e:
-            assert str(e) == 'Row and column count of sparameters table should be equal. Table row count is 2 and column count is 3.'
+        except ValueError as e:
+            assert str(e) == 'Row and column count of sparameter table should be equal. Table row count is 2 and column count is 3.'
         try:
             rfsg_device_session.create_deembedding_sparameter_table_array('', 'myTable1', frequencies, wrong_array_dimensions, nirfsg.SparameterOrientation.PORT2_TOWARDS_DUT)
             assert False
-        except IndexError as e:
+        except ValueError as e:
             assert str(e) == 'Unsupported array dimension. Is 2, expected 3'
 
     def test_read_and_download_waveform_from_file_tdms(self, rfsg_device_session):

--- a/src/nirfsg/system_tests/test_system_nirfsg.py
+++ b/src/nirfsg/system_tests/test_system_nirfsg.py
@@ -177,10 +177,10 @@ class SystemTests:
         simulated_5831_device_session.ports['if1'].deembedding_type = requested_deembedding_type
         assert simulated_5831_device_session.ports['if1'].deembedding_type == requested_deembedding_type
 
-    def test_lo_channels_rep_cap(self, simulated_5831_device_session):
+    def test_los_rep_cap(self, simulated_5831_device_session):
         requested_lo_source = "SG_SA_Shared"
-        simulated_5831_device_session.lo_channels[2].lo_source = requested_lo_source
-        assert simulated_5831_device_session.lo_channels[2].lo_source == requested_lo_source
+        simulated_5831_device_session.los[2].lo_source = requested_lo_source
+        assert simulated_5831_device_session.los[2].lo_source == requested_lo_source
 
 # Configuration methods related tests
     def test_configure_rf(self, rfsg_device_session):
@@ -363,31 +363,10 @@ class SystemTests:
         rfsg_device_session.script_triggers[3].disable_script_trigger()
         assert rfsg_device_session.script_triggers[3].script_trigger_type == nirfsg.ScriptTriggerType.NONE
 
-    def test_export_signal(self, rfsg_device_session):
-        rfsg_device_session.export_signal(nirfsg.Signal.START_TRIGGER, '', 'PXI_Trig0')
-        assert rfsg_device_session.exported_start_trigger_output_terminal == 'PXI_Trig0'
-        rfsg_device_session.export_signal(nirfsg.Signal.SCRIPT_TRIGGER, 'scriptTrigger2', 'PXI_Trig1')
-        assert rfsg_device_session.script_triggers[2].exported_script_trigger_output_terminal == 'PXI_Trig1'
-        rfsg_device_session.export_signal(nirfsg.Signal.MARKER_EVENT, 'marker1', 'PXI_Trig2')
-        assert rfsg_device_session.markers[1].exported_marker_event_output_terminal == 'PXI_Trig2'
-        rfsg_device_session.export_signal(nirfsg.Signal.REF_CLOCK, '', '')
-        assert rfsg_device_session.exported_ref_clock_output_terminal == ''
-        rfsg_device_session.export_signal(nirfsg.Signal.STARTED_EVENT, '', 'PXI_Trig3')
-        assert rfsg_device_session.exported_started_event_output_terminal == 'PXI_Trig3'
-        rfsg_device_session.export_signal(nirfsg.Signal.DONE_EVENT, '', 'PFI0')
-        assert rfsg_device_session.exported_done_event_output_terminal == 'PFI0'
-
-    def test_export_signal_with_invalid_signal(self, rfsg_device_session):
-        try:
-            rfsg_device_session.export_signal(nirfsg.Signal.INVALID, '', 'PXI_Trig0')
-            assert False
-        except AttributeError:
-            pass
-
     @pytest.mark.skipif(use_simulated_session is True, reason="RoCo is not invoked for simulated device")
-    def test_export_signal_with_invalid_terminal(self, rfsg_device_session):
+    def test_export_started_event_with_invalid_terminal(self, rfsg_device_session):
         try:
-            rfsg_device_session.export_signal(nirfsg.Signal.START_TRIGGER, '', 'InvalidTerminal')
+            rfsg_device_session.exported_started_event_output_terminal = 'InvalidTerminal'
             rfsg_device_session.commit()
             assert False
         except nirfsg.Error as e:
@@ -557,6 +536,37 @@ class SystemTests:
         rfsg_device_session.ports[''].deembedding_selected_table = ''
         with rfsg_device_session.initiate():
             rfsg_device_session.check_generation_status()
+
+    def test_set_get_deembedding_table(self, rfsg_device_session):
+        frequencies = np.array([1e9, 2e9, 3e9], dtype=np.float64)
+        sparameter_tables = np.array([[[1+1j, 2+2j], [3+3j, 4+4j]],[[5+5j, 6+6j], [7+7j, 8+8j]],[[9+9j, 10+10j], [11+11j, 12+12j]]], dtype=np.complex128)
+        expected_sparameter_table = np.array([[5+5j, 6+6j], [7+7j, 8+8j]], dtype=np.complex128)
+        rfsg_device_session.create_deembedding_sparameter_table_array('', 'myTable1', frequencies, sparameter_tables, nirfsg.SparameterOrientation.PORT2_TOWARDS_DUT)
+        rfsg_device_session.frequency = 2e9
+        returned_sparameter_table, number_of_ports = rfsg_device_session.get_deembedding_sparameters()
+        assert number_of_ports == 2
+        assert returned_sparameter_table.all() == expected_sparameter_table.all()
+
+    def test_configure_deembedding_table_error_cases(self, rfsg_device_session):
+        frequencies = np.array([1e9, 2e9, 3e9], dtype=np.float64)
+        wrong_number_of_tables = np.full((2, 2, 2), 2.0 + 0.0j, dtype=np.complex128)
+        wrong_table_size = np.full((3, 2, 3), 2.0 + 0.0j, dtype=np.complex128)
+        wrong_array_dimensions = np.full((3, 2), 2.0 + 0.0j, dtype=np.complex128)
+        try:
+            rfsg_device_session.create_deembedding_sparameter_table_array('', 'myTable1', frequencies, wrong_number_of_tables, nirfsg.SparameterOrientation.PORT2_TOWARDS_DUT)
+            assert False
+        except IndexError as e:
+            assert str(e) == 'Frequencies count does not match the sparameter table count. Frequencies count is 3 and s parameter table count is 2.'
+        try:
+            rfsg_device_session.create_deembedding_sparameter_table_array('', 'myTable1', frequencies, wrong_table_size, nirfsg.SparameterOrientation.PORT2_TOWARDS_DUT)
+            assert False
+        except IndexError as e:
+            assert str(e) == 'Row and column count of sparameters table should be equal. Table row count is 2 and column count is 3.'
+        try:
+            rfsg_device_session.create_deembedding_sparameter_table_array('', 'myTable1', frequencies, wrong_array_dimensions, nirfsg.SparameterOrientation.PORT2_TOWARDS_DUT)
+            assert False
+        except IndexError as e:
+            assert str(e) == 'Unsupported array dimension. Is 2, expected 3'
 
     def test_read_and_download_waveform_from_file_tdms(self, rfsg_device_session):
         rfsg_device_session.generation_mode = nirfsg.GenerationMode.ARB_WAVEFORM

--- a/src/nirfsg/templates/session.py/create_deembedding_sparameter_table_array.py.mako
+++ b/src/nirfsg/templates/session.py/create_deembedding_sparameter_table_array.py.mako
@@ -1,0 +1,25 @@
+<%page args="f, config, method_template"/>\
+<%
+    '''Ensures that incoming array has appropriate dimension sizes and calculates the number of ports and sparameter table size parameters based on array dimensions before calling into "create_deembedding_sparameter_table_array" method.'''
+    import build.helper as helper
+%>\
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
+        '''${f['python_name']}
+
+        ${helper.get_function_docstring(f, False, config, indent=8)}
+        '''
+        if (str(type(sparameter_table)).find("'numpy.ndarray'") != -1) or (str(type(frequencies)).find("'numpy.ndarray'") != -1):
+            if sparameter_table.ndim == 3:
+                if frequencies.size == sparameter_table.shape[0]:
+                    if sparameter_table.shape[1] == sparameter_table.shape[2]:
+                        number_of_ports = sparameter_table.shape[1]
+                        sparameter_table_size = sparameter_table.size
+                        return self._create_deembedding_sparameter_table_array(port, table_name, frequencies, sparameter_table, sparameter_table_size, number_of_ports, sparameter_orientation)
+                    else:
+                        raise IndexError("Row and column count of sparameters table should be equal. Table row count is {} and column count is {}.".format(sparameter_table.shape[1], sparameter_table.shape[2]))
+                else:
+                    raise IndexError("Frequencies count does not match the sparameter table count. Frequencies count is {} and s parameter table count is {}.".format(frequencies.size, sparameter_table.shape[0]))
+            else:
+                raise IndexError("Unsupported array dimension. Is {}, expected 3".format(sparameter_table.ndim))
+        else:
+            raise TypeError("Unsupported datatype. Expected numpy array.")

--- a/src/nirfsg/templates/session.py/create_deembedding_sparameter_table_array.py.mako
+++ b/src/nirfsg/templates/session.py/create_deembedding_sparameter_table_array.py.mako
@@ -16,10 +16,10 @@
                         sparameter_table_size = sparameter_table.size
                         return self._create_deembedding_sparameter_table_array(port, table_name, frequencies, sparameter_table, sparameter_table_size, number_of_ports, sparameter_orientation)
                     else:
-                        raise IndexError("Row and column count of sparameters table should be equal. Table row count is {} and column count is {}.".format(sparameter_table.shape[1], sparameter_table.shape[2]))
+                        raise ValueError("Row and column count of sparameter table should be equal. Table row count is {} and column count is {}.".format(sparameter_table.shape[1], sparameter_table.shape[2]))
                 else:
-                    raise IndexError("Frequencies count does not match the sparameter table count. Frequencies count is {} and s parameter table count is {}.".format(frequencies.size, sparameter_table.shape[0]))
+                    raise ValueError("Frequencies count does not match the sparameter table count. Frequencies count is {} and sparameter table count is {}.".format(frequencies.size, sparameter_table.shape[0]))
             else:
-                raise IndexError("Unsupported array dimension. Is {}, expected 3".format(sparameter_table.ndim))
+                raise ValueError("Unsupported array dimension. Is {}, expected 3".format(sparameter_table.ndim))
         else:
             raise TypeError("Unsupported datatype. Expected numpy array.")

--- a/src/nirfsg/templates/session.py/get_deembedding_sparameter.py.mako
+++ b/src/nirfsg/templates/session.py/get_deembedding_sparameter.py.mako
@@ -1,0 +1,17 @@
+<%page args="f, config, method_template"/>\
+<%
+    '''Creates a numpy array based on number of ports queried from driver and passes it to "get_deembedding_sparameters" method.'''
+    import build.helper as helper
+%>\
+    def ${f['python_name']}(self):
+        '''${f['python_name']}
+
+        ${helper.get_function_docstring(f, False, config, indent=8)}
+        '''
+        import numpy as np
+        number_of_ports = self._get_deembedding_table_number_of_ports()
+        sparameter_table_size = number_of_ports ** 2
+        sparameters = np.full((number_of_ports, number_of_ports), 0 + 0j, dtype=np.complex128)
+        number_of_ports = self._interpreter.get_deembedding_sparameters(sparameters, sparameter_table_size)
+        sparameters = sparameters.reshape((number_of_ports, number_of_ports))
+        return sparameters, number_of_ports

--- a/src/nirfsg/templates/session.py/write_arb_waveform.py.mako
+++ b/src/nirfsg/templates/session.py/write_arb_waveform.py.mako
@@ -19,6 +19,6 @@
             else:
                 raise TypeError("Unsupported datatype. Is {}, expected {} or {} or {}".format(waveform_data_array.dtype, numpy.complex128, numpy.complex64, numpy.int16))
         else:
-            raise TypeError("Unsupported datatype. Expected {} or {} or {}".format(numpy.complex128, numpy.complex64, numpy.int16))
+            raise TypeError("Unsupported datatype. Expected numpy array of {} or {} or {}".format(numpy.complex128, numpy.complex64, numpy.int16))
 
         return self._write_arb_waveform_complex_f64(waveform_name, waveform_data_array, more_data_pending)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [ ] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?
- Removes export signal method
- Adds configure deembedding table array and get deembedding table methods
  - Adds system tests to validate these
  - Both involve their own custom expansions
  - configure deembedding table array needed a fancy function with custom expansion since we need to ensure valid incoming array and also need to pass number of ports parameter to C
  - get deembedding table method needed custom expansion since we use a different method call to get the size to use
- Fixed a shortened enum name
- Renamed few repeated capabilities and added few
- Minor error string fixes 

### List issues fixed by this Pull Request below, if any.
None

### What testing has been done?
System tests succeed on both simulated and real hardware.
