### PR TITLE
Fix the python session to return correct error message when invalid session for MI drivers

### DIFF
--- a/build/templates/_library_interpreter.py/_get_error_description.py.mako
+++ b/build/templates/_library_interpreter.py/_get_error_description.py.mako
@@ -22,10 +22,20 @@
 
         try:
             '''
+            It is possible that the session is valid but the returned_error_code unequal to error_code
+            '''
+            error_string = self.error_message(error_code)
+            return error_string
+        except errors.Error:
+            pass
+
+        try:
+            '''
             It is expected for get_error to raise when the session is invalid
             (IVI spec requires GetError to fail).
             Use error_message instead. It doesn't require a session.
             '''
+            self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:

--- a/build/templates/_library_interpreter.py/_get_error_description.py.mako
+++ b/build/templates/_library_interpreter.py/_get_error_description.py.mako
@@ -21,9 +21,7 @@
 % if 'error_message' in config['functions']:
 
         try:
-            '''
-            It is possible that the session is valid but the returned_error_code unequal to error_code
-            '''
+            # It is possible that the session is valid but the returned_error_code unequal to error_code
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:

--- a/build/templates/_library_interpreter.py/_get_error_description.py.mako
+++ b/build/templates/_library_interpreter.py/_get_error_description.py.mako
@@ -21,7 +21,12 @@
 % if 'error_message' in config['functions']:
 
         try:
-            # It is possible that the session is valid but the returned_error_code unequal to error_code
+            # get_error reads the session's error queue, which may have been overwritten,
+            # causing it to return a mismatched error code. error_message takes the error
+            # code directly as a parameter and looks up its description without reading the
+            # queue, it will return the description for the specific error code.
+            # Use error_message in current session before the handle reset in the next block.
+
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:
@@ -29,11 +34,10 @@
 
         save_vi = self.get_session_handle()
         try:
-            '''
-            It is expected for get_error to raise when the session is invalid
-            (IVI spec requires GetError to fail).
-            Use error_message instead. It doesn't require a session.
-            '''
+            # It is expected for get_error to raise when the session is invalid
+            # (IVI spec requires GetError to fail).
+            # Use error_message instead. It doesn't require a session.
+
             self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string

--- a/build/templates/_library_interpreter.py/_get_error_description.py.mako
+++ b/build/templates/_library_interpreter.py/_get_error_description.py.mako
@@ -27,13 +27,13 @@
         except errors.Error:
             pass
 
+        save_vi = self.get_session_handle()
         try:
             '''
             It is expected for get_error to raise when the session is invalid
             (IVI spec requires GetError to fail).
             Use error_message instead. It doesn't require a session.
             '''
-            save_vi = self.get_session_handle()
             self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string

--- a/build/templates/_library_interpreter.py/_get_error_description.py.mako
+++ b/build/templates/_library_interpreter.py/_get_error_description.py.mako
@@ -33,10 +33,13 @@
             (IVI spec requires GetError to fail).
             Use error_message instead. It doesn't require a session.
             '''
+            save_vi = self.get_session_handle()
             self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:
             pass
+        finally:
+            self.set_session_handle(save_vi)
 % endif
         return "Failed to retrieve error description."

--- a/generated/nidcpower/nidcpower/_library_interpreter.py
+++ b/generated/nidcpower/nidcpower/_library_interpreter.py
@@ -116,11 +116,14 @@ class LibraryInterpreter(object):
             (IVI spec requires GetError to fail).
             Use error_message instead. It doesn't require a session.
             '''
+            save_vi = self.get_session_handle()
             self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:
             pass
+        finally:
+            self.set_session_handle(save_vi)
         return "Failed to retrieve error description."
 
     def abort(self, channel_name):  # noqa: N802

--- a/generated/nidcpower/nidcpower/_library_interpreter.py
+++ b/generated/nidcpower/nidcpower/_library_interpreter.py
@@ -104,7 +104,12 @@ class LibraryInterpreter(object):
             pass
 
         try:
