### PR TITLE
Add nitlsconfig to optional gRPC dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 
 #### [nidcpower] Unreleased
 - Added
+  - (Common) Added `nitlsconfig[grpc]>=1.0.0a1` to the optional gRPC dependencies.
 - Changed
 - Removed
 
@@ -555,6 +556,7 @@
 
 #### [nidigital] Unreleased
 - Added
+  - (Common) Added `nitlsconfig[grpc]>=1.0.0a1` to the optional gRPC dependencies.
 - Changed
 - Removed
 
@@ -796,6 +798,7 @@
 
 #### [nidmm] Unreleased
 - Added
+  - (Common) Added `nitlsconfig[grpc]>=1.0.0a1` to the optional gRPC dependencies.
 - Changed
 - Removed
 
@@ -1119,6 +1122,7 @@
 
 #### [nifgen] Unreleased
 - Added
+  - (Common) Added `nitlsconfig[grpc]>=1.0.0a1` to the optional gRPC dependencies.
 - Changed
 - Removed
 
@@ -1732,6 +1736,7 @@
 
 #### [nirfsa] Unreleased
 - Added
+  - (Common) Added `nitlsconfig[grpc]>=1.0.0a1` to the optional gRPC dependencies.
 - Changed
 - Removed
 
@@ -1749,6 +1754,7 @@
 
 #### [nirfsg] Unreleased
 - Added
+  - (Common) Added `nitlsconfig[grpc]>=1.0.0a1` to the optional gRPC dependencies.
 - Changed
 - Removed
 
@@ -1887,6 +1893,7 @@
 
 #### [niscope] Unreleased
 - Added
+  - (Common) Added `nitlsconfig[grpc]>=1.0.0a1` to the optional gRPC dependencies.
 - Changed
 - Removed
 
@@ -2498,6 +2505,7 @@
 
 #### [niswitch] Unreleased
 - Added
+  - (Common) Added `nitlsconfig[grpc]>=1.0.0a1` to the optional gRPC dependencies.
 - Changed
 - Removed
 

--- a/build/templates/setup.py.mako
+++ b/build/templates/setup.py.mako
@@ -53,7 +53,8 @@ setup(
         'grpc': [
             'grpcio>=1.59.0,<2.0',
             'protobuf>=4.21.6',
-            'ni.grpcdevice.v1.proto>=1.0.0'
+            'ni.grpcdevice.v1.proto>=1.0.0',
+            'nitlsconfig[grpc]>=1.0.0a1',
         ],
     },
     % endif

--- a/generated/nidcpower/setup.py
+++ b/generated/nidcpower/setup.py
@@ -37,7 +37,8 @@ setup(
         'grpc': [
             'grpcio>=1.59.0,<2.0',
             'protobuf>=4.21.6',
-            'ni.grpcdevice.v1.proto>=1.0.0'
+            'ni.grpcdevice.v1.proto>=1.0.0',
+            'nitlsconfig[grpc]>=1.0.0a1',
         ],
     },
     classifiers=[

--- a/generated/nidigital/setup.py
+++ b/generated/nidigital/setup.py
@@ -38,7 +38,8 @@ setup(
         'grpc': [
             'grpcio>=1.59.0,<2.0',
             'protobuf>=4.21.6',
-            'ni.grpcdevice.v1.proto>=1.0.0'
+            'ni.grpcdevice.v1.proto>=1.0.0',
+            'nitlsconfig[grpc]>=1.0.0a1',
         ],
     },
     classifiers=[

--- a/generated/nidmm/setup.py
+++ b/generated/nidmm/setup.py
@@ -37,7 +37,8 @@ setup(
         'grpc': [
             'grpcio>=1.59.0,<2.0',
             'protobuf>=4.21.6',
-            'ni.grpcdevice.v1.proto>=1.0.0'
+            'ni.grpcdevice.v1.proto>=1.0.0',
+            'nitlsconfig[grpc]>=1.0.0a1',
         ],
     },
     classifiers=[

--- a/generated/nifake/setup.py
+++ b/generated/nifake/setup.py
@@ -39,7 +39,8 @@ setup(
         'grpc': [
             'grpcio>=1.59.0,<2.0',
             'protobuf>=4.21.6',
-            'ni.grpcdevice.v1.proto>=1.0.0'
+            'ni.grpcdevice.v1.proto>=1.0.0',
+            'nitlsconfig[grpc]>=1.0.0a1',
         ],
     },
     classifiers=[

--- a/generated/nifgen/setup.py
+++ b/generated/nifgen/setup.py
@@ -38,7 +38,8 @@ setup(
         'grpc': [
             'grpcio>=1.59.0,<2.0',
             'protobuf>=4.21.6',
-            'ni.grpcdevice.v1.proto>=1.0.0'
+            'ni.grpcdevice.v1.proto>=1.0.0',
+            'nitlsconfig[grpc]>=1.0.0a1',
         ],
     },
     classifiers=[

--- a/generated/nirfsa/setup.py
+++ b/generated/nirfsa/setup.py
@@ -39,7 +39,8 @@ setup(
         'grpc': [
             'grpcio>=1.59.0,<2.0',
             'protobuf>=4.21.6',
-            'ni.grpcdevice.v1.proto>=1.0.0'
+            'ni.grpcdevice.v1.proto>=1.0.0',
+            'nitlsconfig[grpc]>=1.0.0a1',
         ],
     },
     classifiers=[

--- a/generated/nirfsg/setup.py
+++ b/generated/nirfsg/setup.py
@@ -39,7 +39,8 @@ setup(
         'grpc': [
             'grpcio>=1.59.0,<2.0',
             'protobuf>=4.21.6',
-            'ni.grpcdevice.v1.proto>=1.0.0'
+            'ni.grpcdevice.v1.proto>=1.0.0',
+            'nitlsconfig[grpc]>=1.0.0a1',
         ],
     },
     classifiers=[

--- a/generated/niscope/setup.py
+++ b/generated/niscope/setup.py
@@ -38,7 +38,8 @@ setup(
         'grpc': [
             'grpcio>=1.59.0,<2.0',
             'protobuf>=4.21.6',
-            'ni.grpcdevice.v1.proto>=1.0.0'
+            'ni.grpcdevice.v1.proto>=1.0.0',
+            'nitlsconfig[grpc]>=1.0.0a1',
         ],
     },
     classifiers=[

--- a/generated/niswitch/setup.py
+++ b/generated/niswitch/setup.py
@@ -37,7 +37,8 @@ setup(
         'grpc': [
             'grpcio>=1.59.0,<2.0',
             'protobuf>=4.21.6',
-            'ni.grpcdevice.v1.proto>=1.0.0'
+            'ni.grpcdevice.v1.proto>=1.0.0',
+            'nitlsconfig[grpc]>=1.0.0a1',
         ],
     },
     classifiers=[


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [x] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

~~- [ ] I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

Adds `nitlsconfig[grpc]>=1.0.0a1` to the optional dependencies of gRPC-capable nimi-python driver packages, enabling applications to create NI-TLS-configured TLS/mTLS channels for CRA readiness and pass them to the existing `GrpcSessionOptions` API.

The shared package template and generated `setup.py` files are updated together. Existing gRPC APIs and caller-provided secure or insecure channels remain unchanged.

### What testing has been done?

- Verified all nitlsconfig-python has been added to optional grpc packages in setup.py files

- Built a local `nidmm` wheel from this branch and verified that `nidmm[grpc]` installs  `nitlsconfig==1.0.0a1` from production PyPI.