### PR TITLE
Add a delay at the end of the system tests to try avoid a crash

### DIFF
--- a/build/templates/tox-system_tests.ini.mako
+++ b/build/templates/tox-system_tests.ini.mako
@@ -61,7 +61,7 @@ commands =
 % endif
     ${module_name}-system_tests: python -c "import ${module_name}; ${module_name}.print_diagnostic_information()"
     ${module_name}-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source ${module_name} --parallel-mode -m pytest ../../src/${module_name}/examples --junitxml=../junit/junit-${module_name}-{envname}-examples-{env:BITNESS:64}.xml {posargs}
-    ${module_name}-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source ${module_name} --parallel-mode -m pytest ../../src/${module_name}/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-${module_name}-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
+    ${module_name}-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source ${module_name} --parallel-mode -m pytest ../../src/${module_name}/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-${module_name}-{envname}-{env:BITNESS:64}.xml --durations=5 -p system_test_pytest_delay_terminate_plugin {posargs}
 
     ${module_name}-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./
     # Create the report to upload
@@ -102,6 +102,9 @@ passenv =
     BRANCH_NAME
     JENKINS_URL
     BUILD_NUMBER
+
+setenv =
+    PYTHONPATH = ../../src/shared
 
 [pytest]
 addopts = --verbose

--- a/generated/nidcpower/tox-system_tests.ini
+++ b/generated/nidcpower/tox-system_tests.ini
@@ -23,7 +23,7 @@ commands =
     nidcpower-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     nidcpower-system_tests: python -c "import nidcpower; nidcpower.print_diagnostic_information()"
     nidcpower-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidcpower --parallel-mode -m pytest ../../src/nidcpower/examples --junitxml=../junit/junit-nidcpower-{envname}-examples-{env:BITNESS:64}.xml {posargs}
-    nidcpower-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidcpower --parallel-mode -m pytest ../../src/nidcpower/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nidcpower-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
+    nidcpower-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidcpower --parallel-mode -m pytest ../../src/nidcpower/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nidcpower-{envname}-{env:BITNESS:64}.xml --durations=5 -p system_test_pytest_delay_terminate_plugin {posargs}
 
     nidcpower-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./
     # Create the report to upload
@@ -52,6 +52,9 @@ passenv =
     BRANCH_NAME
     JENKINS_URL
     BUILD_NUMBER
+
+setenv =
+    PYTHONPATH = ../../src/shared
 
 [pytest]
 addopts = --verbose

--- a/generated/nidigital/tox-system_tests.ini
+++ b/generated/nidigital/tox-system_tests.ini
@@ -28,7 +28,7 @@ commands =
     nidigital-system_tests: python ../../tools/install_local_wheel.py --driver nitclk --start-path ../..
     nidigital-system_tests: python -c "import nidigital; nidigital.print_diagnostic_information()"
     nidigital-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidigital --parallel-mode -m pytest ../../src/nidigital/examples --junitxml=../junit/junit-nidigital-{envname}-examples-{env:BITNESS:64}.xml {posargs}
-    nidigital-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidigital --parallel-mode -m pytest ../../src/nidigital/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nidigital-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
+    nidigital-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidigital --parallel-mode -m pytest ../../src/nidigital/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nidigital-{envname}-{env:BITNESS:64}.xml --durations=5 -p system_test_pytest_delay_terminate_plugin {posargs}
 
     nidigital-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./
     # Create the report to upload
@@ -61,6 +61,9 @@ passenv =
     BRANCH_NAME
     JENKINS_URL
     BUILD_NUMBER
+
+setenv =
+    PYTHONPATH = ../../src/shared
 
 [pytest]
 addopts = --verbose

