### PR TITLE
Add new deembedding type in NI-RFSA

### DIFF
--- a/docs/nirfsa/class.rst
+++ b/docs/nirfsa/class.rst
@@ -3330,7 +3330,7 @@ deembedding_type
 
         **Valid Values for PXIe-5830/5832/5840/5841** : :py:data:`~nirfsa.DeembeddingType.NONE` or :py:data:`~nirfsa.DeembeddingType.SCALAR`
 
-        **Valid Values for PXIe-5842/5860** : :py:data:`~nirfsa.DeembeddingType.NONE` or :py:data:`~nirfsa.DeembeddingType.SCALAR` or :py:data:`~nirfsa.NIRFSA_VAL_DEEMBEDDING_TYPE_AMPLITUDE_FLATNESS` or :py:data:`~nirfsa.NIRFSA_VAL_DEEMBEDDING_TYPE_AMPLITUDE_AND_PHASE_FLATNESS`
+        **Valid Values for PXIe-5842/5860** : :py:data:`~nirfsa.DeembeddingType.NONE` or :py:data:`~nirfsa.DeembeddingType.SCALAR` or :py:data:`~nirfsa.DeembeddingType.AMPLITUDE_FLATNESS`
 
         **Valid Values for PXIe-5831:** :py:data:`~nirfsa.DeembeddingType.NONE`, :py:data:`~nirfsa.DeembeddingType.SCALAR`, or :py:data:`~nirfsa.DeembeddingType.VECTOR`. :py:data:`~nirfsa.DeembeddingType.VECTOR` is only supported for TRX Ports in a Semiconductor Test System (STS).
 
@@ -3338,17 +3338,17 @@ deembedding_type
 
         **Defined Values**:
 
-        +-------------------------------------------+------------------------------------------------------------------------+
-        | Name                                      | Description                                                            |
-        +===========================================+========================================================================+
-        | :py:data:`~nirfsa.DeembeddingType.NONE`   | De-embedding is not applied to the measurement.                        |
-        +-------------------------------------------+------------------------------------------------------------------------+
-        | :py:data:`~nirfsa.DeembeddingType.SCALAR` | De-embeds the measurement using only the gain term.                    |
-        +-------------------------------------------+------------------------------------------------------------------------+
-        | :py:data:`~nirfsa.DeembeddingType.VECTOR` | De-embeds the measurement using the gain term and the reflection term. |
-        +-------------------------------------------+------------------------------------------------------------------------+
-
-        .. note:: One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
+        +-------------------------------------------------------+-------------------------------------------------------------------------+
+        | Name                                                  | Description                                                             |
+        +=======================================================+=========================================================================+
+        | :py:data:`~nirfsa.DeembeddingType.NONE`               | De-embedding is not applied to the measurement.                         |
+        +-------------------------------------------------------+-------------------------------------------------------------------------+
+        | :py:data:`~nirfsa.DeembeddingType.SCALAR`             | De-embeds the measurement using only the gain term.                     |
+        +-------------------------------------------------------+-------------------------------------------------------------------------+
+        | :py:data:`~nirfsa.DeembeddingType.VECTOR`             | De-embeds the measurement using the gain term and the reflection term.  |
+        +-------------------------------------------------------+-------------------------------------------------------------------------+
+        | :py:data:`~nirfsa.DeembeddingType.AMPLITUDE_FLATNESS` | De-embeds the measurement using wideband amplitude flatness correction. |
+        +-------------------------------------------------------+-------------------------------------------------------------------------+
 
 
         .. tip:: This property can be set/get on specific ports within your :py:class:`nirfsa.Session` instance.

--- a/docs/nirfsa/enums.rst
+++ b/docs/nirfsa/enums.rst
@@ -391,6 +391,16 @@ DeembeddingType
 
 
 
+    .. py:attribute:: DeembeddingType.AMPLITUDE_FLATNESS
+
+
+
+        De-embeds the measurement using wideband amplitude flatness correction.
+
+        
+
+
+
 DeviceResponseType
 ------------------
 

--- a/generated/nirfsa/nirfsa/enums.py
+++ b/generated/nirfsa/nirfsa/enums.py
@@ -168,6 +168,10 @@ class DeembeddingType(Enum):
     r'''
     De-embeds the measurement using the gain term and the reflection term.
     '''
