### PR TITLE
Updating the return type of get_all_named_waveform_names and get_all_script_names for nirfsg.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1691,6 +1691,7 @@
 #### [nirfsg] Unreleased
 - Added
 - Changed
+  - Fixed the return type of `get_all_script_names` and `get_all_named_waveform_names` to remove the size parameter and return a list of strings instead of a comma-separated string
 - Removed
 
 #### [nirfsg] 1.0.0 - 2025-08-05

--- a/docs/nirfsg/class.rst
+++ b/docs/nirfsg/class.rst
@@ -1574,28 +1574,13 @@ get_all_named_waveform_names
 
 
 
-            :rtype: tuple (waveform_names, actual_buffer_size)
-
-                WHERE
-
-                waveform_names (str): 
+            :rtype: list of str
+            :return:
 
 
-                    Returns a string having waveform names separated by commas.
+                    Returns a list of string having waveform names.
 
                     
-
-
-                actual_buffer_size (int): 
-
-
-                    Fetch the number of bytes needed to pass in the :py:attr:`nirfsg.Session.BUFFER_SIZE` parameter.
-
-                    It can be fetch by passing VI_NULL in the :py:attr:`nirfsg.Session.WAVEFORM_NAMES` parameter.
-
-                    
-
-                    .. note:: One or more of the referenced properties are not in the Python API for this driver.
 
 
 
@@ -1614,28 +1599,13 @@ get_all_script_names
 
 
 
-            :rtype: tuple (script_names, actual_buffer_size)
-
-                WHERE
-
-                script_names (str): 
+            :rtype: list of str
+            :return:
 
 
-                    Returns a string having script names separated by commas.
+                    Returns a list of string having script names.
 
                     
-
-
-                actual_buffer_size (int): 
-
-
-                    Fetch the number of bytes needed to pass in the :py:attr:`nirfsg.Session.BUFFER_SIZE` parameter.
-
-                    It can be fetch by passing VI_NULL in the :py:attr:`nirfsg.Session.SCRIPT_NAMES` parameter.
-
-                    
-
-                    .. note:: One or more of the referenced properties are not in the Python API for this driver.
 
 
 