-            # It is possible that the session is valid but the returned_error_code unequal to error_code
+            # get_error reads the session's error queue, which may have been overwritten,
+            # causing it to return a mismatched error code. error_message takes the error
+            # code directly as a parameter and looks up its description without reading the
+            # queue, it will return the description for the specific error code.
+            # Use error_message in current session before the handle reset in the next block.
+
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:
@@ -112,11 +117,10 @@ class LibraryInterpreter(object):
 
         save_vi = self.get_session_handle()
         try:
-            '''
-            It is expected for get_error to raise when the session is invalid
-            (IVI spec requires GetError to fail).
-            Use error_message instead. It doesn't require a session.
-            '''
+            # It is expected for get_error to raise when the session is invalid
+            # (IVI spec requires GetError to fail).
+            # Use error_message instead. It doesn't require a session.
+
             self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string

--- a/generated/nidcpower/nidcpower/_library_interpreter.py
+++ b/generated/nidcpower/nidcpower/_library_interpreter.py
@@ -104,9 +104,7 @@ class LibraryInterpreter(object):
             pass
 
         try:
-            '''
-            It is possible that the session is valid but the returned_error_code unequal to error_code
-            '''
+            # It is possible that the session is valid but the returned_error_code unequal to error_code
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:

--- a/generated/nidcpower/nidcpower/_library_interpreter.py
+++ b/generated/nidcpower/nidcpower/_library_interpreter.py
@@ -110,13 +110,13 @@ class LibraryInterpreter(object):
         except errors.Error:
             pass
 
+        save_vi = self.get_session_handle()
         try:
             '''
             It is expected for get_error to raise when the session is invalid
             (IVI spec requires GetError to fail).
             Use error_message instead. It doesn't require a session.
             '''
-            save_vi = self.get_session_handle()
             self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string

--- a/generated/nidcpower/nidcpower/_library_interpreter.py
+++ b/generated/nidcpower/nidcpower/_library_interpreter.py
@@ -105,10 +105,20 @@ class LibraryInterpreter(object):
 
         try:
             '''
+            It is possible that the session is valid but the returned_error_code unequal to error_code
+            '''
+            error_string = self.error_message(error_code)
+            return error_string
+        except errors.Error:
+            pass
+
+        try:
+            '''
             It is expected for get_error to raise when the session is invalid
             (IVI spec requires GetError to fail).
             Use error_message instead. It doesn't require a session.
             '''
+            self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:

--- a/generated/nidigital/nidigital/_library_interpreter.py
+++ b/generated/nidigital/nidigital/_library_interpreter.py
@@ -102,7 +102,12 @@ class LibraryInterpreter(object):
             pass
 
         try:
-            # It is possible that the session is valid but the returned_error_code unequal to error_code
+            # get_error reads the session's error queue, which may have been overwritten,
+            # causing it to return a mismatched error code. error_message takes the error
+            # code directly as a parameter and looks up its description without reading the
+            # queue, it will return the description for the specific error code.
+            # Use error_message in current session before the handle reset in the next block.
+
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:
@@ -110,11 +115,10 @@ class LibraryInterpreter(object):
 
         save_vi = self.get_session_handle()
         try:
-            '''
-            It is expected for get_error to raise when the session is invalid
-            (IVI spec requires GetError to fail).
-            Use error_message instead. It doesn't require a session.
-            '''
+            # It is expected for get_error to raise when the session is invalid
+            # (IVI spec requires GetError to fail).
+            # Use error_message instead. It doesn't require a session.
+
             self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string

--- a/generated/nidigital/nidigital/_library_interpreter.py
+++ b/generated/nidigital/nidigital/_library_interpreter.py
@@ -114,11 +114,14 @@ class LibraryInterpreter(object):
             (IVI spec requires GetError to fail).
             Use error_message instead. It doesn't require a session.
             '''
+            save_vi = self.get_session_handle()
             self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:
             pass
+        finally:
+            self.set_session_handle(save_vi)
         return "Failed to retrieve error description."
 
     def abort(self):  # noqa: N802

--- a/generated/nidigital/nidigital/_library_interpreter.py
+++ b/generated/nidigital/nidigital/_library_interpreter.py
@@ -103,10 +103,20 @@ class LibraryInterpreter(object):
 
         try:
             '''
