### PR TITLE
Stop importing deprecated pkg_resources module

### DIFF
--- a/build/templates/__init__.py.mako
+++ b/build/templates/__init__.py.mako
@@ -107,22 +107,16 @@ def get_diagnostic_information():
     else:
         raise SystemError('Unsupported platform: {}'.format(platform.system()))
 
-    if sys.version_info[1] >= 10:
-        installed_packages_names = [
-            name
-            for name_list in importlib.metadata.packages_distributions().values()
-            for name in name_list
-        ]
-        installed_packages_names = set(installed_packages_names)
-        installed_packages_list = [
-            {'name': name, 'version': importlib.metadata.distribution(name).version}
-            for name in sorted(installed_packages_names)
-        ]
-    ## TODO (ni-jfitzger): Delete use of pkg_resources when we drop Python 3.9 support. See https://github.com/ni/nimi-python/issues/2047
-    else:
-        import pkg_resources
-        installed_packages = pkg_resources.working_set
-        installed_packages_list = [{'name': i.key, 'version': i.version, } for i in installed_packages]
+    installed_packages_names = [
+        name
+        for name_list in importlib.metadata.packages_distributions().values()
+        for name in name_list
+    ]
+    installed_packages_names = set(installed_packages_names)
+    installed_packages_list = [
+        {'name': name, 'version': importlib.metadata.distribution(name).version}
+        for name in sorted(installed_packages_names)
+    ]
 
     info['os']['name'] = os_name
     info['os']['version'] = platform.version()

--- a/generated/nidcpower/nidcpower/__init__.py
+++ b/generated/nidcpower/nidcpower/__init__.py
@@ -64,21 +64,16 @@ def get_diagnostic_information():
     else:
         raise SystemError('Unsupported platform: {}'.format(platform.system()))
 
-    if sys.version_info[1] >= 10:
-        installed_packages_names = [
-            name
-            for name_list in importlib.metadata.packages_distributions().values()
-            for name in name_list
-        ]
-        installed_packages_names = set(installed_packages_names)
-        installed_packages_list = [
-            {'name': name, 'version': importlib.metadata.distribution(name).version}
-            for name in sorted(installed_packages_names)
-        ]
-    else:
-        import pkg_resources
-        installed_packages = pkg_resources.working_set
-        installed_packages_list = [{'name': i.key, 'version': i.version, } for i in installed_packages]
+    installed_packages_names = [
+        name
+        for name_list in importlib.metadata.packages_distributions().values()
+        for name in name_list
+    ]
+    installed_packages_names = set(installed_packages_names)
+    installed_packages_list = [
+        {'name': name, 'version': importlib.metadata.distribution(name).version}
+        for name in sorted(installed_packages_names)
+    ]
 
     info['os']['name'] = os_name
     info['os']['version'] = platform.version()

--- a/generated/nidigital/nidigital/__init__.py
+++ b/generated/nidigital/nidigital/__init__.py
@@ -58,21 +58,16 @@ def get_diagnostic_information():
     else:
         raise SystemError('Unsupported platform: {}'.format(platform.system()))
 
-    if sys.version_info[1] >= 10:
-        installed_packages_names = [
-            name
-            for name_list in importlib.metadata.packages_distributions().values()
-            for name in name_list
-        ]
-        installed_packages_names = set(installed_packages_names)
-        installed_packages_list = [
-            {'name': name, 'version': importlib.metadata.distribution(name).version}
-            for name in sorted(installed_packages_names)
-        ]
-    else:
-        import pkg_resources
-        installed_packages = pkg_resources.working_set
-        installed_packages_list = [{'name': i.key, 'version': i.version, } for i in installed_packages]
+    installed_packages_names = [
+        name
+        for name_list in importlib.metadata.packages_distributions().values()
+        for name in name_list
+    ]
+    installed_packages_names = set(installed_packages_names)
+    installed_packages_list = [
+        {'name': name, 'version': importlib.metadata.distribution(name).version}
+        for name in sorted(installed_packages_names)
+    ]
 
     info['os']['name'] = os_name
     info['os']['version'] = platform.version()