--- a/generated/nirfsg/nirfsg/_library_interpreter.py
+++ b/generated/nirfsg/nirfsg/_library_interpreter.py
@@ -390,29 +390,29 @@ class LibraryInterpreter(object):
 
     def get_all_named_waveform_names(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        waveform_names_ctype = None  # case C050
-        buffer_size_ctype = _visatype.ViInt32()  # case S170
+        waveform_names_ctype = None  # case C090
+        buffer_size_ctype = _visatype.ViInt32(0)  # case S190
         actual_buffer_size_ctype = _visatype.ViInt32()  # case S220
         error_code = self._library.niRFSG_GetAllNamedWaveformNames(vi_ctype, waveform_names_ctype, buffer_size_ctype, None if actual_buffer_size_ctype is None else (ctypes.pointer(actual_buffer_size_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
-        buffer_size_ctype = _visatype.ViInt32(error_code)  # case S180
-        waveform_names_ctype = (_visatype.ViChar * buffer_size_ctype.value)()  # case C060
+        buffer_size_ctype = _visatype.ViInt32(actual_buffer_size_ctype.value)  # case S200
+        waveform_names_ctype = (_visatype.ViChar * actual_buffer_size_ctype.value)()  # case C100
         error_code = self._library.niRFSG_GetAllNamedWaveformNames(vi_ctype, waveform_names_ctype, buffer_size_ctype, None if actual_buffer_size_ctype is None else (ctypes.pointer(actual_buffer_size_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return waveform_names_ctype.value.decode(self._encoding), int(actual_buffer_size_ctype.value)
+        return waveform_names_ctype.value.decode(self._encoding)
 
     def get_all_script_names(self):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110
-        script_names_ctype = None  # case C050
-        buffer_size_ctype = _visatype.ViInt32()  # case S170
+        script_names_ctype = None  # case C090
+        buffer_size_ctype = _visatype.ViInt32(0)  # case S190
         actual_buffer_size_ctype = _visatype.ViInt32()  # case S220
         error_code = self._library.niRFSG_GetAllScriptNames(vi_ctype, script_names_ctype, buffer_size_ctype, None if actual_buffer_size_ctype is None else (ctypes.pointer(actual_buffer_size_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=True, is_error_handling=False)
-        buffer_size_ctype = _visatype.ViInt32(error_code)  # case S180
-        script_names_ctype = (_visatype.ViChar * buffer_size_ctype.value)()  # case C060
+        buffer_size_ctype = _visatype.ViInt32(actual_buffer_size_ctype.value)  # case S200
+        script_names_ctype = (_visatype.ViChar * actual_buffer_size_ctype.value)()  # case C100
         error_code = self._library.niRFSG_GetAllScriptNames(vi_ctype, script_names_ctype, buffer_size_ctype, None if actual_buffer_size_ctype is None else (ctypes.pointer(actual_buffer_size_ctype)))
         errors.handle_error(self, error_code, ignore_warnings=False, is_error_handling=False)
-        return script_names_ctype.value.decode(self._encoding), int(actual_buffer_size_ctype.value)
+        return script_names_ctype.value.decode(self._encoding)
 
     def get_attribute_vi_boolean(self, channel_name, attribute):  # noqa: N802
         vi_ctype = _visatype.ViSession(self._vi)  # case S110

--- a/generated/nirfsg/nirfsg/session.py
+++ b/generated/nirfsg/nirfsg/session.py
@@ -7278,18 +7278,11 @@ class Session(_SessionBase):
         **Supported Devices** :PXIe-5830/5831/5840/5841/5842E
 
         Returns:
-            waveform_names (str): Returns a string having waveform names separated by commas.
-
-            actual_buffer_size (int): Fetch the number of bytes needed to pass in the BUFFER_SIZE parameter.
-
-                It can be fetch by passing VI_NULL in the WAVEFORM_NAMES parameter.
-
-                Note:
-                One or more of the referenced properties are not in the Python API for this driver.
+            waveform_names (list of str): Returns a list of string having waveform names.
 
         '''
-        waveform_names, actual_buffer_size = self._interpreter.get_all_named_waveform_names()
-        return _converters.convert_comma_separated_string_to_list(waveform_names), actual_buffer_size
+        waveform_names = self._interpreter.get_all_named_waveform_names()
+        return _converters.convert_comma_separated_string_to_list(waveform_names)
 
     @ivi_synchronized
     def get_all_script_names(self):
@@ -7300,18 +7293,11 @@ class Session(_SessionBase):
         **Supported Devices** :PXIe-5830/5831/5840/5841/5842E
 
         Returns:
-            script_names (str): Returns a string having script names separated by commas.
-
-            actual_buffer_size (int): Fetch the number of bytes needed to pass in the BUFFER_SIZE parameter.
-
-                It can be fetch by passing VI_NULL in the SCRIPT_NAMES parameter.
-
-                Note:
-                One or more of the referenced properties are not in the Python API for this driver.
+            script_names (list of str): Returns a list of string having script names.
 
         '''
-        script_names, actual_buffer_size = self._interpreter.get_all_script_names()
-        return script_names, actual_buffer_size
+        script_names = self._interpreter.get_all_script_names()
+        return _converters.convert_comma_separated_string_to_list(script_names)
 
     @ivi_synchronized
     def get_channel_name(self, index):

--- a/src/nirfsg/metadata/attributes.py
+++ b/src/nirfsg/metadata/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-RFSG API metadata version 25.8.0d9999
+# This file is generated from NI-RFSG API metadata version 25.8.0d197
 attributes = {
     1050002: {
         'access': 'read-write',

--- a/src/nirfsg/metadata/config.py
+++ b/src/nirfsg/metadata/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-RFSG API metadata version 25.8.0d9999
+# This file is generated from NI-RFSG API metadata version 25.8.0d197
 config = {
-    'api_version': '25.8.0d9999',
+    'api_version': '25.8.0d197',
     'c_function_prefix': 'niRFSG_',
     'close_function': 'close',
     'context_manager_name': {

--- a/src/nirfsg/metadata/enums.py
+++ b/src/nirfsg/metadata/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-RFSG API metadata version 25.8.0d9999
+# This file is generated from NI-RFSG API metadata version 25.8.0d197
 enums = {
     'AllowOutOfSpecificationUserSettings': {
         'values': [

--- a/src/nirfsg/metadata/functions.py
+++ b/src/nirfsg/metadata/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-RFSG API metadata version 25.8.0d9999 
+# This file is generated from NI-RFSG API metadata version 25.8.0d197
 functions = {
     'Abort': {
         'codegen_method': 'public',
@@ -2125,15 +2125,17 @@ functions = {
             {
                 'direction': 'out',
                 'documentation': {
-                    'description': 'Returns a string having waveform names separated by commas.'
+                    'description': 'Returns a list of string having waveform names.'
                 },
                 'name': 'waveformNames',
                 'python_api_converter_name': 'convert_comma_separated_string_to_list',
                 'size': {
-                    'mechanism': 'ivi-dance',
-                    'value': 'bufferSize'
+                    'mechanism': 'ivi-dance-with-a-twist',
+                    'value': 'bufferSize',
+                    'value_twist': 'actualBufferSize'
                 },
                 'type': 'ViChar[]',
+                'type_in_documentation': 'list of str',
                 'use_array': False,
                 'use_in_python_api': True
             },
@@ -2188,14 +2190,17 @@ functions = {
             {
                 'direction': 'out',
                 'documentation': {
-                    'description': 'Returns a string having script names separated by commas.'
+                    'description': 'Returns a list of string having script names.'
                 },
                 'name': 'scriptNames',
+                'python_api_converter_name': 'convert_comma_separated_string_to_list',
                 'size': {
-                    'mechanism': 'ivi-dance',
-                    'value': 'bufferSize'
+                    'mechanism': 'ivi-dance-with-a-twist',
+                    'value': 'bufferSize',
+                    'value_twist': 'actualBufferSize'
                 },
                 'type': 'ViChar[]',
+                'type_in_documentation': 'list of str',
                 'use_array': False,
                 'use_in_python_api': True
             },

--- a/src/nirfsg/system_tests/test_system_nirfsg.py
+++ b/src/nirfsg/system_tests/test_system_nirfsg.py
@@ -578,6 +578,37 @@ class SystemTests:
         with rfsg_device_session.initiate():
             rfsg_device_session.wait_until_settled(15000)
 
+    def test_get_all_named_waveform_names(self, rfsg_device_session):
+        rfsg_device_session.generation_mode = nirfsg.GenerationMode.ARB_WAVEFORM
+        waveform_data1 = np.full(1000, 1 + 0j, dtype=np.complex128)
+        waveform_data2 = np.full(800, 1 + 0j, dtype=np.complex128)
+        rfsg_device_session.write_arb_waveform('waveform1', waveform_data1, False)
+        rfsg_device_session.write_arb_waveform('waveform2', waveform_data2, False)
+        names = rfsg_device_session.get_all_named_waveform_names()
+        assert 'waveform1' in names
+        assert 'waveform2' in names
+
+    @pytest.mark.skipif(use_simulated_session is True, reason="Scripts not compiled on simulated device")
+    def test_get_all_script_names(self, rfsg_device_session):
+        rfsg_device_session.generation_mode = nirfsg.GenerationMode.SCRIPT
+        waveform_data = np.full(1000, 0.707 + 0.707j, dtype=np.complex64)
+        rfsg_device_session.write_arb_waveform('mywaveform', waveform_data, False)
+        script1 = '''script myScript1
+        repeat forever
+        generate mywaveform
+        end repeat
+        end script'''
+        script2 = '''script myScript2
+        repeat forever
+        generate mywaveform
+        end repeat
+        end script'''
+        rfsg_device_session.write_script(script1)
+        rfsg_device_session.write_script(script2)
+        script_names = rfsg_device_session.get_all_script_names()
+        assert 'myScript1' in script_names
+        assert 'myScript2' in script_names
+
 
 class TestLibrary(SystemTests):
     @pytest.fixture(scope='class')


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

This PR updates the nimi-python repository's nirfsg module metadata files with those from NI's private repository to correct the return types of get_all_script_names and get_all_named_waveform_names APIs. These APIs now return a list of strings instead of a comma-separated string, and the size parameter has been removed.
Additionally, system tests have been included for these APIs to verify their updated return types and behavior.

### What testing has been done?

Successful execution of tox for all supported Python versions.
Verified that the newly added system tests for get_all_script_names and get_all_named_waveform_names pass as expected.
