### PR TITLE
NI-RFSG metadata from codegenerated files with some cleanup and dev status override logic

### DIFF
--- a/build/helper/helper.py
+++ b/build/helper/helper.py
@@ -117,21 +117,24 @@ def get_development_status(config):
        .bN, cN, rcN - Beta
        <nothing> or postN - Stable
     '''
-    v = Version(config['module_version'])
-    if v.release[0] == 0 and v.release[1] < 5:
-        dev_status = '3 - Alpha'
-    elif v.release[0] == 0:
-        dev_status = '4 - Beta'
+    if 'development_status' in config:
+        dev_status = config['development_status']
     else:
-        if v.dev is not None or (v.pre is not None and v.pre[0] == 'a'):
-            # .devN or .aN
+        v = Version(config['module_version'])
+        if v.release[0] == 0 and v.release[1] < 5:
             dev_status = '3 - Alpha'
-        elif v.pre is not None:
-            # .bN, .cN, .rcN
+        elif v.release[0] == 0:
             dev_status = '4 - Beta'
         else:
-            # <nothing> or .postN
-            dev_status = '5 - Production/Stable'
+            if v.dev is not None or (v.pre is not None and v.pre[0] == 'a'):
+                # .devN or .aN
+                dev_status = '3 - Alpha'
+            elif v.pre is not None:
+                # .bN, .cN, .rcN
+                dev_status = '4 - Beta'
+            else:
+                # <nothing> or .postN
+                dev_status = '5 - Production/Stable'
 
     return dev_status
 

--- a/docs/nirfsg/class.rst
+++ b/docs/nirfsg/class.rst
@@ -944,7 +944,7 @@ configure_digital_level_script_trigger
 
     .. py:currentmodule:: nirfsg.Session
 
-    .. py:method:: configure_digital_level_script_trigger(trigger_id, source, level)
+    .. py:method:: configure_digital_level_script_trigger(source, level)
 
             Configures a specified Script Trigger for digital level triggering.
 
@@ -961,16 +961,17 @@ configure_digital_level_script_trigger
             
 
 
+            .. tip:: This method can be called on specific script_triggers within your :py:class:`nirfsg.Session` instance.
+                Use Python index notation on the repeated capabilities container script_triggers to specify a subset,
+                and then call this method on the result.
 
-            :param trigger_id:
+                Example: :py:meth:`my_session.script_triggers[ ... ].configure_digital_level_script_trigger`
+
+                To call the method on all script_triggers, you can call it directly on the :py:class:`nirfsg.Session`.
+
+                Example: :py:meth:`my_session.configure_digital_level_script_trigger`
 
 
-                Specifies the Script Trigger to configure.
-
-                
-
-
-            :type trigger_id: str
             :param source:
 
 
@@ -1238,7 +1239,7 @@ create_deembedding_sparameter_table_array
 
             **Related Topics**
 
-            `De-embedding Overview <https://www.ni.com/docs/en-US/bundle/pxie-5840/page/de-embedding-overview.html>`_
+            `De-embedding Overview<https://www.ni.com/docs/en-US/bundle/pxie-5840/page/de-embedding-overview.html>`_
 
             
 
@@ -1285,7 +1286,9 @@ create_deembedding_sparameter_table_array
             :param sparameter_orientation:
 
 
-                Specifies the orientation of the input data relative to the port on the DUT port. **Defined Values** :
+                Specifies the orientation of the input data relative to the port on the DUT port.
+
+                **Defined Values** :
 
                 +------------------------------------------------------------+----------------+-----------------------------------------------------+
                 | Name                                                       | Value          | Description                                         |
@@ -1500,7 +1503,7 @@ error_message
 
                 Pass the status parameter that is returned from any NI-RFSG method.
 
-                        **Default Value** : 0 (VI_SUCCESS)
+                **Default Value** : 0 (VI_SUCCESS)
 
                 
 
@@ -1511,7 +1514,7 @@ error_message
 
                 Returns the user-readable message string that corresponds to the status code you specify.
 
-                        You must pass a ViChar array with at least 256 bytes to this parameter.
+                You must pass a ViChar array with at least 256 bytes to this parameter.
 
                 
 
@@ -1550,7 +1553,7 @@ error_query
 
                     Returns the error message string read from the instrument error message queue.
 
-                            You must pass a ViChar array with at least 256 bytes.
+                    You must pass a ViChar array with at least 256 bytes.
 
                     
 
@@ -1676,7 +1679,7 @@ get_deembedding_sparameters
 
     .. py:currentmodule:: nirfsg.Session
 
-    .. py:method:: get_deembedding_sparameters(sparameter_array_size)
+    .. py:method:: get_deembedding_sparameters(sparameters_array_size)
 
             Returns the S-parameters used for de-embedding a measurement on the selected port.
 
@@ -1686,13 +1689,13 @@ get_deembedding_sparameters
 
             **Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860
 
-            **Note**: The port orientation for the returned S-parameters is normalized to :py:data:`~nirfsg.SparameterOrientation.PORT1_TOWARDS_DUT`.
-
             
 
+            .. note:: The port orientation for the returned S-parameters is normalized to :py:data:`~nirfsg.SparameterOrientation.PORT1_TOWARDS_DUT`.
 
 
-            :param sparameter_array_size:
+
+            :param sparameters_array_size:
 
 
                 Specifies the size of the array that is returned by the :py:attr:`nirfsg.Session.SPARAMETERS` output.
@@ -1702,7 +1705,7 @@ get_deembedding_sparameters
                 .. note:: One or more of the referenced properties are not in the Python API for this driver.
 
 
-            :type sparameter_array_size: int
+            :type sparameters_array_size: int
 
             :rtype: tuple (sparameters, number_of_ports)
 
@@ -1880,7 +1883,9 @@ get_self_calibration_temperature
             :param module:
 
 
-                Specifies from which stand-alone module to retrieve the last successful self-calibration temperature.     **Default Value** : :py:data:`~nirfsg.Module.PRIMARY_MODULE`    **Defined Values** :
+                Specifies from which stand-alone module to retrieve the last successful self-calibration temperature.
+                                    **Default Value** : :py:data:`~nirfsg.Module.PRIMARY_MODULE`
+                                    **Defined Values** :
 
                 +------------------------------------------+----------------+---------------------------------------------------------------------+
                 | Name                                     | Value          | Description                                                         |
@@ -2508,7 +2513,9 @@ reset_with_options
 
             **Related Topics**
 
-            `Triggers <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/triggers.html>``Events <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/events.html>`_
+            `Triggers <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/triggers.html>`_
+
+            `Events <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/events.html>`_
 
             
 
@@ -3101,9 +3108,9 @@ write_arb_waveform
 
             Writes an arbitrary waveform to the NI-RFSG device starting at the position of the last data written in onboard memory.
 
-            This method accepts the complex baseband data in the form of numpy array of numpy.complex64 or numpy.complex128 or interleaved numpy array of numpy.int16. If the waveform to write is already allocated using the :py:meth:`nirfsg.Session.allocate_arb_waveform` method, the **:py:attr:`nirfsg.Session.MORE_DATA_PENDING`** parameter is ignored. The PXI-5670/5671 must be in the Configuration state before you call this method. When streaming is enabled, this method can be called when the PXIe-5672/5673/5673E or PXIe-5820/5830/5831/5832/5840/5841/5842/5860 is in the Generation state.
+            This method accepts the complex baseband data in the form of numpy array of numpy.complex64 or numpy.complex128 or interleaved numpy array of numpy.int16. If the waveform to write is already allocated using the :py:meth:`nirfsg.Session.allocate_arb_waveform`, the **:py:attr:`nirfsg.Session.MORE_DATA_PENDING`** parameter is ignored. The PXI-5670/5671 must be in the Configuration state before you call this method. When streaming is enabled, you can call this method when the PXIe-5672/5673/5673E or PXIe-5820/5830/5831/5832/5840/5841/5842/5860 is in the Generation state.
 
-            **Supported Devices** : PXIe-5644/5645/5646, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
+            **Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 
             **Related Topics**
 
@@ -3113,7 +3120,8 @@ write_arb_waveform
 
             
 
-            .. note:: This method only supports :py:data:`~nirfsg.PowerLevelType.PEAK` mode as specified in the :py:attr:`nirfsg.Session.power_level_type` property. If you download a waveform when using this method, you cannot set the :py:attr:`nirfsg.Session.power_level_type` to :py:data:`~nirfsg.PowerLevelType.AVERAGE` without causing error in the output.
+            .. note:: On the PXIe-5644/5645/5646, PXIe-5672/5673/5673E, and PXIe-5820/5830/5831/5832/5840/5841/5842/5860, the **:py:attr:`nirfsg.Session.MORE_DATA_PENDING`** parameter is always ignored. To write data in blocks on these devices, you must allocate the waveform before writing it.
+                If you are writing interleaved numpy array of numpy.int16, then this method only supports :py:data:`~nirfsg.PowerLevelType.PEAK` mode as specified in the :py:attr:`nirfsg.Session.power_level_type` property. If you download a waveform as interleaved numpy array of numpy.int16 when using this method, you cannot set the :py:attr:`nirfsg.Session.power_level_type` to :py:data:`~nirfsg.PowerLevelType.AVERAGE` without causing error in the output.
 
             .. note:: One or more of the referenced properties are not in the Python API for this driver.
 
@@ -8948,9 +8956,9 @@ lo_out_export_configure_from_rfsa
 
         Specifies whether to allow NI-RFSA to control the NI-RFSG LO out export.
 
-        Set this property to :py:data:`~nirfsg.LoOutExportConfigureFromRFSaEnable.ENABLE` to allow NI-RFSA to control the LO out export. Use the RF OUT LO EXPORT ENABLED property to control the LO out export from NI-RFSA.
+        Set this property to :py:data:`~nirfsg.LoOutExportConfigureFromRfsaEnable.ENABLE` to allow NI-RFSA to control the LO out export. Use the RF OUT LO EXPORT ENABLED property to control the LO out export from NI-RFSA.
 
-        **Default Value:** :py:data:`~nirfsg.LoOutExportConfigureFromRFSaEnable.DISABLE`
+        **Default Value:** :py:data:`~nirfsg.LoOutExportConfigureFromRfsaEnable.DISABLE`
 
         **Supported Devices**: PXIe-5840/5841/5842
 
@@ -8959,9 +8967,9 @@ lo_out_export_configure_from_rfsa
         +---------------------------------------------------------------+---------+----------------------------------------------------------------------+
         | Name                                                          | Value   | Description                                                          |
         +===============================================================+=========+======================================================================+
-        | :py:data:`~nirfsg.LoOutExportConfigureFromRFSaEnable.ENABLE`  | 0 (0x0) | Do not allow NI-RFSA to control the NI-RFSG local oscillator export. |
+        | :py:data:`~nirfsg.LoOutExportConfigureFromRfsaEnable.ENABLE`  | 0 (0x0) | Do not allow NI-RFSA to control the NI-RFSG local oscillator export. |
         +---------------------------------------------------------------+---------+----------------------------------------------------------------------+
-        | :py:data:`~nirfsg.LoOutExportConfigureFromRFSaEnable.DISABLE` | 1 (0x1) | Allow NI-RFSA to control the NI-RFSG local oscillator export.        |
+        | :py:data:`~nirfsg.LoOutExportConfigureFromRfsaEnable.DISABLE` | 1 (0x1) | Allow NI-RFSA to control the NI-RFSG local oscillator export.        |
         +---------------------------------------------------------------+---------+----------------------------------------------------------------------+
 
         .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
@@ -8971,7 +8979,7 @@ lo_out_export_configure_from_rfsa
             +-----------------------+------------------------------------------+
             | Characteristic        | Value                                    |
             +=======================+==========================================+
-            | Datatype              | enums.LoOutExportConfigureFromRFSaEnable |
+            | Datatype              | enums.LoOutExportConfigureFromRfsaEnable |
             +-----------------------+------------------------------------------+
             | Permissions           | read-write                               |
             +-----------------------+------------------------------------------+
@@ -9044,7 +9052,7 @@ lo_pll_fractional_mode_enabled
 
         To use this property for the PXIe-5830/5831/5832, you must use the channelName parameter of the :py:meth:`nirfsg.Session._set_attribute_vi_int32` method to specify the name of the channel you are configuring. You can configure the LO1 and LO2 channels by using lo1 or lo2 as the channel string, or set the channel string to lo1,lo2 to configure both channels. For all other devices, the the only valid value for the channel string is "" .
 
-        **Default Value:** :py:data:`~nirfsg.LoPlLfractionalModeEnabled.ENABLE`
+        **Default Value:** :py:data:`~nirfsg.LoPllFractionalModeEnabled.ENABLE`
 
         **Supported Devices:** PXIe-5644/5645/5646, PXIe-5830/5831/5832/5840/5841/5842
 
@@ -9057,9 +9065,9 @@ lo_pll_fractional_mode_enabled
         +-------------------------------------------------------+---------+------------------------------------------+
         | Name                                                  | Value   | Description                              |
         +=======================================================+=========+==========================================+
-        | :py:data:`~nirfsg.LoPlLfractionalModeEnabled.ENABLE`  | 0 (0x0) | Disables fractional mode for the LO PLL. |
+        | :py:data:`~nirfsg.LoPllFractionalModeEnabled.ENABLE`  | 0 (0x0) | Disables fractional mode for the LO PLL. |
         +-------------------------------------------------------+---------+------------------------------------------+
-        | :py:data:`~nirfsg.LoPlLfractionalModeEnabled.DISABLE` | 1 (0x1) | Enables fractional mode for the LO PLL.  |
+        | :py:data:`~nirfsg.LoPllFractionalModeEnabled.DISABLE` | 1 (0x1) | Enables fractional mode for the LO PLL.  |
         +-------------------------------------------------------+---------+------------------------------------------+
 
         .. note:: For the PXIe-5841 with PXIe-5655, this property is ignored if the PXIe-5655 is used as the LO source.
@@ -9081,7 +9089,7 @@ lo_pll_fractional_mode_enabled
             +-----------------------+----------------------------------+
             | Characteristic        | Value                            |
             +=======================+==================================+
-            | Datatype              | enums.LoPlLfractionalModeEnabled |
+            | Datatype              | enums.LoPllFractionalModeEnabled |
             +-----------------------+----------------------------------+
             | Permissions           | read-write                       |
             +-----------------------+----------------------------------+

--- a/docs/nirfsg/class.rst
+++ b/docs/nirfsg/class.rst
@@ -1679,7 +1679,7 @@ get_deembedding_sparameters
 
     .. py:currentmodule:: nirfsg.Session
 
-    .. py:method:: get_deembedding_sparameters(sparameters_array_size)
+    .. py:method:: get_deembedding_sparameters()
 
             Returns the S-parameters used for de-embedding a measurement on the selected port.
 
@@ -1695,34 +1695,11 @@ get_deembedding_sparameters
 
 
 
-            :param sparameters_array_size:
-
-
-                Specifies the size of the array that is returned by the :py:attr:`nirfsg.Session.SPARAMETERS` output.
-
-                
-
-                .. note:: One or more of the referenced properties are not in the Python API for this driver.
-
-
-            :type sparameters_array_size: int
-
-            :rtype: tuple (sparameters, number_of_ports)
-
-                WHERE
-
-                sparameters (list of NIComplexNumber): 
+            :rtype: numpy.array(dtype=numpy.complex128)
+            :return:
 
 
                     Returns an array of S-parameters. The S-parameters are returned in the following order: s11, s12, s21, s22.
-
-                    
-
-
-                number_of_ports (int): 
-
-
-                    Returns the number of S-parameter ports. The **sparameter** array is always *n* x *n*, where span *n* is the number of ports.
 
                     
 
@@ -3108,7 +3085,7 @@ write_arb_waveform
 
             Writes an arbitrary waveform to the NI-RFSG device starting at the position of the last data written in onboard memory.
 
-            This method accepts the complex baseband data in the form of numpy array of numpy.complex64 or numpy.complex128 or interleaved numpy array of numpy.int16. If the waveform to write is already allocated using the :py:meth:`nirfsg.Session.allocate_arb_waveform`, the **:py:attr:`nirfsg.Session.MORE_DATA_PENDING`** parameter is ignored. The PXI-5670/5671 must be in the Configuration state before you call this method. When streaming is enabled, you can call this method when the PXIe-5672/5673/5673E or PXIe-5820/5830/5831/5832/5840/5841/5842/5860 is in the Generation state.
+            This method accepts the complex baseband data in the form of numpy array of numpy.complex64 or numpy.complex128 or interleaved numpy array of numpy.int16. If the waveform to write is already allocated using the :py:meth:`nirfsg.Session.allocate_arb_waveform`, the more_data_pending parameter is ignored. The PXI-5670/5671 must be in the Configuration state before you call this method. When streaming is enabled, you can call this method when the PXIe-5672/5673/5673E or PXIe-5820/5830/5831/5832/5840/5841/5842/5860 is in the Generation state.
 
             **Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 
@@ -3120,10 +3097,8 @@ write_arb_waveform
 
             
 
-            .. note:: On the PXIe-5644/5645/5646, PXIe-5672/5673/5673E, and PXIe-5820/5830/5831/5832/5840/5841/5842/5860, the **:py:attr:`nirfsg.Session.MORE_DATA_PENDING`** parameter is always ignored. To write data in blocks on these devices, you must allocate the waveform before writing it.
+            .. note:: On the PXIe-5644/5645/5646, PXIe-5672/5673/5673E, and PXIe-5820/5830/5831/5832/5840/5841/5842/5860, the more_data_pending parameter is always ignored. To write data in blocks on these devices, you must allocate the waveform before writing it.
                 If you are writing interleaved numpy array of numpy.int16, then this method only supports :py:data:`~nirfsg.PowerLevelType.PEAK` mode as specified in the :py:attr:`nirfsg.Session.power_level_type` property. If you download a waveform as interleaved numpy array of numpy.int16 when using this method, you cannot set the :py:attr:`nirfsg.Session.power_level_type` to :py:data:`~nirfsg.PowerLevelType.AVERAGE` without causing error in the output.
-
-            .. note:: One or more of the referenced properties are not in the Python API for this driver.
 
 
 
@@ -3148,11 +3123,9 @@ write_arb_waveform
             :param more_data_pending:
 
 
-                Specifies whether or not the data block contains the end of the waveform. Set this parameter to True to allow data to be appended later to the waveform. Splitting the waveform into multiple data blocks can reduce the memory requirements of the write operation. Append data to a previously written waveform by using the same waveform in the **name** parameter. Set **:py:attr:`nirfsg.Session.MORE_DATA_PENDING`** to False to indicate that this data block contains the end of the waveform. If the waveform is already allocated, this parameter is ignored.
+                Specifies whether or not the data block contains the end of the waveform. Set this parameter to True to allow data to be appended later to the waveform. Splitting the waveform into multiple data blocks can reduce the memory requirements of the write operation. Append data to a previously written waveform by using the same waveform in the **name** parameter. Set more_data_pending to False to indicate that this data block contains the end of the waveform. If the waveform is already allocated, this parameter is ignored.
 
                 
-
-                .. note:: One or more of the referenced properties are not in the Python API for this driver.
 
 
             :type more_data_pending: bool

--- a/docs/nirfsg/enums.rst
+++ b/docs/nirfsg/enums.rst
@@ -651,12 +651,12 @@ IQOutPortTerminalConfiguration
 
 
 
-LoOutExportConfigureFromRFSaEnable
+LoOutExportConfigureFromRfsaEnable
 ----------------------------------
 
-.. py:class:: LoOutExportConfigureFromRFSaEnable
+.. py:class:: LoOutExportConfigureFromRfsaEnable
 
-    .. py:attribute:: LoOutExportConfigureFromRFSaEnable.DISABLE
+    .. py:attribute:: LoOutExportConfigureFromRfsaEnable.DISABLE
 
 
 
@@ -666,7 +666,7 @@ LoOutExportConfigureFromRFSaEnable
 
 
 
-    .. py:attribute:: LoOutExportConfigureFromRFSaEnable.ENABLE
+    .. py:attribute:: LoOutExportConfigureFromRfsaEnable.ENABLE
 
 
 
@@ -676,12 +676,12 @@ LoOutExportConfigureFromRFSaEnable
 
 
 
-LoPlLfractionalModeEnabled
+LoPllFractionalModeEnabled
 --------------------------
 
-.. py:class:: LoPlLfractionalModeEnabled
+.. py:class:: LoPllFractionalModeEnabled
 
-    .. py:attribute:: LoPlLfractionalModeEnabled.DISABLE
+    .. py:attribute:: LoPllFractionalModeEnabled.DISABLE
 
 
 
@@ -691,7 +691,7 @@ LoPlLfractionalModeEnabled
 
 
 
-    .. py:attribute:: LoPlLfractionalModeEnabled.ENABLE
+    .. py:attribute:: LoPllFractionalModeEnabled.ENABLE
 
 
 

--- a/generated/nirfsg/nirfsg/_library.py
+++ b/generated/nirfsg/nirfsg/_library.py
@@ -499,13 +499,13 @@ class Library(object):
                 self.niRFSG_GetChannelName_cfunc.restype = ViStatus  # noqa: F405
         return self.niRFSG_GetChannelName_cfunc(vi, index, buffer_size, name)
 
-    def niRFSG_GetDeembeddingSparameters(self, vi, sparameters, sparameter_array_size, number_of_sparameters, number_of_ports):  # noqa: N802
+    def niRFSG_GetDeembeddingSparameters(self, vi, sparameters, sparameters_array_size, number_of_sparameters, number_of_ports):  # noqa: N802
         with self._func_lock:
             if self.niRFSG_GetDeembeddingSparameters_cfunc is None:
                 self.niRFSG_GetDeembeddingSparameters_cfunc = self._get_library_function('niRFSG_GetDeembeddingSparameters')
                 self.niRFSG_GetDeembeddingSparameters_cfunc.argtypes = [ViSession, ctypes.POINTER(NIComplexNumber), ViInt32, ctypes.POINTER(ViInt32), ctypes.POINTER(ViInt32)]  # noqa: F405
                 self.niRFSG_GetDeembeddingSparameters_cfunc.restype = ViStatus  # noqa: F405
-        return self.niRFSG_GetDeembeddingSparameters_cfunc(vi, sparameters, sparameter_array_size, number_of_sparameters, number_of_ports)
+        return self.niRFSG_GetDeembeddingSparameters_cfunc(vi, sparameters, sparameters_array_size, number_of_sparameters, number_of_ports)
 
     def niRFSG_GetDeembeddingTableNumberOfPorts(self, vi, number_of_ports):  # noqa: N802
         with self._func_lock:

--- a/generated/nirfsg/nirfsg/_library_interpreter.py
+++ b/generated/nirfsg/nirfsg/_library_interpreter.py
@@ -264,7 +264,7 @@ class LibraryInterpreter(object):
 
     def configure_digital_level_script_trigger(self, trigger_id, source, level):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        trigger_id_ctype = ctypes.create_string_buffer(trigger_id.encode(self._encoding))  # case C020
+        trigger_id_ctype = ctypes.create_string_buffer(trigger_id.encode(self._encoding))  # case C010
         source_ctype = ctypes.create_string_buffer(source.encode(self._encoding))  # case C020
         level_ctype = _visatype.ViInt32(level)  # case S150
         error_code = self._library.niRFSG_ConfigureDigitalLevelScriptTrigger(vi_ctype, trigger_id_ctype, source_ctype, level_ctype)
@@ -486,13 +486,13 @@ class LibraryInterpreter(object):
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return name_ctype.value.decode(self._encoding)
 
-    def get_deembedding_sparameters(self, sparameters, sparameter_array_size):  # noqa: N802
+    def get_deembedding_sparameters(self, sparameters, sparameters_array_size):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
         sparameters_ctype = _get_ctypes_pointer_for_buffer(value=sparameters, library_type=_complextype.NIComplexNumber)  # case B510
-        sparameter_array_size_ctype = _visatype.ViInt32(sparameter_array_size)  # case S150
+        sparameters_array_size_ctype = _visatype.ViInt32(sparameters_array_size)  # case S150
         number_of_sparameters_ctype = _visatype.ViInt32()  # case S220
         number_of_ports_ctype = _visatype.ViInt32()  # case S220
-        error_code = self._library.niRFSG_GetDeembeddingSparameters(vi_ctype, sparameters_ctype, sparameter_array_size_ctype, None if number_of_sparameters_ctype is None else (ctypes.pointer(number_of_sparameters_ctype)), None if number_of_ports_ctype is None else (ctypes.pointer(number_of_ports_ctype)))
+        error_code = self._library.niRFSG_GetDeembeddingSparameters(vi_ctype, sparameters_ctype, sparameters_array_size_ctype, None if number_of_sparameters_ctype is None else (ctypes.pointer(number_of_sparameters_ctype)), None if number_of_ports_ctype is None else (ctypes.pointer(number_of_ports_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
         return int(number_of_ports_ctype.value)
 

--- a/generated/nirfsg/nirfsg/_library_interpreter.py
+++ b/generated/nirfsg/nirfsg/_library_interpreter.py
@@ -494,7 +494,7 @@ class LibraryInterpreter(object):
         number_of_ports_ctype = _visatype.ViInt32()  # case S220
         error_code = self._library.niRFSG_GetDeembeddingSparameters(vi_ctype, sparameters_ctype, sparameters_array_size_ctype, None if number_of_sparameters_ctype is None else (ctypes.pointer(number_of_sparameters_ctype)), None if number_of_ports_ctype is None else (ctypes.pointer(number_of_ports_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return int(number_of_ports_ctype.value)
+        return int(number_of_sparameters_ctype.value), int(number_of_ports_ctype.value)
 
     def get_deembedding_table_number_of_ports(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110

--- a/generated/nirfsg/nirfsg/enums.py
+++ b/generated/nirfsg/nirfsg/enums.py
@@ -284,7 +284,7 @@ class IQOutPortTerminalConfiguration(Enum):
     '''
 
 