+            It is possible that the session is valid but the returned_error_code unequal to error_code
+            '''
+            error_string = self.error_message(error_code)
+            return error_string
+        except errors.Error:
+            pass
+
+        try:
+            '''
             It is expected for get_error to raise when the session is invalid
             (IVI spec requires GetError to fail).
             Use error_message instead. It doesn't require a session.
             '''
+            self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:

--- a/generated/nidigital/nidigital/_library_interpreter.py
+++ b/generated/nidigital/nidigital/_library_interpreter.py
@@ -108,13 +108,13 @@ class LibraryInterpreter(object):
         except errors.Error:
             pass
 
+        save_vi = self.get_session_handle()
         try:
             '''
             It is expected for get_error to raise when the session is invalid
             (IVI spec requires GetError to fail).
             Use error_message instead. It doesn't require a session.
             '''
-            save_vi = self.get_session_handle()
             self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string

--- a/generated/nidigital/nidigital/_library_interpreter.py
+++ b/generated/nidigital/nidigital/_library_interpreter.py
@@ -102,9 +102,7 @@ class LibraryInterpreter(object):
             pass
 
         try:
-            '''
-            It is possible that the session is valid but the returned_error_code unequal to error_code
-            '''
+            # It is possible that the session is valid but the returned_error_code unequal to error_code
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:

--- a/generated/nidmm/nidmm/_library_interpreter.py
+++ b/generated/nidmm/nidmm/_library_interpreter.py
@@ -106,13 +106,13 @@ class LibraryInterpreter(object):
         except errors.Error:
             pass
 
+        save_vi = self.get_session_handle()
         try:
             '''
             It is expected for get_error to raise when the session is invalid
             (IVI spec requires GetError to fail).
             Use error_message instead. It doesn't require a session.
             '''
-            save_vi = self.get_session_handle()
             self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string

--- a/generated/nidmm/nidmm/_library_interpreter.py
+++ b/generated/nidmm/nidmm/_library_interpreter.py
@@ -100,7 +100,12 @@ class LibraryInterpreter(object):
             pass
 
         try:
-            # It is possible that the session is valid but the returned_error_code unequal to error_code
+            # get_error reads the session's error queue, which may have been overwritten,
+            # causing it to return a mismatched error code. error_message takes the error
+            # code directly as a parameter and looks up its description without reading the
+            # queue, it will return the description for the specific error code.
+            # Use error_message in current session before the handle reset in the next block.
+
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:
@@ -108,11 +113,10 @@ class LibraryInterpreter(object):
 
         save_vi = self.get_session_handle()
         try:
-            '''
-            It is expected for get_error to raise when the session is invalid
-            (IVI spec requires GetError to fail).
-            Use error_message instead. It doesn't require a session.
-            '''
+            # It is expected for get_error to raise when the session is invalid
+            # (IVI spec requires GetError to fail).
+            # Use error_message instead. It doesn't require a session.
+
             self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string

--- a/generated/nidmm/nidmm/_library_interpreter.py
+++ b/generated/nidmm/nidmm/_library_interpreter.py
@@ -112,11 +112,14 @@ class LibraryInterpreter(object):
             (IVI spec requires GetError to fail).
             Use error_message instead. It doesn't require a session.
             '''
+            save_vi = self.get_session_handle()
             self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:
             pass
+        finally:
+            self.set_session_handle(save_vi)
         return "Failed to retrieve error description."
 
     def abort(self):  # noqa: N802

--- a/generated/nidmm/nidmm/_library_interpreter.py
+++ b/generated/nidmm/nidmm/_library_interpreter.py
@@ -101,10 +101,20 @@ class LibraryInterpreter(object):
 
         try:
             '''
+            It is possible that the session is valid but the returned_error_code unequal to error_code
+            '''
+            error_string = self.error_message(error_code)
+            return error_string
+        except errors.Error:
+            pass
+
+        try:
+            '''
             It is expected for get_error to raise when the session is invalid
             (IVI spec requires GetError to fail).
             Use error_message instead. It doesn't require a session.
             '''