--- a/generated/nidmm/nidmm/__init__.py
+++ b/generated/nidmm/nidmm/__init__.py
@@ -56,21 +56,16 @@ def get_diagnostic_information():
     else:
         raise SystemError('Unsupported platform: {}'.format(platform.system()))
 
-    if sys.version_info[1] >= 10:
-        installed_packages_names = [
-            name
-            for name_list in importlib.metadata.packages_distributions().values()
-            for name in name_list
-        ]
-        installed_packages_names = set(installed_packages_names)
-        installed_packages_list = [
-            {'name': name, 'version': importlib.metadata.distribution(name).version}
-            for name in sorted(installed_packages_names)
-        ]
-    else:
-        import pkg_resources
-        installed_packages = pkg_resources.working_set
-        installed_packages_list = [{'name': i.key, 'version': i.version, } for i in installed_packages]
+    installed_packages_names = [
+        name
+        for name_list in importlib.metadata.packages_distributions().values()
+        for name in name_list
+    ]
+    installed_packages_names = set(installed_packages_names)
+    installed_packages_list = [
+        {'name': name, 'version': importlib.metadata.distribution(name).version}
+        for name in sorted(installed_packages_names)
+    ]
 
     info['os']['name'] = os_name
     info['os']['version'] = platform.version()

--- a/generated/nifake/nifake/__init__.py
+++ b/generated/nifake/nifake/__init__.py
@@ -68,21 +68,16 @@ def get_diagnostic_information():
     else:
         raise SystemError('Unsupported platform: {}'.format(platform.system()))
 
-    if sys.version_info[1] >= 10:
-        installed_packages_names = [
-            name
-            for name_list in importlib.metadata.packages_distributions().values()
-            for name in name_list
-        ]
-        installed_packages_names = set(installed_packages_names)
-        installed_packages_list = [
-            {'name': name, 'version': importlib.metadata.distribution(name).version}
-            for name in sorted(installed_packages_names)
-        ]
-    else:
-        import pkg_resources
-        installed_packages = pkg_resources.working_set
-        installed_packages_list = [{'name': i.key, 'version': i.version, } for i in installed_packages]
+    installed_packages_names = [
+        name
+        for name_list in importlib.metadata.packages_distributions().values()
+        for name in name_list
+    ]
+    installed_packages_names = set(installed_packages_names)
+    installed_packages_list = [
+        {'name': name, 'version': importlib.metadata.distribution(name).version}
+        for name in sorted(installed_packages_names)
+    ]
 
     info['os']['name'] = os_name
     info['os']['version'] = platform.version()

--- a/generated/nifgen/nifgen/__init__.py
+++ b/generated/nifgen/nifgen/__init__.py
@@ -56,21 +56,16 @@ def get_diagnostic_information():
     else:
         raise SystemError('Unsupported platform: {}'.format(platform.system()))
 
-    if sys.version_info[1] >= 10:
-        installed_packages_names = [
-            name
-            for name_list in importlib.metadata.packages_distributions().values()
-            for name in name_list
-        ]
-        installed_packages_names = set(installed_packages_names)
-        installed_packages_list = [
-            {'name': name, 'version': importlib.metadata.distribution(name).version}
-            for name in sorted(installed_packages_names)
-        ]
-    else:
-        import pkg_resources
-        installed_packages = pkg_resources.working_set
-        installed_packages_list = [{'name': i.key, 'version': i.version, } for i in installed_packages]
+    installed_packages_names = [
+        name
+        for name_list in importlib.metadata.packages_distributions().values()
+        for name in name_list
+    ]
+    installed_packages_names = set(installed_packages_names)
+    installed_packages_list = [
+        {'name': name, 'version': importlib.metadata.distribution(name).version}
+        for name in sorted(installed_packages_names)
+    ]
 
     info['os']['name'] = os_name
     info['os']['version'] = platform.version()

