### PR TITLE
Utilize nitlsconfig 1.0.0a2 + nitlsconfig's new gRPC audit session connect feature and error elaboration improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
 
 #### [nidcpower] Unreleased
 - Added
-  - (Common) Added `nitlsconfig[grpc]>=1.0.0a1` to the optional gRPC dependencies.
+  - (Common) Added `nitlsconfig[grpc]>=1.0.0a2` to the optional gRPC dependencies.
 - Changed
 - Removed
 
@@ -556,7 +556,7 @@
 
 #### [nidigital] Unreleased
 - Added
-  - (Common) Added `nitlsconfig[grpc]>=1.0.0a1` to the optional gRPC dependencies.
+  - (Common) Added `nitlsconfig[grpc]>=1.0.0a2` to the optional gRPC dependencies.
 - Changed
 - Removed
 
@@ -798,7 +798,7 @@
 
 #### [nidmm] Unreleased
 - Added
-  - (Common) Added `nitlsconfig[grpc]>=1.0.0a1` to the optional gRPC dependencies.
+  - (Common) Added `nitlsconfig[grpc]>=1.0.0a2` to the optional gRPC dependencies.
 - Changed
 - Removed
 
@@ -1122,7 +1122,7 @@
 
 #### [nifgen] Unreleased
 - Added
-  - (Common) Added `nitlsconfig[grpc]>=1.0.0a1` to the optional gRPC dependencies.
+  - (Common) Added `nitlsconfig[grpc]>=1.0.0a2` to the optional gRPC dependencies.
 - Changed
 - Removed
 
@@ -1736,7 +1736,7 @@
 
 #### [nirfsa] Unreleased
 - Added
-  - (Common) Added `nitlsconfig[grpc]>=1.0.0a1` to the optional gRPC dependencies.
+  - (Common) Added `nitlsconfig[grpc]>=1.0.0a2` to the optional gRPC dependencies.
 - Changed
 - Removed
 
@@ -1754,7 +1754,7 @@
 
 #### [nirfsg] Unreleased
 - Added
-  - (Common) Added `nitlsconfig[grpc]>=1.0.0a1` to the optional gRPC dependencies.
+  - (Common) Added `nitlsconfig[grpc]>=1.0.0a2` to the optional gRPC dependencies.
 - Changed
 - Removed
 
@@ -1893,7 +1893,7 @@
 
 #### [niscope] Unreleased
 - Added
-  - (Common) Added `nitlsconfig[grpc]>=1.0.0a1` to the optional gRPC dependencies.
+  - (Common) Added `nitlsconfig[grpc]>=1.0.0a2` to the optional gRPC dependencies.
 - Changed
 - Removed
 
@@ -2505,7 +2505,7 @@
 
 #### [niswitch] Unreleased
 - Added
-  - (Common) Added `nitlsconfig[grpc]>=1.0.0a1` to the optional gRPC dependencies.
+  - (Common) Added `nitlsconfig[grpc]>=1.0.0a2` to the optional gRPC dependencies.
 - Changed
 - Removed
 

--- a/build/templates/_grpc_stub_interpreter.py.mako
+++ b/build/templates/_grpc_stub_interpreter.py.mako
@@ -13,6 +13,7 @@ are_complex_parameters_used = helper.are_complex_parameters_used(functions)
 
 import grpc
 import hightime  # noqa: F401
+import nitlsconfig
 import session_pb2 as session_grpc_types
 import threading
 import warnings
@@ -69,7 +70,11 @@ class GrpcStubInterpreter(object):
             elif grpc_error == grpc.StatusCode.INVALID_ARGUMENT:
                 raise ValueError(error_message) from None
             elif grpc_error == grpc.StatusCode.UNAVAILABLE:
-                error_message = 'Failed to connect to server'
+                # gRPC reports a rejected TLS handshake and an unreachable server with the
+                # same code, so ask NI-TLS whether it built this channel and can say more.
+                error_message = nitlsconfig.get_tls_connection_error_elaboration(
+                    self._grpc_options.grpc_channel
+                ) or 'Failed to connect to server'
             elif grpc_error == grpc.StatusCode.UNIMPLEMENTED:
                 error_message = (
                     'This operation is not supported by the NI gRPC Device Server being used. Upgrade NI gRPC Device Server.'

--- a/build/templates/session.py.mako
+++ b/build/templates/session.py.mako
@@ -276,7 +276,18 @@ if grpc_supported:
         # if ${init_function['python_name']} fails, the error handler can reference it.
         # And then here, once ${init_function['python_name']} succeeds, we call set_session_handle
         # with the actual session handle.
+% if grpc_supported:
+        connected = False
+        try:
+            self._interpreter.set_session_handle(self.${init_function['python_name']}(${init_call_params}))
+            connected = True
+        finally:
+            if grpc_options:
+                import nitlsconfig
+                nitlsconfig.audit_session_connect('${config['driver_name']}', grpc_options.grpc_channel, connected)
+% else:
         self._interpreter.set_session_handle(self.${init_function['python_name']}(${init_call_params}))
+% endif
 
 % if config['uses_nitclk']:
 %   if grpc_supported:

--- a/build/templates/setup.py.mako
+++ b/build/templates/setup.py.mako
@@ -54,7 +54,7 @@ setup(
             'grpcio>=1.59.0,<2.0',
             'protobuf>=4.21.6',
             'ni.grpcdevice.v1.proto>=1.0.0',
-            'nitlsconfig[grpc]>=1.0.0a1',
+            'nitlsconfig[grpc]>=1.0.0a2',
         ],
     },
     % endif