+            self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:

--- a/generated/nidmm/nidmm/_library_interpreter.py
+++ b/generated/nidmm/nidmm/_library_interpreter.py
@@ -100,9 +100,7 @@ class LibraryInterpreter(object):
             pass
 
         try:
-            '''
-            It is possible that the session is valid but the returned_error_code unequal to error_code
-            '''
+            # It is possible that the session is valid but the returned_error_code unequal to error_code
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:

--- a/generated/nifake/nifake/_library_interpreter.py
+++ b/generated/nifake/nifake/_library_interpreter.py
@@ -122,13 +122,13 @@ class LibraryInterpreter(object):
         except errors.Error:
             pass
 
+        save_vi = self.get_session_handle()
         try:
             '''
             It is expected for get_error to raise when the session is invalid
             (IVI spec requires GetError to fail).
             Use error_message instead. It doesn't require a session.
             '''
-            save_vi = self.get_session_handle()
             self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string

--- a/generated/nifake/nifake/_library_interpreter.py
+++ b/generated/nifake/nifake/_library_interpreter.py
@@ -116,7 +116,12 @@ class LibraryInterpreter(object):
             pass
 
         try:
-            # It is possible that the session is valid but the returned_error_code unequal to error_code
+            # get_error reads the session's error queue, which may have been overwritten,
+            # causing it to return a mismatched error code. error_message takes the error
+            # code directly as a parameter and looks up its description without reading the
+            # queue, it will return the description for the specific error code.
+            # Use error_message in current session before the handle reset in the next block.
+
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:
@@ -124,11 +129,10 @@ class LibraryInterpreter(object):
 
         save_vi = self.get_session_handle()
         try:
-            '''
-            It is expected for get_error to raise when the session is invalid
-            (IVI spec requires GetError to fail).
-            Use error_message instead. It doesn't require a session.
-            '''
+            # It is expected for get_error to raise when the session is invalid
+            # (IVI spec requires GetError to fail).
+            # Use error_message instead. It doesn't require a session.
+
             self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string

--- a/generated/nifake/nifake/_library_interpreter.py
+++ b/generated/nifake/nifake/_library_interpreter.py
@@ -128,11 +128,14 @@ class LibraryInterpreter(object):
             (IVI spec requires GetError to fail).
             Use error_message instead. It doesn't require a session.
             '''
+            save_vi = self.get_session_handle()
             self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:
             pass
+        finally:
+            self.set_session_handle(save_vi)
         return "Failed to retrieve error description."
 
     def abort(self):  # noqa: N802

--- a/generated/nifake/nifake/_library_interpreter.py
+++ b/generated/nifake/nifake/_library_interpreter.py
@@ -116,9 +116,7 @@ class LibraryInterpreter(object):
             pass
 
         try:
-            '''
-            It is possible that the session is valid but the returned_error_code unequal to error_code
-            '''
+            # It is possible that the session is valid but the returned_error_code unequal to error_code
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:

--- a/generated/nifake/nifake/_library_interpreter.py
+++ b/generated/nifake/nifake/_library_interpreter.py
@@ -117,10 +117,20 @@ class LibraryInterpreter(object):
 
         try:
             '''