-class LoOutExportConfigureFromRFSaEnable(Enum):
+class LoOutExportConfigureFromRfsaEnable(Enum):
     DISABLE = 0
     r'''
     Do not allow NI-RFSA to control the NI-RFSG local oscillator export.
@@ -295,7 +295,7 @@ class LoOutExportConfigureFromRFSaEnable(Enum):
     '''
 
 
-class LoPlLfractionalModeEnabled(Enum):
+class LoPllFractionalModeEnabled(Enum):
     DISABLE = 0
     r'''
     Disables fractional mode for the LO PLL.

--- a/generated/nirfsg/nirfsg/session.py
+++ b/generated/nirfsg/nirfsg/session.py
@@ -3269,14 +3269,14 @@ class _SessionBase(object):
 
     Example: :py:attr:`my_session.lo_out_enabled`
     '''
-    lo_out_export_configure_from_rfsa = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.LoOutExportConfigureFromRFSaEnable, 1150242)
-    '''Type: enums.LoOutExportConfigureFromRFSaEnable
+    lo_out_export_configure_from_rfsa = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.LoOutExportConfigureFromRfsaEnable, 1150242)
+    '''Type: enums.LoOutExportConfigureFromRfsaEnable
 
     Specifies whether to allow NI-RFSA to control the NI-RFSG LO out export.
 
-    Set this property to LoOutExportConfigureFromRFSaEnable.ENABLE to allow NI-RFSA to control the LO out export. Use the RF OUT LO EXPORT ENABLED property to control the LO out export from NI-RFSA.
+    Set this property to LoOutExportConfigureFromRfsaEnable.ENABLE to allow NI-RFSA to control the LO out export. Use the RF OUT LO EXPORT ENABLED property to control the LO out export from NI-RFSA.
 
-    **Default Value:** LoOutExportConfigureFromRFSaEnable.DISABLE
+    **Default Value:** LoOutExportConfigureFromRfsaEnable.DISABLE
 
     **Supported Devices**: PXIe-5840/5841/5842
 
@@ -3285,9 +3285,9 @@ class _SessionBase(object):
     +--------------------------------------------+---------+----------------------------------------------------------------------+
     | Name                                       | Value   | Description                                                          |
     +============================================+=========+======================================================================+
-    | LoOutExportConfigureFromRFSaEnable.ENABLE  | 0 (0x0) | Do not allow NI-RFSA to control the NI-RFSG local oscillator export. |
+    | LoOutExportConfigureFromRfsaEnable.ENABLE  | 0 (0x0) | Do not allow NI-RFSA to control the NI-RFSG local oscillator export. |
     +--------------------------------------------+---------+----------------------------------------------------------------------+
-    | LoOutExportConfigureFromRFSaEnable.DISABLE | 1 (0x1) | Allow NI-RFSA to control the NI-RFSG local oscillator export.        |
+    | LoOutExportConfigureFromRfsaEnable.DISABLE | 1 (0x1) | Allow NI-RFSA to control the NI-RFSG local oscillator export.        |
     +--------------------------------------------+---------+----------------------------------------------------------------------+
 
     Note:
@@ -3320,8 +3320,8 @@ class _SessionBase(object):
 
     Example: :py:attr:`my_session.lo_out_power`
     '''
-    lo_pll_fractional_mode_enabled = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.LoPlLfractionalModeEnabled, 1150152)
-    '''Type: enums.LoPlLfractionalModeEnabled
+    lo_pll_fractional_mode_enabled = _attributes.AttributeEnum(_attributes.AttributeViInt32, enums.LoPllFractionalModeEnabled, 1150152)
+    '''Type: enums.LoPllFractionalModeEnabled
 
     Specifies whether to use fractional mode for the local oscillator (LO) phase-locked loop (PLL). This property enables or disables fractional frequency tuning in the LO. Fractional mode provides a finer frequency step resolution and allows smaller values for the lo_frequency_step_size property. However, fractional mode may introduce non-harmonic spurs.
 
@@ -3329,7 +3329,7 @@ class _SessionBase(object):
 
     To use this property for the PXIe-5830/5831/5832, you must use the channelName parameter of the _set_attribute_vi_int32 method to specify the name of the channel you are configuring. You can configure the LO1 and LO2 channels by using lo1 or lo2 as the channel string, or set the channel string to lo1,lo2 to configure both channels. For all other devices, the the only valid value for the channel string is "" .
 
-    **Default Value:** LoPlLfractionalModeEnabled.ENABLE
+    **Default Value:** LoPllFractionalModeEnabled.ENABLE
 
     **Supported Devices:** PXIe-5644/5645/5646, PXIe-5830/5831/5832/5840/5841/5842
 
@@ -3342,9 +3342,9 @@ class _SessionBase(object):
     +------------------------------------+---------+------------------------------------------+
     | Name                               | Value   | Description                              |
     +====================================+=========+==========================================+
-    | LoPlLfractionalModeEnabled.ENABLE  | 0 (0x0) | Disables fractional mode for the LO PLL. |
+    | LoPllFractionalModeEnabled.ENABLE  | 0 (0x0) | Disables fractional mode for the LO PLL. |
     +------------------------------------+---------+------------------------------------------+
-    | LoPlLfractionalModeEnabled.DISABLE | 1 (0x1) | Enables fractional mode for the LO PLL.  |
+    | LoPllFractionalModeEnabled.DISABLE | 1 (0x1) | Enables fractional mode for the LO PLL.  |
     +------------------------------------+---------+------------------------------------------+
 
     Note: For the PXIe-5841 with PXIe-5655, this property is ignored if the PXIe-5655 is used as the LO source.
@@ -5514,6 +5514,41 @@ class _SessionBase(object):
         self._interpreter.configure_digital_edge_script_trigger(self._repeated_capability, source, edge)
 
     @ivi_synchronized
+    def configure_digital_level_script_trigger(self, source, level):
+        r'''configure_digital_level_script_trigger
+
+        Configures a specified Script Trigger for digital level triggering.
+
+        The NI-RFSG device must be in the Configuration state before calling this method.
+
+        **Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
+
+        **Related Topics**
+
+        `Script Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/script_triggers.html>`_
+
+        `Digital Level Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/trigger_level.html>`_
+
+        Tip:
+        This method can be called on specific script_triggers within your :py:class:`nirfsg.Session` instance.
+        Use Python index notation on the repeated capabilities container script_triggers to specify a subset,
+        and then call this method on the result.
+
+        Example: :py:meth:`my_session.script_triggers[ ... ].configure_digital_level_script_trigger`
+
+        To call the method on all script_triggers, you can call it directly on the :py:class:`nirfsg.Session`.
+
+        Example: :py:meth:`my_session.configure_digital_level_script_trigger`
+
+        Args:
+            source (str): Specifies the trigger source terminal for the digital level Script Trigger. NI-RFSG sets the digital_level_script_trigger_source property to this value.
+
+            level (int): Specifies the active level for the digital level Script Trigger. NI-RFSG sets the digital_level_script_trigger_active_level property to this value.
+
+        '''
+        self._interpreter.configure_digital_level_script_trigger(self._repeated_capability, source, level)
+
+    @ivi_synchronized
     def configure_software_script_trigger(self):
         r'''configure_software_script_trigger
 
@@ -5579,11 +5614,11 @@ class _SessionBase(object):
         Args:
             error_code (int): Pass the status parameter that is returned from any NI-RFSG method.
 
-                        **Default Value** : 0 (VI_SUCCESS)
+                **Default Value** : 0 (VI_SUCCESS)
 
             error_message (str): Returns the user-readable message string that corresponds to the status code you specify.
 
-                        You must pass a ViChar array with at least 256 bytes to this parameter.
+                You must pass a ViChar array with at least 256 bytes to this parameter.
 
         '''
         self._interpreter.error_message(error_code, error_message)
@@ -6852,32 +6887,6 @@ class Session(_SessionBase):
         self._interpreter.configure_digital_edge_start_trigger(source, edge)
 
     @ivi_synchronized
-    def configure_digital_level_script_trigger(self, trigger_id, source, level):
-        r'''configure_digital_level_script_trigger
-
-        Configures a specified Script Trigger for digital level triggering.
-
-        The NI-RFSG device must be in the Configuration state before calling this method.
-
-        **Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
-
-        **Related Topics**
-
-        `Script Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/script_triggers.html>`_
-
-        `Digital Level Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/trigger_level.html>`_
-
-        Args:
-            trigger_id (str): Specifies the Script Trigger to configure.
-
-            source (str): Specifies the trigger source terminal for the digital level Script Trigger. NI-RFSG sets the digital_level_script_trigger_source property to this value.
-
-            level (int): Specifies the active level for the digital level Script Trigger. NI-RFSG sets the digital_level_script_trigger_active_level property to this value.
-
-        '''
-        self._interpreter.configure_digital_level_script_trigger(trigger_id, source, level)
-
-    @ivi_synchronized
     def configure_digital_modulation_user_defined_waveform(self, number_of_samples, user_defined_waveform):
         r'''configure_digital_modulation_user_defined_waveform
 