--- a/generated/nidcpower/nidcpower/_grpc_stub_interpreter.py
+++ b/generated/nidcpower/nidcpower/_grpc_stub_interpreter.py
@@ -3,6 +3,7 @@
 
 import grpc
 import hightime  # noqa: F401
+import nitlsconfig
 import session_pb2 as session_grpc_types
 import threading
 import warnings
@@ -54,7 +55,11 @@ class GrpcStubInterpreter(object):
             elif grpc_error == grpc.StatusCode.INVALID_ARGUMENT:
                 raise ValueError(error_message) from None
             elif grpc_error == grpc.StatusCode.UNAVAILABLE:
-                error_message = 'Failed to connect to server'
+                # gRPC reports a rejected TLS handshake and an unreachable server with the
+                # same code, so ask NI-TLS whether it built this channel and can say more.
+                error_message = nitlsconfig.get_tls_connection_error_elaboration(
+                    self._grpc_options.grpc_channel
+                ) or 'Failed to connect to server'
             elif grpc_error == grpc.StatusCode.UNIMPLEMENTED:
                 error_message = (
                     'This operation is not supported by the NI gRPC Device Server being used. Upgrade NI gRPC Device Server.'

--- a/generated/nidcpower/nidcpower/session.py
+++ b/generated/nidcpower/nidcpower/session.py
@@ -7681,7 +7681,14 @@ class Session(_SessionBase):
         # if _fancy_initialize fails, the error handler can reference it.
         # And then here, once _fancy_initialize succeeds, we call set_session_handle
         # with the actual session handle.
-        self._interpreter.set_session_handle(self._fancy_initialize(resource_name, channels, reset, options, independent_channels))
+        connected = False
+        try:
+            self._interpreter.set_session_handle(self._fancy_initialize(resource_name, channels, reset, options, independent_channels))
+            connected = True
+        finally:
+            if grpc_options:
+                import nitlsconfig
+                nitlsconfig.audit_session_connect('NI-DCPower', grpc_options.grpc_channel, connected)
 
         # Store the parameter list for later printing in __repr__
         param_list = []

--- a/generated/nidcpower/setup.py
+++ b/generated/nidcpower/setup.py
@@ -38,7 +38,7 @@ setup(
             'grpcio>=1.59.0,<2.0',
             'protobuf>=4.21.6',
             'ni.grpcdevice.v1.proto>=1.0.0',
-            'nitlsconfig[grpc]>=1.0.0a1',
+            'nitlsconfig[grpc]>=1.0.0a2',
         ],
     },
     classifiers=[

--- a/generated/nidigital/nidigital/_grpc_stub_interpreter.py
+++ b/generated/nidigital/nidigital/_grpc_stub_interpreter.py
@@ -3,6 +3,7 @@
 
 import grpc
 import hightime  # noqa: F401
+import nitlsconfig
 import session_pb2 as session_grpc_types
 import threading
 import warnings
@@ -52,7 +53,11 @@ class GrpcStubInterpreter(object):
             elif grpc_error == grpc.StatusCode.INVALID_ARGUMENT:
                 raise ValueError(error_message) from None
             elif grpc_error == grpc.StatusCode.UNAVAILABLE:
-                error_message = 'Failed to connect to server'
+                # gRPC reports a rejected TLS handshake and an unreachable server with the
+                # same code, so ask NI-TLS whether it built this channel and can say more.
+                error_message = nitlsconfig.get_tls_connection_error_elaboration(
+                    self._grpc_options.grpc_channel
+                ) or 'Failed to connect to server'
             elif grpc_error == grpc.StatusCode.UNIMPLEMENTED:
                 error_message = (
                     'This operation is not supported by the NI gRPC Device Server being used. Upgrade NI gRPC Device Server.'

--- a/generated/nidigital/nidigital/session.py
+++ b/generated/nidigital/nidigital/session.py
@@ -3280,7 +3280,14 @@ class Session(_SessionBase):
         # if _init_with_options fails, the error handler can reference it.
         # And then here, once _init_with_options succeeds, we call set_session_handle
         # with the actual session handle.
-        self._interpreter.set_session_handle(self._init_with_options(resource_name, id_query, reset_device, options))
+        connected = False
+        try:
+            self._interpreter.set_session_handle(self._init_with_options(resource_name, id_query, reset_device, options))
+            connected = True
+        finally:
+            if grpc_options:
+                import nitlsconfig
+                nitlsconfig.audit_session_connect('NI-Digital Pattern Driver', grpc_options.grpc_channel, connected)
 
         # NI-TClk does not work over NI gRPC Device Server
         if not grpc_options:

--- a/generated/nidigital/setup.py
+++ b/generated/nidigital/setup.py
@@ -39,7 +39,7 @@ setup(
             'grpcio>=1.59.0,<2.0',
             'protobuf>=4.21.6',
             'ni.grpcdevice.v1.proto>=1.0.0',
-            'nitlsconfig[grpc]>=1.0.0a1',
+            'nitlsconfig[grpc]>=1.0.0a2',
         ],
     },
     classifiers=[

--- a/generated/nidmm/nidmm/_grpc_stub_interpreter.py
+++ b/generated/nidmm/nidmm/_grpc_stub_interpreter.py
@@ -3,6 +3,7 @@
 
 import grpc
 import hightime  # noqa: F401
+import nitlsconfig
 import session_pb2 as session_grpc_types
 import threading
 import warnings
@@ -50,7 +51,11 @@ class GrpcStubInterpreter(object):
             elif grpc_error == grpc.StatusCode.INVALID_ARGUMENT:
                 raise ValueError(error_message) from None
             elif grpc_error == grpc.StatusCode.UNAVAILABLE:
-                error_message = 'Failed to connect to server'
+                # gRPC reports a rejected TLS handshake and an unreachable server with the
+                # same code, so ask NI-TLS whether it built this channel and can say more.
+                error_message = nitlsconfig.get_tls_connection_error_elaboration(
+                    self._grpc_options.grpc_channel
+                ) or 'Failed to connect to server'
             elif grpc_error == grpc.StatusCode.UNIMPLEMENTED:
                 error_message = (
                     'This operation is not supported by the NI gRPC Device Server being used. Upgrade NI gRPC Device Server.'

--- a/generated/nidmm/nidmm/session.py
+++ b/generated/nidmm/nidmm/session.py
@@ -1049,7 +1049,14 @@ class Session(_SessionBase):
         # if _init_with_options fails, the error handler can reference it.
         # And then here, once _init_with_options succeeds, we call set_session_handle
         # with the actual session handle.
-        self._interpreter.set_session_handle(self._init_with_options(resource_name, id_query, reset_device, options))
+        connected = False
+        try:
+            self._interpreter.set_session_handle(self._init_with_options(resource_name, id_query, reset_device, options))
+            connected = True
+        finally:
+            if grpc_options:
+                import nitlsconfig
+                nitlsconfig.audit_session_connect('NI-DMM', grpc_options.grpc_channel, connected)
 
         # Store the parameter list for later printing in __repr__
         param_list = []

--- a/generated/nidmm/setup.py
+++ b/generated/nidmm/setup.py
@@ -38,7 +38,7 @@ setup(
             'grpcio>=1.59.0,<2.0',
             'protobuf>=4.21.6',
             'ni.grpcdevice.v1.proto>=1.0.0',
-            'nitlsconfig[grpc]>=1.0.0a1',
+            'nitlsconfig[grpc]>=1.0.0a2',
         ],
     },
     classifiers=[

--- a/generated/nifake/nifake/_grpc_stub_interpreter.py
+++ b/generated/nifake/nifake/_grpc_stub_interpreter.py
@@ -3,6 +3,7 @@
 
 import grpc
 import hightime  # noqa: F401
+import nitlsconfig
 import session_pb2 as session_grpc_types
 import threading
 import warnings
@@ -57,7 +58,11 @@ class GrpcStubInterpreter(object):
             elif grpc_error == grpc.StatusCode.INVALID_ARGUMENT:
                 raise ValueError(error_message) from None
             elif grpc_error == grpc.StatusCode.UNAVAILABLE:
-                error_message = 'Failed to connect to server'
+                # gRPC reports a rejected TLS handshake and an unreachable server with the
+                # same code, so ask NI-TLS whether it built this channel and can say more.
+                error_message = nitlsconfig.get_tls_connection_error_elaboration(
+                    self._grpc_options.grpc_channel
+                ) or 'Failed to connect to server'
             elif grpc_error == grpc.StatusCode.UNIMPLEMENTED:
                 error_message = (
                     'This operation is not supported by the NI gRPC Device Server being used. Upgrade NI gRPC Device Server.'

--- a/generated/nifake/nifake/session.py
+++ b/generated/nifake/nifake/session.py
@@ -728,7 +728,14 @@ class Session(_SessionBase):
         # if _init_with_options fails, the error handler can reference it.
         # And then here, once _init_with_options succeeds, we call set_session_handle
         # with the actual session handle.
-        self._interpreter.set_session_handle(self._init_with_options(resource_name, options, id_query, reset_device))
+        connected = False
+        try:
+            self._interpreter.set_session_handle(self._init_with_options(resource_name, options, id_query, reset_device))
+            connected = True
+        finally:
+            if grpc_options:
+                import nitlsconfig
+                nitlsconfig.audit_session_connect('NI-FAKE', grpc_options.grpc_channel, connected)
 
         # NI-TClk does not work over NI gRPC Device Server
         if not grpc_options:

--- a/generated/nifake/nifake/unit_tests/conftest.py
+++ b/generated/nifake/nifake/unit_tests/conftest.py
@@ -1,0 +1,16 @@
+import grpc
+import nitlsconfig.channel_tag
+import pytest
+
+
+@pytest.fixture
+def nitls_tagged_channel():
+    """A real gRPC channel tagged the way nitlsconfig.create_grpc_device_channel tags one.
+
+    The factory itself shells out to the NI-installed nitlsconfig CLI, so it cannot run here.
+    """
+    target = 'localhost:31763'
+    with grpc.insecure_channel(target) as channel:
+        nitlsconfig.channel_tag.tag_channel_target(channel, target)
+        assert nitlsconfig.channel_tag.is_nitls_channel(channel), 'nitlsconfig no longer recognizes a channel it tagged'
+        yield channel

--- a/generated/nifake/nifake/unit_tests/conftest.py
+++ b/generated/nifake/nifake/unit_tests/conftest.py
@@ -7,7 +7,10 @@ import pytest
 def nitls_tagged_channel():
     """A real gRPC channel tagged the way nitlsconfig.create_grpc_device_channel tags one.
 
-    The factory itself shells out to the NI-installed nitlsconfig CLI, so it cannot run here.
+    nitlsconfig.create_grpc_device_channel itself requires the nitlsconfig library to be
+    installed on the system in order to access the CLI. As a result, we are unable to directly
+    leverage it in our unit tests. But, this can at least allow us to unit-test our code
+    that relies on channels being created from nitlsconfig.create_grpc_device_channel.
     """
     target = 'localhost:31763'
     with grpc.insecure_channel(target) as channel:

--- a/generated/nifake/nifake/unit_tests/test_grpc.py
+++ b/generated/nifake/nifake/unit_tests/test_grpc.py
@@ -4,6 +4,7 @@ import grpc
 import math
 import nifake
 import nifake.errors
+import nitlsconfig
 import numpy
 import pytest
 import session_pb2
@@ -175,6 +176,24 @@ class TestGrpcStubInterpreter:
         expected_error_message = 'Failed to connect to server'
         self._set_side_effect(library_func, side_effect=MyRpcError(None, '', grpc_error=grpc_error))
         grpc_options = nifake.GrpcSessionOptions(object(), '', initialization_behavior=nifake.SessionInitializationBehavior.AUTO)
+        interpreter = nifake._grpc_stub_interpreter.GrpcStubInterpreter(grpc_options)
+        try:
+            interpreter.init_with_options('dev1', False, False, '')
+            assert False
+        except nifake.Error as e:
+            assert e.rpc_code == grpc_error
+            assert e.description == expected_error_message
+            assert str(e) == f'StatusCode.UNAVAILABLE: {expected_error_message}'
+
+    def test_server_unavailable_with_tls_elaboration(self, nitls_tagged_channel):
+        library_func = 'InitWithOptions'
+        grpc_error = grpc.StatusCode.UNAVAILABLE
+        self._set_side_effect(library_func, side_effect=MyRpcError(None, '', grpc_error=grpc_error))
+        # The real elaboration, so this fails if nitlsconfig stops recognizing our channel.
+        expected_error_message = nitlsconfig.get_tls_connection_error_elaboration(nitls_tagged_channel)
+        assert expected_error_message is not None
+        assert expected_error_message != 'Failed to connect to server'
+        grpc_options = nifake.GrpcSessionOptions(nitls_tagged_channel, '', initialization_behavior=nifake.SessionInitializationBehavior.AUTO)
         interpreter = nifake._grpc_stub_interpreter.GrpcStubInterpreter(grpc_options)
         try:
             interpreter.init_with_options('dev1', False, False, '')

--- a/generated/nifake/nifake/unit_tests/test_session.py
+++ b/generated/nifake/nifake/unit_tests/test_session.py
@@ -68,6 +68,12 @@ class TestSession:
         session.close()
         self.patched_library_interpreter.close.assert_called_once_with()
 
+    def test_init_without_grpc_options_does_not_audit(self):
+        with patch('nitlsconfig.audit_session_connect', autospec=True) as patched_audit:
+            with nifake.Session('dev1'):
+                pass
+        patched_audit.assert_not_called()
+
     def test_close(self):
         session = nifake.Session('dev1')
         assert session._interpreter._vi == SESSION_NUM_FOR_TEST
@@ -965,6 +971,19 @@ class TestGrpcSession:
         assert session._interpreter._vi == GRPC_SESSION_OBJECT_FOR_TEST
         session.close()
         self.patched_grpc_interpreter.close.assert_called_once_with()
+
+    def test_init_audits_successful_connect(self, nitls_tagged_channel):
+        with patch('nitlsconfig.audit_session_connect', autospec=True) as patched_audit:
+            with nifake.Session('dev1', grpc_options=nifake.GrpcSessionOptions(nitls_tagged_channel, '')):
+                pass
+        patched_audit.assert_called_once_with('NI-FAKE', nitls_tagged_channel, True)
+
+    def test_init_audits_failed_connect(self, nitls_tagged_channel):
+        self.patched_grpc_interpreter.init_with_options.side_effect = nifake.Error('Fake init failure')
+        with patch('nitlsconfig.audit_session_connect', autospec=True) as patched_audit:
+            with pytest.raises(nifake.Error):
+                nifake.Session('dev1', grpc_options=nifake.GrpcSessionOptions(nitls_tagged_channel, ''))
+        patched_audit.assert_called_once_with('NI-FAKE', nitls_tagged_channel, False)
 
     # Session locking
 

--- a/generated/nifake/setup.py
+++ b/generated/nifake/setup.py
@@ -40,7 +40,7 @@ setup(
             'grpcio>=1.59.0,<2.0',
             'protobuf>=4.21.6',
             'ni.grpcdevice.v1.proto>=1.0.0',
-            'nitlsconfig[grpc]>=1.0.0a1',
+            'nitlsconfig[grpc]>=1.0.0a2',
         ],
     },
     classifiers=[

--- a/generated/nifgen/nifgen/_grpc_stub_interpreter.py
+++ b/generated/nifgen/nifgen/_grpc_stub_interpreter.py
@@ -3,6 +3,7 @@
 
 import grpc
 import hightime  # noqa: F401
+import nitlsconfig
 import session_pb2 as session_grpc_types
 import threading
 import warnings
@@ -50,7 +51,11 @@ class GrpcStubInterpreter(object):
             elif grpc_error == grpc.StatusCode.INVALID_ARGUMENT:
                 raise ValueError(error_message) from None
             elif grpc_error == grpc.StatusCode.UNAVAILABLE:
-                error_message = 'Failed to connect to server'
+                # gRPC reports a rejected TLS handshake and an unreachable server with the
+                # same code, so ask NI-TLS whether it built this channel and can say more.
+                error_message = nitlsconfig.get_tls_connection_error_elaboration(
+                    self._grpc_options.grpc_channel
+                ) or 'Failed to connect to server'
             elif grpc_error == grpc.StatusCode.UNIMPLEMENTED:
                 error_message = (
                     'This operation is not supported by the NI gRPC Device Server being used. Upgrade NI gRPC Device Server.'

--- a/generated/nifgen/nifgen/session.py
+++ b/generated/nifgen/nifgen/session.py
@@ -3166,7 +3166,14 @@ class Session(_SessionBase):
         # if _initialize_with_channels fails, the error handler can reference it.
         # And then here, once _initialize_with_channels succeeds, we call set_session_handle
         # with the actual session handle.
-        self._interpreter.set_session_handle(self._initialize_with_channels(resource_name, channel_name, reset_device, options))
+        connected = False
+        try:
+            self._interpreter.set_session_handle(self._initialize_with_channels(resource_name, channel_name, reset_device, options))
+            connected = True
+        finally:
+            if grpc_options:
+                import nitlsconfig
+                nitlsconfig.audit_session_connect('NI-FGEN', grpc_options.grpc_channel, connected)
 
         # NI-TClk does not work over NI gRPC Device Server
         if not grpc_options:

--- a/generated/nifgen/setup.py
+++ b/generated/nifgen/setup.py
@@ -39,7 +39,7 @@ setup(
             'grpcio>=1.59.0,<2.0',
             'protobuf>=4.21.6',
             'ni.grpcdevice.v1.proto>=1.0.0',
-            'nitlsconfig[grpc]>=1.0.0a1',
+            'nitlsconfig[grpc]>=1.0.0a2',
         ],
     },
     classifiers=[

--- a/generated/nirfsa/nirfsa/_grpc_stub_interpreter.py
+++ b/generated/nirfsa/nirfsa/_grpc_stub_interpreter.py
@@ -3,6 +3,7 @@
 
 import grpc
 import hightime  # noqa: F401
+import nitlsconfig
 import session_pb2 as session_grpc_types
 import threading
 import warnings
@@ -57,7 +58,11 @@ class GrpcStubInterpreter(object):
             elif grpc_error == grpc.StatusCode.INVALID_ARGUMENT:
                 raise ValueError(error_message) from None
             elif grpc_error == grpc.StatusCode.UNAVAILABLE:
-                error_message = 'Failed to connect to server'
+                # gRPC reports a rejected TLS handshake and an unreachable server with the
+                # same code, so ask NI-TLS whether it built this channel and can say more.
+                error_message = nitlsconfig.get_tls_connection_error_elaboration(
+                    self._grpc_options.grpc_channel
+                ) or 'Failed to connect to server'
             elif grpc_error == grpc.StatusCode.UNIMPLEMENTED:
                 error_message = (
                     'This operation is not supported by the NI gRPC Device Server being used. Upgrade NI gRPC Device Server.'

--- a/generated/nirfsa/nirfsa/session.py
+++ b/generated/nirfsa/nirfsa/session.py
@@ -6777,7 +6777,14 @@ class Session(_SessionBase):
         # if _init_with_options fails, the error handler can reference it.
         # And then here, once _init_with_options succeeds, we call set_session_handle
         # with the actual session handle.
-        self._interpreter.set_session_handle(self._init_with_options(resource_name, id_query, reset_device, options))
+        connected = False
+        try:
+            self._interpreter.set_session_handle(self._init_with_options(resource_name, id_query, reset_device, options))
+            connected = True
+        finally:
+            if grpc_options:
+                import nitlsconfig
+                nitlsconfig.audit_session_connect('NI-RFSA', grpc_options.grpc_channel, connected)
 
         # NI-TClk does not work over NI gRPC Device Server
         if not grpc_options:

--- a/generated/nirfsa/setup.py
+++ b/generated/nirfsa/setup.py
@@ -40,7 +40,7 @@ setup(
             'grpcio>=1.59.0,<2.0',
             'protobuf>=4.21.6',
             'ni.grpcdevice.v1.proto>=1.0.0',
-            'nitlsconfig[grpc]>=1.0.0a1',
+            'nitlsconfig[grpc]>=1.0.0a2',
         ],
     },
     classifiers=[

--- a/generated/nirfsg/nirfsg/_grpc_stub_interpreter.py
+++ b/generated/nirfsg/nirfsg/_grpc_stub_interpreter.py
@@ -3,6 +3,7 @@
 
 import grpc
 import hightime  # noqa: F401
+import nitlsconfig
 import session_pb2 as session_grpc_types
 import threading
 import warnings
@@ -51,7 +52,11 @@ class GrpcStubInterpreter(object):
             elif grpc_error == grpc.StatusCode.INVALID_ARGUMENT:
                 raise ValueError(error_message) from None
             elif grpc_error == grpc.StatusCode.UNAVAILABLE:
-                error_message = 'Failed to connect to server'
+                # gRPC reports a rejected TLS handshake and an unreachable server with the
+                # same code, so ask NI-TLS whether it built this channel and can say more.
+                error_message = nitlsconfig.get_tls_connection_error_elaboration(
+                    self._grpc_options.grpc_channel
+                ) or 'Failed to connect to server'
             elif grpc_error == grpc.StatusCode.UNIMPLEMENTED:
                 error_message = (
                     'This operation is not supported by the NI gRPC Device Server being used. Upgrade NI gRPC Device Server.'

--- a/generated/nirfsg/nirfsg/session.py
+++ b/generated/nirfsg/nirfsg/session.py
@@ -5713,7 +5713,14 @@ class Session(_SessionBase):
         # if _init_with_options fails, the error handler can reference it.
         # And then here, once _init_with_options succeeds, we call set_session_handle
         # with the actual session handle.
-        self._interpreter.set_session_handle(self._init_with_options(resource_name, id_query, reset_device, options))
+        connected = False
+        try:
+            self._interpreter.set_session_handle(self._init_with_options(resource_name, id_query, reset_device, options))
+            connected = True
+        finally:
+            if grpc_options:
+                import nitlsconfig
+                nitlsconfig.audit_session_connect('NI-RFSG', grpc_options.grpc_channel, connected)
 
         # NI-TClk does not work over NI gRPC Device Server
         if not grpc_options:

--- a/generated/nirfsg/setup.py
+++ b/generated/nirfsg/setup.py
@@ -40,7 +40,7 @@ setup(
             'grpcio>=1.59.0,<2.0',
             'protobuf>=4.21.6',
             'ni.grpcdevice.v1.proto>=1.0.0',
-            'nitlsconfig[grpc]>=1.0.0a1',
+            'nitlsconfig[grpc]>=1.0.0a2',
         ],
     },
     classifiers=[

--- a/generated/niscope/niscope/_grpc_stub_interpreter.py
+++ b/generated/niscope/niscope/_grpc_stub_interpreter.py
@@ -3,6 +3,7 @@
 
 import grpc
 import hightime  # noqa: F401
+import nitlsconfig
 import session_pb2 as session_grpc_types
 import threading
 import warnings
@@ -54,7 +55,11 @@ class GrpcStubInterpreter(object):
             elif grpc_error == grpc.StatusCode.INVALID_ARGUMENT:
                 raise ValueError(error_message) from None
             elif grpc_error == grpc.StatusCode.UNAVAILABLE:
-                error_message = 'Failed to connect to server'
+                # gRPC reports a rejected TLS handshake and an unreachable server with the
+                # same code, so ask NI-TLS whether it built this channel and can say more.
+                error_message = nitlsconfig.get_tls_connection_error_elaboration(
+                    self._grpc_options.grpc_channel
+                ) or 'Failed to connect to server'
             elif grpc_error == grpc.StatusCode.UNIMPLEMENTED:
                 error_message = (
                     'This operation is not supported by the NI gRPC Device Server being used. Upgrade NI gRPC Device Server.'

--- a/generated/niscope/niscope/session.py
+++ b/generated/niscope/niscope/session.py
@@ -4035,7 +4035,14 @@ class Session(_SessionBase):
         # if _init_with_options fails, the error handler can reference it.
         # And then here, once _init_with_options succeeds, we call set_session_handle
         # with the actual session handle.
-        self._interpreter.set_session_handle(self._init_with_options(resource_name, id_query, reset_device, options))
+        connected = False
+        try:
+            self._interpreter.set_session_handle(self._init_with_options(resource_name, id_query, reset_device, options))
+            connected = True
+        finally:
+            if grpc_options:
+                import nitlsconfig
+                nitlsconfig.audit_session_connect('NI-SCOPE', grpc_options.grpc_channel, connected)
 
         # NI-TClk does not work over NI gRPC Device Server
         if not grpc_options:

--- a/generated/niscope/setup.py
+++ b/generated/niscope/setup.py
@@ -39,7 +39,7 @@ setup(
             'grpcio>=1.59.0,<2.0',
             'protobuf>=4.21.6',
             'ni.grpcdevice.v1.proto>=1.0.0',
-            'nitlsconfig[grpc]>=1.0.0a1',
+            'nitlsconfig[grpc]>=1.0.0a2',
         ],
     },
     classifiers=[

--- a/generated/niswitch/niswitch/_grpc_stub_interpreter.py
+++ b/generated/niswitch/niswitch/_grpc_stub_interpreter.py
@@ -3,6 +3,7 @@
 
 import grpc
 import hightime  # noqa: F401
+import nitlsconfig
 import session_pb2 as session_grpc_types
 import threading
 import warnings
@@ -50,7 +51,11 @@ class GrpcStubInterpreter(object):
             elif grpc_error == grpc.StatusCode.INVALID_ARGUMENT:
                 raise ValueError(error_message) from None
             elif grpc_error == grpc.StatusCode.UNAVAILABLE:
-                error_message = 'Failed to connect to server'
+                # gRPC reports a rejected TLS handshake and an unreachable server with the
+                # same code, so ask NI-TLS whether it built this channel and can say more.
+                error_message = nitlsconfig.get_tls_connection_error_elaboration(
+                    self._grpc_options.grpc_channel
+                ) or 'Failed to connect to server'
             elif grpc_error == grpc.StatusCode.UNIMPLEMENTED:
                 error_message = (
                     'This operation is not supported by the NI gRPC Device Server being used. Upgrade NI gRPC Device Server.'

--- a/generated/niswitch/niswitch/session.py
+++ b/generated/niswitch/niswitch/session.py
@@ -1374,7 +1374,14 @@ class Session(_SessionBase):
         # if _init_with_topology fails, the error handler can reference it.
         # And then here, once _init_with_topology succeeds, we call set_session_handle
         # with the actual session handle.
-        self._interpreter.set_session_handle(self._init_with_topology(resource_name, topology, simulate, reset_device))
+        connected = False
+        try:
+            self._interpreter.set_session_handle(self._init_with_topology(resource_name, topology, simulate, reset_device))
+            connected = True
+        finally:
+            if grpc_options:
+                import nitlsconfig
+                nitlsconfig.audit_session_connect('NI-SWITCH', grpc_options.grpc_channel, connected)
 
         # Store the parameter list for later printing in __repr__
         param_list = []

--- a/generated/niswitch/setup.py
+++ b/generated/niswitch/setup.py
@@ -38,7 +38,7 @@ setup(
             'grpcio>=1.59.0,<2.0',
             'protobuf>=4.21.6',
             'ni.grpcdevice.v1.proto>=1.0.0',
-            'nitlsconfig[grpc]>=1.0.0a1',
+            'nitlsconfig[grpc]>=1.0.0a2',
         ],
     },
     classifiers=[

--- a/src/nifake/unit_tests/conftest.py
+++ b/src/nifake/unit_tests/conftest.py
@@ -1,0 +1,19 @@
+import grpc
+import nitlsconfig.channel_tag
+import pytest
+
+
+@pytest.fixture
+def nitls_tagged_channel():
+    """A real gRPC channel tagged the way nitlsconfig.create_grpc_device_channel tags one.
+
+    nitlsconfig.create_grpc_device_channel itself requires the nitlsconfig library to be
+    installed on the system in order to access the CLI. As a result, we are unable to directly
+    leverage it in our unit tests. But, this can at least allow us to unit-test our code
+    that relies on channels being created from nitlsconfig.create_grpc_device_channel.
+    """
+    target = 'localhost:31763'
+    with grpc.insecure_channel(target) as channel:
+        nitlsconfig.channel_tag.tag_channel_target(channel, target)
+        assert nitlsconfig.channel_tag.is_nitls_channel(channel), 'nitlsconfig no longer recognizes a channel it tagged'
+        yield channel

--- a/src/nifake/unit_tests/test_grpc.py
+++ b/src/nifake/unit_tests/test_grpc.py
@@ -4,6 +4,7 @@ import grpc
 import math
 import nifake
 import nifake.errors
+import nitlsconfig
 import numpy
 import pytest
 import session_pb2
@@ -175,6 +176,24 @@ class TestGrpcStubInterpreter:
         expected_error_message = 'Failed to connect to server'
         self._set_side_effect(library_func, side_effect=MyRpcError(None, '', grpc_error=grpc_error))
         grpc_options = nifake.GrpcSessionOptions(object(), '', initialization_behavior=nifake.SessionInitializationBehavior.AUTO)
+        interpreter = nifake._grpc_stub_interpreter.GrpcStubInterpreter(grpc_options)
+        try:
+            interpreter.init_with_options('dev1', False, False, '')
+            assert False
+        except nifake.Error as e:
+            assert e.rpc_code == grpc_error
+            assert e.description == expected_error_message
+            assert str(e) == f'StatusCode.UNAVAILABLE: {expected_error_message}'
+
+    def test_server_unavailable_with_tls_elaboration(self, nitls_tagged_channel):
+        library_func = 'InitWithOptions'
+        grpc_error = grpc.StatusCode.UNAVAILABLE
+        self._set_side_effect(library_func, side_effect=MyRpcError(None, '', grpc_error=grpc_error))
+        # The real elaboration, so this fails if nitlsconfig stops recognizing our channel.
+        expected_error_message = nitlsconfig.get_tls_connection_error_elaboration(nitls_tagged_channel)
+        assert expected_error_message is not None
+        assert expected_error_message != 'Failed to connect to server'
+        grpc_options = nifake.GrpcSessionOptions(nitls_tagged_channel, '', initialization_behavior=nifake.SessionInitializationBehavior.AUTO)
         interpreter = nifake._grpc_stub_interpreter.GrpcStubInterpreter(grpc_options)
         try:
             interpreter.init_with_options('dev1', False, False, '')

--- a/src/nifake/unit_tests/test_session.py
+++ b/src/nifake/unit_tests/test_session.py
@@ -68,6 +68,12 @@ class TestSession:
         session.close()
         self.patched_library_interpreter.close.assert_called_once_with()
 
+    def test_init_without_grpc_options_does_not_audit(self):
+        with patch('nitlsconfig.audit_session_connect', autospec=True) as patched_audit:
+            with nifake.Session('dev1'):
+                pass
+        patched_audit.assert_not_called()
+
     def test_close(self):
         session = nifake.Session('dev1')
         assert session._interpreter._vi == SESSION_NUM_FOR_TEST
@@ -965,6 +971,19 @@ class TestGrpcSession:
         assert session._interpreter._vi == GRPC_SESSION_OBJECT_FOR_TEST
         session.close()
         self.patched_grpc_interpreter.close.assert_called_once_with()
+
+    def test_init_audits_successful_connect(self, nitls_tagged_channel):
+        with patch('nitlsconfig.audit_session_connect', autospec=True) as patched_audit:
+            with nifake.Session('dev1', grpc_options=nifake.GrpcSessionOptions(nitls_tagged_channel, '')):
+                pass
+        patched_audit.assert_called_once_with('NI-FAKE', nitls_tagged_channel, True)
+
+    def test_init_audits_failed_connect(self, nitls_tagged_channel):
+        self.patched_grpc_interpreter.init_with_options.side_effect = nifake.Error('Fake init failure')
+        with patch('nitlsconfig.audit_session_connect', autospec=True) as patched_audit:
+            with pytest.raises(nifake.Error):
+                nifake.Session('dev1', grpc_options=nifake.GrpcSessionOptions(nitls_tagged_channel, ''))
+        patched_audit.assert_called_once_with('NI-FAKE', nitls_tagged_channel, False)
 
     # Session locking
 

--- a/tox.ini
+++ b/tox.ini
@@ -150,6 +150,7 @@ deps =
     test: grpcio == 1.75.1  # Compatible with Python 3.14; should be backwards compatible with grpcio-tools 1.59.0
     test: protobuf == 5.27.2  # Compatible with Python 3.14; should be backwards compatible with grpcio-tools 1.59.0
     test: ni.grpcdevice.v1.proto >= 1.0.0  # Provides session_pb2 package at runtime since we no longer generate it per-driver
+    test: nitlsconfig >= 1.0.0a2  # Pinned while the API is still moving through alphas
     build_test: pytest
     build_test: coverage
     build_test: mako

--- a/tox.ini
+++ b/tox.ini
@@ -150,7 +150,7 @@ deps =
     test: grpcio == 1.75.1  # Compatible with Python 3.14; should be backwards compatible with grpcio-tools 1.59.0
     test: protobuf == 5.27.2  # Compatible with Python 3.14; should be backwards compatible with grpcio-tools 1.59.0
     test: ni.grpcdevice.v1.proto >= 1.0.0  # Provides session_pb2 package at runtime since we no longer generate it per-driver
-    test: nitlsconfig >= 1.0.0a2  # Pinned while the API is still moving through alphas
+    test: nitlsconfig >= 1.0.0a2
     build_test: pytest
     build_test: coverage
     build_test: mako


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- [X] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.

- ~~[ ] I've added tests applicable for this pull request~~

No system tests added as of this time, but we will make a subsequent PR to add system testing. My reasoning is:

1. What is being added here is fairly minor changes. Both nitlsconfig entrypoints we are utilizing inside of nimi-python itself will not change or add behavior whatsoever unless a channel is created with nitlsconfig's create_grpc_device_channel. For full system tests to succeed, we need to figure out how to do certificate provisioning, and modify the gRPC device json file to utilize nitlsconfig.
2. For now, I have opted to add unit tests though by simply creating a fake gRPC channel that is tagged with the same mechanism used in nitlsconfig to enable the auditing and error elaboration query capability and confirm the behavior. This at least gives us solid coverage of the changes proposed here.

### What does this Pull Request accomplish?

We need to ensure we pull in the latest alpha version of nitlsconfig and integrate with latest changes which adds:

1. A new audit_session_connect function. This function when called will check whether the channel passed in via gRPC options was created from nitlsconfig's create_grpc_device_channel. If it WAS, then we will perform audit logging for whether the gRPC connection succeeded and what the target address + port for it was. This means it was an NI-sanctioned NI-TLS utilizing channel and we want to add client-side logging for it.
2. Utilize the get_tls_connection_error_elaboration function to replace the gRPC unavailable's generic message. This function returns None if the channel was not supplied by nitlsconfig's create_grpc_device_channel. The unavailable message is what gets reported when the TLS handshake fails which is VERY unhelpful otherwise. Instead, we want to tell users that they might want to verify against Hardware Manager what their TLS settings are. This matches the behavior we've encoded into our LabVIEW API.
3. nitlsconfig 1.0.0a2 also has a breaking change to improve the API naming and parameter set. We should anchor ourselves with 1.0.0a2 as our floor as this no longer intends to change (for now)
4. Added unit tests using a fake gRPC channel that is tagged with the same mechanism nitlsconfigtest uses to opt us into auditing and error elaborations and exercises our changes.


### List issues fixed by this Pull Request below, if any.

N/A. This is new development.

### What testing has been done?

Ran the unit tests locally. New tests and the pre-existing tests proceed to succeed as-is