+            It is possible that the session is valid but the returned_error_code unequal to error_code
+            '''
+            error_string = self.error_message(error_code)
+            return error_string
+        except errors.Error:
+            pass
+
+        try:
+            '''
             It is expected for get_error to raise when the session is invalid
             (IVI spec requires GetError to fail).
             Use error_message instead. It doesn't require a session.
             '''
+            self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:

--- a/generated/nifake/nifake/unit_tests/test_library_interpreter.py
+++ b/generated/nifake/nifake/unit_tests/test_library_interpreter.py
@@ -716,6 +716,36 @@ class TestLibraryInterpreter:
             assert e.description == test_error_desc
         self.patched_library.niFake_error_message.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViInt32Matcher(test_error_code), _matchers.ViCharBufferMatcher(256))
 
+    def test_get_error_description_error_message_after_session_reset(self):
+        test_error_code = -42
+        test_error_desc = "The answer to the ultimate question"
+        self.patched_library.niFake_PoorlyNamedSimpleFunction.side_effect = self.side_effects_helper.niFake_PoorlyNamedSimpleFunction
+        self.side_effects_helper['PoorlyNamedSimpleFunction']['return'] = test_error_code
+        self.patched_library.niFake_GetError.side_effect = self.side_effects_helper.niFake_GetError
+        self.side_effects_helper['GetError']['errorCode'] = -1
+        self.side_effects_helper['GetError']['description'] = "Shouldn't get this"
+        self.side_effects_helper['GetError']['return'] = -2
+        self.side_effects_helper['error_message']['errorMessage'] = test_error_desc
+
+        def error_message_side_effect(vi, error_code, error_message_buf):
+            if vi.value == SESSION_NUM_FOR_TEST:
+                return -3
+            return self.side_effects_helper.niFake_error_message(vi, error_code, error_message_buf)
+
+        self.patched_library.niFake_error_message.side_effect = error_message_side_effect
+        interpreter = self.get_initialized_library_interpreter()
+        try:
+            interpreter.simple_function()
+            assert False
+        except nifake.Error as e:
+            assert e.code == test_error_code
+            assert e.description == test_error_desc
+        assert self.patched_library.niFake_error_message.call_count == 2
+        self.patched_library.niFake_error_message.assert_has_calls([
+            call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViInt32Matcher(test_error_code), _matchers.ViCharBufferMatcher(256)),
+            call(_matchers.ViSessionMatcher(0), _matchers.ViInt32Matcher(test_error_code), _matchers.ViCharBufferMatcher(256)),
+        ])
+
     # Custom types
 
     def test_set_custom_type(self):

--- a/generated/nifgen/nifgen/_library_interpreter.py
+++ b/generated/nifgen/nifgen/_library_interpreter.py
@@ -106,13 +106,13 @@ class LibraryInterpreter(object):
         except errors.Error:
             pass
 
+        save_vi = self.get_session_handle()
         try:
             '''
             It is expected for get_error to raise when the session is invalid
             (IVI spec requires GetError to fail).
             Use error_message instead. It doesn't require a session.
             '''
-            save_vi = self.get_session_handle()
             self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string

--- a/generated/nifgen/nifgen/_library_interpreter.py
+++ b/generated/nifgen/nifgen/_library_interpreter.py
@@ -100,7 +100,12 @@ class LibraryInterpreter(object):
             pass
 
         try:
-            # It is possible that the session is valid but the returned_error_code unequal to error_code
+            # get_error reads the session's error queue, which may have been overwritten,
+            # causing it to return a mismatched error code. error_message takes the error
+            # code directly as a parameter and looks up its description without reading the
+            # queue, it will return the description for the specific error code.
+            # Use error_message in current session before the handle reset in the next block.
+
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:
@@ -108,11 +113,10 @@ class LibraryInterpreter(object):
 
         save_vi = self.get_session_handle()
         try:
-            '''
-            It is expected for get_error to raise when the session is invalid
-            (IVI spec requires GetError to fail).
-            Use error_message instead. It doesn't require a session.
-            '''
+            # It is expected for get_error to raise when the session is invalid
+            # (IVI spec requires GetError to fail).
+            # Use error_message instead. It doesn't require a session.
+
             self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string

--- a/generated/nifgen/nifgen/_library_interpreter.py
+++ b/generated/nifgen/nifgen/_library_interpreter.py
@@ -112,11 +112,14 @@ class LibraryInterpreter(object):
             (IVI spec requires GetError to fail).
             Use error_message instead. It doesn't require a session.
             '''
+            save_vi = self.get_session_handle()
             self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:
             pass
+        finally:
+            self.set_session_handle(save_vi)
         return "Failed to retrieve error description."
 
     def abort(self):  # noqa: N802