+    AMPLITUDE_FLATNESS = 3903
+    r'''
+    De-embeds the measurement using wideband amplitude flatness correction.
+    '''
 
 
 class DeviceResponseType(Enum):

--- a/generated/nirfsa/nirfsa/session.py
+++ b/generated/nirfsa/nirfsa/session.py
@@ -482,7 +482,7 @@ class _SessionBase(object):
 
     **Valid Values for PXIe-5830/5832/5840/5841** : DeembeddingType.NONE or DeembeddingType.SCALAR
 
-    **Valid Values for PXIe-5842/5860** : DeembeddingType.NONE or DeembeddingType.SCALAR or NIRFSA_VAL_DEEMBEDDING_TYPE_AMPLITUDE_FLATNESS or NIRFSA_VAL_DEEMBEDDING_TYPE_AMPLITUDE_AND_PHASE_FLATNESS
+    **Valid Values for PXIe-5842/5860** : DeembeddingType.NONE or DeembeddingType.SCALAR or DeembeddingType.AMPLITUDE_FLATNESS
 
     **Valid Values for PXIe-5831:** DeembeddingType.NONE, DeembeddingType.SCALAR, or DeembeddingType.VECTOR. DeembeddingType.VECTOR is only supported for TRX Ports in a Semiconductor Test System (STS).
 
@@ -490,18 +490,17 @@ class _SessionBase(object):
 
     **Defined Values**:
 
-    +------------------------+------------------------------------------------------------------------+
-    | Name                   | Description                                                            |
-    +========================+========================================================================+
-    | DeembeddingType.NONE   | De-embedding is not applied to the measurement.                        |
-    +------------------------+------------------------------------------------------------------------+
-    | DeembeddingType.SCALAR | De-embeds the measurement using only the gain term.                    |
-    +------------------------+------------------------------------------------------------------------+
-    | DeembeddingType.VECTOR | De-embeds the measurement using the gain term and the reflection term. |
-    +------------------------+------------------------------------------------------------------------+
-
-    Note:
-    One or more of the referenced values are not in the Python API for this driver. Enums that only define values, or represent True/False, have been removed.
+    +------------------------------------+-------------------------------------------------------------------------+
+    | Name                               | Description                                                             |
+    +====================================+=========================================================================+
+    | DeembeddingType.NONE               | De-embedding is not applied to the measurement.                         |
+    +------------------------------------+-------------------------------------------------------------------------+
+    | DeembeddingType.SCALAR             | De-embeds the measurement using only the gain term.                     |
+    +------------------------------------+-------------------------------------------------------------------------+
+    | DeembeddingType.VECTOR             | De-embeds the measurement using the gain term and the reflection term.  |
+    +------------------------------------+-------------------------------------------------------------------------+
+    | DeembeddingType.AMPLITUDE_FLATNESS | De-embeds the measurement using wideband amplitude flatness correction. |
+    +------------------------------------+-------------------------------------------------------------------------+
 
     Tip:
     This property can be set/get on specific ports within your :py:class:`nirfsa.Session` instance.