--- a/generated/nimodinst/nimodinst/__init__.py
+++ b/generated/nimodinst/nimodinst/__init__.py
@@ -54,21 +54,16 @@ def get_diagnostic_information():
     else:
         raise SystemError('Unsupported platform: {}'.format(platform.system()))
 
-    if sys.version_info[1] >= 10:
-        installed_packages_names = [
-            name
-            for name_list in importlib.metadata.packages_distributions().values()
-            for name in name_list
-        ]
-        installed_packages_names = set(installed_packages_names)
-        installed_packages_list = [
-            {'name': name, 'version': importlib.metadata.distribution(name).version}
-            for name in sorted(installed_packages_names)
-        ]
-    else:
-        import pkg_resources
-        installed_packages = pkg_resources.working_set
-        installed_packages_list = [{'name': i.key, 'version': i.version, } for i in installed_packages]
+    installed_packages_names = [
+        name
+        for name_list in importlib.metadata.packages_distributions().values()
+        for name in name_list
+    ]
+    installed_packages_names = set(installed_packages_names)
+    installed_packages_list = [
+        {'name': name, 'version': importlib.metadata.distribution(name).version}
+        for name in sorted(installed_packages_names)
+    ]
 
     info['os']['name'] = os_name
     info['os']['version'] = platform.version()

--- a/generated/nirfsg/nirfsg/__init__.py
+++ b/generated/nirfsg/nirfsg/__init__.py
@@ -55,21 +55,16 @@ def get_diagnostic_information():
     else:
         raise SystemError('Unsupported platform: {}'.format(platform.system()))
 
-    if sys.version_info[1] >= 10:
-        installed_packages_names = [
-            name
-            for name_list in importlib.metadata.packages_distributions().values()
-            for name in name_list
-        ]
-        installed_packages_names = set(installed_packages_names)
-        installed_packages_list = [
-            {'name': name, 'version': importlib.metadata.distribution(name).version}
-            for name in sorted(installed_packages_names)
-        ]
-    else:
-        import pkg_resources
-        installed_packages = pkg_resources.working_set
-        installed_packages_list = [{'name': i.key, 'version': i.version, } for i in installed_packages]
+    installed_packages_names = [
+        name
+        for name_list in importlib.metadata.packages_distributions().values()
+        for name in name_list
+    ]
+    installed_packages_names = set(installed_packages_names)
+    installed_packages_list = [
+        {'name': name, 'version': importlib.metadata.distribution(name).version}
+        for name in sorted(installed_packages_names)
+    ]
 
     info['os']['name'] = os_name
     info['os']['version'] = platform.version()

--- a/generated/niscope/niscope/__init__.py
+++ b/generated/niscope/niscope/__init__.py
@@ -62,21 +62,16 @@ def get_diagnostic_information():
     else:
         raise SystemError('Unsupported platform: {}'.format(platform.system()))
 
-    if sys.version_info[1] >= 10:
-        installed_packages_names = [
-            name
-            for name_list in importlib.metadata.packages_distributions().values()
-            for name in name_list
-        ]
-        installed_packages_names = set(installed_packages_names)
-        installed_packages_list = [
-            {'name': name, 'version': importlib.metadata.distribution(name).version}
-            for name in sorted(installed_packages_names)
-        ]
-    else:
-        import pkg_resources
-        installed_packages = pkg_resources.working_set
-        installed_packages_list = [{'name': i.key, 'version': i.version, } for i in installed_packages]
+    installed_packages_names = [
+        name
+        for name_list in importlib.metadata.packages_distributions().values()
+        for name in name_list
+    ]
+    installed_packages_names = set(installed_packages_names)
+    installed_packages_list = [
+        {'name': name, 'version': importlib.metadata.distribution(name).version}
+        for name in sorted(installed_packages_names)
+    ]
 
     info['os']['name'] = os_name
     info['os']['version'] = platform.version()