--- a/generated/nifgen/nifgen/_library_interpreter.py
+++ b/generated/nifgen/nifgen/_library_interpreter.py
@@ -101,10 +101,20 @@ class LibraryInterpreter(object):
 
         try:
             '''
+            It is possible that the session is valid but the returned_error_code unequal to error_code
+            '''
+            error_string = self.error_message(error_code)
+            return error_string
+        except errors.Error:
+            pass
+
+        try:
+            '''
             It is expected for get_error to raise when the session is invalid
             (IVI spec requires GetError to fail).
             Use error_message instead. It doesn't require a session.
             '''
+            self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:

--- a/generated/nifgen/nifgen/_library_interpreter.py
+++ b/generated/nifgen/nifgen/_library_interpreter.py
@@ -100,9 +100,7 @@ class LibraryInterpreter(object):
             pass
 
         try:
-            '''
-            It is possible that the session is valid but the returned_error_code unequal to error_code
-            '''
+            # It is possible that the session is valid but the returned_error_code unequal to error_code
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:

--- a/generated/niscope/niscope/_library_interpreter.py
+++ b/generated/niscope/niscope/_library_interpreter.py
@@ -104,7 +104,12 @@ class LibraryInterpreter(object):
             pass
 
         try:
-            # It is possible that the session is valid but the returned_error_code unequal to error_code
+            # get_error reads the session's error queue, which may have been overwritten,
+            # causing it to return a mismatched error code. error_message takes the error
+            # code directly as a parameter and looks up its description without reading the
+            # queue, it will return the description for the specific error code.
+            # Use error_message in current session before the handle reset in the next block.
+
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:
@@ -112,11 +117,10 @@ class LibraryInterpreter(object):
 
         save_vi = self.get_session_handle()
         try:
-            '''
-            It is expected for get_error to raise when the session is invalid
-            (IVI spec requires GetError to fail).
-            Use error_message instead. It doesn't require a session.
-            '''
+            # It is expected for get_error to raise when the session is invalid
+            # (IVI spec requires GetError to fail).
+            # Use error_message instead. It doesn't require a session.
+
             self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string

--- a/generated/niscope/niscope/_library_interpreter.py
+++ b/generated/niscope/niscope/_library_interpreter.py
@@ -104,9 +104,7 @@ class LibraryInterpreter(object):
             pass
 
         try:
-            '''
-            It is possible that the session is valid but the returned_error_code unequal to error_code
-            '''
+            # It is possible that the session is valid but the returned_error_code unequal to error_code
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:

--- a/generated/niscope/niscope/_library_interpreter.py
+++ b/generated/niscope/niscope/_library_interpreter.py
@@ -110,13 +110,13 @@ class LibraryInterpreter(object):
         except errors.Error:
             pass
 
+        save_vi = self.get_session_handle()
         try:
             '''
             It is expected for get_error to raise when the session is invalid
             (IVI spec requires GetError to fail).
             Use error_message instead. It doesn't require a session.
             '''
-            save_vi = self.get_session_handle()
             self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string

--- a/generated/niscope/niscope/_library_interpreter.py
+++ b/generated/niscope/niscope/_library_interpreter.py
@@ -105,10 +105,20 @@ class LibraryInterpreter(object):
 
         try:
             '''
+            It is possible that the session is valid but the returned_error_code unequal to error_code
+            '''
+            error_string = self.error_message(error_code)
+            return error_string
+        except errors.Error:
+            pass
+
+        try:
+            '''
             It is expected for get_error to raise when the session is invalid
             (IVI spec requires GetError to fail).
             Use error_message instead. It doesn't require a session.
             '''
+            self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:

--- a/generated/niscope/niscope/_library_interpreter.py
+++ b/generated/niscope/niscope/_library_interpreter.py
@@ -116,11 +116,14 @@ class LibraryInterpreter(object):
             (IVI spec requires GetError to fail).
             Use error_message instead. It doesn't require a session.
             '''
+            save_vi = self.get_session_handle()
             self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:
             pass
+        finally:
+            self.set_session_handle(save_vi)
         return "Failed to retrieve error description."
 
     def abort(self):  # noqa: N802

--- a/generated/niswitch/niswitch/_library_interpreter.py
+++ b/generated/niswitch/niswitch/_library_interpreter.py
@@ -106,13 +106,13 @@ class LibraryInterpreter(object):
         except errors.Error:
             pass
 
+        save_vi = self.get_session_handle()
         try:
             '''
             It is expected for get_error to raise when the session is invalid
             (IVI spec requires GetError to fail).
             Use error_message instead. It doesn't require a session.
             '''
-            save_vi = self.get_session_handle()
             self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string

--- a/generated/niswitch/niswitch/_library_interpreter.py
+++ b/generated/niswitch/niswitch/_library_interpreter.py
@@ -100,7 +100,12 @@ class LibraryInterpreter(object):
             pass
 
         try:
-            # It is possible that the session is valid but the returned_error_code unequal to error_code
+            # get_error reads the session's error queue, which may have been overwritten,
+            # causing it to return a mismatched error code. error_message takes the error
+            # code directly as a parameter and looks up its description without reading the
+            # queue, it will return the description for the specific error code.
+            # Use error_message in current session before the handle reset in the next block.
+
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:
@@ -108,11 +113,10 @@ class LibraryInterpreter(object):
 
         save_vi = self.get_session_handle()
         try:
-            '''
-            It is expected for get_error to raise when the session is invalid
-            (IVI spec requires GetError to fail).
-            Use error_message instead. It doesn't require a session.
-            '''
+            # It is expected for get_error to raise when the session is invalid
+            # (IVI spec requires GetError to fail).
+            # Use error_message instead. It doesn't require a session.
+
             self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string

--- a/generated/niswitch/niswitch/_library_interpreter.py
+++ b/generated/niswitch/niswitch/_library_interpreter.py
@@ -112,11 +112,14 @@ class LibraryInterpreter(object):
             (IVI spec requires GetError to fail).
             Use error_message instead. It doesn't require a session.
             '''
+            save_vi = self.get_session_handle()
             self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:
             pass
+        finally:
+            self.set_session_handle(save_vi)
         return "Failed to retrieve error description."
 
     def abort(self):  # noqa: N802

--- a/generated/niswitch/niswitch/_library_interpreter.py
+++ b/generated/niswitch/niswitch/_library_interpreter.py
@@ -101,10 +101,20 @@ class LibraryInterpreter(object):
 
         try:
             '''
+            It is possible that the session is valid but the returned_error_code unequal to error_code
+            '''
+            error_string = self.error_message(error_code)
+            return error_string
+        except errors.Error:
+            pass
+
+        try:
+            '''
             It is expected for get_error to raise when the session is invalid
             (IVI spec requires GetError to fail).
             Use error_message instead. It doesn't require a session.
             '''
+            self.set_session_handle()
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:

--- a/generated/niswitch/niswitch/_library_interpreter.py
+++ b/generated/niswitch/niswitch/_library_interpreter.py
@@ -100,9 +100,7 @@ class LibraryInterpreter(object):
             pass
 
         try:
-            '''
-            It is possible that the session is valid but the returned_error_code unequal to error_code
-            '''
+            # It is possible that the session is valid but the returned_error_code unequal to error_code
             error_string = self.error_message(error_code)
             return error_string
         except errors.Error:

--- a/src/nifake/unit_tests/test_library_interpreter.py
+++ b/src/nifake/unit_tests/test_library_interpreter.py
@@ -716,6 +716,36 @@ class TestLibraryInterpreter:
             assert e.description == test_error_desc
         self.patched_library.niFake_error_message.assert_called_once_with(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViInt32Matcher(test_error_code), _matchers.ViCharBufferMatcher(256))
 