--- a/generated/nidmm/tox-system_tests.ini
+++ b/generated/nidmm/tox-system_tests.ini
@@ -23,7 +23,7 @@ commands =
     nidmm-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     nidmm-system_tests: python -c "import nidmm; nidmm.print_diagnostic_information()"
     nidmm-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidmm --parallel-mode -m pytest ../../src/nidmm/examples --junitxml=../junit/junit-nidmm-{envname}-examples-{env:BITNESS:64}.xml {posargs}
-    nidmm-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidmm --parallel-mode -m pytest ../../src/nidmm/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nidmm-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
+    nidmm-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nidmm --parallel-mode -m pytest ../../src/nidmm/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nidmm-{envname}-{env:BITNESS:64}.xml --durations=5 -p system_test_pytest_delay_terminate_plugin {posargs}
 
     nidmm-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./
     # Create the report to upload
@@ -52,6 +52,9 @@ passenv =
     BRANCH_NAME
     JENKINS_URL
     BUILD_NUMBER
+
+setenv =
+    PYTHONPATH = ../../src/shared
 
 [pytest]
 addopts = --verbose

--- a/generated/nifake/tox-system_tests.ini
+++ b/generated/nifake/tox-system_tests.ini
@@ -28,7 +28,7 @@ commands =
     nifake-system_tests: python ../../tools/install_local_wheel.py --driver nitclk --start-path ../..
     nifake-system_tests: python -c "import nifake; nifake.print_diagnostic_information()"
     nifake-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nifake --parallel-mode -m pytest ../../src/nifake/examples --junitxml=../junit/junit-nifake-{envname}-examples-{env:BITNESS:64}.xml {posargs}
-    nifake-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nifake --parallel-mode -m pytest ../../src/nifake/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nifake-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
+    nifake-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nifake --parallel-mode -m pytest ../../src/nifake/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nifake-{envname}-{env:BITNESS:64}.xml --durations=5 -p system_test_pytest_delay_terminate_plugin {posargs}
 
     nifake-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./
     # Create the report to upload
@@ -60,6 +60,9 @@ passenv =
     BRANCH_NAME
     JENKINS_URL
     BUILD_NUMBER
+
+setenv =
+    PYTHONPATH = ../../src/shared
 
 [pytest]
 addopts = --verbose

--- a/generated/nifgen/tox-system_tests.ini
+++ b/generated/nifgen/tox-system_tests.ini
@@ -28,7 +28,7 @@ commands =
     nifgen-system_tests: python ../../tools/install_local_wheel.py --driver nitclk --start-path ../..
     nifgen-system_tests: python -c "import nifgen; nifgen.print_diagnostic_information()"
     nifgen-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nifgen --parallel-mode -m pytest ../../src/nifgen/examples --junitxml=../junit/junit-nifgen-{envname}-examples-{env:BITNESS:64}.xml {posargs}
-    nifgen-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nifgen --parallel-mode -m pytest ../../src/nifgen/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nifgen-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
+    nifgen-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nifgen --parallel-mode -m pytest ../../src/nifgen/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nifgen-{envname}-{env:BITNESS:64}.xml --durations=5 -p system_test_pytest_delay_terminate_plugin {posargs}
 
     nifgen-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./
     # Create the report to upload
@@ -60,6 +60,9 @@ passenv =
     BRANCH_NAME
     JENKINS_URL
     BUILD_NUMBER
+
+setenv =
+    PYTHONPATH = ../../src/shared
 
 [pytest]
 addopts = --verbose

--- a/generated/nimodinst/tox-system_tests.ini
+++ b/generated/nimodinst/tox-system_tests.ini
@@ -23,7 +23,7 @@ commands =
     nimodinst-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     nimodinst-system_tests: python -c "import nimodinst; nimodinst.print_diagnostic_information()"
     nimodinst-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nimodinst --parallel-mode -m pytest ../../src/nimodinst/examples --junitxml=../junit/junit-nimodinst-{envname}-examples-{env:BITNESS:64}.xml {posargs}
