### PR TITLE
raise TypeError if input is not list of str for convert_list_to_comma_separated_string converter

### DIFF
--- a/build/templates/_converters.py.mako
+++ b/build/templates/_converters.py.mako
@@ -339,16 +339,16 @@ def convert_comma_separated_string_to_list(comma_separated_string):
 
 
 def convert_list_to_comma_separated_string(list_of_strings):
-    '''Convert a list of strings into a comma-separated string.
+    '''Convert a list or tuple of strings into a comma-separated string.
 
     Args:
-        list_of_strings (list[str]): List of strings.
+        list_of_strings (list or tuple of str): List or tuple of strings.
 
     Returns:
         str: Comma-separated string.
     '''
-    if not isinstance(list_of_strings, list) or not all(isinstance(item, str) for item in list_of_strings):
-        raise TypeError('Input must be a list of str')
+    if not isinstance(list_of_strings, (list, tuple)) or not all(isinstance(item, str) for item in list_of_strings):
+        raise TypeError('Input must be a list or tuple of str')
     return ','.join(list_of_strings)
 
 

--- a/generated/nidcpower/nidcpower/_converters.py
+++ b/generated/nidcpower/nidcpower/_converters.py
@@ -330,16 +330,16 @@ def convert_comma_separated_string_to_list(comma_separated_string):
 
 
 def convert_list_to_comma_separated_string(list_of_strings):
-    '''Convert a list of strings into a comma-separated string.
+    '''Convert a list or tuple of strings into a comma-separated string.
 
     Args:
-        list_of_strings (list[str]): List of strings.
+        list_of_strings (list or tuple of str): List or tuple of strings.
 
     Returns:
         str: Comma-separated string.
     '''
-    if not isinstance(list_of_strings, list) or not all(isinstance(item, str) for item in list_of_strings):
-        raise TypeError('Input must be a list of str')
+    if not isinstance(list_of_strings, (list, tuple)) or not all(isinstance(item, str) for item in list_of_strings):
+        raise TypeError('Input must be a list or tuple of str')
     return ','.join(list_of_strings)
 
 

--- a/generated/nidigital/nidigital/_converters.py
+++ b/generated/nidigital/nidigital/_converters.py
@@ -329,16 +329,16 @@ def convert_comma_separated_string_to_list(comma_separated_string):
 
 
 def convert_list_to_comma_separated_string(list_of_strings):
-    '''Convert a list of strings into a comma-separated string.
+    '''Convert a list or tuple of strings into a comma-separated string.
 
     Args:
-        list_of_strings (list[str]): List of strings.
+        list_of_strings (list or tuple of str): List or tuple of strings.
 
     Returns:
         str: Comma-separated string.
     '''
-    if not isinstance(list_of_strings, list) or not all(isinstance(item, str) for item in list_of_strings):
-        raise TypeError('Input must be a list of str')
+    if not isinstance(list_of_strings, (list, tuple)) or not all(isinstance(item, str) for item in list_of_strings):
+        raise TypeError('Input must be a list or tuple of str')
     return ','.join(list_of_strings)
 
 

--- a/generated/nidmm/nidmm/_converters.py
+++ b/generated/nidmm/nidmm/_converters.py
@@ -329,16 +329,16 @@ def convert_comma_separated_string_to_list(comma_separated_string):
 
 
 def convert_list_to_comma_separated_string(list_of_strings):
-    '''Convert a list of strings into a comma-separated string.
+    '''Convert a list or tuple of strings into a comma-separated string.
 
     Args:
-        list_of_strings (list[str]): List of strings.
+        list_of_strings (list or tuple of str): List or tuple of strings.
 
     Returns:
         str: Comma-separated string.
     '''
-    if not isinstance(list_of_strings, list) or not all(isinstance(item, str) for item in list_of_strings):
-        raise TypeError('Input must be a list of str')
+    if not isinstance(list_of_strings, (list, tuple)) or not all(isinstance(item, str) for item in list_of_strings):
+        raise TypeError('Input must be a list or tuple of str')
     return ','.join(list_of_strings)
 
 

--- a/generated/nifake/nifake/_converters.py
+++ b/generated/nifake/nifake/_converters.py
@@ -330,16 +330,16 @@ def convert_comma_separated_string_to_list(comma_separated_string):
 
 
 def convert_list_to_comma_separated_string(list_of_strings):
-    '''Convert a list of strings into a comma-separated string.
+    '''Convert a list or tuple of strings into a comma-separated string.
 
     Args:
-        list_of_strings (list[str]): List of strings.
+        list_of_strings (list or tuple of str): List or tuple of strings.
 
     Returns:
         str: Comma-separated string.
     '''
-    if not isinstance(list_of_strings, list) or not all(isinstance(item, str) for item in list_of_strings):
-        raise TypeError('Input must be a list of str')
+    if not isinstance(list_of_strings, (list, tuple)) or not all(isinstance(item, str) for item in list_of_strings):
+        raise TypeError('Input must be a list or tuple of str')
     return ','.join(list_of_strings)
 
 

--- a/generated/nifake/nifake/unit_tests/test_converters.py
+++ b/generated/nifake/nifake/unit_tests/test_converters.py
@@ -418,4 +418,4 @@ def test_convert_list_to_comma_separated_string():
 def test_convert_list_to_comma_separated_string_invalid_input():
     with pytest.raises(TypeError) as error_info:
         _converters.convert_list_to_comma_separated_string('PinA,PinB,PinC')
-    assert str(error_info.value) == 'Input must be a list of str'
+    assert str(error_info.value) == 'Input must be a list or tuple of str'

--- a/generated/nifgen/nifgen/_converters.py
+++ b/generated/nifgen/nifgen/_converters.py
@@ -329,16 +329,16 @@ def convert_comma_separated_string_to_list(comma_separated_string):
 
 
 def convert_list_to_comma_separated_string(list_of_strings):
-    '''Convert a list of strings into a comma-separated string.
+    '''Convert a list or tuple of strings into a comma-separated string.
 
     Args:
-        list_of_strings (list[str]): List of strings.
+        list_of_strings (list or tuple of str): List or tuple of strings.
 
     Returns:
         str: Comma-separated string.
     '''
-    if not isinstance(list_of_strings, list) or not all(isinstance(item, str) for item in list_of_strings):
-        raise TypeError('Input must be a list of str')
+    if not isinstance(list_of_strings, (list, tuple)) or not all(isinstance(item, str) for item in list_of_strings):
+        raise TypeError('Input must be a list or tuple of str')
     return ','.join(list_of_strings)
 
 

--- a/generated/nimodinst/nimodinst/_converters.py
+++ b/generated/nimodinst/nimodinst/_converters.py
@@ -329,16 +329,16 @@ def convert_comma_separated_string_to_list(comma_separated_string):
 
 
 def convert_list_to_comma_separated_string(list_of_strings):
-    '''Convert a list of strings into a comma-separated string.
+    '''Convert a list or tuple of strings into a comma-separated string.
 
     Args:
-        list_of_strings (list[str]): List of strings.
+        list_of_strings (list or tuple of str): List or tuple of strings.
 
     Returns:
         str: Comma-separated string.
     '''
-    if not isinstance(list_of_strings, list) or not all(isinstance(item, str) for item in list_of_strings):
-        raise TypeError('Input must be a list of str')
+    if not isinstance(list_of_strings, (list, tuple)) or not all(isinstance(item, str) for item in list_of_strings):
+        raise TypeError('Input must be a list or tuple of str')
     return ','.join(list_of_strings)
 
 

--- a/generated/nirfsg/nirfsg/_converters.py
+++ b/generated/nirfsg/nirfsg/_converters.py
@@ -329,16 +329,16 @@ def convert_comma_separated_string_to_list(comma_separated_string):
 
 
 def convert_list_to_comma_separated_string(list_of_strings):
-    '''Convert a list of strings into a comma-separated string.
+    '''Convert a list or tuple of strings into a comma-separated string.
 
     Args:
-        list_of_strings (list[str]): List of strings.
+        list_of_strings (list or tuple of str): List or tuple of strings.
 
     Returns:
         str: Comma-separated string.
     '''
-    if not isinstance(list_of_strings, list) or not all(isinstance(item, str) for item in list_of_strings):
-        raise TypeError('Input must be a list of str')
+    if not isinstance(list_of_strings, (list, tuple)) or not all(isinstance(item, str) for item in list_of_strings):
+        raise TypeError('Input must be a list or tuple of str')
     return ','.join(list_of_strings)
 
 

--- a/generated/niscope/niscope/_converters.py
+++ b/generated/niscope/niscope/_converters.py
@@ -329,16 +329,16 @@ def convert_comma_separated_string_to_list(comma_separated_string):
 
 
 def convert_list_to_comma_separated_string(list_of_strings):
-    '''Convert a list of strings into a comma-separated string.
+    '''Convert a list or tuple of strings into a comma-separated string.
 
     Args:
