### PR TITLE
RFSG examples default value fix and clean up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1691,7 +1691,6 @@
 #### [nirfsg] Unreleased
 - Added
 - Changed
-  - Fix default value for option string in examples to be empty and make resource name as required input
   - Fixed the return type of `get_all_script_names` and `get_all_named_waveform_names` to remove the size parameter and return a list of strings instead of a comma-separated string
 - Removed
 

--- a/src/nirfsg/examples/nirfsg_arb_waveform.py
+++ b/src/nirfsg/examples/nirfsg_arb_waveform.py
@@ -19,7 +19,7 @@ def example(resource_name, options, frequency, power_level, number_of_samples):
 
 def _main(argsv):
     parser = argparse.ArgumentParser(description='Continuously generates an arbitrary waveform using NI-RFSG.', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('-n', '--resource-name', default='', required=True, help='Resource name of the NI RF signal generator.')
+    parser.add_argument('-n', '--resource-name', default='PXI1Slot2', help='Resource name of the NI RF signal generator.')
     parser.add_argument('-f', '--frequency', default=1e9, type=float, help='Frequency in Hz.')
     parser.add_argument('-p', '--power-level', default=-10.0, type=float, help='Power level in dBm.')
     parser.add_argument('-s', '--number-of-samples', default=1000, type=int, help='Number of samples.')

--- a/src/nirfsg/examples/nirfsg_cw.py
+++ b/src/nirfsg/examples/nirfsg_cw.py
@@ -19,7 +19,7 @@ def example(resource_name, options, frequency, power_level):
 
 def _main(argsv):
     parser = argparse.ArgumentParser(description='Generates a continuous wave (CW) signal using NI-RFSG.', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('-n', '--resource-name', default='', required=True, help='Resource name of the NI RF signal generator.')
+    parser.add_argument('-n', '--resource-name', default='PXI1Slot2', help='Resource name of the NI RF signal generator.')
     parser.add_argument('-f', '--frequency', default=1e9, type=float, help='Frequency in Hz.')
     parser.add_argument('-p', '--power-level', default=-10.0, type=float, help='Power level in dBm.')
     parser.add_argument('-op', '--option-string', default='', type=str, help='Option string for the session.')

--- a/src/nirfsg/examples/nirfsg_script.py
+++ b/src/nirfsg/examples/nirfsg_script.py
@@ -28,7 +28,7 @@ def example(resource_name, options, frequency, power_level, number_of_samples):
 
 def _main(argsv):
     parser = argparse.ArgumentParser(description='Generates a signal based on the script provided.', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('-n', '--resource-name', default='', required=True, help='Resource name of the NI RF signal generator.')
+    parser.add_argument('-n', '--resource-name', default='PXI1Slot2', help='Resource name of the NI RF signal generator.')
     parser.add_argument('-f', '--frequency', default=1e9, type=float, help='Frequency in Hz.')
     parser.add_argument('-p', '--power-level', default=-10.0, type=float, help='Power level in dBm.')
     parser.add_argument('-s', '--number-of-samples', default=1000, type=int, help='Number of samples.')


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [ ] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [ ] ~~I've added tests applicable for this pull request~~


### What does this Pull Request accomplish?
- Examples updated
  - Fix default value for option string in examples to be empty
  - Make resource name default as PXI1Slot2 to be consistent with other driver examples
  - Changed _options_ in test_example function to use python style objects to specify options instead of string
    - This will demonstrate the objects way of specifying Initialize options (change is internal though) 
  - Renamed the simulated device name used in test functions

### List issues fixed by this Pull Request below, if any.
None

### What testing has been done?
- Examples do not default to simulation option string if not specified