@@ -7037,7 +7046,9 @@ class Session(_SessionBase):
 
             sparameter_table (numpy.array(dtype=numpy.complex128)): Specifies the S-parameters for each frequency. S-parameters for each frequency are placed in the array in the following order: s11, s12, s21, s22.
 
-            sparameter_orientation (enums.SparameterOrientation): Specifies the orientation of the input data relative to the port on the DUT port. **Defined Values** :
+            sparameter_orientation (enums.SparameterOrientation): Specifies the orientation of the input data relative to the port on the DUT port.
+
+                **Defined Values** :
 
                 +-----------------------------------------+----------------+-----------------------------------------------------+
                 | Name                                    | Value          | Description                                         |
@@ -7173,13 +7184,12 @@ class Session(_SessionBase):
 
             error_message (str): Returns the error message string read from the instrument error message queue.
 
-                        You must pass a ViChar array with at least 256 bytes.
+                You must pass a ViChar array with at least 256 bytes.
 
         '''
         error_code, error_message = self._interpreter.error_query()
         return error_code, error_message
 
-    @ivi_synchronized
     def create_deembedding_sparameter_table_array(self, port, table_name, frequencies, sparameter_table, sparameter_orientation):
         '''create_deembedding_sparameter_table_array
 
@@ -7191,7 +7201,7 @@ class Session(_SessionBase):
 
         **Related Topics**
 
-        `De-embedding Overview <https://www.ni.com/docs/en-US/bundle/pxie-5840/page/de-embedding-overview.html>`_
+        `De-embedding Overview<https://www.ni.com/docs/en-US/bundle/pxie-5840/page/de-embedding-overview.html>`_
 
         Args:
             port (str): Specifies the name of the port. The only valid value for the PXIe-5840/5841/5842/5860 is "" (empty string).
@@ -7205,7 +7215,9 @@ class Session(_SessionBase):
 
             sparameter_table (numpy.array(dtype=numpy.complex128)): Specifies the S-parameters for each frequency. S-parameters for each frequency are placed in the array in the following order: s11, s12, s21, s22.
 
-            sparameter_orientation (enums.SparameterOrientation): Specifies the orientation of the input data relative to the port on the DUT port. **Defined Values** :
+            sparameter_orientation (enums.SparameterOrientation): Specifies the orientation of the input data relative to the port on the DUT port.
+
+                **Defined Values** :
 
                 +-----------------------------------------+----------------+-----------------------------------------------------+
                 | Name                                    | Value          | Description                                         |
@@ -7307,10 +7319,10 @@ class Session(_SessionBase):
 
         **Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860
 
-        **Note**: The port orientation for the returned S-parameters is normalized to SparameterOrientation.PORT1_TOWARDS_DUT.
+        Note: The port orientation for the returned S-parameters is normalized to SparameterOrientation.PORT1_TOWARDS_DUT.
 
         Args:
-            sparameter_array_size (int): Specifies the size of the array that is returned by the SPARAMETERS output.
+            sparameters_array_size (int): Specifies the size of the array that is returned by the SPARAMETERS output.
 
                 Note:
                 One or more of the referenced properties are not in the Python API for this driver.
@@ -7481,7 +7493,9 @@ class Session(_SessionBase):
         **Supported Devices** : PXI-5610, PXIe-5653, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831 (IF only)/5832 (IF only)/5840/5841/5842/5860
 
         Args:
-            module (enums.Module): Specifies from which stand-alone module to retrieve the last successful self-calibration temperature.     **Default Value** : Module.PRIMARY_MODULE    **Defined Values** :
+            module (enums.Module): Specifies from which stand-alone module to retrieve the last successful self-calibration temperature.
+                                    **Default Value** : Module.PRIMARY_MODULE
+                                    **Defined Values** :
 
                 +-----------------------+----------------+---------------------------------------------------------------------+
                 | Name                  | Value          | Description                                                         |
@@ -7838,7 +7852,9 @@ class Session(_SessionBase):
 
         **Related Topics**
 
-        `Triggers <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/triggers.html>``Events <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/events.html>`_
+        `Triggers <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/triggers.html>`_
+
+        `Events <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/events.html>`_
 
         Note:
         One or more of the referenced properties are not in the Python API for this driver.
@@ -8080,6 +8096,7 @@ class Session(_SessionBase):
         '''
         self._interpreter.wait_until_settled(max_time_milliseconds)
 
+    @ivi_synchronized
     def _write_arb_waveform_complex_f32(self, waveform_name, waveform_data_array, more_data_pending):
         r'''_write_arb_waveform_complex_f32
 
@@ -8123,12 +8140,13 @@ class Session(_SessionBase):
             raise TypeError('waveform_data_array must be numpy.ndarray of dimension=1, is ' + str(waveform_data_array.ndim))
         self._interpreter.write_arb_waveform_complex_f32(waveform_name, waveform_data_array, more_data_pending)
 
+    @ivi_synchronized
     def _write_arb_waveform_complex_f64(self, waveform_name, waveform_data_array, more_data_pending):
         r'''_write_arb_waveform_complex_f64
 
         Writes an arbitrary waveform to the NI-RFSG device starting at the position of the last data written in onboard memory.
 
-        This method accepts the complex baseband data in the form of complex doubles. If the waveform to write is already allocated using the allocate_arb_waveform, the moreDataPending parameter is ignored. The PXI-5670/5671 must be in the Configuration state before you call this method. When streaming is enabled, you can call this method when the PXIe-5672/5673/5673E or PXIe-5820/5830/5831/5832/5840/5841/5842 is in the Generation state.
+        This method accepts the complex baseband data in the form of complex doubles. If the waveform to write is already allocated using the allocate_arb_waveform, the **MORE_DATA_PENDING** parameter is ignored. The PXI-5670/5671 must be in the Configuration state before you call this method. When streaming is enabled, you can call this method when the PXIe-5672/5673/5673E or PXIe-5820/5830/5831/5832/5840/5841/5842 is in the Generation state.
 
         **Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842
 
@@ -8138,7 +8156,10 @@ class Session(_SessionBase):
 
         `Assigning Properties or Properties to a Waveform <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/assigning-properties-or-properties-to-a-wavef.html>`_
 
-        Note: On the PXIe-5644/5645/5646, PXIe-5672/5673/5673E, and PXIe-5820/5830/5831/5832/5840/5841/5842, the moreDataPending parameter is always ignored. To write data in blocks on these devices, you must allocate the waveform before writing it.
+        Note: On the PXIe-5644/5645/5646, PXIe-5672/5673/5673E, and PXIe-5820/5830/5831/5832/5840/5841/5842, the **MORE_DATA_PENDING** parameter is always ignored. To write data in blocks on these devices, you must allocate the waveform before writing it.
+
+        Note:
+        One or more of the referenced properties are not in the Python API for this driver.
 
         Args:
             waveform_name (str): Specifies the name used to identify the waveform. This string is case-insensitive and alphanumeric, and it does not use reserved words.
@@ -8163,6 +8184,7 @@ class Session(_SessionBase):
             raise TypeError('waveform_data_array must be numpy.ndarray of dimension=1, is ' + str(waveform_data_array.ndim))
         self._interpreter.write_arb_waveform_complex_f64(waveform_name, waveform_data_array, more_data_pending)
 
+    @ivi_synchronized
     def _write_arb_waveform_complex_i16(self, waveform_name, waveform_data_array):
         r'''_write_arb_waveform_complex_i16
 
@@ -8203,9 +8225,9 @@ class Session(_SessionBase):
 
         Writes an arbitrary waveform to the NI-RFSG device starting at the position of the last data written in onboard memory.
 
-        This method accepts the complex baseband data in the form of numpy array of numpy.complex64 or numpy.complex128 or interleaved numpy array of numpy.int16. If the waveform to write is already allocated using the allocate_arb_waveform method, the **MORE_DATA_PENDING** parameter is ignored. The PXI-5670/5671 must be in the Configuration state before you call this method. When streaming is enabled, this method can be called when the PXIe-5672/5673/5673E or PXIe-5820/5830/5831/5832/5840/5841/5842/5860 is in the Generation state.
+        This method accepts the complex baseband data in the form of numpy array of numpy.complex64 or numpy.complex128 or interleaved numpy array of numpy.int16. If the waveform to write is already allocated using the allocate_arb_waveform, the **MORE_DATA_PENDING** parameter is ignored. The PXI-5670/5671 must be in the Configuration state before you call this method. When streaming is enabled, you can call this method when the PXIe-5672/5673/5673E or PXIe-5820/5830/5831/5832/5840/5841/5842/5860 is in the Generation state.
 
-        **Supported Devices** : PXIe-5644/5645/5646, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
+        **Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860
 
         **Related Topics**
 
@@ -8213,7 +8235,8 @@ class Session(_SessionBase):
 
         `Assigning Properties or Properties to a Waveform <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/assigning-properties-or-properties-to-a-wavef.html>`_
 
-        Note: This method only supports PowerLevelType.PEAK mode as specified in the power_level_type property. If you download a waveform when using this method, you cannot set the power_level_type to PowerLevelType.AVERAGE without causing error in the output.
+        Note: On the PXIe-5644/5645/5646, PXIe-5672/5673/5673E, and PXIe-5820/5830/5831/5832/5840/5841/5842/5860, the **MORE_DATA_PENDING** parameter is always ignored. To write data in blocks on these devices, you must allocate the waveform before writing it.
+        If you are writing interleaved numpy array of numpy.int16, then this method only supports PowerLevelType.PEAK mode as specified in the power_level_type property. If you download a waveform as interleaved numpy array of numpy.int16 when using this method, you cannot set the power_level_type to PowerLevelType.AVERAGE without causing error in the output.
 
         Note:
         One or more of the referenced properties are not in the Python API for this driver.

--- a/generated/nirfsg/nirfsg/session.py
+++ b/generated/nirfsg/nirfsg/session.py
@@ -7265,7 +7265,7 @@ class Session(_SessionBase):
         number_of_ports = self._get_deembedding_table_number_of_ports()
         sparameter_array_size = number_of_ports ** 2
         sparameters = np.full((number_of_ports, number_of_ports), 0 + 0j, dtype=np.complex128)
-        number_of_sparameters, number_of_ports = self._get_deembedding_sparameters(sparameters, sparameter_array_size)
+        _, number_of_ports = self._get_deembedding_sparameters(sparameters, sparameter_array_size)
         sparameters = sparameters.reshape((number_of_ports, number_of_ports))
         return sparameters
 
@@ -8279,8 +8279,6 @@ class Session(_SessionBase):
                 raise TypeError("Unsupported datatype. Is {}, expected {} or {} or {}".format(waveform_data_array.dtype, numpy.complex128, numpy.complex64, numpy.int16))
         else:
             raise TypeError("Unsupported datatype. Expected numpy array of {} or {} or {}".format(numpy.complex128, numpy.complex64, numpy.int16))
-
-        return self._write_arb_waveform_complex_f64(waveform_name, waveform_data_array, more_data_pending)
 
     @ivi_synchronized
     def write_script(self, script):

--- a/generated/nirfsg/nirfsg/unit_tests/_mock_helper.py
+++ b/generated/nirfsg/nirfsg/unit_tests/_mock_helper.py
@@ -589,7 +589,7 @@ class SideEffectsHelper(object):
         name.value = self._defaults['GetChannelName']['name'].encode('ascii')
         return self._defaults['GetChannelName']['return']
 
-    def niRFSG_GetDeembeddingSparameters(self, vi, sparameters, sparameter_array_size, number_of_sparameters, number_of_ports):  # noqa: N802
+    def niRFSG_GetDeembeddingSparameters(self, vi, sparameters, sparameters_array_size, number_of_sparameters, number_of_ports):  # noqa: N802
         if self._defaults['GetDeembeddingSparameters']['return'] != 0:
             return self._defaults['GetDeembeddingSparameters']['return']
         # sparameters