-        list_of_strings (list[str]): List of strings.
+        list_of_strings (list or tuple of str): List or tuple of strings.
 
     Returns:
         str: Comma-separated string.
     '''
-    if not isinstance(list_of_strings, list) or not all(isinstance(item, str) for item in list_of_strings):
-        raise TypeError('Input must be a list of str')
+    if not isinstance(list_of_strings, (list, tuple)) or not all(isinstance(item, str) for item in list_of_strings):
+        raise TypeError('Input must be a list or tuple of str')
     return ','.join(list_of_strings)
 
 

--- a/generated/nise/nise/_converters.py
+++ b/generated/nise/nise/_converters.py
@@ -329,16 +329,16 @@ def convert_comma_separated_string_to_list(comma_separated_string):
 
 
 def convert_list_to_comma_separated_string(list_of_strings):
-    '''Convert a list of strings into a comma-separated string.
+    '''Convert a list or tuple of strings into a comma-separated string.
 
     Args:
-        list_of_strings (list[str]): List of strings.
+        list_of_strings (list or tuple of str): List or tuple of strings.
 
     Returns:
         str: Comma-separated string.
     '''
-    if not isinstance(list_of_strings, list) or not all(isinstance(item, str) for item in list_of_strings):
-        raise TypeError('Input must be a list of str')
+    if not isinstance(list_of_strings, (list, tuple)) or not all(isinstance(item, str) for item in list_of_strings):
+        raise TypeError('Input must be a list or tuple of str')
     return ','.join(list_of_strings)
 
 

--- a/generated/niswitch/niswitch/_converters.py
+++ b/generated/niswitch/niswitch/_converters.py
@@ -329,16 +329,16 @@ def convert_comma_separated_string_to_list(comma_separated_string):
 
 
 def convert_list_to_comma_separated_string(list_of_strings):
-    '''Convert a list of strings into a comma-separated string.
+    '''Convert a list or tuple of strings into a comma-separated string.
 
     Args:
-        list_of_strings (list[str]): List of strings.
+        list_of_strings (list or tuple of str): List or tuple of strings.
 
     Returns:
         str: Comma-separated string.
     '''
-    if not isinstance(list_of_strings, list) or not all(isinstance(item, str) for item in list_of_strings):
-        raise TypeError('Input must be a list of str')
+    if not isinstance(list_of_strings, (list, tuple)) or not all(isinstance(item, str) for item in list_of_strings):
+        raise TypeError('Input must be a list or tuple of str')
     return ','.join(list_of_strings)
 
 

--- a/generated/nitclk/nitclk/_converters.py
+++ b/generated/nitclk/nitclk/_converters.py
@@ -329,16 +329,16 @@ def convert_comma_separated_string_to_list(comma_separated_string):
 
 
 def convert_list_to_comma_separated_string(list_of_strings):
-    '''Convert a list of strings into a comma-separated string.
+    '''Convert a list or tuple of strings into a comma-separated string.
 
     Args:
-        list_of_strings (list[str]): List of strings.
+        list_of_strings (list or tuple of str): List or tuple of strings.
 
     Returns:
         str: Comma-separated string.
     '''
-    if not isinstance(list_of_strings, list) or not all(isinstance(item, str) for item in list_of_strings):
-        raise TypeError('Input must be a list of str')
+    if not isinstance(list_of_strings, (list, tuple)) or not all(isinstance(item, str) for item in list_of_strings):
+        raise TypeError('Input must be a list or tuple of str')
     return ','.join(list_of_strings)
 
 

--- a/src/nifake/unit_tests/test_converters.py
+++ b/src/nifake/unit_tests/test_converters.py
@@ -418,4 +418,4 @@ def test_convert_list_to_comma_separated_string():
 def test_convert_list_to_comma_separated_string_invalid_input():
     with pytest.raises(TypeError) as error_info:
         _converters.convert_list_to_comma_separated_string('PinA,PinB,PinC')
-    assert str(error_info.value) == 'Input must be a list of str'
+    assert str(error_info.value) == 'Input must be a list or tuple of str'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [ ] ~~I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?
convert_list_to_comma_separated_string converter now checks if the input is a list of str and raise a TypeError if its not, so that we do not accidentally take in any other type of input and do a join on that in case of writeable attributes using this type. 

### List issues fixed by this Pull Request below, if any.
convert_list_to_comma_separated_string was assuming a list input, which could be wrong.

### What testing has been done?
Add a nifake unit test to confirm that TypeError is thrown.
