### PR TITLE
NI-FGEN: Update expected `maximum_sequence_length` in test_query_arb_seq_capabilities

### DIFF
--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -217,8 +217,7 @@ class SystemTests:
         maximum_number_of_sequences, minimum_sequence_length, maximum_sequence_length, maximum_loop_count = session.query_arb_seq_capabilities()
         assert maximum_number_of_sequences == 65535
         assert minimum_sequence_length == 1
-        # expect maximum_sequence_length to be greater than 1 as it will change in development side
-        assert maximum_sequence_length > 1 
+        assert maximum_sequence_length >= minimum_sequence_length
         assert maximum_loop_count == 16777215
 
     def test_create_arb_sequence(self, session):

--- a/src/nifgen/system_tests/test_system_nifgen.py
+++ b/src/nifgen/system_tests/test_system_nifgen.py
@@ -217,7 +217,8 @@ class SystemTests:
         maximum_number_of_sequences, minimum_sequence_length, maximum_sequence_length, maximum_loop_count = session.query_arb_seq_capabilities()
         assert maximum_number_of_sequences == 65535
         assert minimum_sequence_length == 1
-        assert maximum_sequence_length == 65535
+        # expect maximum_sequence_length to be greater than 1 as it will change in development side
+        assert maximum_sequence_length > 1 
         assert maximum_loop_count == 16777215
 
     def test_create_arb_sequence(self, session):


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
~- [ ]  I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?

The value of `maximum_sequence_length` will be updated in the upcoming NI-FGEN release, hence this PR is to update the NI-FGEN system tests to simply verify that `maximum_sequence_length` >= `minimum_sequence_length` instead of a specific value. This should be sufficient for an API test.

That driver change is causing our internal nimi-python test events to fail, so we need this update to fix those failures. 

### What testing has been done?
- [ ] PR build is successful 