--- a/src/nirfsg/metadata/attributes.py
+++ b/src/nirfsg/metadata/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-RFSG API metadata version 25.5.0d9999
+# This file is generated from NI-RFSG API metadata version 25.8.0d9999
 attributes = {
     1050002: {
         'access': 'read-write',
@@ -3013,7 +3013,7 @@ attributes = {
                 'Description'
             ]
         },
-        'enum': 'LoPlLfractionalModeEnabled',
+        'enum': 'LoPllFractionalModeEnabled',
         'lv_property': 'Device Specific:Vector Signal Transceiver:Signal Path:LO PLL Fractional Mode Enabled',
         'name': 'LO_PLL_FRACTIONAL_MODE_ENABLED',
         'supported_rep_caps': [
@@ -3790,7 +3790,7 @@ attributes = {
                 'Description'
             ]
         },
-        'enum': 'LoOutExportConfigureFromRFSaEnable',
+        'enum': 'LoOutExportConfigureFromRfsaEnable',
         'lv_property': 'RF:LO Out Export Configure From RFSA',
         'name': 'LO_OUT_EXPORT_CONFIGURE_FROM_RFSA',
         'type': 'ViInt32'

--- a/src/nirfsg/metadata/config.py
+++ b/src/nirfsg/metadata/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-RFSG API metadata version 25.5.0d9999
+# This file is generated from NI-RFSG API metadata version 25.8.0d9999
 config = {
-    'api_version': '25.5.0d9999',
+    'api_version': '25.8.0d9999',
     'c_function_prefix': 'niRFSG_',
     'close_function': 'close',
     'context_manager_name': {
@@ -12,7 +12,16 @@ config = {
     'custom_types': [
     ],
     'driver_name': 'NI-RFSG',
+    'enum_whitelist_prefix': [
+        'RANGE_',
+        'CLOCK_RATE_'
+    ],
     'enum_whitelist_suffix': [
+        '_HERTZ',
+        '_KILOHERTZ',
+        '_MEGAHERTZ',
+        '_GIGAHERTZ',
+        '_TOWARDS_DUT'
     ],
     'extra_errors_used': [
         'InvalidRepeatedCapabilityError',
@@ -39,17 +48,6 @@ config = {
         }
     },
     'module_name': 'nirfsg',
-    'enum_whitelist_prefix': [
-        'RANGE_',
-        'CLOCK_RATE_'
-    ],
-    'enum_whitelist_suffix': [
-        '_HERTZ',
-        '_KILOHERTZ',
-        '_MEGAHERTZ',
-        '_GIGAHERTZ',
-        '_TOWARDS_DUT'
-    ],
     'repeated_capabilities': [
         {
             'prefix': 'marker',

--- a/src/nirfsg/metadata/enums.py
+++ b/src/nirfsg/metadata/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-RFSG API metadata version 25.5.0d9999
+# This file is generated from NI-RFSG API metadata version 25.8.0d9999
 enums = {
     'AllowOutOfSpecificationUserSettings': {
         'values': [
@@ -255,6 +255,24 @@ enums = {
             }
         ]
     },
+    'DigitalEqualizationEnabled': {
+        'values': [
+            {
+                'documentation': {
+                    'description': 'Filter is not applied'
+                },
+                'name': 'NIRFSG_VAL_DISABLE',
+                'value': 0
+            },
+            {
+                'documentation': {
+                    'description': 'Filter is applied.'
+                },
+                'name': 'NIRFSG_VAL_ENABLE',
+                'value': 1
+            }
+        ]
+    },
     'DigitalModulationType': {
         'values': [
             {
@@ -302,24 +320,6 @@ enums = {
                 },
                 'name': 'NIRFSG_VAL_USER_DEFINED',
                 'value': 5001
-            }
-        ]
-    },
-    'DigitalEqualizationEnabled': {
-        'values': [
-            {
-                'documentation': {
-                    'description': 'Filter is not applied'
-                },
-                'name': 'NIRFSG_VAL_DISABLE',
-                'value': 0
-            },
-            {
-                'documentation': {
-                    'description': 'Filter is applied.'
-                },
-                'name': 'NIRFSG_VAL_ENABLE',
-                'value': 1
             }
         ]
     },
@@ -466,7 +466,7 @@ enums = {
             }
         ]
     },
-    'LoOutExportConfigureFromRFSaEnable': {
+    'LoOutExportConfigureFromRfsaEnable': {
         'values': [
             {
                 'documentation': {
@@ -484,7 +484,7 @@ enums = {
             }
         ]
     },
-    'LoPlLfractionalModeEnabled': {
+    'LoPllFractionalModeEnabled': {
         'values': [
             {
                 'documentation': {
@@ -867,31 +867,6 @@ enums = {
             }
         ]
     },
-    'ReferencePllBandwidth': {
-        'values': [
-            {
-                'documentation': {
-                    'description': 'Uses the narrowest loop bandwidth setting for the PLL. Setting this attribute to NIRFSG_VAL_NARROW allows the PXIe-5653 to lock to a reference with worse phase noise than the PXIe-5653 and utilize the better phase noise of the PXIe-5653.'
-                },
-                'name': 'NIRFSG_VAL_NARROW',
-                'value': 0
-            },
-            {
-                'documentation': {
-                    'description': 'Uses the medium loop bandwidth setting for the PLL.'
-                },
-                'name': 'NIRFSG_VAL_MEDIUM',
-                'value': 1
-            },
-            {
-                'documentation': {
-                    'description': 'Uses the widest loop bandwidth setting for the PLL. Setting this attribute to NIRFSG_VAL_WIDE on the PXIe-5653 allows the reference PLL to lock to a better reference with better phase noise than the PXIe-5653 and utilize the better phase noise of the reference.'
-                },
-                'name': 'NIRFSG_VAL_WIDE',
-                'value': 2
-            }
-        ]
-    },
     'ReferenceClockExportedRate': {
         'values': [
             {
@@ -936,6 +911,31 @@ enums = {
                 'name': 'NIRFSG_VAL_10MHZ',
                 'python_name': 'CLOCK_RATE_10_MEGAHERTZ',
                 'value': 10000000
+            }
+        ]
+    },
+    'ReferencePllBandwidth': {
+        'values': [
+            {
+                'documentation': {
+                    'description': 'Uses the narrowest loop bandwidth setting for the PLL. Setting this attribute to NIRFSG_VAL_NARROW allows the PXIe-5653 to lock to a reference with worse phase noise than the PXIe-5653 and utilize the better phase noise of the PXIe-5653.'
+                },
+                'name': 'NIRFSG_VAL_NARROW',
+                'value': 0
+            },
+            {
+                'documentation': {
+                    'description': 'Uses the medium loop bandwidth setting for the PLL.'
+                },
+                'name': 'NIRFSG_VAL_MEDIUM',
+                'value': 1
+            },
+            {
+                'documentation': {
+                    'description': 'Uses the widest loop bandwidth setting for the PLL. Setting this attribute to NIRFSG_VAL_WIDE on the PXIe-5653 allows the reference PLL to lock to a better reference with better phase noise than the PXIe-5653 and utilize the better phase noise of the reference.'
+                },
+                'name': 'NIRFSG_VAL_WIDE',
+                'value': 2
             }
         ]
     },

--- a/src/nirfsg/metadata/functions.py
+++ b/src/nirfsg/metadata/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-RFSG API metadata version 25.5.0d9999
+# This file is generated from NI-RFSG API metadata version 25.8.0d9999
 functions = {
     'Abort': {
         'codegen_method': 'public',
@@ -810,240 +810,6 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
-    'CreateDeembeddingSparameterTableArray': {
-        'codegen_method': 'private',
-        'documentation': {
-        'description': '\nCreates an s-parameter de-embedding table for the port from the input data.\n\nIf you only create one table for a port, NI-RFSG automatically selects that table to de-embed the measurement.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`De-embedding Overview <https://www.ni.com/docs/en-US/bundle/pxie-5840/page/de-embedding-overview.html>`_'
-        },
-        'included_in_proto': True,
-        'method_templates': [
-            {
-                'documentation_filename': 'numpy_method',
-                'library_interpreter_filename': 'numpy_write_method',
-                'method_python_name_suffix': '',
-                'session_filename': 'numpy_write_method'
-            }
-        ],
-        'parameters': [
-            {
-                'direction': 'in',
-                'name': 'vi',
-                'documentation': {
-                    'description': 'Identifies your instrument session. NIRFSG_ATTR_VI is obtained from the nirfsg_Init or nirfsg_InitWithOptions function.'
-                },
-                'type': 'ViSession',
-                'use_array': False,
-                'use_in_python_api': True
-            },
-            {
-                'direction': 'in',
-                'name': 'port',
-                'documentation': {
-                    'description': 'Specifies the name of the port. The only valid value for the PXIe-5840/5841/5842/5860 is \"\" (empty string).'
-                },
-                'type': 'ViConstString',
-                'use_array': False,
-                'use_in_python_api': True
-            },
-            {
-                'direction': 'in',
-                'name': 'tableName',
-                'documentation': {
-                    'description': 'Specifies the name of the table. The name must be unique for a given port, but not across ports. If you use the same name as an existing table, the table is replaced.'
-                },
-                'type': 'ViConstString',
-                'use_array': False,
-                'use_in_python_api': True
-            },
-            {
-                'direction': 'in',
-                'name': 'frequencies',
-                'documentation': {
-                    'description': 'Specifies the frequencies for the NIRFSG_ATTR_SPARAMETER_TABLE rows. Frequencies must be unique and in ascending order.'
-                },
-                'type': 'ViReal64[]',
-                'size': {
-                    'mechanism': 'len',
-                    'value': 'frequenciesSize'
-                },
-                'numpy': True,
-                'use_in_python_api': True
-            },
-            {
-                'direction': 'in',
-                'name': 'frequenciesSize',
-                'documentation': {
-                    'description': 'Specifies the size of the frequency array.'
-                },
-                'type': 'ViInt32',
-                'use_array': False,
-                'use_in_python_api': False
-            },
-            {
-                'complex_type': 'numpy',
-                'direction': 'in',
-                'name': 'sparameterTable',
-                'documentation': {
-                    'description': 'Specifies the S-parameters for each frequency. S-parameters for each frequency are placed in the array in the following order: s11, s12, s21, s22.'
-                },
-                'type': 'NIComplexNumber[]',
-                'numpy': True,
-                'use_in_python_api': True,
-                'array_dimension': 3
-            },
-            {
-                'direction': 'in',
-                'name': 'sparameterTableSize',
-                'documentation': {
-                    'description': 'Specifies the size of the S-parameter table array.'
-                },
-                'type': 'ViInt32',
-                'use_array': False,
-                'use_in_python_api': False
-            },
-            {
-                'direction': 'in',
-                'name': 'numberOfPorts',
-                'documentation': {
-                    'description': 'Specifies the number of DUT ports.'
-                },
-                'type': 'ViInt32',
-                'use_array': False,
-                'use_in_python_api': False
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': ' Specifies the orientation of the input data relative to the port on the DUT port. **Defined Values** :',
-                    'table_body': [
-                        [
-                            'NIRFSG_VAL_PORT1_TOWARDS_DUT',
-                            '24000 (0x5dc0)',
-                            'Port 1 of the S2P is oriented towards the DUT port.'
-                        ],
-                        [
-                            'NIRFSG_VAL_PORT2_TOWARDS_DUT',
-                            '24001 (0x5dc1)',
-                            'Port 2 of the S2P is oriented towards the DUT port.'
-                        ]
-                    ],
-                    'table_header': [
-                        'Name',
-                        'Value',
-                        'Description'
-                    ]
-                },
-                'enum': 'SparameterOrientation',
-                'name': 'sparameterOrientation',
-                'type': 'ViInt32',
-                'use_array': False,
-                'use_in_python_api': True
-            }
-        ],
-        'returns': 'ViStatus',
-    },
-    'FancyCreateDeembeddingSparameterTableArray': {
-        'codegen_method': 'python-only',
-        'documentation': {
-        'description': '\nCreates an s-parameter de-embedding table for the port from the input data.\n\nIf you only create one table for a port, NI-RFSG automatically selects that table to de-embed the measurement.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`De-embedding Overview <https://www.ni.com/docs/en-US/bundle/pxie-5840/page/de-embedding-overview.html>`_'
-        },
-        'included_in_proto': True,
-        'method_templates': [
-            {
-                'documentation_filename': 'default_method',
-                'library_interpreter_filename': 'none',
-                'method_python_name_suffix': '',
-                'session_filename': 'create_deembedding_sparameter_table_array'
-            }
-        ],
-        'parameters': [
-            {
-                'direction': 'in',
-                'name': 'vi',
-                'documentation': {
-                    'description': 'Identifies your instrument session. NIRFSG_ATTR_VI is obtained from the nirfsg_Init or nirfsg_InitWithOptions function.'
-                },
-                'type': 'ViSession',
-                'use_array': False,
-                'use_in_python_api': True
-            },
-            {
-                'direction': 'in',
-                'name': 'port',
-                'documentation': {
-                    'description': 'Specifies the name of the port. The only valid value for the PXIe-5840/5841/5842/5860 is \"\" (empty string).'
-                },
-                'type': 'ViConstString',
-                'use_array': False,
-                'use_in_python_api': True
-            },
-            {
-                'direction': 'in',
-                'name': 'tableName',
-                'documentation': {
-                    'description': 'Specifies the name of the table. The name must be unique for a given port, but not across ports. If you use the same name as an existing table, the table is replaced.'
-                },
-                'type': 'ViConstString',
-                'use_array': False,
-                'use_in_python_api': True
-            },
-            {
-                'complex_type': 'numpy',
-                'direction': 'in',
-                'name': 'frequencies',
-                'documentation': {
-                    'description': 'Specifies the frequencies for the NIRFSG_ATTR_SPARAMETER_TABLE rows. Frequencies must be unique and in ascending order.'
-                },
-                'type_in_documentation': 'numpy.array(dtype=numpy.float64)',
-                'type': 'ViReal64[]',
-                'numpy': True,
-                'use_in_python_api': True
-            },
-            {
-                'complex_type': 'numpy',
-                'direction': 'in',
-                'name': 'sparameterTable',
-                'documentation': {
-                    'description': 'Specifies the S-parameters for each frequency. S-parameters for each frequency are placed in the array in the following order: s11, s12, s21, s22.'
-                },
-                'type_in_documentation': 'numpy.array(dtype=numpy.complex128)',
-                'type': 'NIComplexNumber[]',
-                'numpy': True,
-                'use_in_python_api': True,
-                'array_dimension': 3
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': ' Specifies the orientation of the input data relative to the port on the DUT port. **Defined Values** :',
-                    'table_body': [
-                        [
-                            'NIRFSG_VAL_PORT1_TOWARDS_DUT',
-                            '24000 (0x5dc0)',
-                            'Port 1 of the S2P is oriented towards the DUT port.'
-                        ],
-                        [
-                            'NIRFSG_VAL_PORT2_TOWARDS_DUT',
-                            '24001 (0x5dc1)',
-                            'Port 2 of the S2P is oriented towards the DUT port.'
-                        ]
-                    ],
-                    'table_header': [
-                        'Name',
-                        'Value',
-                        'Description'
-                    ]
-                },
-                'enum': 'SparameterOrientation',
-                'name': 'sparameterOrientation',
-                'type': 'ViInt32',
-                'use_array': False,
-                'use_in_python_api': True
-            }
-        ],
-        'python_name': 'create_deembedding_sparameter_table_array',
-        'returns': 'ViStatus',
-    },
     'ConfigureDeembeddingTableInterpolationLinear': {
         'codegen_method': 'public',
         'documentation': {
@@ -1221,126 +987,12 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
-    'GetDeembeddingTableNumberOfPorts': {
-        'codegen_method': 'private',
-        'documentation': {
-            'description': '\nReturns the number of S-parameter ports.'
-        },
-        'included_in_proto': False,
-        'is_error_handling': False,
-        'method_templates': [
-            {
-                'documentation_filename': 'default_method',
-                'library_interpreter_filename': 'default_method',
-                'method_python_name_suffix': '',
-                'session_filename': 'default_method'
-            }
-        ],
-        'parameters': [
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies your instrument session. The ViSession handle is obtained from the nirfsg_Init function or the nirfsg_InitWithOptions function and identifies a particular instrument session.'
-                },
-                'name': 'vi',
-                'type': 'ViSession',
-                'use_array': False,
-                'use_in_python_api': True
-            },
-            {
-                'direction': 'out',
-                'documentation': {
-                    'description': 'Returns the number of S-parameter ports. The **sparameter** array is always *n* x *n*, where span *n* is the number of ports.'
-                },
-                'name': 'numberOfPorts',
-                'type': 'ViInt32',
-                'use_array': False,
-                'use_in_python_api': True
-            }
-        ],
-        'returns': 'ViStatus'
-    },
-    'GetDeembeddingSparameters': {
-        'codegen_method': 'public',
-        'documentation': {
-            'description': '\nReturns the S-parameters used for de-embedding a measurement on the selected port. \n\nThis includes interpolation of the parameters based on the configured carrier frequency. This function returns an empty array if no de-embedding is done.\n\nIf you want to call this function just to get the required buffer size, you can pass 0 for **S-parameter Size** and VI_NULL for the **S-parameters** buffer.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860\n\n**Note**: The port orientation for the returned S-parameters is normalized to NIRFSG_VAL_PORT1_TOWARDS_DUT.\n                '
-        },
-        'included_in_proto': False,
-        'is_error_handling': False,
-        'method_templates': [
-            {
-                'documentation_filename': 'default_method',
-                'library_interpreter_filename': 'numpy_read_method',
-                'method_python_name_suffix': '',
-                'session_filename': 'get_deembedding_sparameter'
-            }
-        ],
-        'parameters': [
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies your instrument session. The ViSession handle is obtained from the nirfsg_Init function or the nirfsg_InitWithOptions function and identifies a particular instrument session.'
-                },
-                'name': 'vi',
-                'type': 'ViSession',
-                'use_array': False,
-                'use_in_python_api': True
-            },
-            {
-                'direction': 'out',
-                'documentation': {
-                    'description': 'Returns an array of S-parameters. The S-parameters are returned in the following order: s11, s12, s21, s22.'
-                },
-                'name': 'sparameters',
-                'size': {
-                    'mechanism': 'pass',
-                    'value': 'numberOfSparameters'
-                },
-                'numpy': True,
-                'type': 'NIComplexNumber[]',
-                'complex_type': 'numpy',
-                'use_in_python_api': True,
-                'array_dimension': 3
-            },
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Specifies the size of the array that is returned by the NIRFSG_ATTR_SPARAMETERS output.'
-                },
-                'name': 'sparameterArraySize',
-                'type': 'ViInt32',
-                'use_array': False,
-                'use_in_python_api': True
-            },
-            {
-                'direction': 'out',
-                'name': 'numberOfSparameters',
-                'documentation': {
-                    'description': 'Returns the number of S-parameters.'
-                },
-                'type': 'ViInt32',
-                'use_array': False,
-                'use_in_python_api': False
-            },
-            {
-                'direction': 'out',
-                'name': 'numberOfPorts',
-                'documentation': {
-                    'description': 'Returns the number of S-parameter ports. The **sparameter** array is always *n* x *n*, where span *n* is the number of ports.'
-                },
-                'type': 'ViInt32',
-                'use_array': False,
-                'use_in_python_api': True
-            }
-        ],
-        'python_name': 'get_deembedding_sparameters',
-        'returns': 'ViStatus'
-    },
     'ConfigureDigitalEdgeScriptTrigger': {
         'codegen_method': 'public',
         'documentation': {
             'description': '\nConfigures the specified Script Trigger for digital edge triggering.\n\nThe NI-RFSG device must be in the Configuration state before calling this function.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Script Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/script_triggers.html>`_\n\n`Digital Edge Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/trigger_edge.html>`_'
         },
+        'has_repeated_capability': True,
         'included_in_proto': True,
         'method_templates': [
             {
@@ -1366,10 +1018,10 @@ functions = {
                 'documentation': {
                     'description': 'Specifies the Script Trigger to configure.'
                 },
-                'name': 'triggerId',
-                'type': 'ViConstString',
                 'is_repeated_capability': True,
+                'name': 'triggerId',
                 'repeated_capability_type': 'script_triggers',
+                'type': 'ViConstString',
                 'use_array': False,
                 'use_in_python_api': True
             },
@@ -1388,13 +1040,15 @@ functions = {
                 'documentation': {
                     'description': 'Specifies the active edge for the digital edge Script Trigger. NI-RFSG sets the NIRFSG_ATTR_DIGITAL_EDGE_SCRIPT_TRIGGER_EDGE attribute to this value.'
                 },
-                'name': 'edge',
                 'enum': 'ScriptTriggerDigitalEdgeEdge',
+                'grpc_enum': None,
+                'name': 'edge',
                 'type': 'ViInt32',
                 'use_array': False,
                 'use_in_python_api': True
             }
         ],
+        'repeated_capability_type': 'script_triggers',
         'returns': 'ViStatus'
     },
     'ConfigureDigitalEdgeStartTrigger': {
@@ -1438,8 +1092,9 @@ functions = {
                 'documentation': {
                     'description': 'Specifies the active edge for the Start Trigger. NI-RFSG sets the NIRFSG_ATTR_DIGITAL_EDGE_START_TRIGGER_EDGE attribute to this value.'
                 },
-                'name': 'edge',
                 'enum': 'StartTriggerDigitalEdgeEdge',
+                'grpc_enum': None,
+                'name': 'edge',
                 'type': 'ViInt32',
                 'use_array': False,
                 'use_in_python_api': True
@@ -1452,6 +1107,7 @@ functions = {
         'documentation': {
             'description': '\nConfigures a specified Script Trigger for digital level triggering.\n\nThe NI-RFSG device must be in the Configuration state before calling this function.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Script Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/script_triggers.html>`_\n\n`Digital Level Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/trigger_level.html>`_'
         },
+        'has_repeated_capability': True,
         'included_in_proto': True,
         'method_templates': [
             {
@@ -1477,7 +1133,9 @@ functions = {
                 'documentation': {
                     'description': 'Specifies the Script Trigger to configure.'
                 },
+                'is_repeated_capability': True,
                 'name': 'triggerId',
+                'repeated_capability_type': 'script_triggers',
                 'type': 'ViConstString',
                 'use_array': False,
                 'use_in_python_api': True
@@ -1503,6 +1161,7 @@ functions = {
                 'use_in_python_api': True
             }
         ],
+        'repeated_capability_type': 'script_triggers',
         'returns': 'ViStatus'
     },
     'ConfigureDigitalModulationUserDefinedWaveform': {
@@ -1726,6 +1385,7 @@ functions = {
         'documentation': {
             'description': '\nConfigures the Script Trigger for software triggering.\n\nRefer to the nirfsg_SendSoftwareEdgeTrigger function for more information about using the software Script Trigger. The NI-RFSG device must be in the Configuration state before calling this function.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Script Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/script_triggers.html>`_\n\n`Trigger Types <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/trigger_types.html>`_'
         },
+        'has_repeated_capability': True,
         'included_in_proto': True,
         'method_templates': [
             {
@@ -1751,14 +1411,15 @@ functions = {
                 'documentation': {
                     'description': 'Specifies the Script Trigger to configure.'
                 },
-                'name': 'triggerId',
-                'type': 'ViConstString',
                 'is_repeated_capability': True,
+                'name': 'triggerId',
                 'repeated_capability_type': 'script_triggers',
+                'type': 'ViConstString',
                 'use_array': False,
                 'use_in_python_api': True
             }
         ],
+        'repeated_capability_type': 'script_triggers',
         'returns': 'ViStatus'
     },
     'ConfigureSoftwareStartTrigger': {
@@ -1783,6 +1444,137 @@ functions = {
                 },
                 'name': 'vi',
                 'type': 'ViSession',
+                'use_array': False,
+                'use_in_python_api': True
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'CreateDeembeddingSparameterTableArray': {
+        'codegen_method': 'private',
+        'documentation': {
+            'description': '\nCreates an s-parameter de-embedding table for the port from the input data.\n\nIf you only create one table for a port, NI-RFSG automatically selects that table to de-embed the measurement.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`De-embedding Overview <https://www.ni.com/docs/en-US/bundle/pxie-5840/page/de-embedding-overview.html>`_'
+        },
+        'included_in_proto': True,
+        'method_templates': [
+            {
+                'documentation_filename': 'numpy_method',
+                'library_interpreter_filename': 'numpy_write_method',
+                'method_python_name_suffix': '',
+                'session_filename': 'numpy_write_method'
+            }
+        ],
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Identifies your instrument session. The ViSession handle is obtained from the nirfsg_Init function or the nirfsg_InitWithOptions function and identifies a particular instrument session.'
+                },
+                'name': 'vi',
+                'type': 'ViSession',
+                'use_array': False,
+                'use_in_python_api': True
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Specifies the name of the port. The only valid value for the PXIe-5840/5841/5842/5860 is "" (empty string).'
+                },
+                'name': 'port',
+                'type': 'ViConstString',
+                'use_array': False,
+                'use_in_python_api': True
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Specifies the name of the table. The name must be unique for a given port, but not across ports. If you use the same name as an existing table, the table is replaced.'
+                },
+                'name': 'tableName',
+                'type': 'ViConstString',
+                'use_array': False,
+                'use_in_python_api': True
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Specifies the frequencies for the NIRFSG_ATTR_SPARAMETER_TABLE rows. Frequencies must be unique and in ascending order.'
+                },
+                'name': 'frequencies',
+                'numpy': True,
+                'size': {
+                    'mechanism': 'len',
+                    'value': 'frequenciesSize'
+                },
+                'type': 'ViReal64[]',
+                'use_in_python_api': True
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Specifies the size of the frequency array.'
+                },
+                'name': 'frequenciesSize',
+                'type': 'ViInt32',
+                'use_array': False
+            },
+            {
+                'array_dimension': 3,
+                'complex_type': 'numpy',
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Specifies the S-parameters for each frequency. S-parameters for each frequency are placed in the array in the following order: s11, s12, s21, s22.'
+                },
+                'name': 'sparameterTable',
+                'numpy': True,
+                'type': 'NIComplexNumber[]',
+                'use_in_python_api': True
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Specifies the size of the S-parameter table array.'
+                },
+                'name': 'sparameterTableSize',
+                'type': 'ViInt32',
+                'use_array': False,
+                'use_in_python_api': False
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Specifies the number of DUT ports.'
+                },
+                'name': 'numberOfPorts',
+                'type': 'ViInt32',
+                'use_array': False,
+                'use_in_python_api': False
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Specifies the orientation of the input data relative to the port on the DUT port.\n\n**Defined Values** :',
+                    'table_body': [
+                        [
+                            'NIRFSG_VAL_PORT1_TOWARDS_DUT',
+                            '24000 (0x5dc0)',
+                            'Port 1 of the S2P is oriented towards the DUT port.'
+                        ],
+                        [
+                            'NIRFSG_VAL_PORT2_TOWARDS_DUT',
+                            '24001 (0x5dc1)',
+                            'Port 2 of the S2P is oriented towards the DUT port.'
+                        ]
+                    ],
+                    'table_header': [
+                        'Name',
+                        'Value',
+                        'Description'
+                    ]
+                },
+                'enum': 'SparameterOrientation',
+                'name': 'sparameterOrientation',
+                'type': 'ViInt32',
                 'use_array': False,
                 'use_in_python_api': True
             }
@@ -1984,6 +1776,7 @@ functions = {
         'documentation': {
             'description': '\nConfigures the device not to wait for the specified Script Trigger.\n\nCall this function only if you previously configured a Script Trigger and now want it disabled. The NI-RFSG device must be in the Configuration state before you call this function.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Script Trigger <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/script_triggers.html>`_'
         },
+        'has_repeated_capability': True,
         'included_in_proto': True,
         'method_templates': [
             {
@@ -2009,14 +1802,15 @@ functions = {
                 'documentation': {
                     'description': 'Specifies the Script trigger to configure.'
                 },
-                'name': 'triggerId',
-                'type': 'ViConstString',
                 'is_repeated_capability': True,
+                'name': 'triggerId',
                 'repeated_capability_type': 'script_triggers',
+                'type': 'ViConstString',
                 'use_array': False,
                 'use_in_python_api': True
             }
         ],
+        'repeated_capability_type': 'script_triggers',
         'returns': 'ViStatus'
     },
     'DisableStartTrigger': {
@@ -2066,7 +1860,7 @@ functions = {
             {
                 'direction': 'in',
                 'documentation': {
-                    'description': '                        The ViSession handle that you obtain from nirfsg_Init or nirfsg_InitWithOptions. The handle identifies a particular instrument session.\n\n        You can pass VI_NULL for this parameter. Passing VI_NULL is useful when nirfsg_Init or nirfsg_InitWithOptions fails.\n\n        **Default Value** : VI_NULL\n\n        '
+                    'description': 'The ViSession handle that you obtain from nirfsg_Init or nirfsg_InitWithOptions. The handle identifies a particular instrument session.\n\nYou can pass VI_NULL for this parameter. Passing VI_NULL is useful when nirfsg_Init or nirfsg_InitWithOptions fails.\n\n**Default Value** : VI_NULL'
                 },
                 'name': 'vi',
                 'type': 'ViSession',
@@ -2076,7 +1870,7 @@ functions = {
             {
                 'direction': 'in',
                 'documentation': {
-                    'description': '                        Pass the status parameter that is returned from any NI-RFSG function.\n\n        **Default Value** : 0 (VI_SUCCESS)\n\n        '
+                    'description': 'Pass the status parameter that is returned from any NI-RFSG function.\n\n**Default Value** : 0 (VI_SUCCESS)'
                 },
                 'name': 'errorCode',
                 'type': 'ViStatus',
@@ -2086,7 +1880,7 @@ functions = {
             {
                 'direction': 'in',
                 'documentation': {
-                    'description': '                        Returns the user-readable message string that corresponds to the status code you specify.\n\n        You must pass a ViChar array with at least 256 bytes to this parameter.\n\n        '
+                    'description': 'Returns the user-readable message string that corresponds to the status code you specify.\n\nYou must pass a ViChar array with at least 256 bytes to this parameter.'
                 },
                 'name': 'errorMessage',
                 'size': {
@@ -2139,7 +1933,7 @@ functions = {
             {
                 'direction': 'out',
                 'documentation': {
-                    'description': '                        Returns the error message string read from the instrument error message queue.\n\n        You must pass a ViChar array with at least 256 bytes.        '
+                    'description': 'Returns the error message string read from the instrument error message queue.\n\nYou must pass a ViChar array with at least 256 bytes.'
                 },
                 'name': 'errorMessage',
                 'size': {
@@ -2152,6 +1946,110 @@ functions = {
             }
         ],
         'returns': 'ViStatus'
+    },
+    'FancyCreateDeembeddingSparameterTableArray': {
+        'codegen_method': 'python-only',
+        'documentation': {
+            'description': '\nCreates an s-parameter de-embedding table for the port from the input data.\n\nIf you only create one table for a port, NI-RFSG automatically selects that table to de-embed the measurement.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`De-embedding Overview<https://www.ni.com/docs/en-US/bundle/pxie-5840/page/de-embedding-overview.html>`_'
+        },
+        'included_in_proto': True,
+        'method_name_for_documentation': 'create_deembedding_sparameter_table_array',
+        'method_templates': [
+            {
+                'documentation_filename': 'default_method',
+                'library_interpreter_filename': 'none',
+                'method_python_name_suffix': '',
+                'session_filename': 'create_deembedding_sparameter_table_array'
+            }
+        ],
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Identifies your instrument session. The ViSession handle is obtained from the nirfsg_Init function or the nirfsg_InitWithOptions function and identifies a particular instrument session.'
+                },
+                'name': 'vi',
+                'type': 'ViSession',
+                'use_array': False,
+                'use_in_python_api': True
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Specifies the name of the port. The only valid value for the PXIe-5840/5841/5842/5860 is "" (empty string).'
+                },
+                'name': 'port',
+                'type': 'ViConstString',
+                'use_array': False,
+                'use_in_python_api': True
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Specifies the name of the table. The name must be unique for a given port, but not across ports. If you use the same name as an existing table, the table is replaced.'
+                },
+                'name': 'tableName',
+                'type': 'ViConstString',
+                'use_array': False,
+                'use_in_python_api': True
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Specifies the frequencies for the NIRFSG_ATTR_SPARAMETER_TABLE rows. Frequencies must be unique and in ascending order.'
+                },
+                'name': 'frequencies',
+                'numpy': True,
+                'type': 'ViReal64[]',
+                'type_in_documentation': 'numpy.array(dtype=numpy.float64)',
+                'use_in_python_api': True
+            },
+            {
+                'array_dimension': 3,
+                'complex_type': 'numpy',
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Specifies the S-parameters for each frequency. S-parameters for each frequency are placed in the array in the following order: s11, s12, s21, s22.'
+                },
+                'name': 'sparameterTable',
+                'numpy': True,
+                'type': 'NIComplexNumber[]',
+                'type_in_documentation': 'numpy.array(dtype=numpy.complex128)',
+                'use_in_python_api': True
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Specifies the orientation of the input data relative to the port on the DUT port.\n\n**Defined Values** :',
+                    'table_body': [
+                        [
+                            'NIRFSG_VAL_PORT1_TOWARDS_DUT',
+                            '24000 (0x5dc0)',
+                            'Port 1 of the S2P is oriented towards the DUT port.'
+                        ],
+                        [
+                            'NIRFSG_VAL_PORT2_TOWARDS_DUT',
+                            '24001 (0x5dc1)',
+                            'Port 2 of the S2P is oriented towards the DUT port.'
+                        ]
+                    ],
+                    'table_header': [
+                        'Name',
+                        'Value',
+                        'Description'
+                    ]
+                },
+                'enum': 'SparameterOrientation',
+                'grpc_enum': None,
+                'name': 'sparameterOrientation',
+                'type': 'ViInt32',
+                'use_array': False,
+                'use_in_python_api': True
+            }
+        ],
+        'python_name': 'create_deembedding_sparameter_table_array',
+        'returns': 'ViStatus',
+        'use_session_lock': False
     },
     'GetAllNamedWaveformNames': {
         'codegen_method': 'public',
@@ -2702,6 +2600,103 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
+    'GetDeembeddingSparameters': {
+        'codegen_method': 'public',
+        'documentation': {
+            'description': '\nReturns the S-parameters used for de-embedding a measurement on the selected port.\n\nThis includes interpolation of the parameters based on the configured carrier frequency. This function returns an empty array if no de-embedding is done.\n\nIf you want to call this function just to get the required buffer size, you can pass 0 for **S-parameter Size** and VI_NULL for the **S-parameters** buffer.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860',
+            'note': 'The port orientation for the returned S-parameters is normalized to NIRFSG_VAL_PORT1_TOWARDS_DUT.'
+        },
+        'included_in_proto': True,
+        'method_templates': [
+            {
+                'documentation_filename': 'default_method',
+                'library_interpreter_filename': 'numpy_read_method',
+                'method_python_name_suffix': '',
+                'session_filename': 'get_deembedding_sparameter'
+            }
+        ],
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Identifies your instrument session. The ViSession handle is obtained from the nirfsg_Init function or the nirfsg_InitWithOptions function and identifies a particular instrument session.'
+                },
+                'name': 'vi',
+                'type': 'ViSession',
+                'use_array': False,
+                'use_in_python_api': True
+            },
+            {
+                'array_dimension': 2,
+                'complex_type': 'numpy',
+                'direction': 'out',
+                'documentation': {
+                    'description': 'Returns an array of S-parameters. The S-parameters are returned in the following order: s11, s12, s21, s22.'
+                },
+                'name': 'sparameters',
+                'numpy': True,
+                'type': 'NIComplexNumber[]',
+                'use_array': False,
+                'use_in_python_api': True
+            },
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Specifies the size of the array that is returned by the NIRFSG_ATTR_SPARAMETERS output.'
+                },
+                'name': 'sparametersArraySize',
+                'type': 'ViInt32',
+                'use_array': False
+            },
+            {
+                'direction': 'out',
+                'documentation': {
+                    'description': 'Returns the number of S-parameters.'
+                },
+                'name': 'numberOfSparameters',
+                'type': 'ViInt32',
+                'use_array': False,
+                'use_in_python_api': False
+            },
+            {
+                'direction': 'out',
+                'documentation': {
+                    'description': 'Returns the number of S-parameter ports. The **sparameter** array is always *n* x *n*, where span *n* is the number of ports.'
+                },
+                'name': 'numberOfPorts',
+                'type': 'ViInt32',
+                'use_array': False,
+                'use_in_python_api': True
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'GetDeembeddingTableNumberOfPorts': {
+        'codegen_method': 'private',
+        'documentation': {
+            'description': '\nReturns the number of S-parameter ports.'
+        },
+        'included_in_proto': True,
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Identifies your instrument session. The ViSession handle is obtained from the nirfsg_Init function or the nirfsg_InitWithOptions function and identifies a particular instrument session.'
+                },
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'out',
+                'documentation': {
+                    'description': 'Returns the number of S-parameter ports. The **sparameter** array is always *n* x *n*, where span *n* is the number of ports.'
+                },
+                'name': 'numberOfPorts',
+                'type': 'ViInt32'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
     'GetError': {
         'codegen_method': 'public',
         'documentation': {
@@ -2896,19 +2891,18 @@ functions = {
         'parameters': [
             {
                 'direction': 'in',
-                'name': 'vi',
-                'type': 'ViSession'
-            },
-            {
-                'direction': 'in',
                 'documentation': {
                     'description': 'Specifies from which stand-alone module to retrieve the last successful self-calibration date and time.'
                 },
-                'name': 'module',
                 'enum': 'Module',
-                'type': 'ViInt32',
-                'use_array': False,
-                'use_in_python_api': True
+                'grpc_enum': None,
+                'name': 'module',
+                'type': 'ViInt32'
+            },
+            {
+                'direction': 'in',
+                'name': 'vi',
+                'type': 'ViSession'
             },
             {
                 'direction': 'out',
@@ -2981,8 +2975,9 @@ functions = {
                 'documentation': {
                     'description': 'Specifies from which stand-alone module to retrieve the last successful self-calibration date and time.'
                 },
-                'name': 'module',
                 'enum': 'Module',
+                'grpc_enum': None,
+                'name': 'module',
                 'type': 'ViInt32',
                 'use_array': False,
                 'use_in_python_api': True
@@ -3078,7 +3073,7 @@ functions = {
             {
                 'direction': 'in',
                 'documentation': {
-                    'description': 'Specifies from which stand-alone module to retrieve the last successful self-calibration temperature.     **Default Value** : NIRFSG_VAL_PRIMARY_MODULE    **Defined Values** :    ',
+                    'description': 'Specifies from which stand-alone module to retrieve the last successful self-calibration temperature. \n                    **Default Value** : NIRFSG_VAL_PRIMARY_MODULE\n                    **Defined Values** :\n                    ',
                     'table_body': [
                         [
                             'NIRFSG_VAL_PRIMARY_MODULE',
@@ -3149,7 +3144,7 @@ functions = {
             {
                 'direction': 'in',
                 'documentation': {
-                    'description': 'Specifies the signal to query. **Defined Values** :    ',
+                    'description': 'Specifies the signal to query. **Defined Values** :\n                    ',
                     'table_body': [
                         [
                             'NIRFSG_VAL_START_TRIGGER',
@@ -3207,7 +3202,7 @@ functions = {
             {
                 'direction': 'in',
                 'documentation': {
-                    'description': 'Specifies which instance of the selected signal to query. This parameter is necessary when you set the NIRFSG_ATTR_SIGNAL parameter to NIRFSG_VAL_SCRIPT_TRIGGER or NIRFSG_VAL_MARKER_EVENT  . Otherwise, set the NIRFSG_ATTR_SIGNAL_IDENTIFIER parameter to "" (empty string). **Possible Values** :    ',
+                    'description': 'Specifies which instance of the selected signal to query. This parameter is necessary when you set the NIRFSG_ATTR_SIGNAL parameter to NIRFSG_VAL_SCRIPT_TRIGGER or NIRFSG_VAL_MARKER_EVENT  . Otherwise, set the NIRFSG_ATTR_SIGNAL_IDENTIFIER parameter to "" (empty string). **Possible Values** :\n                    ',
                     'table_body': [
                         [
                             '"marker0"',
@@ -3284,6 +3279,7 @@ functions = {
         'documentation': {
             'description': '\nReturns the burst start locations of the waveform stored in the NI-RFSG session.\n\n**Supported Devices** : PXIe-5820/5830/5831/5832/5840/5841/5842'
         },
+        'has_repeated_capability': True,
         'included_in_proto': True,
         'method_templates': [
             {
@@ -3309,8 +3305,8 @@ functions = {
                 'documentation': {
                     'description': 'Specifies the waveform name and the marker name. Example: "waveform::waveform0/marker0"'
                 },
-                'name': 'channelName',
                 'is_repeated_capability': True,
+                'name': 'channelName',
                 'repeated_capability_type': 'waveforms',
                 'type': 'ViConstString',
                 'use_array': False,
@@ -3351,6 +3347,7 @@ functions = {
                 'use_in_python_api': True
             }
         ],
+        'repeated_capability_type': 'waveforms',
         'returns': 'ViStatus'
     },
     'GetWaveformBurstStopLocations': {
@@ -3358,6 +3355,7 @@ functions = {
         'documentation': {
             'description': '\nReturns the burst stop locations of the waveform stored in the NI-RFSG session.\n\n**Supported Devices** : PXIe-5820/5830/5831/5832/5840/5841/5842'
         },
+        'has_repeated_capability': True,
         'included_in_proto': True,
         'method_templates': [
             {
@@ -3383,8 +3381,8 @@ functions = {
                 'documentation': {
                     'description': 'Specifies the waveform name and the marker name. Example: "waveform::waveform0/marker0"'
                 },
-                'name': 'channelName',
                 'is_repeated_capability': True,
+                'name': 'channelName',
                 'repeated_capability_type': 'waveforms',
                 'type': 'ViConstString',
                 'use_array': False,
@@ -3425,6 +3423,7 @@ functions = {
                 'use_in_python_api': True
             }
         ],
+        'repeated_capability_type': 'waveforms',
         'returns': 'ViStatus'
     },
     'GetWaveformMarkerEventLocations': {
@@ -3432,6 +3431,7 @@ functions = {
         'documentation': {
             'description': '\nReturns the marker locations associated with the waveform and the marker stored in the NI-RFSG session.\n\n**Supported Devices** : PXIe-5820/5830/5831/5832/5840/5841/5842'
         },
+        'has_repeated_capability': True,
         'included_in_proto': True,
         'method_templates': [
             {
@@ -3455,10 +3455,10 @@ functions = {
             {
                 'direction': 'in',
                 'documentation': {
-                    'description': '                        Specifies the waveform name and the marker name.\n\n        Example:\n\n        "waveform::waveform0/marker0"        '
+                    'description': 'Specifies the waveform name and the marker name.\n\nExample:\n\n"waveform::waveform0/marker0"'
                 },
-                'name': 'channelName',
                 'is_repeated_capability': True,
+                'name': 'channelName',
                 'repeated_capability_type': 'markers',
                 'type': 'ViConstString',
                 'use_array': False,
@@ -3499,6 +3499,7 @@ functions = {
                 'use_in_python_api': True
             }
         ],
+        'repeated_capability_type': 'markers',
         'returns': 'ViStatus'
     },
     'InitWithOptions': {
@@ -3922,35 +3923,6 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
-    'reset': {
-        'codegen_method': 'public',
-        'documentation': {
-            'description': '\nResets all attributes to their default values and moves the NI-RFSG device to the Configuration state.\n\nThis function aborts the generation, deletes all de-embedding tables, clears all routes, and resets session attributes to their initial values. During a reset, routes of signals between this and other devices are released, regardless of which device created the route.\n\nGenerally, calling this function instead of the nirfsg_ResetDevice function is acceptable. The nirfsg_Reset function executes faster than the nirfsg_ResetDevice function.\n\nTo avoid resetting routes on the PXIe-5644/5645/5646 and PXIe-5820/5830/5831/5832/5840/5841/5842/5860 that are in use by NI-RFSA sessions, NI recommends using the nirfsg_ResetWithOptions function, with **stepsToOmit** set to NIRFSG_VAL_RESET_WITH_OPTIONS_ROUTES .\n\n**Supported Devices** : PXI-5610, PXIe-5611, PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860',
-            'note': 'This function resets all configured routes for the PXIe-5644/5645/5646 and PXIe-5820/5830/5831/5832/5840/5841/5842/5860 in NI-RFSA and NI-RFSG.'
-        },
-        'included_in_proto': True,
-        'method_templates': [
-            {
-                'documentation_filename': 'default_method',
-                'library_interpreter_filename': 'default_method',
-                'method_python_name_suffix': '',
-                'session_filename': 'default_method'
-            }
-        ],
-        'parameters': [
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies your instrument session. The ViSession handle is obtained from the nirfsg_Init function or the nirfsg_InitWithOptions function and identifies a particular instrument session.'
-                },
-                'name': 'vi',
-                'type': 'ViSession',
-                'use_array': False,
-                'use_in_python_api': True
-            }
-        ],
-        'returns': 'ViStatus'
-    },
     'ResetAttribute': {
         'codegen_method': 'public',
         'documentation': {
@@ -4056,66 +4028,10 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
-    'RevisionQuery': {
-        'codegen_method': 'public',
-        'documentation': {
-            'description': '\nReturns the revision numbers of the NI-RFSG driver and the instrument firmware.\n\n**Supported Devices** : PXI-5610, PXIe-5611, PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860'
-        },
-        'included_in_proto': True,
-        'method_templates': [
-            {
-                'documentation_filename': 'default_method',
-                'library_interpreter_filename': 'default_method',
-                'method_python_name_suffix': '',
-                'session_filename': 'default_method'
-            }
-        ],
-        'parameters': [
-            {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies your instrument session. The ViSession handle is obtained from the nirfsg_Init function or the nirfsg_InitWithOptions function and identifies a particular instrument session.'
-                },
-                'name': 'vi',
-                'type': 'ViSession',
-                'use_array': False,
-                'use_in_python_api': True
-            },
-            {
-                'direction': 'out',
-                'documentation': {
-                    'description': 'Returns the value of the NIRFSG_ATTR_SPECIFIC_DRIVER_REVISION attribute in the form of a string.\n\nYou must pass a ViChar array with at least 256 bytes.'
-                },
-                'name': 'instrumentDriverRevision',
-                'size': {
-                    'mechanism': 'fixed',
-                    'value': 256
-                },
-                'type': 'ViChar[]',
-                'use_array': False,
-                'use_in_python_api': True
-            },
-            {
-                'direction': 'out',
-                'documentation': {
-                    'description': 'Returns the value of the NIRFSG_ATTR_INSTRUMENT_FIRMWARE_REVISION attribute in the form of a string.\n\nYou must pass a ViChar array with at least 256 bytes.'
-                },
-                'name': 'firmwareRevision',
-                'size': {
-                    'mechanism': 'fixed',
-                    'value': 256
-                },
-                'type': 'ViChar[]',
-                'use_array': False,
-                'use_in_python_api': True
-            }
-        ],
-        'returns': 'ViStatus'
-    },
     'ResetWithOptions': {
         'codegen_method': 'public',
         'documentation': {
-            'description': '\nResets all properties to default values and specifies steps to omit during the reset process, such as signal routes.\n\nBy default, this function exhibits the same behavior as nirfsg_Reset. You can specify steps to omit using the steps to omit parameter. For example, if you specify NIRFSG_VAL_RESET_WITH_OPTIONS_ROUTES for the NIRFSG_ATTR_STEPS_TO_OMIT parameter, this function does not release signal routes during the reset process.\n\nWhen routes of signals between two devices are released, they are released regardless of which device created the route.\n\nTo avoid resetting routes on PXIe-5820/5830/5831/5832/5840/5841/5842/5860 that are in use by NI-RFSA sessions, NI recommends using this function instead of nirfsg_Reset, with NIRFSG_ATTR_STEPS_TO_OMIT set to NIRFSG_VAL_RESET_WITH_OPTIONS_ROUTES.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Triggers <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/triggers.html>``Events <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/events.html>`_'
+            'description': '\nResets all properties to default values and specifies steps to omit during the reset process, such as signal routes.\n\nBy default, this function exhibits the same behavior as nirfsg_Reset. You can specify steps to omit using the steps to omit parameter. For example, if you specify NIRFSG_VAL_RESET_WITH_OPTIONS_ROUTES for the NIRFSG_ATTR_STEPS_TO_OMIT parameter, this function does not release signal routes during the reset process.\n\nWhen routes of signals between two devices are released, they are released regardless of which device created the route.\n\nTo avoid resetting routes on PXIe-5820/5830/5831/5832/5840/5841/5842/5860 that are in use by NI-RFSA sessions, NI recommends using this function instead of nirfsg_Reset, with NIRFSG_ATTR_STEPS_TO_OMIT set to NIRFSG_VAL_RESET_WITH_OPTIONS_ROUTES.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Triggers <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/triggers.html>`_\n\n`Events <https://www.ni.com/docs/en-US/bundle/rfsg/page/rfsg/events.html>`_'
         },
         'included_in_proto': True,
         'method_templates': [
@@ -4175,10 +4091,66 @@ functions = {
                         'Description'
                     ]
                 },
-                'type_in_documentation': 'Bitwise combination of enums.ResetWithOptionsStepsToOmit flags',
                 'enum': 'ResetWithOptionsStepsToOmit',
                 'name': 'stepsToOmit',
                 'type': 'ViUInt64',
+                'type_in_documentation': 'Bitwise combination of enums.ResetWithOptionsStepsToOmit flags',
+                'use_array': False,
+                'use_in_python_api': True
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'RevisionQuery': {
+        'codegen_method': 'public',
+        'documentation': {
+            'description': '\nReturns the revision numbers of the NI-RFSG driver and the instrument firmware.\n\n**Supported Devices** : PXI-5610, PXIe-5611, PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860'
+        },
+        'included_in_proto': True,
+        'method_templates': [
+            {
+                'documentation_filename': 'default_method',
+                'library_interpreter_filename': 'default_method',
+                'method_python_name_suffix': '',
+                'session_filename': 'default_method'
+            }
+        ],
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Identifies your instrument session. The ViSession handle is obtained from the nirfsg_Init function or the nirfsg_InitWithOptions function and identifies a particular instrument session.'
+                },
+                'name': 'vi',
+                'type': 'ViSession',
+                'use_array': False,
+                'use_in_python_api': True
+            },
+            {
+                'direction': 'out',
+                'documentation': {
+                    'description': 'Returns the value of the NIRFSG_ATTR_SPECIFIC_DRIVER_REVISION attribute in the form of a string.\n\nYou must pass a ViChar array with at least 256 bytes.'
+                },
+                'name': 'instrumentDriverRevision',
+                'size': {
+                    'mechanism': 'fixed',
+                    'value': 256
+                },
+                'type': 'ViChar[]',
+                'use_array': False,
+                'use_in_python_api': True
+            },
+            {
+                'direction': 'out',
+                'documentation': {
+                    'description': 'Returns the value of the NIRFSG_ATTR_INSTRUMENT_FIRMWARE_REVISION attribute in the form of a string.\n\nYou must pass a ViChar array with at least 256 bytes.'
+                },
+                'name': 'firmwareRevision',
+                'size': {
+                    'mechanism': 'fixed',
+                    'value': 256
+                },
+                'type': 'ViChar[]',
                 'use_array': False,
                 'use_in_python_api': True
             }
@@ -4369,10 +4341,10 @@ functions = {
                         'Description'
                     ]
                 },
-                'type_in_documentation': 'Bitwise combination of enums.SelfCalibrateRangeStepsToOmit flags',
                 'enum': 'SelfCalibrateRangeStepsToOmit',
                 'name': 'stepsToOmit',
                 'type': 'ViInt64',
+                'type_in_documentation': 'Bitwise combination of enums.SelfCalibrateRangeStepsToOmit flags',
                 'use_array': False,
                 'use_in_python_api': True
             },
@@ -5003,6 +4975,7 @@ functions = {
         'documentation': {
             'description': '\nConfigures the start location of the burst in samples where the burst refers to the active portion of a waveform.\n\n**Supported Devices** : PXIe-5820/5830/5831/5832/5840/5841/5842'
         },
+        'has_repeated_capability': True,
         'included_in_proto': True,
         'method_templates': [
             {
@@ -5028,8 +5001,8 @@ functions = {
                 'documentation': {
                     'description': 'Specifies the waveform name and the marker name. Example: "waveform::waveform0/marker0"'
                 },
-                'name': 'channelName',
                 'is_repeated_capability': True,
+                'name': 'channelName',
                 'repeated_capability_type': 'waveforms',
                 'type': 'ViConstString',
                 'use_array': False,
@@ -5042,8 +5015,7 @@ functions = {
                 },
                 'name': 'numberOfLocations',
                 'type': 'ViInt32',
-                'use_array': False,
-                'use_in_python_api': False
+                'use_array': False
             },
             {
                 'direction': 'in',
@@ -5059,6 +5031,7 @@ functions = {
                 'use_in_python_api': True
             }
         ],
+        'repeated_capability_type': 'waveforms',
         'returns': 'ViStatus'
     },
     'SetWaveformBurstStopLocations': {
@@ -5066,6 +5039,7 @@ functions = {
         'documentation': {
             'description': '\nConfigures the stop location of the burst in samples where the burst refers to the active portion of a waveform.\n\n**Supported Devices** : PXIe-5820/5830/5831/5832/5840/5841/5842'
         },
+        'has_repeated_capability': True,
         'included_in_proto': True,
         'method_templates': [
             {
@@ -5089,10 +5063,10 @@ functions = {
             {
                 'direction': 'in',
                 'documentation': {
-                    'description': '                        Specifies the waveform name and the marker name.\n\n        Example:\n\n        "waveform::waveform0/marker0"        '
+                    'description': 'Specifies the waveform name and the marker name.\n\nExample:\n\n"waveform::waveform0/marker0"'
                 },
-                'name': 'channelName',
                 'is_repeated_capability': True,
+                'name': 'channelName',
                 'repeated_capability_type': 'waveforms',
                 'type': 'ViConstString',
                 'use_array': False,
@@ -5105,8 +5079,7 @@ functions = {
                 },
                 'name': 'numberOfLocations',
                 'type': 'ViInt32',
-                'use_array': False,
-                'use_in_python_api': False
+                'use_array': False
             },
             {
                 'direction': 'in',
@@ -5122,6 +5095,7 @@ functions = {
                 'use_in_python_api': True
             }
         ],
+        'repeated_capability_type': 'waveforms',
         'returns': 'ViStatus'
     },
     'SetWaveformMarkerEventLocations': {
@@ -5129,6 +5103,7 @@ functions = {
         'documentation': {
             'description': '\nConfigures the marker locations associated with waveform and marker in the NI-RFSG session.\n\n**Supported Devices** : PXIe-5820/5830/5831/5832/5840/5841/5842'
         },
+        'has_repeated_capability': True,
         'included_in_proto': True,
         'method_templates': [
             {
@@ -5152,10 +5127,10 @@ functions = {
             {
                 'direction': 'in',
                 'documentation': {
-                    'description': '                        Specifies the waveform name and the marker name.\n\n        Example:\n\n        "waveform::waveform0/marker0"        '
+                    'description': 'Specifies the waveform name and the marker name.\n\nExample:\n\n"waveform::waveform0/marker0"'
                 },
-                'name': 'channelName',
                 'is_repeated_capability': True,
+                'name': 'channelName',
                 'repeated_capability_type': 'markers',
                 'type': 'ViConstString',
                 'use_array': False,
@@ -5168,8 +5143,7 @@ functions = {
                 },
                 'name': 'numberOfLocations',
                 'type': 'ViInt32',
-                'use_array': False,
-                'use_in_python_api': False
+                'use_array': False
             },
             {
                 'direction': 'in',
@@ -5185,6 +5159,7 @@ functions = {
                 'use_in_python_api': True
             }
         ],
+        'repeated_capability_type': 'markers',
         'returns': 'ViStatus'
     },
     'UnlockSession': {
@@ -5266,13 +5241,13 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
-     'WriteArbWaveformComplexF32': {
+    'WriteArbWaveformComplexF32': {
         'codegen_method': 'private',
         'documentation': {
             'description': '\nWrites an arbitrary waveform to the NI-RFSG device starting at the position of the last data written in onboard memory.\n\nThis function accepts the complex baseband data in the form of complex singles. If the waveform to write is already allocated using the nirfsg_AllocateArbWaveform function, the **NIRFSG_ATTR_MORE_DATA_PENDING** parameter is ignored. The PXI-5670/5671 must be in the Configuration state before you call this function. When streaming is enabled, you can call this function when the PXIe-5672/5673/5673E or PXIe-5820/5830/5831/5832/5840/5841/5842/5860 is in the Generation state.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Streaming <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/streaming.html>`_\n\n`Assigning Properties or Attributes to a Waveform <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/assigning-properties-or-attributes-to-a-wavef.html>`_',
             'note': 'On the PXIe-5644/5645/5646, PXIe-5672/5673/5673E, and PXIe-5820/5830/5831/5832/5840/5841/5842/5860, the **NIRFSG_ATTR_MORE_DATA_PENDING** parameter is always ignored. To write data in blocks on these devices, you must allocate the waveform before writing it.'
         },
-        'included_in_proto': False,
+        'included_in_proto': True,
         'is_error_handling': False,
         'method_name_for_documentation': 'write_arb_waveform',
         'method_templates': [
@@ -5311,8 +5286,7 @@ functions = {
                 },
                 'name': 'numberOfSamples',
                 'type': 'ViInt32',
-                'use_array': False,
-                'use_in_python_api': False
+                'use_array': False
             },
             {
                 'complex_type': 'numpy',
@@ -5327,8 +5301,7 @@ functions = {
                     'value': 'numberOfSamples'
                 },
                 'type': 'NIComplexNumberF32[]',
-                'use_in_python_api': True,
-                'use_array': True
+                'use_in_python_api': True
             },
             {
                 'direction': 'in',
@@ -5341,16 +5314,15 @@ functions = {
                 'use_in_python_api': True
             }
         ],
-        'returns': 'ViStatus',
-        'use_session_lock': False
+        'returns': 'ViStatus'
     },
     'WriteArbWaveformComplexF64': {
         'codegen_method': 'private',
         'documentation': {
-            'description': '\nWrites an arbitrary waveform to the NI-RFSG device starting at the position of the last data written in onboard memory.\n\nThis function accepts the complex baseband data in the form of complex doubles. If the waveform to write is already allocated using the nirfsg_AllocateArbWaveform, the moreDataPending parameter is ignored. The PXI-5670/5671 must be in the Configuration state before you call this function. When streaming is enabled, you can call this function when the PXIe-5672/5673/5673E or PXIe-5820/5830/5831/5832/5840/5841/5842 is in the Generation state.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842\n\n**Related Topics**\n\n`Streaming <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/streaming.html>`_\n\n`Assigning Properties or Attributes to a Waveform <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/assigning-properties-or-attributes-to-a-wavef.html>`_',
-            'note': 'On the PXIe-5644/5645/5646, PXIe-5672/5673/5673E, and PXIe-5820/5830/5831/5832/5840/5841/5842, the moreDataPending parameter is always ignored. To write data in blocks on these devices, you must allocate the waveform before writing it.'
+            'description': '\nWrites an arbitrary waveform to the NI-RFSG device starting at the position of the last data written in onboard memory.\n\nThis function accepts the complex baseband data in the form of complex doubles. If the waveform to write is already allocated using the nirfsg_AllocateArbWaveform, the **NIRFSG_ATTR_MORE_DATA_PENDING** parameter is ignored. The PXI-5670/5671 must be in the Configuration state before you call this function. When streaming is enabled, you can call this function when the PXIe-5672/5673/5673E or PXIe-5820/5830/5831/5832/5840/5841/5842 is in the Generation state.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842\n\n**Related Topics**\n\n`Streaming <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/streaming.html>`_\n\n`Assigning Properties or Attributes to a Waveform <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/assigning-properties-or-attributes-to-a-wavef.html>`_',
+            'note': 'On the PXIe-5644/5645/5646, PXIe-5672/5673/5673E, and PXIe-5820/5830/5831/5832/5840/5841/5842, the **NIRFSG_ATTR_MORE_DATA_PENDING** parameter is always ignored. To write data in blocks on these devices, you must allocate the waveform before writing it.'
         },
-        'included_in_proto': False,
+        'included_in_proto': True,
         'is_error_handling': False,
         'method_name_for_documentation': 'write_arb_waveform',
         'method_templates': [
@@ -5389,8 +5361,7 @@ functions = {
                 },
                 'name': 'numberOfSamples',
                 'type': 'ViInt32',
-                'use_array': False,
-                'use_in_python_api': False
+                'use_array': False
             },
             {
                 'complex_type': 'numpy',
@@ -5405,8 +5376,7 @@ functions = {
                     'value': 'numberOfSamples'
                 },
                 'type': 'NIComplexNumber[]',
-                'use_in_python_api': True,
-                'use_array': True
+                'use_in_python_api': True
             },
             {
                 'direction': 'in',
@@ -5419,8 +5389,7 @@ functions = {
                 'use_in_python_api': True
             }
         ],
-        'returns': 'ViStatus',
-        'use_session_lock': False
+        'returns': 'ViStatus'
     },
     'WriteArbWaveformComplexI16': {
         'codegen_method': 'private',
@@ -5428,7 +5397,7 @@ functions = {
             'description': '\nWrites an arbitrary waveform to the NI-RFSG device starting at the position of the last data written in onboard memory.\n\nThis function accepts the interleaved I/Q data of a complex baseband signal. The PXI-5670/5671 must be in the Configuration state before you call this function. When streaming is enabled, this function can be called when the PXIe-5672/5673/5673E or PXIe-5820/5830/5831/5832/5840/5841/5842/5860 is in the Generation state.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Streaming <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/streaming.html>`_\n\n`Assigning Properties or Attributes to a Waveform <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/assigning-properties-or-attributes-to-a-wavef.html>`_',
             'note': 'This function only supports NIRFSG_VAL_PEAK_POWER mode as specified in the NIRFSG_ATTR_POWER_LEVEL_TYPE attribute. If you download a waveform when using this function, you cannot set the NIRFSG_ATTR_POWER_LEVEL_TYPE to NIRFSG_VAL_AVERAGE_POWER without causing error in the output.'
         },
-        'included_in_proto': False,
+        'included_in_proto': True,
         'is_error_handling': False,
         'method_name_for_documentation': 'write_arb_waveform',
         'method_templates': [
@@ -5467,8 +5436,7 @@ functions = {
                 },
                 'name': 'numberOfSamples',
                 'type': 'ViInt32',
-                'use_array': False,
-                'use_in_python_api': False
+                'use_array': False
             },
             {
                 'complex_type': 'interleaved',
@@ -5483,21 +5451,20 @@ functions = {
                     'value': 'numberOfSamples'
                 },
                 'type': 'NIComplexI16[]',
-                'use_in_python_api': True,
-                'use_array': True
+                'use_in_python_api': True
             }
         ],
-        'returns': 'ViStatus',
-        'use_session_lock': False
+        'returns': 'ViStatus'
     },
     'WriteArbWaveformDispatcher': {
         'codegen_method': 'python-only',
         'documentation': {
-            'description': '\nWrites an arbitrary waveform to the NI-RFSG device starting at the position of the last data written in onboard memory.\n\nThis function accepts the complex baseband data in the form of numpy array of numpy.complex64 or numpy.complex128 or interleaved numpy array of numpy.int16. If the waveform to write is already allocated using the nirfsg_AllocateArbWaveform function, the **NIRFSG_ATTR_MORE_DATA_PENDING** parameter is ignored. The PXI-5670/5671 must be in the Configuration state before you call this function. When streaming is enabled, this function can be called when the PXIe-5672/5673/5673E or PXIe-5820/5830/5831/5832/5840/5841/5842/5860 is in the Generation state.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Streaming <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/streaming.html>`_\n\n`Assigning Properties or Attributes to a Waveform <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/assigning-properties-or-attributes-to-a-wavef.html>`_',
-            'note': 'This function only supports NIRFSG_VAL_PEAK_POWER mode as specified in the NIRFSG_ATTR_POWER_LEVEL_TYPE attribute. If you download a waveform when using this function, you cannot set the NIRFSG_ATTR_POWER_LEVEL_TYPE to NIRFSG_VAL_AVERAGE_POWER without causing error in the output.'
+            'description': '\nWrites an arbitrary waveform to the NI-RFSG device starting at the position of the last data written in onboard memory.\n\nThis function accepts the complex baseband data in the form of numpy array of numpy.complex64 or numpy.complex128 or interleaved numpy array of numpy.int16. If the waveform to write is already allocated using the nirfsg_AllocateArbWaveform, the **NIRFSG_ATTR_MORE_DATA_PENDING** parameter is ignored. The PXI-5670/5671 must be in the Configuration state before you call this function. When streaming is enabled, you can call this function when the PXIe-5672/5673/5673E or PXIe-5820/5830/5831/5832/5840/5841/5842/5860 is in the Generation state.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Streaming <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/streaming.html>`_\n\n`Assigning Properties or Attributes to a Waveform <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/assigning-properties-or-attributes-to-a-wavef.html>`_',
+            'note': 'On the PXIe-5644/5645/5646, PXIe-5672/5673/5673E, and PXIe-5820/5830/5831/5832/5840/5841/5842/5860, the **NIRFSG_ATTR_MORE_DATA_PENDING** parameter is always ignored. To write data in blocks on these devices, you must allocate the waveform before writing it.\nIf you are writing interleaved numpy array of numpy.int16, then this function only supports NIRFSG_VAL_PEAK_POWER mode as specified in the NIRFSG_ATTR_POWER_LEVEL_TYPE attribute. If you download a waveform as interleaved numpy array of numpy.int16 when using this function, you cannot set the NIRFSG_ATTR_POWER_LEVEL_TYPE to NIRFSG_VAL_AVERAGE_POWER without causing error in the output.'
         },
         'included_in_proto': False,
         'is_error_handling': False,
+        'method_name_for_documentation': 'write_arb_waveform',
         'method_templates': [
             {
                 'documentation_filename': 'default_method',
@@ -5528,40 +5495,25 @@ functions = {
                 'use_in_python_api': True
             },
             {
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Specifies the number of samples in the data array.'
-                },
-                'name': 'numberOfSamples',
-                'type': 'ViInt32',
-                'use_array': False,
-                'use_in_python_api': False
-            },
-            {
                 'complex_type': 'numpy',
                 'direction': 'in',
                 'documentation': {
                     'description': 'Specifies the array of data to load into the waveform. The array must have at least as many elements as the value in the **size_in_samples** parameter in the nirfsg_AllocateArbWaveform function.'
                 },
-                'type_in_documentation': 'numpy array of numpy.complex64, numpy array of numpy.complex128 or interleaved complex data in the form of numpy array of numpy.int16',
                 'name': 'waveformDataArray',
                 'numpy': True,
-                'size': {
-                    'mechanism': 'len',
-                    'value': 'numberOfSamples'
-                },
                 'type': 'NIComplexNumber[]',
-                'use_in_python_api': True,
-                'use_array': True
+                'type_in_documentation': 'numpy array of numpy.complex64, numpy array of numpy.complex128 or interleaved complex data in the form of numpy array of numpy.int16',
+                'use_in_python_api': True
             },
             {
+                'default_value': False,
                 'direction': 'in',
                 'documentation': {
                     'description': 'Specifies whether or not the data block contains the end of the waveform. Set this parameter to VI_TRUE to allow data to be appended later to the waveform. Splitting the waveform into multiple data blocks can reduce the memory requirements of the write operation. Append data to a previously written waveform by using the same waveform in the **name** parameter. Set **NIRFSG_ATTR_MORE_DATA_PENDING** to VI_FALSE to indicate that this data block contains the end of the waveform. If the waveform is already allocated, this parameter is ignored.'
                 },
                 'name': 'moreDataPending',
                 'type': 'ViBoolean',
-                'default_value': False,
                 'use_array': False,
                 'use_in_python_api': True
             }
@@ -5631,5 +5583,35 @@ functions = {
         'python_name': '_close',
         'returns': 'ViStatus',
         'use_session_lock': False
+    },
+    'reset': {
+        'codegen_method': 'public',
+        'documentation': {
+            'description': '\nResets all attributes to their default values and moves the NI-RFSG device to the Configuration state.\n\nThis function aborts the generation, deletes all de-embedding tables, clears all routes, and resets session attributes to their initial values. During a reset, routes of signals between this and other devices are released, regardless of which device created the route.\n\nGenerally, calling this function instead of the nirfsg_ResetDevice function is acceptable. The nirfsg_Reset function executes faster than the nirfsg_ResetDevice function.\n\nTo avoid resetting routes on the PXIe-5644/5645/5646 and PXIe-5820/5830/5831/5832/5840/5841/5842/5860 that are in use by NI-RFSA sessions, NI recommends using the nirfsg_ResetWithOptions function, with **stepsToOmit** set to NIRFSG_VAL_RESET_WITH_OPTIONS_ROUTES .\n\n**Supported Devices** : PXI-5610, PXIe-5611, PXIe-5644/5645/5646, PXI/PXIe-5650/5651/5652, PXIe-5653/5654/5654 with PXIe-5696, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860',
+            'note': 'This function resets all configured routes for the PXIe-5644/5645/5646 and PXIe-5820/5830/5831/5832/5840/5841/5842/5860 in NI-RFSA and NI-RFSG.'
+        },
+        'grpc_name': 'Reset',
+        'included_in_proto': True,
+        'method_templates': [
+            {
+                'documentation_filename': 'default_method',
+                'library_interpreter_filename': 'default_method',
+                'method_python_name_suffix': '',
+                'session_filename': 'default_method'
+            }
+        ],
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Identifies your instrument session. The ViSession handle is obtained from the nirfsg_Init function or the nirfsg_InitWithOptions function and identifies a particular instrument session.'
+                },
+                'name': 'vi',
+                'type': 'ViSession',
+                'use_array': False,
+                'use_in_python_api': True
+            }
+        ],
+        'returns': 'ViStatus'
     }
 }

--- a/src/nirfsg/metadata/functions.py
+++ b/src/nirfsg/metadata/functions.py
@@ -2051,6 +2051,52 @@ functions = {
         'returns': 'ViStatus',
         'use_session_lock': False
     },
+    'FancyGetDeembeddingSparameters': {
+        'codegen_method': 'python-only',
+        'documentation': {
+            'description': '\nReturns the S-parameters used for de-embedding a measurement on the selected port.\n\nThis includes interpolation of the parameters based on the configured carrier frequency. This function returns an empty array if no de-embedding is done.\n\nIf you want to call this function just to get the required buffer size, you can pass 0 for **S-parameter Size** and VI_NULL for the **S-parameters** buffer.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860',
+            'note': 'The port orientation for the returned S-parameters is normalized to NIRFSG_VAL_PORT1_TOWARDS_DUT.'
+        },
+        'included_in_proto': True,
+        'method_name_for_documentation': 'get_deembedding_sparameters',
+        'method_templates': [
+            {
+                'documentation_filename': 'default_method',
+                'library_interpreter_filename': 'none',
+                'method_python_name_suffix': '',
+                'session_filename': 'get_deembedding_sparameter'
+            }
+        ],
+        'parameters': [
+            {
+                'direction': 'in',
+                'documentation': {
+                    'description': 'Identifies your instrument session. The ViSession handle is obtained from the nirfsg_Init function or the nirfsg_InitWithOptions function and identifies a particular instrument session.'
+                },
+                'name': 'vi',
+                'type': 'ViSession',
+                'use_array': False,
+                'use_in_python_api': True
+            },
+            {
+                'array_dimension': 2,
+                'complex_type': 'numpy',
+                'direction': 'out',
+                'documentation': {
+                    'description': 'Returns an array of S-parameters. The S-parameters are returned in the following order: s11, s12, s21, s22.'
+                },
+                'name': 'sparameters',
+                'numpy': True,
+                'type': 'NIComplexNumber[]',
+                'type_in_documentation': 'numpy.array(dtype=numpy.complex128)',
+                'use_array': False,
+                'use_in_python_api': True
+            }
+        ],
+        'python_name': 'get_deembedding_sparameters',
+        'returns': None,
+        'use_session_lock': False
+    },
     'GetAllNamedWaveformNames': {
         'codegen_method': 'public',
         'documentation': {
@@ -2601,7 +2647,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'GetDeembeddingSparameters': {
-        'codegen_method': 'public',
+        'codegen_method': 'private',
         'documentation': {
             'description': '\nReturns the S-parameters used for de-embedding a measurement on the selected port.\n\nThis includes interpolation of the parameters based on the configured carrier frequency. This function returns an empty array if no de-embedding is done.\n\nIf you want to call this function just to get the required buffer size, you can pass 0 for **S-parameter Size** and VI_NULL for the **S-parameters** buffer.\n\n**Supported Devices** : PXIe-5830/5831/5832/5840/5841/5842/5860',
             'note': 'The port orientation for the returned S-parameters is normalized to NIRFSG_VAL_PORT1_TOWARDS_DUT.'
@@ -2609,10 +2655,10 @@ functions = {
         'included_in_proto': True,
         'method_templates': [
             {
-                'documentation_filename': 'default_method',
+                'documentation_filename': 'numpy_method',
                 'library_interpreter_filename': 'numpy_read_method',
                 'method_python_name_suffix': '',
-                'session_filename': 'get_deembedding_sparameter'
+                'session_filename': 'numpy_read_method'
             }
         ],
         'parameters': [
@@ -2656,7 +2702,7 @@ functions = {
                 'name': 'numberOfSparameters',
                 'type': 'ViInt32',
                 'use_array': False,
-                'use_in_python_api': False
+                'use_in_python_api': True
             },
             {
                 'direction': 'out',
@@ -5244,8 +5290,8 @@ functions = {
     'WriteArbWaveformComplexF32': {
         'codegen_method': 'private',
         'documentation': {
-            'description': '\nWrites an arbitrary waveform to the NI-RFSG device starting at the position of the last data written in onboard memory.\n\nThis function accepts the complex baseband data in the form of complex singles. If the waveform to write is already allocated using the nirfsg_AllocateArbWaveform function, the **NIRFSG_ATTR_MORE_DATA_PENDING** parameter is ignored. The PXI-5670/5671 must be in the Configuration state before you call this function. When streaming is enabled, you can call this function when the PXIe-5672/5673/5673E or PXIe-5820/5830/5831/5832/5840/5841/5842/5860 is in the Generation state.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Streaming <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/streaming.html>`_\n\n`Assigning Properties or Attributes to a Waveform <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/assigning-properties-or-attributes-to-a-wavef.html>`_',
-            'note': 'On the PXIe-5644/5645/5646, PXIe-5672/5673/5673E, and PXIe-5820/5830/5831/5832/5840/5841/5842/5860, the **NIRFSG_ATTR_MORE_DATA_PENDING** parameter is always ignored. To write data in blocks on these devices, you must allocate the waveform before writing it.'
+            'description': '\nWrites an arbitrary waveform to the NI-RFSG device starting at the position of the last data written in onboard memory.\n\nThis function accepts the complex baseband data in the form of complex singles. If the waveform to write is already allocated using the nirfsg_AllocateArbWaveform function, the more_data_pending parameter is ignored. The PXI-5670/5671 must be in the Configuration state before you call this function. When streaming is enabled, you can call this function when the PXIe-5672/5673/5673E or PXIe-5820/5830/5831/5832/5840/5841/5842/5860 is in the Generation state.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Streaming <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/streaming.html>`_\n\n`Assigning Properties or Attributes to a Waveform <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/assigning-properties-or-attributes-to-a-wavef.html>`_',
+            'note': 'On the PXIe-5644/5645/5646, PXIe-5672/5673/5673E, and PXIe-5820/5830/5831/5832/5840/5841/5842/5860, the more_data_pending parameter is always ignored. To write data in blocks on these devices, you must allocate the waveform before writing it.'
         },
         'included_in_proto': True,
         'is_error_handling': False,
@@ -5306,7 +5352,7 @@ functions = {
             {
                 'direction': 'in',
                 'documentation': {
-                    'description': 'Specifies whether or not the data block contains the end of the waveform. Set this parameter to VI_TRUE to allow data to be appended later to the waveform. Splitting the waveform into multiple data blocks can reduce the memory requirements of the write operation. Append data to a previously written waveform by using the same waveform in the NIRFSG_ATTR_WAVEFORM_NAME parameter. Set **NIRFSG_ATTR_MORE_DATA_PENDING** to VI_FALSE to indicate that this data block contains the end of the waveform. If the waveform is already allocated, this parameter is ignored.'
+                    'description': 'Specifies whether or not the data block contains the end of the waveform. Set this parameter to VI_TRUE to allow data to be appended later to the waveform. Splitting the waveform into multiple data blocks can reduce the memory requirements of the write operation. Append data to a previously written waveform by using the same waveform in the NIRFSG_ATTR_WAVEFORM_NAME parameter. Set more_data_pending to VI_FALSE to indicate that this data block contains the end of the waveform. If the waveform is already allocated, this parameter is ignored.'
                 },
                 'name': 'moreDataPending',
                 'type': 'ViBoolean',
@@ -5319,8 +5365,8 @@ functions = {
     'WriteArbWaveformComplexF64': {
         'codegen_method': 'private',
         'documentation': {
-            'description': '\nWrites an arbitrary waveform to the NI-RFSG device starting at the position of the last data written in onboard memory.\n\nThis function accepts the complex baseband data in the form of complex doubles. If the waveform to write is already allocated using the nirfsg_AllocateArbWaveform, the **NIRFSG_ATTR_MORE_DATA_PENDING** parameter is ignored. The PXI-5670/5671 must be in the Configuration state before you call this function. When streaming is enabled, you can call this function when the PXIe-5672/5673/5673E or PXIe-5820/5830/5831/5832/5840/5841/5842 is in the Generation state.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842\n\n**Related Topics**\n\n`Streaming <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/streaming.html>`_\n\n`Assigning Properties or Attributes to a Waveform <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/assigning-properties-or-attributes-to-a-wavef.html>`_',
-            'note': 'On the PXIe-5644/5645/5646, PXIe-5672/5673/5673E, and PXIe-5820/5830/5831/5832/5840/5841/5842, the **NIRFSG_ATTR_MORE_DATA_PENDING** parameter is always ignored. To write data in blocks on these devices, you must allocate the waveform before writing it.'
+            'description': '\nWrites an arbitrary waveform to the NI-RFSG device starting at the position of the last data written in onboard memory.\n\nThis function accepts the complex baseband data in the form of complex doubles. If the waveform to write is already allocated using the nirfsg_AllocateArbWaveform, the more_data_pending parameter is ignored. The PXI-5670/5671 must be in the Configuration state before you call this function. When streaming is enabled, you can call this function when the PXIe-5672/5673/5673E or PXIe-5820/5830/5831/5832/5840/5841/5842 is in the Generation state.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842\n\n**Related Topics**\n\n`Streaming <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/streaming.html>`_\n\n`Assigning Properties or Attributes to a Waveform <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/assigning-properties-or-attributes-to-a-wavef.html>`_',
+            'note': 'On the PXIe-5644/5645/5646, PXIe-5672/5673/5673E, and PXIe-5820/5830/5831/5832/5840/5841/5842, the more_data_pending parameter is always ignored. To write data in blocks on these devices, you must allocate the waveform before writing it.'
         },
         'included_in_proto': True,
         'is_error_handling': False,
@@ -5381,7 +5427,7 @@ functions = {
             {
                 'direction': 'in',
                 'documentation': {
-                    'description': 'Specifies whether or not the data block contains the end of the waveform. Set this parameter to VI_TRUE to allow data to be appended later to the waveform. Splitting the waveform into multiple data blocks can reduce the memory requirements of the write operation. Append data to a previously written waveform by using the same waveform in the **name** parameter. Set **NIRFSG_ATTR_MORE_DATA_PENDING** to VI_FALSE to indicate that this data block contains the end of the waveform. If the waveform is already allocated, this parameter is ignored.'
+                    'description': 'Specifies whether or not the data block contains the end of the waveform. Set this parameter to VI_TRUE to allow data to be appended later to the waveform. Splitting the waveform into multiple data blocks can reduce the memory requirements of the write operation. Append data to a previously written waveform by using the same waveform in the **name** parameter. Set more_data_pending to VI_FALSE to indicate that this data block contains the end of the waveform. If the waveform is already allocated, this parameter is ignored.'
                 },
                 'name': 'moreDataPending',
                 'type': 'ViBoolean',
@@ -5459,8 +5505,8 @@ functions = {
     'WriteArbWaveformDispatcher': {
         'codegen_method': 'python-only',
         'documentation': {
-            'description': '\nWrites an arbitrary waveform to the NI-RFSG device starting at the position of the last data written in onboard memory.\n\nThis function accepts the complex baseband data in the form of numpy array of numpy.complex64 or numpy.complex128 or interleaved numpy array of numpy.int16. If the waveform to write is already allocated using the nirfsg_AllocateArbWaveform, the **NIRFSG_ATTR_MORE_DATA_PENDING** parameter is ignored. The PXI-5670/5671 must be in the Configuration state before you call this function. When streaming is enabled, you can call this function when the PXIe-5672/5673/5673E or PXIe-5820/5830/5831/5832/5840/5841/5842/5860 is in the Generation state.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Streaming <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/streaming.html>`_\n\n`Assigning Properties or Attributes to a Waveform <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/assigning-properties-or-attributes-to-a-wavef.html>`_',
-            'note': 'On the PXIe-5644/5645/5646, PXIe-5672/5673/5673E, and PXIe-5820/5830/5831/5832/5840/5841/5842/5860, the **NIRFSG_ATTR_MORE_DATA_PENDING** parameter is always ignored. To write data in blocks on these devices, you must allocate the waveform before writing it.\nIf you are writing interleaved numpy array of numpy.int16, then this function only supports NIRFSG_VAL_PEAK_POWER mode as specified in the NIRFSG_ATTR_POWER_LEVEL_TYPE attribute. If you download a waveform as interleaved numpy array of numpy.int16 when using this function, you cannot set the NIRFSG_ATTR_POWER_LEVEL_TYPE to NIRFSG_VAL_AVERAGE_POWER without causing error in the output.'
+            'description': '\nWrites an arbitrary waveform to the NI-RFSG device starting at the position of the last data written in onboard memory.\n\nThis function accepts the complex baseband data in the form of numpy array of numpy.complex64 or numpy.complex128 or interleaved numpy array of numpy.int16. If the waveform to write is already allocated using the nirfsg_AllocateArbWaveform, the more_data_pending parameter is ignored. The PXI-5670/5671 must be in the Configuration state before you call this function. When streaming is enabled, you can call this function when the PXIe-5672/5673/5673E or PXIe-5820/5830/5831/5832/5840/5841/5842/5860 is in the Generation state.\n\n**Supported Devices** : PXIe-5644/5645/5646, PXI-5670/5671, PXIe-5672/5673/5673E, PXIe-5820/5830/5831/5832/5840/5841/5842/5860\n\n**Related Topics**\n\n`Streaming <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/streaming.html>`_\n\n`Assigning Properties or Attributes to a Waveform <https://www.ni.com/docs/en-US/bundle/ni-rfsg/page/assigning-properties-or-attributes-to-a-wavef.html>`_',
+            'note': 'On the PXIe-5644/5645/5646, PXIe-5672/5673/5673E, and PXIe-5820/5830/5831/5832/5840/5841/5842/5860, the more_data_pending parameter is always ignored. To write data in blocks on these devices, you must allocate the waveform before writing it.\nIf you are writing interleaved numpy array of numpy.int16, then this function only supports NIRFSG_VAL_PEAK_POWER mode as specified in the NIRFSG_ATTR_POWER_LEVEL_TYPE attribute. If you download a waveform as interleaved numpy array of numpy.int16 when using this function, you cannot set the NIRFSG_ATTR_POWER_LEVEL_TYPE to NIRFSG_VAL_AVERAGE_POWER without causing error in the output.'
         },
         'included_in_proto': False,
         'is_error_handling': False,
@@ -5510,7 +5556,7 @@ functions = {
                 'default_value': False,
                 'direction': 'in',
                 'documentation': {
-                    'description': 'Specifies whether or not the data block contains the end of the waveform. Set this parameter to VI_TRUE to allow data to be appended later to the waveform. Splitting the waveform into multiple data blocks can reduce the memory requirements of the write operation. Append data to a previously written waveform by using the same waveform in the **name** parameter. Set **NIRFSG_ATTR_MORE_DATA_PENDING** to VI_FALSE to indicate that this data block contains the end of the waveform. If the waveform is already allocated, this parameter is ignored.'
+                    'description': 'Specifies whether or not the data block contains the end of the waveform. Set this parameter to VI_TRUE to allow data to be appended later to the waveform. Splitting the waveform into multiple data blocks can reduce the memory requirements of the write operation. Append data to a previously written waveform by using the same waveform in the **name** parameter. Set more_data_pending to VI_FALSE to indicate that this data block contains the end of the waveform. If the waveform is already allocated, this parameter is ignored.'
                 },
                 'name': 'moreDataPending',
                 'type': 'ViBoolean',

--- a/src/nirfsg/system_tests/test_system_nirfsg.py
+++ b/src/nirfsg/system_tests/test_system_nirfsg.py
@@ -543,8 +543,7 @@ class SystemTests:
         expected_sparameter_table = np.array([[5 + 5j, 6 + 6j], [7 + 7j, 8 + 8j]], dtype=np.complex128)
         rfsg_device_session.create_deembedding_sparameter_table_array('', 'myTable1', frequencies, sparameter_tables, nirfsg.SparameterOrientation.PORT2_TOWARDS_DUT)
         rfsg_device_session.frequency = 2e9
-        returned_sparameter_table, number_of_ports = rfsg_device_session.get_deembedding_sparameters()
-        assert number_of_ports == 2
+        returned_sparameter_table = rfsg_device_session.get_deembedding_sparameters()
         assert returned_sparameter_table.all() == expected_sparameter_table.all()
 
     def test_create_deembedding_sparameter_table_array_error_cases(self, rfsg_device_session):

--- a/src/nirfsg/templates/session.py/get_deembedding_sparameter.py.mako
+++ b/src/nirfsg/templates/session.py/get_deembedding_sparameter.py.mako
@@ -12,6 +12,6 @@
         number_of_ports = self._get_deembedding_table_number_of_ports()
         sparameter_array_size = number_of_ports ** 2
         sparameters = np.full((number_of_ports, number_of_ports), 0 + 0j, dtype=np.complex128)
-        number_of_sparameters, number_of_ports = self._get_deembedding_sparameters(sparameters, sparameter_array_size)
+        _, number_of_ports = self._get_deembedding_sparameters(sparameters, sparameter_array_size)
         sparameters = sparameters.reshape((number_of_ports, number_of_ports))
         return sparameters

--- a/src/nirfsg/templates/session.py/get_deembedding_sparameter.py.mako
+++ b/src/nirfsg/templates/session.py/get_deembedding_sparameter.py.mako
@@ -3,15 +3,15 @@
     '''Creates a numpy array based on number of ports queried from driver and passes it to "get_deembedding_sparameters" method.'''
     import build.helper as helper
 %>\
-    def ${f['python_name']}(self):
+    def ${f['python_name']}(${helper.get_params_snippet(f, helper.ParameterUsageOptions.SESSION_METHOD_DECLARATION)}):
         '''${f['python_name']}
 
         ${helper.get_function_docstring(f, False, config, indent=8)}
         '''
         import numpy as np
         number_of_ports = self._get_deembedding_table_number_of_ports()
-        sparameter_table_size = number_of_ports ** 2
+        sparameter_array_size = number_of_ports ** 2
         sparameters = np.full((number_of_ports, number_of_ports), 0 + 0j, dtype=np.complex128)
-        number_of_ports = self._interpreter.get_deembedding_sparameters(sparameters, sparameter_table_size)
+        number_of_sparameters, number_of_ports = self._get_deembedding_sparameters(sparameters, sparameter_array_size)
         sparameters = sparameters.reshape((number_of_ports, number_of_ports))
-        return sparameters, number_of_ports
+        return sparameters

--- a/src/nirfsg/templates/session.py/write_arb_waveform.py.mako
+++ b/src/nirfsg/templates/session.py/write_arb_waveform.py.mako
@@ -20,5 +20,3 @@
                 raise TypeError("Unsupported datatype. Is {}, expected {} or {} or {}".format(waveform_data_array.dtype, numpy.complex128, numpy.complex64, numpy.int16))
         else:
             raise TypeError("Unsupported datatype. Expected numpy array of {} or {} or {}".format(numpy.complex128, numpy.complex64, numpy.int16))
-
-        return self._write_arb_waveform_complex_f64(waveform_name, waveform_data_array, more_data_pending)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [ ] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?
- Updated the get_development_status codegen helper logic to allow a override of development status via config_addon(this will be used for setting development status for RFSG release, which does not align with existing version based logic)
- Adding rfsg metadata files out of internal codegeneration tool
  - Corrected couple of enum names
  - Documentation corrections
  - functions.py and attributes.py will contain re-arranged entries, but the generated API being unchanged should validate that its just re-arranged
  - Few default value fields got removed
  - Repcap related fields for functions got added by the codegen tool
- Cleaned up get_deembedding_sparameters method to correctly have only one return value (matches .NET API)
  - Needed to add fancy function to get this working correctly
- Corrected session locking for write_arb_waveform methods 

### What testing has been done?
- System tests pass with simulated and real hardware
- API codegen shows only expected updates as diff
- Verified the development_status override logic to be working fine, if we provide a override value