--- a/generated/nise/nise/__init__.py
+++ b/generated/nise/nise/__init__.py
@@ -55,21 +55,16 @@ def get_diagnostic_information():
     else:
         raise SystemError('Unsupported platform: {}'.format(platform.system()))
 
-    if sys.version_info[1] >= 10:
-        installed_packages_names = [
-            name
-            for name_list in importlib.metadata.packages_distributions().values()
-            for name in name_list
-        ]
-        installed_packages_names = set(installed_packages_names)
-        installed_packages_list = [
-            {'name': name, 'version': importlib.metadata.distribution(name).version}
-            for name in sorted(installed_packages_names)
-        ]
-    else:
-        import pkg_resources
-        installed_packages = pkg_resources.working_set
-        installed_packages_list = [{'name': i.key, 'version': i.version, } for i in installed_packages]
+    installed_packages_names = [
+        name
+        for name_list in importlib.metadata.packages_distributions().values()
+        for name in name_list
+    ]
+    installed_packages_names = set(installed_packages_names)
+    installed_packages_list = [
+        {'name': name, 'version': importlib.metadata.distribution(name).version}
+        for name in sorted(installed_packages_names)
+    ]
 
     info['os']['name'] = os_name
     info['os']['version'] = platform.version()

--- a/generated/niswitch/niswitch/__init__.py
+++ b/generated/niswitch/niswitch/__init__.py
@@ -56,21 +56,16 @@ def get_diagnostic_information():
     else:
         raise SystemError('Unsupported platform: {}'.format(platform.system()))
 
-    if sys.version_info[1] >= 10:
-        installed_packages_names = [
-            name
-            for name_list in importlib.metadata.packages_distributions().values()
-            for name in name_list
-        ]
-        installed_packages_names = set(installed_packages_names)
-        installed_packages_list = [
-            {'name': name, 'version': importlib.metadata.distribution(name).version}
-            for name in sorted(installed_packages_names)
-        ]
-    else:
-        import pkg_resources
-        installed_packages = pkg_resources.working_set
-        installed_packages_list = [{'name': i.key, 'version': i.version, } for i in installed_packages]
+    installed_packages_names = [
+        name
+        for name_list in importlib.metadata.packages_distributions().values()
+        for name in name_list
+    ]
+    installed_packages_names = set(installed_packages_names)
+    installed_packages_list = [
+        {'name': name, 'version': importlib.metadata.distribution(name).version}
+        for name in sorted(installed_packages_names)
+    ]
 
     info['os']['name'] = os_name
     info['os']['version'] = platform.version()

--- a/generated/nitclk/nitclk/__init__.py
+++ b/generated/nitclk/nitclk/__init__.py
@@ -64,21 +64,16 @@ def get_diagnostic_information():
     else:
         raise SystemError('Unsupported platform: {}'.format(platform.system()))
 
-    if sys.version_info[1] >= 10:
-        installed_packages_names = [
-            name
-            for name_list in importlib.metadata.packages_distributions().values()
-            for name in name_list
-        ]
-        installed_packages_names = set(installed_packages_names)
-        installed_packages_list = [
-            {'name': name, 'version': importlib.metadata.distribution(name).version}
-            for name in sorted(installed_packages_names)
-        ]
-    else:
-        import pkg_resources
-        installed_packages = pkg_resources.working_set
-        installed_packages_list = [{'name': i.key, 'version': i.version, } for i in installed_packages]
+    installed_packages_names = [
+        name
+        for name_list in importlib.metadata.packages_distributions().values()
+        for name in name_list
+    ]
+    installed_packages_names = set(installed_packages_names)
+    installed_packages_list = [
+        {'name': name, 'version': importlib.metadata.distribution(name).version}
+        for name in sorted(installed_packages_names)
+    ]
 
     info['os']['name'] = os_name
     info['os']['version'] = platform.version()


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
Delete the dead code that allows conditional importing of `pkg_resources`.
I should have done this when dropping Python 3.9 support.

### List issues fixed by this Pull Request below, if any.

* Fix #2047 

### What testing has been done?

PR Checks