-    nimodinst-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nimodinst --parallel-mode -m pytest ../../src/nimodinst/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nimodinst-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
+    nimodinst-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nimodinst --parallel-mode -m pytest ../../src/nimodinst/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nimodinst-{envname}-{env:BITNESS:64}.xml --durations=5 -p system_test_pytest_delay_terminate_plugin {posargs}
 
     nimodinst-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./
     # Create the report to upload
@@ -51,6 +51,9 @@ passenv =
     BRANCH_NAME
     JENKINS_URL
     BUILD_NUMBER
+
+setenv =
+    PYTHONPATH = ../../src/shared
 
 [pytest]
 addopts = --verbose

--- a/generated/nirfsg/tox-system_tests.ini
+++ b/generated/nirfsg/tox-system_tests.ini
@@ -28,7 +28,7 @@ commands =
     nirfsg-system_tests: python ../../tools/install_local_wheel.py --driver nitclk --start-path ../..
     nirfsg-system_tests: python -c "import nirfsg; nirfsg.print_diagnostic_information()"
     nirfsg-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nirfsg --parallel-mode -m pytest ../../src/nirfsg/examples --junitxml=../junit/junit-nirfsg-{envname}-examples-{env:BITNESS:64}.xml {posargs}
-    nirfsg-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nirfsg --parallel-mode -m pytest ../../src/nirfsg/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nirfsg-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
+    nirfsg-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nirfsg --parallel-mode -m pytest ../../src/nirfsg/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nirfsg-{envname}-{env:BITNESS:64}.xml --durations=5 -p system_test_pytest_delay_terminate_plugin {posargs}
 
     nirfsg-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./
     # Create the report to upload
@@ -60,6 +60,9 @@ passenv =
     BRANCH_NAME
     JENKINS_URL
     BUILD_NUMBER
+
+setenv =
+    PYTHONPATH = ../../src/shared
 
 [pytest]
 addopts = --verbose

--- a/generated/niscope/tox-system_tests.ini
+++ b/generated/niscope/tox-system_tests.ini
@@ -28,7 +28,7 @@ commands =
     niscope-system_tests: python ../../tools/install_local_wheel.py --driver nitclk --start-path ../..
     niscope-system_tests: python -c "import niscope; niscope.print_diagnostic_information()"
     niscope-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source niscope --parallel-mode -m pytest ../../src/niscope/examples --junitxml=../junit/junit-niscope-{envname}-examples-{env:BITNESS:64}.xml {posargs}
-    niscope-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source niscope --parallel-mode -m pytest ../../src/niscope/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-niscope-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
+    niscope-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source niscope --parallel-mode -m pytest ../../src/niscope/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-niscope-{envname}-{env:BITNESS:64}.xml --durations=5 -p system_test_pytest_delay_terminate_plugin {posargs}
 
     niscope-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./
     # Create the report to upload
@@ -60,6 +60,9 @@ passenv =
     BRANCH_NAME
     JENKINS_URL
     BUILD_NUMBER
+
+setenv =
+    PYTHONPATH = ../../src/shared
 
 [pytest]
 addopts = --verbose

--- a/generated/nise/tox-system_tests.ini
+++ b/generated/nise/tox-system_tests.ini
@@ -23,7 +23,7 @@ commands =
     nise-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     nise-system_tests: python -c "import nise; nise.print_diagnostic_information()"
     nise-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nise --parallel-mode -m pytest ../../src/nise/examples --junitxml=../junit/junit-nise-{envname}-examples-{env:BITNESS:64}.xml {posargs}
-    nise-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nise --parallel-mode -m pytest ../../src/nise/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nise-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
+    nise-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nise --parallel-mode -m pytest ../../src/nise/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nise-{envname}-{env:BITNESS:64}.xml --durations=5 -p system_test_pytest_delay_terminate_plugin {posargs}
 
     nise-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./
     # Create the report to upload
@@ -51,6 +51,9 @@ passenv =
     BRANCH_NAME
     JENKINS_URL
     BUILD_NUMBER