+    def test_get_error_description_error_message_after_session_reset(self):
+        test_error_code = -42
+        test_error_desc = "The answer to the ultimate question"
+        self.patched_library.niFake_PoorlyNamedSimpleFunction.side_effect = self.side_effects_helper.niFake_PoorlyNamedSimpleFunction
+        self.side_effects_helper['PoorlyNamedSimpleFunction']['return'] = test_error_code
+        self.patched_library.niFake_GetError.side_effect = self.side_effects_helper.niFake_GetError
+        self.side_effects_helper['GetError']['errorCode'] = -1
+        self.side_effects_helper['GetError']['description'] = "Shouldn't get this"
+        self.side_effects_helper['GetError']['return'] = -2
+        self.side_effects_helper['error_message']['errorMessage'] = test_error_desc
+
+        def error_message_side_effect(vi, error_code, error_message_buf):
+            if vi.value == SESSION_NUM_FOR_TEST:
+                return -3
+            return self.side_effects_helper.niFake_error_message(vi, error_code, error_message_buf)
+
+        self.patched_library.niFake_error_message.side_effect = error_message_side_effect
+        interpreter = self.get_initialized_library_interpreter()
+        try:
+            interpreter.simple_function()
+            assert False
+        except nifake.Error as e:
+            assert e.code == test_error_code
+            assert e.description == test_error_desc
+        assert self.patched_library.niFake_error_message.call_count == 2
+        self.patched_library.niFake_error_message.assert_has_calls([
+            call(_matchers.ViSessionMatcher(SESSION_NUM_FOR_TEST), _matchers.ViInt32Matcher(test_error_code), _matchers.ViCharBufferMatcher(256)),
+            call(_matchers.ViSessionMatcher(0), _matchers.ViInt32Matcher(test_error_code), _matchers.ViCharBufferMatcher(256)),
+        ])
+
     # Custom types
 
     def test_set_custom_type(self):


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.
- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

- Fix get_error_description returning "Failed to retrieve error description." when the session is invalid
  - **TRY Block 1 — Try `get_error` (reads session error queue)**
If the session is valid and the error queue has not been overwritten, returned_error_code matches error_code and we return the description immediately.
    - Test: invalid resource name error
    <img width="804" height="185" alt="image" src="https://github.com/user-attachments/assets/09bf29a9-6710-42f9-9a78-481722a3e134" />
   - **TRY Block 2 — Try error_message with current session**
Reached if Block 1 fell through — either `get_error` raised, or it returned a mismatched code (queue was overwritten). Unlike `get_error`, `error_message` is a direct lookup by `error_code` and does not read the error queue. If the session is still valid, this returns the correct description without touching the session handle.
    ( second try statement is exactly same with the second try statement in original file. I only updated the docstring section).
  - **TRY Block 3 — Reset session handle to 0, retry error_message**
Reached only when Block 2 also failed — meaning the error_message in TRY block 2 fail to retrieve error due to internal error or it is an invalid session. `error_message` rejects calls with an invalid session handle, but succeeds with `vi=0`. 
    -  No test for real behaviour of valid session in third try block because did not manage to trigger a real internal in valid session that failed in first and second try statement.
 - Updated the mako template and regenerated the affected drivers (nidcpower, nidigital, nidmm, nifake, nifgen, niscope, niswitch).
 - Added nifake unit test to verify the session-handle reset path calls error_message again with vi=0
### List issues fixed by this Pull Request below, if any.

* Fix [ bug 3877024](https://ni.visualstudio.com/DevCentral/_workitems/edit/3877024)
<img width="363" height="144" alt="Labview error description" src="https://github.com/user-attachments/assets/dff1d48a-a34d-420d-a002-c8b667ade6d0" />
<img width="899" height="185" alt="python error description" src="https://github.com/user-attachments/assets/253c612e-7d9e-4436-afeb-64da6d782154" />
When session2 is opened after session1, driver will no longer have session handle of session1. It will have session handle of session2. If we use the invalidated session1, the error description between Labview and Python is different. The expected error description of python should be same with Labview, which is "(Hex 0xBFFA1190) The session handle is not valid.".

### What testing has been done?
- Test of invalid session (this bug after fixing):
      <img width="886" height="171" alt="image" src="https://github.com/user-attachments/assets/b694907d-51c3-4974-a02f-ae63d87f789c" />

- Unit tests and flake8 passed.
