### PR TITLE
adding new attribute classes and converters for comma separated string and timedelta in months

### DIFF
--- a/build/templates/_attributes.py.mako
+++ b/build/templates/_attributes.py.mako
@@ -35,6 +35,15 @@ class AttributeViInt32TimeDeltaMilliseconds(Attribute):
         session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_milliseconds_int32(value))
 
 
+class AttributeViInt32TimeDeltaMonths(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_month_to_timedelta(session._get_attribute_vi_int32(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_months_int32(value))
+
+
 class AttributeViInt64(Attribute):
 
     def __get__(self, session, session_type):
@@ -78,6 +87,15 @@ class AttributeViStringRepeatedCapability(Attribute):
 
     def __set__(self, session, value):
         session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
+class AttributeViStringCommaSeparated(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_comma_separated_string_to_list(session._get_attribute_vi_string(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_list_to_comma_separated_string(value))
 
 
 class AttributeViBoolean(Attribute):

--- a/build/templates/_converters.py.mako
+++ b/build/templates/_converters.py.mako
@@ -266,6 +266,12 @@ def convert_month_to_timedelta(months):
     return hightime.timedelta(days=(30.4167 * months))
 
 
+# Scaling factor to apply on seconds to get months
+# would be 1/(60 seconds * 60 minutes * 24 hours * 30.4167 days)
+def convert_timedelta_to_months_int32(value):
+    return _convert_timedelta(value, _visatype.ViInt32, 1.0 / (60 * 60 * 24 * 30.4167))
+
+
 # This converter is not called from the normal codegen path for function. Instead it is
 # call from init and is a special case.
 def convert_init_with_options_dictionary(values):
@@ -330,6 +336,18 @@ def convert_to_bytes(value):  # noqa: F811
 
 def convert_comma_separated_string_to_list(comma_separated_string):
     return [x.strip() for x in comma_separated_string.split(',')]
+
+
+def convert_list_to_comma_separated_string(list_of_strings):
+    '''Convert a list of strings into a comma-separated string.
+
+    Args:
+        list_of_strings (list[str]): List of strings.
+
+    Returns:
+        str: Comma-separated string.
+    '''
+    return ','.join(list_of_strings)
 
 
 def convert_chained_repeated_capability_to_parts(chained_repeated_capability):

--- a/generated/nidcpower/nidcpower/_attributes.py
+++ b/generated/nidcpower/nidcpower/_attributes.py
@@ -31,6 +31,15 @@ class AttributeViInt32TimeDeltaMilliseconds(Attribute):
         session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_milliseconds_int32(value))
 
 
+class AttributeViInt32TimeDeltaMonths(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_month_to_timedelta(session._get_attribute_vi_int32(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_months_int32(value))
+
+
 class AttributeViInt64(Attribute):
 
     def __get__(self, session, session_type):
@@ -74,6 +83,15 @@ class AttributeViStringRepeatedCapability(Attribute):
 
     def __set__(self, session, value):
         session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
+class AttributeViStringCommaSeparated(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_comma_separated_string_to_list(session._get_attribute_vi_string(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_list_to_comma_separated_string(value))
 
 
 class AttributeViBoolean(Attribute):

--- a/generated/nidcpower/nidcpower/_converters.py
+++ b/generated/nidcpower/nidcpower/_converters.py
@@ -257,6 +257,12 @@ def convert_month_to_timedelta(months):
     return hightime.timedelta(days=(30.4167 * months))
 
 
+# Scaling factor to apply on seconds to get months
+# would be 1/(60 seconds * 60 minutes * 24 hours * 30.4167 days)
+def convert_timedelta_to_months_int32(value):
+    return _convert_timedelta(value, _visatype.ViInt32, 1.0 / (60 * 60 * 24 * 30.4167))
+
+
 # This converter is not called from the normal codegen path for function. Instead it is
 # call from init and is a special case.
 def convert_init_with_options_dictionary(values):
@@ -321,6 +327,18 @@ def convert_to_bytes(value):  # noqa: F811
 
 def convert_comma_separated_string_to_list(comma_separated_string):
     return [x.strip() for x in comma_separated_string.split(',')]
+
+
+def convert_list_to_comma_separated_string(list_of_strings):
+    '''Convert a list of strings into a comma-separated string.
+
+    Args:
+        list_of_strings (list[str]): List of strings.
+
+    Returns:
+        str: Comma-separated string.
+    '''
+    return ','.join(list_of_strings)
 
 
 def convert_chained_repeated_capability_to_parts(chained_repeated_capability):

--- a/generated/nidigital/nidigital/_attributes.py
+++ b/generated/nidigital/nidigital/_attributes.py
@@ -31,6 +31,15 @@ class AttributeViInt32TimeDeltaMilliseconds(Attribute):
         session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_milliseconds_int32(value))
 
 
+class AttributeViInt32TimeDeltaMonths(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_month_to_timedelta(session._get_attribute_vi_int32(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_months_int32(value))
+
+
 class AttributeViInt64(Attribute):
 
     def __get__(self, session, session_type):
@@ -74,6 +83,15 @@ class AttributeViStringRepeatedCapability(Attribute):
 
     def __set__(self, session, value):
         session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
+class AttributeViStringCommaSeparated(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_comma_separated_string_to_list(session._get_attribute_vi_string(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_list_to_comma_separated_string(value))
 
 
 class AttributeViBoolean(Attribute):

--- a/generated/nidigital/nidigital/_converters.py
+++ b/generated/nidigital/nidigital/_converters.py
@@ -256,6 +256,12 @@ def convert_month_to_timedelta(months):
     return hightime.timedelta(days=(30.4167 * months))
 
 
+# Scaling factor to apply on seconds to get months
+# would be 1/(60 seconds * 60 minutes * 24 hours * 30.4167 days)
+def convert_timedelta_to_months_int32(value):
+    return _convert_timedelta(value, _visatype.ViInt32, 1.0 / (60 * 60 * 24 * 30.4167))
+
+
 # This converter is not called from the normal codegen path for function. Instead it is
 # call from init and is a special case.
 def convert_init_with_options_dictionary(values):
@@ -320,6 +326,18 @@ def convert_to_bytes(value):  # noqa: F811
 
 def convert_comma_separated_string_to_list(comma_separated_string):
     return [x.strip() for x in comma_separated_string.split(',')]
+
+
+def convert_list_to_comma_separated_string(list_of_strings):
+    '''Convert a list of strings into a comma-separated string.
+
+    Args:
+        list_of_strings (list[str]): List of strings.
+
+    Returns:
+        str: Comma-separated string.
+    '''
+    return ','.join(list_of_strings)
 
 
 def convert_chained_repeated_capability_to_parts(chained_repeated_capability):

--- a/generated/nidmm/nidmm/_attributes.py
+++ b/generated/nidmm/nidmm/_attributes.py
@@ -31,6 +31,15 @@ class AttributeViInt32TimeDeltaMilliseconds(Attribute):
         session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_milliseconds_int32(value))
 
 
+class AttributeViInt32TimeDeltaMonths(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_month_to_timedelta(session._get_attribute_vi_int32(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_months_int32(value))
+
+
 class AttributeViInt64(Attribute):
 
     def __get__(self, session, session_type):
@@ -74,6 +83,15 @@ class AttributeViStringRepeatedCapability(Attribute):
 
     def __set__(self, session, value):
         session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
+class AttributeViStringCommaSeparated(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_comma_separated_string_to_list(session._get_attribute_vi_string(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_list_to_comma_separated_string(value))
 
 
 class AttributeViBoolean(Attribute):

--- a/generated/nidmm/nidmm/_converters.py
+++ b/generated/nidmm/nidmm/_converters.py
@@ -256,6 +256,12 @@ def convert_month_to_timedelta(months):
     return hightime.timedelta(days=(30.4167 * months))
 
 
+# Scaling factor to apply on seconds to get months
+# would be 1/(60 seconds * 60 minutes * 24 hours * 30.4167 days)
+def convert_timedelta_to_months_int32(value):
+    return _convert_timedelta(value, _visatype.ViInt32, 1.0 / (60 * 60 * 24 * 30.4167))
+
+
 # This converter is not called from the normal codegen path for function. Instead it is
 # call from init and is a special case.
 def convert_init_with_options_dictionary(values):
@@ -320,6 +326,18 @@ def convert_to_bytes(value):  # noqa: F811
 
 def convert_comma_separated_string_to_list(comma_separated_string):
     return [x.strip() for x in comma_separated_string.split(',')]
+
+
+def convert_list_to_comma_separated_string(list_of_strings):
+    '''Convert a list of strings into a comma-separated string.
+
+    Args:
+        list_of_strings (list[str]): List of strings.
+
+    Returns:
+        str: Comma-separated string.
+    '''
+    return ','.join(list_of_strings)
 
 
 def convert_chained_repeated_capability_to_parts(chained_repeated_capability):

--- a/generated/nifake/nifake/_attributes.py
+++ b/generated/nifake/nifake/_attributes.py
@@ -31,6 +31,15 @@ class AttributeViInt32TimeDeltaMilliseconds(Attribute):
         session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_milliseconds_int32(value))
 
 
+class AttributeViInt32TimeDeltaMonths(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_month_to_timedelta(session._get_attribute_vi_int32(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_months_int32(value))
+
+
 class AttributeViInt64(Attribute):
 
     def __get__(self, session, session_type):
@@ -74,6 +83,15 @@ class AttributeViStringRepeatedCapability(Attribute):
 
     def __set__(self, session, value):
         session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
+class AttributeViStringCommaSeparated(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_comma_separated_string_to_list(session._get_attribute_vi_string(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_list_to_comma_separated_string(value))
 
 
 class AttributeViBoolean(Attribute):

--- a/generated/nifake/nifake/_converters.py
+++ b/generated/nifake/nifake/_converters.py
@@ -257,6 +257,12 @@ def convert_month_to_timedelta(months):
     return hightime.timedelta(days=(30.4167 * months))
 
 
+# Scaling factor to apply on seconds to get months
+# would be 1/(60 seconds * 60 minutes * 24 hours * 30.4167 days)
+def convert_timedelta_to_months_int32(value):
+    return _convert_timedelta(value, _visatype.ViInt32, 1.0 / (60 * 60 * 24 * 30.4167))
+
+
 # This converter is not called from the normal codegen path for function. Instead it is
 # call from init and is a special case.
 def convert_init_with_options_dictionary(values):
@@ -321,6 +327,18 @@ def convert_to_bytes(value):  # noqa: F811
 
 def convert_comma_separated_string_to_list(comma_separated_string):
     return [x.strip() for x in comma_separated_string.split(',')]
+
+
+def convert_list_to_comma_separated_string(list_of_strings):
+    '''Convert a list of strings into a comma-separated string.
+
+    Args:
+        list_of_strings (list[str]): List of strings.
+
+    Returns:
+        str: Comma-separated string.
+    '''
+    return ','.join(list_of_strings)
 
 
 def convert_chained_repeated_capability_to_parts(chained_repeated_capability):

--- a/generated/nifake/nifake/session.py
+++ b/generated/nifake/nifake/session.py
@@ -116,6 +116,11 @@ class _SessionBase(object):
 
     A property of type Color with read/write access.
     '''
+    read_write_comma_separated_string = _attributes.AttributeViStringCommaSeparated(1000015)
+    '''Type: str
+
+    A property of type comma separated string with read/write access.
+    '''
     read_write_double = _attributes.AttributeViReal64(1000001)
     '''Type: float
 
@@ -154,6 +159,11 @@ class _SessionBase(object):
     '''Type: hightime.timedelta, datetime.timedelta, or int in milliseconds
 
     Property in milliseconds
+    '''
+    read_write_integer_with_month_converter = _attributes.AttributeViInt32TimeDeltaMonths(1000014)
+    '''Type: hightime.timedelta, datetime.timedelta, or int in months
+
+    Property in months
     '''
     read_write_string = _attributes.AttributeViString(1000002)
     '''Type: str

--- a/generated/nifake/nifake/unit_tests/test_converters.py
+++ b/generated/nifake/nifake/unit_tests/test_converters.py
@@ -50,6 +50,19 @@ def test_convert_timedeltas_to_seconds_real64():
     assert all([actual == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
 
 
+def test_convert_timedelta_to_months_int32():
+    # 1 month = 60*60*24*30.4167 seconds = 2628002.88 seconds
+    seconds_per_month = 60 * 60 * 24 * 30.4167
+    test_result = _converters.convert_timedelta_to_months_int32(hightime.timedelta(seconds=seconds_per_month))
+    assert test_result == 1
+    test_result = _converters.convert_timedelta_to_months_int32(hightime.timedelta(seconds=-5 * seconds_per_month))
+    assert test_result == -5
+    test_result = _converters.convert_timedelta_to_months_int32(seconds_per_month * 2)
+    assert test_result == 2
+    test_result = _converters.convert_timedelta_to_months_int32(-seconds_per_month)
+    assert test_result == -1
+
+
 def test_convert_seconds_real64_to_timedelta():
     time_value = -5e-10
     test_result = _converters.convert_seconds_real64_to_timedelta(time_value)
@@ -395,3 +408,8 @@ def test_string_to_list_prefix():
 def test_convert_comma_separated_string_to_list():
     out_list = _converters.convert_comma_separated_string_to_list(' PinA ,  PinB , PinC  ')
     assert out_list == ['PinA', 'PinB', 'PinC']
+
+
+def test_convert_list_to_comma_separated_string():
+    out_string = _converters.convert_list_to_comma_separated_string(['PinA', 'PinB', 'PinC'])
+    assert out_string == 'PinA,PinB,PinC'

--- a/generated/nifake/nifake/unit_tests/test_session.py
+++ b/generated/nifake/nifake/unit_tests/test_session.py
@@ -402,6 +402,24 @@ class TestSession:
             session.read_write_integer_with_converter = hightime.timedelta(milliseconds=test_number_ms)
             self.patched_library_interpreter.set_attribute_vi_int32.assert_called_once_with('', attribute_id, test_number_ms)
 
+    def test_get_attribute_int32_with_month_converter(self):
+        attribute_id = 1000014
+        test_number_months = 2
+        test_number_s = 5256005.76
+        self.patched_library_interpreter.get_attribute_vi_int32.side_effect = [test_number_months]
+        with nifake.Session('dev1') as session:
+            attr_timedelta = session.read_write_integer_with_month_converter
+            assert attr_timedelta.total_seconds() == test_number_s
+            self.patched_library_interpreter.get_attribute_vi_int32.assert_called_once_with('', attribute_id)
+
+    def test_set_attribute_int32_with_month_converter(self):
+        self.patched_library_interpreter.set_attribute_vi_int32.side_effect = [None]
+        attribute_id = 1000014
+        test_number_months = 3
+        with nifake.Session('dev1') as session:
+            session.read_write_integer_with_month_converter = hightime.timedelta(seconds=60 * 60 * 24 * 30.4167 * test_number_months)
+            self.patched_library_interpreter.set_attribute_vi_int32.assert_called_once_with('', attribute_id, test_number_months)
+
     def test_get_attribute_real64(self):
         attribute_id = 1000001
         test_number = 1.5
@@ -452,6 +470,25 @@ class TestSession:
         with nifake.Session('dev1') as session:
             session.read_write_string = attrib_string
             self.patched_library_interpreter.set_attribute_vi_string.assert_called_once_with('', attribute_id, 'This is test string')
+
+    def test_get_attribute_comma_separated_string(self):
+        comma_separated_string = 'PinA,PinB,PinC'
+        expected_list = ['PinA', 'PinB', 'PinC']
+        self.patched_library_interpreter.get_attribute_vi_string.side_effect = [comma_separated_string]
+        attribute_id = 1000015
+        with nifake.Session('dev1') as session:
+            attr_list = session.read_write_comma_separated_string
+            assert attr_list == expected_list
+            self.patched_library_interpreter.get_attribute_vi_string.assert_called_once_with('', attribute_id)
+
+    def test_set_attribute_comma_separated_string(self):
+        self.patched_library_interpreter.set_attribute_vi_string.side_effect = [None]
+        attribute_id = 1000015
+        attrib_list = ['PinA', 'PinB', 'PinC']
+        expected_string = 'PinA,PinB,PinC'
+        with nifake.Session('dev1') as session:
+            session.read_write_comma_separated_string = attrib_list
+            self.patched_library_interpreter.set_attribute_vi_string.assert_called_once_with('', attribute_id, expected_string)
 
     def test_get_attribute_string_with_converter(self):
         string = 'not that interesting'

--- a/generated/nifgen/nifgen/_attributes.py
+++ b/generated/nifgen/nifgen/_attributes.py
@@ -31,6 +31,15 @@ class AttributeViInt32TimeDeltaMilliseconds(Attribute):
         session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_milliseconds_int32(value))
 
 
+class AttributeViInt32TimeDeltaMonths(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_month_to_timedelta(session._get_attribute_vi_int32(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_months_int32(value))
+
+
 class AttributeViInt64(Attribute):
 
     def __get__(self, session, session_type):
@@ -74,6 +83,15 @@ class AttributeViStringRepeatedCapability(Attribute):
 
     def __set__(self, session, value):
         session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
+class AttributeViStringCommaSeparated(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_comma_separated_string_to_list(session._get_attribute_vi_string(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_list_to_comma_separated_string(value))
 
 
 class AttributeViBoolean(Attribute):

--- a/generated/nifgen/nifgen/_converters.py
+++ b/generated/nifgen/nifgen/_converters.py
@@ -256,6 +256,12 @@ def convert_month_to_timedelta(months):
     return hightime.timedelta(days=(30.4167 * months))
 
 
+# Scaling factor to apply on seconds to get months
+# would be 1/(60 seconds * 60 minutes * 24 hours * 30.4167 days)
+def convert_timedelta_to_months_int32(value):
+    return _convert_timedelta(value, _visatype.ViInt32, 1.0 / (60 * 60 * 24 * 30.4167))
+
+
 # This converter is not called from the normal codegen path for function. Instead it is
 # call from init and is a special case.
 def convert_init_with_options_dictionary(values):
@@ -320,6 +326,18 @@ def convert_to_bytes(value):  # noqa: F811
 
 def convert_comma_separated_string_to_list(comma_separated_string):
     return [x.strip() for x in comma_separated_string.split(',')]
+
+
+def convert_list_to_comma_separated_string(list_of_strings):
+    '''Convert a list of strings into a comma-separated string.
+
+    Args:
+        list_of_strings (list[str]): List of strings.
+
+    Returns:
+        str: Comma-separated string.
+    '''
+    return ','.join(list_of_strings)
 
 
 def convert_chained_repeated_capability_to_parts(chained_repeated_capability):

--- a/generated/nimodinst/nimodinst/_converters.py
+++ b/generated/nimodinst/nimodinst/_converters.py
@@ -256,6 +256,12 @@ def convert_month_to_timedelta(months):
     return hightime.timedelta(days=(30.4167 * months))
 
 
+# Scaling factor to apply on seconds to get months
+# would be 1/(60 seconds * 60 minutes * 24 hours * 30.4167 days)
+def convert_timedelta_to_months_int32(value):
+    return _convert_timedelta(value, _visatype.ViInt32, 1.0 / (60 * 60 * 24 * 30.4167))
+
+
 # This converter is not called from the normal codegen path for function. Instead it is
 # call from init and is a special case.
 def convert_init_with_options_dictionary(values):
@@ -320,6 +326,18 @@ def convert_to_bytes(value):  # noqa: F811
 
 def convert_comma_separated_string_to_list(comma_separated_string):
     return [x.strip() for x in comma_separated_string.split(',')]
+
+
+def convert_list_to_comma_separated_string(list_of_strings):
+    '''Convert a list of strings into a comma-separated string.
+
+    Args:
+        list_of_strings (list[str]): List of strings.
+
+    Returns:
+        str: Comma-separated string.
+    '''
+    return ','.join(list_of_strings)
 
 
 def convert_chained_repeated_capability_to_parts(chained_repeated_capability):

--- a/generated/nirfsg/nirfsg/_attributes.py
+++ b/generated/nirfsg/nirfsg/_attributes.py
@@ -31,6 +31,15 @@ class AttributeViInt32TimeDeltaMilliseconds(Attribute):
         session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_milliseconds_int32(value))
 
 
+class AttributeViInt32TimeDeltaMonths(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_month_to_timedelta(session._get_attribute_vi_int32(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_months_int32(value))
+
+
 class AttributeViInt64(Attribute):
 
     def __get__(self, session, session_type):
@@ -74,6 +83,15 @@ class AttributeViStringRepeatedCapability(Attribute):
 
     def __set__(self, session, value):
         session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
+class AttributeViStringCommaSeparated(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_comma_separated_string_to_list(session._get_attribute_vi_string(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_list_to_comma_separated_string(value))
 
 
 class AttributeViBoolean(Attribute):

--- a/generated/nirfsg/nirfsg/_converters.py
+++ b/generated/nirfsg/nirfsg/_converters.py
@@ -256,6 +256,12 @@ def convert_month_to_timedelta(months):
     return hightime.timedelta(days=(30.4167 * months))
 
 
+# Scaling factor to apply on seconds to get months
+# would be 1/(60 seconds * 60 minutes * 24 hours * 30.4167 days)
+def convert_timedelta_to_months_int32(value):
+    return _convert_timedelta(value, _visatype.ViInt32, 1.0 / (60 * 60 * 24 * 30.4167))
+
+
 # This converter is not called from the normal codegen path for function. Instead it is
 # call from init and is a special case.
 def convert_init_with_options_dictionary(values):
@@ -320,6 +326,18 @@ def convert_to_bytes(value):  # noqa: F811
 
 def convert_comma_separated_string_to_list(comma_separated_string):
     return [x.strip() for x in comma_separated_string.split(',')]
+
+
+def convert_list_to_comma_separated_string(list_of_strings):
+    '''Convert a list of strings into a comma-separated string.
+
+    Args:
+        list_of_strings (list[str]): List of strings.
+
+    Returns:
+        str: Comma-separated string.
+    '''
+    return ','.join(list_of_strings)
 
 
 def convert_chained_repeated_capability_to_parts(chained_repeated_capability):

--- a/generated/niscope/niscope/_attributes.py
+++ b/generated/niscope/niscope/_attributes.py
@@ -31,6 +31,15 @@ class AttributeViInt32TimeDeltaMilliseconds(Attribute):
         session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_milliseconds_int32(value))
 
 
+class AttributeViInt32TimeDeltaMonths(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_month_to_timedelta(session._get_attribute_vi_int32(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_months_int32(value))
+
+
 class AttributeViInt64(Attribute):
 
     def __get__(self, session, session_type):
@@ -74,6 +83,15 @@ class AttributeViStringRepeatedCapability(Attribute):
 
     def __set__(self, session, value):
         session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
+class AttributeViStringCommaSeparated(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_comma_separated_string_to_list(session._get_attribute_vi_string(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_list_to_comma_separated_string(value))
 
 
 class AttributeViBoolean(Attribute):

--- a/generated/niscope/niscope/_converters.py
+++ b/generated/niscope/niscope/_converters.py
@@ -256,6 +256,12 @@ def convert_month_to_timedelta(months):
     return hightime.timedelta(days=(30.4167 * months))
 
 
+# Scaling factor to apply on seconds to get months
+# would be 1/(60 seconds * 60 minutes * 24 hours * 30.4167 days)
+def convert_timedelta_to_months_int32(value):
+    return _convert_timedelta(value, _visatype.ViInt32, 1.0 / (60 * 60 * 24 * 30.4167))
+
+
 # This converter is not called from the normal codegen path for function. Instead it is
 # call from init and is a special case.
 def convert_init_with_options_dictionary(values):
@@ -320,6 +326,18 @@ def convert_to_bytes(value):  # noqa: F811
 
 def convert_comma_separated_string_to_list(comma_separated_string):
     return [x.strip() for x in comma_separated_string.split(',')]
+
+
+def convert_list_to_comma_separated_string(list_of_strings):
+    '''Convert a list of strings into a comma-separated string.
+
+    Args:
+        list_of_strings (list[str]): List of strings.
+
+    Returns:
+        str: Comma-separated string.
+    '''
+    return ','.join(list_of_strings)
 
 
 def convert_chained_repeated_capability_to_parts(chained_repeated_capability):

--- a/generated/nise/nise/_converters.py
+++ b/generated/nise/nise/_converters.py
@@ -256,6 +256,12 @@ def convert_month_to_timedelta(months):
     return hightime.timedelta(days=(30.4167 * months))
 
 
+# Scaling factor to apply on seconds to get months
+# would be 1/(60 seconds * 60 minutes * 24 hours * 30.4167 days)
+def convert_timedelta_to_months_int32(value):
+    return _convert_timedelta(value, _visatype.ViInt32, 1.0 / (60 * 60 * 24 * 30.4167))
+
+
 # This converter is not called from the normal codegen path for function. Instead it is
 # call from init and is a special case.
 def convert_init_with_options_dictionary(values):
@@ -320,6 +326,18 @@ def convert_to_bytes(value):  # noqa: F811
 
 def convert_comma_separated_string_to_list(comma_separated_string):
     return [x.strip() for x in comma_separated_string.split(',')]
+
+
+def convert_list_to_comma_separated_string(list_of_strings):
+    '''Convert a list of strings into a comma-separated string.
+
+    Args:
+        list_of_strings (list[str]): List of strings.
+
+    Returns:
+        str: Comma-separated string.
+    '''
+    return ','.join(list_of_strings)
 
 
 def convert_chained_repeated_capability_to_parts(chained_repeated_capability):

--- a/generated/niswitch/niswitch/_attributes.py
+++ b/generated/niswitch/niswitch/_attributes.py
@@ -31,6 +31,15 @@ class AttributeViInt32TimeDeltaMilliseconds(Attribute):
         session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_milliseconds_int32(value))
 
 
+class AttributeViInt32TimeDeltaMonths(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_month_to_timedelta(session._get_attribute_vi_int32(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_months_int32(value))
+
+
 class AttributeViInt64(Attribute):
 
     def __get__(self, session, session_type):
@@ -74,6 +83,15 @@ class AttributeViStringRepeatedCapability(Attribute):
 
     def __set__(self, session, value):
         session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
+class AttributeViStringCommaSeparated(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_comma_separated_string_to_list(session._get_attribute_vi_string(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_list_to_comma_separated_string(value))
 
 
 class AttributeViBoolean(Attribute):

--- a/generated/niswitch/niswitch/_converters.py
+++ b/generated/niswitch/niswitch/_converters.py
@@ -256,6 +256,12 @@ def convert_month_to_timedelta(months):
     return hightime.timedelta(days=(30.4167 * months))
 
 
+# Scaling factor to apply on seconds to get months
+# would be 1/(60 seconds * 60 minutes * 24 hours * 30.4167 days)
+def convert_timedelta_to_months_int32(value):
+    return _convert_timedelta(value, _visatype.ViInt32, 1.0 / (60 * 60 * 24 * 30.4167))
+
+
 # This converter is not called from the normal codegen path for function. Instead it is
 # call from init and is a special case.
 def convert_init_with_options_dictionary(values):
@@ -320,6 +326,18 @@ def convert_to_bytes(value):  # noqa: F811
 
 def convert_comma_separated_string_to_list(comma_separated_string):
     return [x.strip() for x in comma_separated_string.split(',')]
+
+
+def convert_list_to_comma_separated_string(list_of_strings):
+    '''Convert a list of strings into a comma-separated string.
+
+    Args:
+        list_of_strings (list[str]): List of strings.
+
+    Returns:
+        str: Comma-separated string.
+    '''
+    return ','.join(list_of_strings)
 
 
 def convert_chained_repeated_capability_to_parts(chained_repeated_capability):

--- a/generated/nitclk/nitclk/_attributes.py
+++ b/generated/nitclk/nitclk/_attributes.py
@@ -31,6 +31,15 @@ class AttributeViInt32TimeDeltaMilliseconds(Attribute):
         session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_milliseconds_int32(value))
 
 
+class AttributeViInt32TimeDeltaMonths(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_month_to_timedelta(session._get_attribute_vi_int32(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_int32(self._attribute_id, _converters.convert_timedelta_to_months_int32(value))
+
+
 class AttributeViInt64(Attribute):
 
     def __get__(self, session, session_type):
@@ -74,6 +83,15 @@ class AttributeViStringRepeatedCapability(Attribute):
 
     def __set__(self, session, value):
         session._set_attribute_vi_string(self._attribute_id, _converters.convert_repeated_capabilities_without_prefix(value))
+
+
+class AttributeViStringCommaSeparated(Attribute):
+
+    def __get__(self, session, session_type):
+        return _converters.convert_comma_separated_string_to_list(session._get_attribute_vi_string(self._attribute_id))
+
+    def __set__(self, session, value):
+        session._set_attribute_vi_string(self._attribute_id, _converters.convert_list_to_comma_separated_string(value))
 
 
 class AttributeViBoolean(Attribute):

--- a/generated/nitclk/nitclk/_converters.py
+++ b/generated/nitclk/nitclk/_converters.py
@@ -256,6 +256,12 @@ def convert_month_to_timedelta(months):
     return hightime.timedelta(days=(30.4167 * months))
 
 
+# Scaling factor to apply on seconds to get months
+# would be 1/(60 seconds * 60 minutes * 24 hours * 30.4167 days)
+def convert_timedelta_to_months_int32(value):
+    return _convert_timedelta(value, _visatype.ViInt32, 1.0 / (60 * 60 * 24 * 30.4167))
+
+
 # This converter is not called from the normal codegen path for function. Instead it is
 # call from init and is a special case.
 def convert_init_with_options_dictionary(values):
@@ -320,6 +326,18 @@ def convert_to_bytes(value):  # noqa: F811
 
 def convert_comma_separated_string_to_list(comma_separated_string):
     return [x.strip() for x in comma_separated_string.split(',')]
+
+
+def convert_list_to_comma_separated_string(list_of_strings):
+    '''Convert a list of strings into a comma-separated string.
+
+    Args:
+        list_of_strings (list[str]): List of strings.
+
+    Returns:
+        str: Comma-separated string.
+    '''
+    return ','.join(list_of_strings)
 
 
 def convert_chained_repeated_capability_to_parts(chained_repeated_capability):

--- a/src/nifake/metadata/attributes.py
+++ b/src/nifake/metadata/attributes.py
@@ -129,5 +129,26 @@ attributes = {
         'grpc_enum': 'SampleInterval',
         'name': 'SAMPLE_INTERVAL',
         'type': 'ViReal64'
+    },
+    1000014: {
+        'access': 'read-write',
+        'attribute_class': 'AttributeViInt32TimeDeltaMonths',
+        'documentation': {
+            'description': 'Attribute in months'
+        },
+        'lv_property': 'Fake attributes:Read Write Int with month Converter',
+        'name': 'READ_WRITE_INTEGER_WITH_MONTH_CONVERTER',
+        'type': 'ViInt32',
+        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or int in months'
+    },
+    1000015: {
+        'access': 'read-write',
+        'attribute_class': 'AttributeViStringCommaSeparated',
+        'documentation': {
+            'description': 'An attribute of type comma separated string with read/write access.'
+        },
+        'lv_property': 'Fake attributes:Read Write Comma Separated String',
+        'name': 'READ_WRITE_COMMA_SEPARATED_STRING',
+        'type': 'ViString'
     }
 }

--- a/src/nifake/unit_tests/test_converters.py
+++ b/src/nifake/unit_tests/test_converters.py
@@ -50,6 +50,19 @@ def test_convert_timedeltas_to_seconds_real64():
     assert all([actual == pytest.approx(expected) for actual, expected in zip(test_result, time_values)])
 
 
+def test_convert_timedelta_to_months_int32():
+    # 1 month = 60*60*24*30.4167 seconds = 2628002.88 seconds
+    seconds_per_month = 60 * 60 * 24 * 30.4167
+    test_result = _converters.convert_timedelta_to_months_int32(hightime.timedelta(seconds=seconds_per_month))
+    assert test_result == 1
+    test_result = _converters.convert_timedelta_to_months_int32(hightime.timedelta(seconds=-5 * seconds_per_month))
+    assert test_result == -5
+    test_result = _converters.convert_timedelta_to_months_int32(seconds_per_month * 2)
+    assert test_result == 2
+    test_result = _converters.convert_timedelta_to_months_int32(-seconds_per_month)
+    assert test_result == -1
+
+
 def test_convert_seconds_real64_to_timedelta():
     time_value = -5e-10
     test_result = _converters.convert_seconds_real64_to_timedelta(time_value)
@@ -395,3 +408,8 @@ def test_string_to_list_prefix():
 def test_convert_comma_separated_string_to_list():
     out_list = _converters.convert_comma_separated_string_to_list(' PinA ,  PinB , PinC  ')
     assert out_list == ['PinA', 'PinB', 'PinC']
+
+
+def test_convert_list_to_comma_separated_string():
+    out_string = _converters.convert_list_to_comma_separated_string(['PinA', 'PinB', 'PinC'])
+    assert out_string == 'PinA,PinB,PinC'

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -402,6 +402,24 @@ class TestSession:
             session.read_write_integer_with_converter = hightime.timedelta(milliseconds=test_number_ms)
             self.patched_library_interpreter.set_attribute_vi_int32.assert_called_once_with('', attribute_id, test_number_ms)
 
+    def test_get_attribute_int32_with_month_converter(self):
+        attribute_id = 1000014
+        test_number_months = 2
+        test_number_s = 5256005.76
+        self.patched_library_interpreter.get_attribute_vi_int32.side_effect = [test_number_months]
+        with nifake.Session('dev1') as session:
+            attr_timedelta = session.read_write_integer_with_month_converter
+            assert attr_timedelta.total_seconds() == test_number_s
+            self.patched_library_interpreter.get_attribute_vi_int32.assert_called_once_with('', attribute_id)
+
+    def test_set_attribute_int32_with_month_converter(self):
+        self.patched_library_interpreter.set_attribute_vi_int32.side_effect = [None]
+        attribute_id = 1000014
+        test_number_months = 3
+        with nifake.Session('dev1') as session:
+            session.read_write_integer_with_month_converter = hightime.timedelta(seconds=60 * 60 * 24 * 30.4167 * test_number_months)
+            self.patched_library_interpreter.set_attribute_vi_int32.assert_called_once_with('', attribute_id, test_number_months)
+
     def test_get_attribute_real64(self):
         attribute_id = 1000001
         test_number = 1.5
@@ -452,6 +470,25 @@ class TestSession:
         with nifake.Session('dev1') as session:
             session.read_write_string = attrib_string
             self.patched_library_interpreter.set_attribute_vi_string.assert_called_once_with('', attribute_id, 'This is test string')
+
+    def test_get_attribute_comma_separated_string(self):
+        comma_separated_string = 'PinA,PinB,PinC'
+        expected_list = ['PinA', 'PinB', 'PinC']
+        self.patched_library_interpreter.get_attribute_vi_string.side_effect = [comma_separated_string]
+        attribute_id = 1000015
+        with nifake.Session('dev1') as session:
+            attr_list = session.read_write_comma_separated_string
+            assert attr_list == expected_list
+            self.patched_library_interpreter.get_attribute_vi_string.assert_called_once_with('', attribute_id)
+
+    def test_set_attribute_comma_separated_string(self):
+        self.patched_library_interpreter.set_attribute_vi_string.side_effect = [None]
+        attribute_id = 1000015
+        attrib_list = ['PinA', 'PinB', 'PinC']
+        expected_string = 'PinA,PinB,PinC'
+        with nifake.Session('dev1') as session:
+            session.read_write_comma_separated_string = attrib_list
+            self.patched_library_interpreter.set_attribute_vi_string.assert_called_once_with('', attribute_id, expected_string)
 
     def test_get_attribute_string_with_converter(self):
         string = 'not that interesting'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [ ] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
  - Not updating since this is an internal change 
- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?
- Added new attribute classes for
  - Comma separated string, but exposed in python API as list of strings
  - Time interval in months, but exposed in python API as hightime.timedelta
- Added new nifake attributes for these classes and unit tests validating their behavior
- Added converters for
  - list of strings to comma separated string
  - timedelta to months
    - Using the same 365/12=30.4167 conversion that was used previously
    - This is to cater to our C API returning interval values in months and us standardizing on using hightime.timedelta type for intervals in python API
- Converters for the opposite side were already implemented
- Added tests for newly added converters

### List issues fixed by this Pull Request below, if any.
None

### What testing has been done?
Build passes.