+
+setenv =
+    PYTHONPATH = ../../src/shared
 
 [pytest]
 addopts = --verbose

--- a/generated/niswitch/tox-system_tests.ini
+++ b/generated/niswitch/tox-system_tests.ini
@@ -23,7 +23,7 @@ commands =
     niswitch-system_tests: python -m pip install --disable-pip-version-check --upgrade pip
     niswitch-system_tests: python -c "import niswitch; niswitch.print_diagnostic_information()"
     niswitch-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source niswitch --parallel-mode -m pytest ../../src/niswitch/examples --junitxml=../junit/junit-niswitch-{envname}-examples-{env:BITNESS:64}.xml {posargs}
-    niswitch-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source niswitch --parallel-mode -m pytest ../../src/niswitch/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-niswitch-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
+    niswitch-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source niswitch --parallel-mode -m pytest ../../src/niswitch/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-niswitch-{envname}-{env:BITNESS:64}.xml --durations=5 -p system_test_pytest_delay_terminate_plugin {posargs}
 
     niswitch-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./
     # Create the report to upload
@@ -52,6 +52,9 @@ passenv =
     BRANCH_NAME
     JENKINS_URL
     BUILD_NUMBER
+
+setenv =
+    PYTHONPATH = ../../src/shared
 
 [pytest]
 addopts = --verbose

--- a/generated/nitclk/tox-system_tests.ini
+++ b/generated/nitclk/tox-system_tests.ini
@@ -28,7 +28,7 @@ commands =
     nitclk-system_tests: python ../../tools/install_local_wheel.py --driver niscope --start-path ../..
     nitclk-system_tests: python -c "import nitclk; nitclk.print_diagnostic_information()"
     nitclk-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nitclk --parallel-mode -m pytest ../../src/nitclk/examples --junitxml=../junit/junit-nitclk-{envname}-examples-{env:BITNESS:64}.xml {posargs}
-    nitclk-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nitclk --parallel-mode -m pytest ../../src/nitclk/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nitclk-{envname}-{env:BITNESS:64}.xml --durations=5 {posargs}
+    nitclk-system_tests: coverage run --rcfile=../../tools/coverage_system_tests.rc --source nitclk --parallel-mode -m pytest ../../src/nitclk/system_tests -c tox-system_tests.ini --junitxml=../junit/junit-nitclk-{envname}-{env:BITNESS:64}.xml --durations=5 -p system_test_pytest_delay_terminate_plugin {posargs}
 
     nitclk-coverage: coverage combine --rcfile=../../tools/coverage_system_tests.rc ./
     # Create the report to upload
@@ -59,6 +59,9 @@ passenv =
     BRANCH_NAME
     JENKINS_URL
     BUILD_NUMBER
+
+setenv =
+    PYTHONPATH = ../../src/shared
 
 [pytest]
 addopts = --verbose

--- a/src/shared/system_test_pytest_delay_terminate_plugin.py
+++ b/src/shared/system_test_pytest_delay_terminate_plugin.py
@@ -1,0 +1,5 @@
+import time
+
+
+def pytest_sessionfinish(session, exitstatus):
+    time.sleep(5)

--- a/src/shared/system_test_pytest_delay_terminate_plugin.py
+++ b/src/shared/system_test_pytest_delay_terminate_plugin.py
@@ -2,4 +2,5 @@ import time
 
 
 def pytest_sessionfinish(session, exitstatus):
+    # Work around a race condition that can cause a crash during process termination.
     time.sleep(5)


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- ~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
- ~[ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
Pytest is intermittently crashing as it finishes running system tests on Linux, since upgrading the VM from RHEL 8.3 to RHEL 9.6. This change adds a workaround to reduce the likelihood of those crashes occurring.

### List issues fixed by this Pull Request below, if any.
None

### What testing has been done?
PR Checks.