### PR TITLE
remove global declaration for _instance_lock

### DIFF
--- a/build/templates/_library_singleton.py.mako
+++ b/build/templates/_library_singleton.py.mako
@@ -44,7 +44,6 @@ def get():
     Returns the library.Library singleton for ${config['module_name']}.
     '''
     global _instance
-    global _instance_lock
 
     with _instance_lock:
         if _instance is None:

--- a/generated/nidcpower/nidcpower/_library_singleton.py
+++ b/generated/nidcpower/nidcpower/_library_singleton.py
@@ -40,7 +40,6 @@ def get():
     Returns the library.Library singleton for nidcpower.
     '''
     global _instance
-    global _instance_lock
 
     with _instance_lock:
         if _instance is None:

--- a/generated/nidigital/nidigital/_library_singleton.py
+++ b/generated/nidigital/nidigital/_library_singleton.py
@@ -40,7 +40,6 @@ def get():
     Returns the library.Library singleton for nidigital.
     '''
     global _instance
-    global _instance_lock
 
     with _instance_lock:
         if _instance is None:

--- a/generated/nidmm/nidmm/_library_singleton.py
+++ b/generated/nidmm/nidmm/_library_singleton.py
@@ -40,7 +40,6 @@ def get():
     Returns the library.Library singleton for nidmm.
     '''
     global _instance
-    global _instance_lock
 
     with _instance_lock:
         if _instance is None:

--- a/generated/nifake/nifake/_library_singleton.py
+++ b/generated/nifake/nifake/_library_singleton.py
@@ -40,7 +40,6 @@ def get():
     Returns the library.Library singleton for nifake.
     '''
     global _instance
-    global _instance_lock
 
     with _instance_lock:
         if _instance is None:

--- a/generated/nifgen/nifgen/_library_singleton.py
+++ b/generated/nifgen/nifgen/_library_singleton.py
@@ -40,7 +40,6 @@ def get():
     Returns the library.Library singleton for nifgen.
     '''
     global _instance
-    global _instance_lock
 
     with _instance_lock:
         if _instance is None:

--- a/generated/nimodinst/nimodinst/_library_singleton.py
+++ b/generated/nimodinst/nimodinst/_library_singleton.py
@@ -40,7 +40,6 @@ def get():
     Returns the library.Library singleton for nimodinst.
     '''
     global _instance
-    global _instance_lock
 
     with _instance_lock:
         if _instance is None:

--- a/generated/nirfsg/nirfsg/_library_singleton.py
+++ b/generated/nirfsg/nirfsg/_library_singleton.py
@@ -40,7 +40,6 @@ def get():
     Returns the library.Library singleton for nirfsg.
     '''
     global _instance
-    global _instance_lock
 
     with _instance_lock:
         if _instance is None:

--- a/generated/niscope/niscope/_library_singleton.py
+++ b/generated/niscope/niscope/_library_singleton.py
@@ -40,7 +40,6 @@ def get():
     Returns the library.Library singleton for niscope.
     '''
     global _instance
-    global _instance_lock
 
     with _instance_lock:
         if _instance is None:

--- a/generated/nise/nise/_library_singleton.py
+++ b/generated/nise/nise/_library_singleton.py
@@ -40,7 +40,6 @@ def get():
     Returns the library.Library singleton for nise.
     '''
     global _instance
-    global _instance_lock
 
     with _instance_lock:
         if _instance is None:

--- a/generated/niswitch/niswitch/_library_singleton.py
+++ b/generated/niswitch/niswitch/_library_singleton.py
@@ -40,7 +40,6 @@ def get():
     Returns the library.Library singleton for niswitch.
     '''
     global _instance
-    global _instance_lock
 
     with _instance_lock:
         if _instance is None:

--- a/generated/nitclk/nitclk/_library_singleton.py
+++ b/generated/nitclk/nitclk/_library_singleton.py
@@ -40,7 +40,6 @@ def get():
     Returns the library.Library singleton for nitclk.
     '''
     global _instance
-    global _instance_lock
 
     with _instance_lock:
         if _instance is None:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [ ] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [ ] ~~I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?
- Removing the declaration of _instance_lock as global in the get() method since we are only reading it and not assigning value to it
  - Newer flake8 7.3.0 has started throwing F824 error for this declaration
  - See discussion [here](https://github.com/ni/nimi-python/pull/2138#issuecomment-3518499245)

### List issues fixed by this Pull Request below, if any.
- Should fix the F824 flake error in Travis CI

### What testing has been done?
Only tox build.