--- a/src/nirfsa/metadata/attributes.py
+++ b/src/nirfsa/metadata/attributes.py
@@ -3986,7 +3986,7 @@ attributes = {
         'access': 'read-write',
         'codegen_method': 'public',
         'documentation': {
-            'description': 'Specifies the type of de-embedding to apply to measurements on the specified port.\n\nTo use this attribute, you must use the channelName parameter of the nirfsa_SetAttributeViInt32 function to specify the name of the port to configure for de-embedding.\n\nIf you set this attribute to any value besides NIRFSA_VAL_DEEMBEDDING_TYPE_NONE, NI-RFSA adjusts the instrument settings and the returned data to remove the effects of the external network between the instrument and the DUT.\n\n**Default Value**: NIRFSA_VAL_DEEMBEDDING_TYPE_SCALAR\n\n**Valid Values for PXIe-5830/5832/5840/5841** : NIRFSA_VAL_DEEMBEDDING_TYPE_NONE or NIRFSA_VAL_DEEMBEDDING_TYPE_SCALAR\n\n**Valid Values for PXIe-5842/5860** : NIRFSA_VAL_DEEMBEDDING_TYPE_NONE or NIRFSA_VAL_DEEMBEDDING_TYPE_SCALAR or NIRFSA_VAL_DEEMBEDDING_TYPE_AMPLITUDE_FLATNESS or NIRFSA_VAL_DEEMBEDDING_TYPE_AMPLITUDE_AND_PHASE_FLATNESS\n\n**Valid Values for PXIe-5831:** NIRFSA_VAL_DEEMBEDDING_TYPE_NONE, NIRFSA_VAL_DEEMBEDDING_TYPE_SCALAR, or NIRFSA_VAL_DEEMBEDDING_TYPE_VECTOR. NIRFSA_VAL_DEEMBEDDING_TYPE_VECTOR is only supported for TRX Ports in a Semiconductor Test System (STS).\n\n**Supported Devices**: PXIe-5830/5831/5832/5840/5841/5842/5860\n\n**Defined Values**:',
+            'description': 'Specifies the type of de-embedding to apply to measurements on the specified port.\n\nTo use this attribute, you must use the channelName parameter of the nirfsa_SetAttributeViInt32 function to specify the name of the port to configure for de-embedding.\n\nIf you set this attribute to any value besides NIRFSA_VAL_DEEMBEDDING_TYPE_NONE, NI-RFSA adjusts the instrument settings and the returned data to remove the effects of the external network between the instrument and the DUT.\n\n**Default Value**: NIRFSA_VAL_DEEMBEDDING_TYPE_SCALAR\n\n**Valid Values for PXIe-5830/5832/5840/5841** : NIRFSA_VAL_DEEMBEDDING_TYPE_NONE or NIRFSA_VAL_DEEMBEDDING_TYPE_SCALAR\n\n**Valid Values for PXIe-5842/5860** : NIRFSA_VAL_DEEMBEDDING_TYPE_NONE or NIRFSA_VAL_DEEMBEDDING_TYPE_SCALAR or NIRFSA_VAL_DEEMBEDDING_TYPE_AMPLITUDE_FLATNESS\n\n**Valid Values for PXIe-5831:** NIRFSA_VAL_DEEMBEDDING_TYPE_NONE, NIRFSA_VAL_DEEMBEDDING_TYPE_SCALAR, or NIRFSA_VAL_DEEMBEDDING_TYPE_VECTOR. NIRFSA_VAL_DEEMBEDDING_TYPE_VECTOR is only supported for TRX Ports in a Semiconductor Test System (STS).\n\n**Supported Devices**: PXIe-5830/5831/5832/5840/5841/5842/5860\n\n**Defined Values**:',
             'table_body': [
                 [
                     'NIRFSA_VAL_DEEMBEDDING_TYPE_NONE',
@@ -3999,6 +3999,10 @@ attributes = {
                 [
                     'NIRFSA_VAL_DEEMBEDDING_TYPE_VECTOR',
                     'De-embeds the measurement using the gain term and the reflection term.'
+                ],
+                [
+                    'NIRFSA_VAL_DEEMBEDDING_TYPE_AMPLITUDE_FLATNESS',
+                    'De-embeds the measurement using wideband amplitude flatness correction.'
                 ]
             ],
             'table_header': [

--- a/src/nirfsa/metadata/enums.py
+++ b/src/nirfsa/metadata/enums.py
@@ -284,6 +284,13 @@ enums = {
                 },
                 'name': 'NIRFSA_VAL_DEEMBEDDING_TYPE_VECTOR',
                 'value': 3902
+            },
+            {
+                'documentation': {
+                    'description': 'De-embeds the measurement using wideband amplitude flatness correction.'
+                },
+                'name': 'NIRFSA_VAL_DEEMBEDDING_TYPE_AMPLITUDE_FLATNESS',
+                'value': 3903
             }
         ]
     },


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).
- ~~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~~
- ~~[ ] I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

- `AMPLITUDE_FLATNESS` added to enum `DeembeddingType`.

### List issues fixed by this Pull Request below, if any.

### What testing has been done?

- A successful tox execution.
- PR Validations
