### PR TITLE
Add documentation for creating nitlsconfig gRPC channels

### DIFF
--- a/build/templates/conf.py.mako
+++ b/build/templates/conf.py.mako
@@ -204,4 +204,6 @@ intersphinx_mapping = {
 % for module in sorted(external_modules):
     '${module}': ('https://${module}.readthedocs.io/en/latest/', None),
 % endfor
+    # Read the Docs project slug differs from the module name.
+    'nitlsconfig': ('https://nitlsconfig-python.readthedocs.io/en/latest/', None),
 }

--- a/build/templates/grpc_session_options.rst.mako
+++ b/build/templates/grpc_session_options.rst.mako
@@ -26,9 +26,10 @@ Every ${driver_name} gRPC session is created from a ``grpc.Channel`` that you bu
 close it after the last session using it is closed.
 
 The recommended way to create a gRPC channel to a remote system running NI gRPC Device Server is
-``create_grpc_device_channel`` from the `nitlsconfig <https://pypi.org/project/nitlsconfig/>`_ package,
-which the ``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed
-with the ${driver_name} runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
+:py:func:`nitlsconfig.create_grpc_device_channel() <nitlsconfig.grpc_channel.create_grpc_device_channel>`
+from the `nitlsconfig <https://nitlsconfig-python.readthedocs.io/en/latest/>`_ package, which the
+``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed with the
+${driver_name} runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
 
 Before ``create_grpc_device_channel`` can succeed, you must use NI Hardware Manager to perform a
 certificate exchange with the remote system.

--- a/build/templates/grpc_session_options.rst.mako
+++ b/build/templates/grpc_session_options.rst.mako
@@ -14,6 +14,53 @@ Support for using ${driver_name} over gRPC
 
 
 
+Creating a gRPC channel
+-----------------------
+
+Using ${driver_name} over gRPC requires the ``grpc`` extra::
+
+  $ python -m pip install ${module_name}[grpc]
+
+Every ${driver_name} gRPC session is created from a ``grpc.Channel`` that you build and pass to
+:py:class:`${module_name}.GrpcSessionOptions`. You own the channel, not the session, so you must
+close it after the last session using it is closed.
+
+The recommended way to create a gRPC channel to a remote system running NI gRPC Device Server is
+``create_grpc_device_channel`` from the `nitlsconfig <https://pypi.org/project/nitlsconfig/>`_ package,
+which the ``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed
+with the ${driver_name} runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
+
+Before ``create_grpc_device_channel`` can succeed, you must use NI Hardware Manager to perform a
+certificate exchange with the remote system.
+See `Managing mTLS <https://www.ni.com/docs/en-US/bundle/hardwaremanager/page/mtls-manage.html>`_ for
+additional information.
+
+For example::
+
+  import ${module_name}
+  import nitlsconfig
+
+  with nitlsconfig.create_grpc_device_channel('remote_grpc_device', 31763) as channel:
+      options = ${module_name}.GrpcSessionOptions(channel, '')
+      with ${module_name}.Session('dev1', grpc_options=options) as session:
+          # Calls to session over the encrypted channel
+
+.. note:: From NI Hardware Manager, you can disable TLS to make ``create_grpc_device_channel``
+    produce an insecure channel.
+
+.. note:: ``create_grpc_device_channel`` also accepts an ``options`` parameter for gRPC channel
+    arguments such as ``grpc.ssl_target_name_override``, and a ``retry_policy`` parameter. Channel
+    arguments cannot be changed after the channel is built, so they must be supplied here.
+
+.. note:: NI gRPC Device Server must be configured to accept remote connections and to take its
+    TLS settings from nitlsconfig. See
+    `Bind Address Support <https://github.com/ni/grpc-device#bind-address-support>`_ and
+    `NI TLS Config Integration <https://github.com/ni/grpc-device#ni-tls-config-integration>`_ for details.
+
+You can also build the gRPC channel yourself with ``grpc.insecure_channel`` or ``grpc.secure_channel``
+if you need full control over how credentials are supplied.
+
+
 SessionInitializationBehavior
 -----------------------------
 
@@ -62,17 +109,17 @@ GrpcSessionOptions
 
 
     :param grpc_channel:
-        
+
 
         Specifies the channel to the NI gRPC Device Server.
 
-        
+
 
     :type grpc_channel: grpc.Channel
 
 
     :param session_name:
-        
+
 
         User-specified name that identifies the driver session on the NI gRPC Device Server.
 
@@ -81,18 +128,18 @@ GrpcSessionOptions
         You can use an empty string if you want to always initialize a new session on the server.
         To attach to an existing session, you must specify the session name it was initialized with.
 
-        
+
 
     :type session_name: str
 
 
     :param initialization_behavior:
-        
+
 
         Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired.
 
         The driver session exists on the NI gRPC Device Server.
 
-        
+
 
     :type initialization_behavior: :py:data:`${module_name}.SessionInitializationBehavior`

--- a/docs/nidcpower/conf.py
+++ b/docs/nidcpower/conf.py
@@ -195,4 +195,6 @@ intersphinx_mapping = {
     'nise': ('https://nise.readthedocs.io/en/latest/', None),
     'niswitch': ('https://niswitch.readthedocs.io/en/latest/', None),
     'nitclk': ('https://nitclk.readthedocs.io/en/latest/', None),
+    # Read the Docs project slug differs from the module name.
+    'nitlsconfig': ('https://nitlsconfig-python.readthedocs.io/en/latest/', None),
 }

--- a/docs/nidcpower/grpc_session_options.rst
+++ b/docs/nidcpower/grpc_session_options.rst
@@ -7,6 +7,53 @@ Support for using NI-DCPower over gRPC
 
 
 
+Creating a gRPC channel
+-----------------------
+
+Using NI-DCPower over gRPC requires the ``grpc`` extra::
+
+  $ python -m pip install nidcpower[grpc]
+
+Every NI-DCPower gRPC session is created from a ``grpc.Channel`` that you build and pass to
+:py:class:`nidcpower.GrpcSessionOptions`. You own the channel, not the session, so you must
+close it after the last session using it is closed.
+
+The recommended way to create a gRPC channel to a remote system running NI gRPC Device Server is
+``create_grpc_device_channel`` from the `nitlsconfig <https://pypi.org/project/nitlsconfig/>`_ package,
+which the ``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed
+with the NI-DCPower runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
+
+Before ``create_grpc_device_channel`` can succeed, you must use NI Hardware Manager to perform a
+certificate exchange with the remote system.
+See `Managing mTLS <https://www.ni.com/docs/en-US/bundle/hardwaremanager/page/mtls-manage.html>`_ for
+additional information.
+
+For example::
+
+  import nidcpower
+  import nitlsconfig
+
+  with nitlsconfig.create_grpc_device_channel('remote_grpc_device', 31763) as channel:
+      options = nidcpower.GrpcSessionOptions(channel, '')
+      with nidcpower.Session('dev1', grpc_options=options) as session:
+          # Calls to session over the encrypted channel
+
+.. note:: From NI Hardware Manager, you can disable TLS to make ``create_grpc_device_channel``
+    produce an insecure channel.
+
+.. note:: ``create_grpc_device_channel`` also accepts an ``options`` parameter for gRPC channel
+    arguments such as ``grpc.ssl_target_name_override``, and a ``retry_policy`` parameter. Channel
+    arguments cannot be changed after the channel is built, so they must be supplied here.
+
+.. note:: NI gRPC Device Server must be configured to accept remote connections and to take its
+    TLS settings from nitlsconfig. See
+    `Bind Address Support <https://github.com/ni/grpc-device#bind-address-support>`_ and
+    `NI TLS Config Integration <https://github.com/ni/grpc-device#ni-tls-config-integration>`_ for details.
+
+You can also build the gRPC channel yourself with ``grpc.insecure_channel`` or ``grpc.secure_channel``
+if you need full control over how credentials are supplied.
+
+
 SessionInitializationBehavior
 -----------------------------
 
@@ -55,17 +102,17 @@ GrpcSessionOptions
 
 
     :param grpc_channel:
-        
+
 
         Specifies the channel to the NI gRPC Device Server.
 
-        
+
 
     :type grpc_channel: grpc.Channel
 
 
     :param session_name:
-        
+
 
         User-specified name that identifies the driver session on the NI gRPC Device Server.
 
@@ -74,18 +121,18 @@ GrpcSessionOptions
         You can use an empty string if you want to always initialize a new session on the server.
         To attach to an existing session, you must specify the session name it was initialized with.
 
-        
+
 
     :type session_name: str
 
 
     :param initialization_behavior:
-        
+
 
         Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired.
 
         The driver session exists on the NI gRPC Device Server.
 
-        
+
 
     :type initialization_behavior: :py:data:`nidcpower.SessionInitializationBehavior`

--- a/docs/nidcpower/grpc_session_options.rst
+++ b/docs/nidcpower/grpc_session_options.rst
@@ -19,9 +19,10 @@ Every NI-DCPower gRPC session is created from a ``grpc.Channel`` that you build 
 close it after the last session using it is closed.
 
 The recommended way to create a gRPC channel to a remote system running NI gRPC Device Server is
-``create_grpc_device_channel`` from the `nitlsconfig <https://pypi.org/project/nitlsconfig/>`_ package,
-which the ``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed
-with the NI-DCPower runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
+:py:func:`nitlsconfig.create_grpc_device_channel() <nitlsconfig.grpc_channel.create_grpc_device_channel>`
+from the `nitlsconfig <https://nitlsconfig-python.readthedocs.io/en/latest/>`_ package, which the
+``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed with the
+NI-DCPower runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
 
 Before ``create_grpc_device_channel`` can succeed, you must use NI Hardware Manager to perform a
 certificate exchange with the remote system.

--- a/docs/nidigital/conf.py
+++ b/docs/nidigital/conf.py
@@ -195,4 +195,6 @@ intersphinx_mapping = {
     'nise': ('https://nise.readthedocs.io/en/latest/', None),
     'niswitch': ('https://niswitch.readthedocs.io/en/latest/', None),
     'nitclk': ('https://nitclk.readthedocs.io/en/latest/', None),
+    # Read the Docs project slug differs from the module name.
+    'nitlsconfig': ('https://nitlsconfig-python.readthedocs.io/en/latest/', None),
 }

--- a/docs/nidigital/grpc_session_options.rst
+++ b/docs/nidigital/grpc_session_options.rst
@@ -7,6 +7,53 @@ Support for using NI-Digital Pattern Driver over gRPC
 
 
 
+Creating a gRPC channel
+-----------------------
+
+Using NI-Digital Pattern Driver over gRPC requires the ``grpc`` extra::
+
+  $ python -m pip install nidigital[grpc]
+
+Every NI-Digital Pattern Driver gRPC session is created from a ``grpc.Channel`` that you build and pass to
+:py:class:`nidigital.GrpcSessionOptions`. You own the channel, not the session, so you must
+close it after the last session using it is closed.
+
+The recommended way to create a gRPC channel to a remote system running NI gRPC Device Server is
+``create_grpc_device_channel`` from the `nitlsconfig <https://pypi.org/project/nitlsconfig/>`_ package,
+which the ``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed
+with the NI-Digital Pattern Driver runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
+
+Before ``create_grpc_device_channel`` can succeed, you must use NI Hardware Manager to perform a
+certificate exchange with the remote system.
+See `Managing mTLS <https://www.ni.com/docs/en-US/bundle/hardwaremanager/page/mtls-manage.html>`_ for
+additional information.
+
+For example::
+
+  import nidigital
+  import nitlsconfig
+
+  with nitlsconfig.create_grpc_device_channel('remote_grpc_device', 31763) as channel:
+      options = nidigital.GrpcSessionOptions(channel, '')
+      with nidigital.Session('dev1', grpc_options=options) as session:
+          # Calls to session over the encrypted channel
+
+.. note:: From NI Hardware Manager, you can disable TLS to make ``create_grpc_device_channel``
+    produce an insecure channel.
+
+.. note:: ``create_grpc_device_channel`` also accepts an ``options`` parameter for gRPC channel
+    arguments such as ``grpc.ssl_target_name_override``, and a ``retry_policy`` parameter. Channel
+    arguments cannot be changed after the channel is built, so they must be supplied here.
+
+.. note:: NI gRPC Device Server must be configured to accept remote connections and to take its
+    TLS settings from nitlsconfig. See
+    `Bind Address Support <https://github.com/ni/grpc-device#bind-address-support>`_ and
+    `NI TLS Config Integration <https://github.com/ni/grpc-device#ni-tls-config-integration>`_ for details.
+
+You can also build the gRPC channel yourself with ``grpc.insecure_channel`` or ``grpc.secure_channel``
+if you need full control over how credentials are supplied.
+
+
 SessionInitializationBehavior
 -----------------------------
 
@@ -55,17 +102,17 @@ GrpcSessionOptions
 
 
     :param grpc_channel:
-        
+
 
         Specifies the channel to the NI gRPC Device Server.
 
-        
+
 
     :type grpc_channel: grpc.Channel
 
 
     :param session_name:
-        
+
 
         User-specified name that identifies the driver session on the NI gRPC Device Server.
 
@@ -74,18 +121,18 @@ GrpcSessionOptions
         You can use an empty string if you want to always initialize a new session on the server.
         To attach to an existing session, you must specify the session name it was initialized with.
 
-        
+
 
     :type session_name: str
 
 
     :param initialization_behavior:
-        
+
 
         Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired.
 
         The driver session exists on the NI gRPC Device Server.
 
-        
+
 
     :type initialization_behavior: :py:data:`nidigital.SessionInitializationBehavior`

--- a/docs/nidigital/grpc_session_options.rst
+++ b/docs/nidigital/grpc_session_options.rst
@@ -19,9 +19,10 @@ Every NI-Digital Pattern Driver gRPC session is created from a ``grpc.Channel`` 
 close it after the last session using it is closed.
 
 The recommended way to create a gRPC channel to a remote system running NI gRPC Device Server is
-``create_grpc_device_channel`` from the `nitlsconfig <https://pypi.org/project/nitlsconfig/>`_ package,
-which the ``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed
-with the NI-Digital Pattern Driver runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
+:py:func:`nitlsconfig.create_grpc_device_channel() <nitlsconfig.grpc_channel.create_grpc_device_channel>`
+from the `nitlsconfig <https://nitlsconfig-python.readthedocs.io/en/latest/>`_ package, which the
+``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed with the
+NI-Digital Pattern Driver runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
 
 Before ``create_grpc_device_channel`` can succeed, you must use NI Hardware Manager to perform a
 certificate exchange with the remote system.

--- a/docs/nidmm/conf.py
+++ b/docs/nidmm/conf.py
@@ -195,4 +195,6 @@ intersphinx_mapping = {
     'nise': ('https://nise.readthedocs.io/en/latest/', None),
     'niswitch': ('https://niswitch.readthedocs.io/en/latest/', None),
     'nitclk': ('https://nitclk.readthedocs.io/en/latest/', None),
+    # Read the Docs project slug differs from the module name.
+    'nitlsconfig': ('https://nitlsconfig-python.readthedocs.io/en/latest/', None),
 }

--- a/docs/nidmm/grpc_session_options.rst
+++ b/docs/nidmm/grpc_session_options.rst
@@ -19,9 +19,10 @@ Every NI-DMM gRPC session is created from a ``grpc.Channel`` that you build and 
 close it after the last session using it is closed.
 
 The recommended way to create a gRPC channel to a remote system running NI gRPC Device Server is
-``create_grpc_device_channel`` from the `nitlsconfig <https://pypi.org/project/nitlsconfig/>`_ package,
-which the ``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed
-with the NI-DMM runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
+:py:func:`nitlsconfig.create_grpc_device_channel() <nitlsconfig.grpc_channel.create_grpc_device_channel>`
+from the `nitlsconfig <https://nitlsconfig-python.readthedocs.io/en/latest/>`_ package, which the
+``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed with the
+NI-DMM runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
 
 Before ``create_grpc_device_channel`` can succeed, you must use NI Hardware Manager to perform a
 certificate exchange with the remote system.

--- a/docs/nidmm/grpc_session_options.rst
+++ b/docs/nidmm/grpc_session_options.rst
@@ -7,6 +7,53 @@ Support for using NI-DMM over gRPC
 
 
 
+Creating a gRPC channel
+-----------------------
+
+Using NI-DMM over gRPC requires the ``grpc`` extra::
+
+  $ python -m pip install nidmm[grpc]
+
+Every NI-DMM gRPC session is created from a ``grpc.Channel`` that you build and pass to
+:py:class:`nidmm.GrpcSessionOptions`. You own the channel, not the session, so you must
+close it after the last session using it is closed.
+
+The recommended way to create a gRPC channel to a remote system running NI gRPC Device Server is
+``create_grpc_device_channel`` from the `nitlsconfig <https://pypi.org/project/nitlsconfig/>`_ package,
+which the ``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed
+with the NI-DMM runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
+
+Before ``create_grpc_device_channel`` can succeed, you must use NI Hardware Manager to perform a
+certificate exchange with the remote system.
+See `Managing mTLS <https://www.ni.com/docs/en-US/bundle/hardwaremanager/page/mtls-manage.html>`_ for
+additional information.
+
+For example::
+
+  import nidmm
+  import nitlsconfig
+
+  with nitlsconfig.create_grpc_device_channel('remote_grpc_device', 31763) as channel:
+      options = nidmm.GrpcSessionOptions(channel, '')
+      with nidmm.Session('dev1', grpc_options=options) as session:
+          # Calls to session over the encrypted channel
+
+.. note:: From NI Hardware Manager, you can disable TLS to make ``create_grpc_device_channel``
+    produce an insecure channel.
+
+.. note:: ``create_grpc_device_channel`` also accepts an ``options`` parameter for gRPC channel
+    arguments such as ``grpc.ssl_target_name_override``, and a ``retry_policy`` parameter. Channel
+    arguments cannot be changed after the channel is built, so they must be supplied here.
+
+.. note:: NI gRPC Device Server must be configured to accept remote connections and to take its
+    TLS settings from nitlsconfig. See
+    `Bind Address Support <https://github.com/ni/grpc-device#bind-address-support>`_ and
+    `NI TLS Config Integration <https://github.com/ni/grpc-device#ni-tls-config-integration>`_ for details.
+
+You can also build the gRPC channel yourself with ``grpc.insecure_channel`` or ``grpc.secure_channel``
+if you need full control over how credentials are supplied.
+
+
 SessionInitializationBehavior
 -----------------------------
 
@@ -55,17 +102,17 @@ GrpcSessionOptions
 
 
     :param grpc_channel:
-        
+
 
         Specifies the channel to the NI gRPC Device Server.
 
-        
+
 
     :type grpc_channel: grpc.Channel
 
 
     :param session_name:
-        
+
 
         User-specified name that identifies the driver session on the NI gRPC Device Server.
 
@@ -74,18 +121,18 @@ GrpcSessionOptions
         You can use an empty string if you want to always initialize a new session on the server.
         To attach to an existing session, you must specify the session name it was initialized with.
 
-        
+
 
     :type session_name: str
 
 
     :param initialization_behavior:
-        
+
 
         Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired.
 
         The driver session exists on the NI gRPC Device Server.
 
-        
+
 
     :type initialization_behavior: :py:data:`nidmm.SessionInitializationBehavior`

--- a/docs/nifgen/conf.py
+++ b/docs/nifgen/conf.py
@@ -195,4 +195,6 @@ intersphinx_mapping = {
     'nise': ('https://nise.readthedocs.io/en/latest/', None),
     'niswitch': ('https://niswitch.readthedocs.io/en/latest/', None),
     'nitclk': ('https://nitclk.readthedocs.io/en/latest/', None),
+    # Read the Docs project slug differs from the module name.
+    'nitlsconfig': ('https://nitlsconfig-python.readthedocs.io/en/latest/', None),
 }

--- a/docs/nifgen/grpc_session_options.rst
+++ b/docs/nifgen/grpc_session_options.rst
@@ -7,6 +7,53 @@ Support for using NI-FGEN over gRPC
 
 
 
+Creating a gRPC channel
+-----------------------
+
+Using NI-FGEN over gRPC requires the ``grpc`` extra::
+
+  $ python -m pip install nifgen[grpc]
+
+Every NI-FGEN gRPC session is created from a ``grpc.Channel`` that you build and pass to
+:py:class:`nifgen.GrpcSessionOptions`. You own the channel, not the session, so you must
+close it after the last session using it is closed.
+
+The recommended way to create a gRPC channel to a remote system running NI gRPC Device Server is
+``create_grpc_device_channel`` from the `nitlsconfig <https://pypi.org/project/nitlsconfig/>`_ package,
+which the ``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed
+with the NI-FGEN runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
+
+Before ``create_grpc_device_channel`` can succeed, you must use NI Hardware Manager to perform a
+certificate exchange with the remote system.
+See `Managing mTLS <https://www.ni.com/docs/en-US/bundle/hardwaremanager/page/mtls-manage.html>`_ for
+additional information.
+
+For example::
+
+  import nifgen
+  import nitlsconfig
+
+  with nitlsconfig.create_grpc_device_channel('remote_grpc_device', 31763) as channel:
+      options = nifgen.GrpcSessionOptions(channel, '')
+      with nifgen.Session('dev1', grpc_options=options) as session:
+          # Calls to session over the encrypted channel
+
+.. note:: From NI Hardware Manager, you can disable TLS to make ``create_grpc_device_channel``
+    produce an insecure channel.
+
+.. note:: ``create_grpc_device_channel`` also accepts an ``options`` parameter for gRPC channel
+    arguments such as ``grpc.ssl_target_name_override``, and a ``retry_policy`` parameter. Channel
+    arguments cannot be changed after the channel is built, so they must be supplied here.
+
+.. note:: NI gRPC Device Server must be configured to accept remote connections and to take its
+    TLS settings from nitlsconfig. See
+    `Bind Address Support <https://github.com/ni/grpc-device#bind-address-support>`_ and
+    `NI TLS Config Integration <https://github.com/ni/grpc-device#ni-tls-config-integration>`_ for details.
+
+You can also build the gRPC channel yourself with ``grpc.insecure_channel`` or ``grpc.secure_channel``
+if you need full control over how credentials are supplied.
+
+
 SessionInitializationBehavior
 -----------------------------
 
@@ -55,17 +102,17 @@ GrpcSessionOptions
 
 
     :param grpc_channel:
-        
+
 
         Specifies the channel to the NI gRPC Device Server.
 
-        
+
 
     :type grpc_channel: grpc.Channel
 
 
     :param session_name:
-        
+
 
         User-specified name that identifies the driver session on the NI gRPC Device Server.
 
@@ -74,18 +121,18 @@ GrpcSessionOptions
         You can use an empty string if you want to always initialize a new session on the server.
         To attach to an existing session, you must specify the session name it was initialized with.
 
-        
+
 
     :type session_name: str
 
 
     :param initialization_behavior:
-        
+
 
         Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired.
 
         The driver session exists on the NI gRPC Device Server.
 
-        
+
 
     :type initialization_behavior: :py:data:`nifgen.SessionInitializationBehavior`

--- a/docs/nifgen/grpc_session_options.rst
+++ b/docs/nifgen/grpc_session_options.rst
@@ -19,9 +19,10 @@ Every NI-FGEN gRPC session is created from a ``grpc.Channel`` that you build and
 close it after the last session using it is closed.
 
 The recommended way to create a gRPC channel to a remote system running NI gRPC Device Server is
-``create_grpc_device_channel`` from the `nitlsconfig <https://pypi.org/project/nitlsconfig/>`_ package,
-which the ``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed
-with the NI-FGEN runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
+:py:func:`nitlsconfig.create_grpc_device_channel() <nitlsconfig.grpc_channel.create_grpc_device_channel>`
+from the `nitlsconfig <https://nitlsconfig-python.readthedocs.io/en/latest/>`_ package, which the
+``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed with the
+NI-FGEN runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
 
 Before ``create_grpc_device_channel`` can succeed, you must use NI Hardware Manager to perform a
 certificate exchange with the remote system.

--- a/docs/nimodinst/conf.py
+++ b/docs/nimodinst/conf.py
@@ -195,4 +195,6 @@ intersphinx_mapping = {
     'nise': ('https://nise.readthedocs.io/en/latest/', None),
     'niswitch': ('https://niswitch.readthedocs.io/en/latest/', None),
     'nitclk': ('https://nitclk.readthedocs.io/en/latest/', None),
+    # Read the Docs project slug differs from the module name.
+    'nitlsconfig': ('https://nitlsconfig-python.readthedocs.io/en/latest/', None),
 }

--- a/docs/nirfsa/conf.py
+++ b/docs/nirfsa/conf.py
@@ -195,4 +195,6 @@ intersphinx_mapping = {
     'nise': ('https://nise.readthedocs.io/en/latest/', None),
     'niswitch': ('https://niswitch.readthedocs.io/en/latest/', None),
     'nitclk': ('https://nitclk.readthedocs.io/en/latest/', None),
+    # Read the Docs project slug differs from the module name.
+    'nitlsconfig': ('https://nitlsconfig-python.readthedocs.io/en/latest/', None),
 }

--- a/docs/nirfsa/grpc_session_options.rst
+++ b/docs/nirfsa/grpc_session_options.rst
@@ -19,9 +19,10 @@ Every NI-RFSA gRPC session is created from a ``grpc.Channel`` that you build and
 close it after the last session using it is closed.
 
 The recommended way to create a gRPC channel to a remote system running NI gRPC Device Server is
-``create_grpc_device_channel`` from the `nitlsconfig <https://pypi.org/project/nitlsconfig/>`_ package,
-which the ``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed
-with the NI-RFSA runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
+:py:func:`nitlsconfig.create_grpc_device_channel() <nitlsconfig.grpc_channel.create_grpc_device_channel>`
+from the `nitlsconfig <https://nitlsconfig-python.readthedocs.io/en/latest/>`_ package, which the
+``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed with the
+NI-RFSA runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
 
 Before ``create_grpc_device_channel`` can succeed, you must use NI Hardware Manager to perform a
 certificate exchange with the remote system.

--- a/docs/nirfsa/grpc_session_options.rst
+++ b/docs/nirfsa/grpc_session_options.rst
@@ -7,6 +7,53 @@ Support for using NI-RFSA over gRPC
 
 
 
+Creating a gRPC channel
+-----------------------
+
+Using NI-RFSA over gRPC requires the ``grpc`` extra::
+
+  $ python -m pip install nirfsa[grpc]
+
+Every NI-RFSA gRPC session is created from a ``grpc.Channel`` that you build and pass to
+:py:class:`nirfsa.GrpcSessionOptions`. You own the channel, not the session, so you must
+close it after the last session using it is closed.
+
+The recommended way to create a gRPC channel to a remote system running NI gRPC Device Server is
+``create_grpc_device_channel`` from the `nitlsconfig <https://pypi.org/project/nitlsconfig/>`_ package,
+which the ``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed
+with the NI-RFSA runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
+
+Before ``create_grpc_device_channel`` can succeed, you must use NI Hardware Manager to perform a
+certificate exchange with the remote system.
+See `Managing mTLS <https://www.ni.com/docs/en-US/bundle/hardwaremanager/page/mtls-manage.html>`_ for
+additional information.
+
+For example::
+
+  import nirfsa
+  import nitlsconfig
+
+  with nitlsconfig.create_grpc_device_channel('remote_grpc_device', 31763) as channel:
+      options = nirfsa.GrpcSessionOptions(channel, '')
+      with nirfsa.Session('dev1', grpc_options=options) as session:
+          # Calls to session over the encrypted channel
+
+.. note:: From NI Hardware Manager, you can disable TLS to make ``create_grpc_device_channel``
+    produce an insecure channel.
+
+.. note:: ``create_grpc_device_channel`` also accepts an ``options`` parameter for gRPC channel
+    arguments such as ``grpc.ssl_target_name_override``, and a ``retry_policy`` parameter. Channel
+    arguments cannot be changed after the channel is built, so they must be supplied here.
+
+.. note:: NI gRPC Device Server must be configured to accept remote connections and to take its
+    TLS settings from nitlsconfig. See
+    `Bind Address Support <https://github.com/ni/grpc-device#bind-address-support>`_ and
+    `NI TLS Config Integration <https://github.com/ni/grpc-device#ni-tls-config-integration>`_ for details.
+
+You can also build the gRPC channel yourself with ``grpc.insecure_channel`` or ``grpc.secure_channel``
+if you need full control over how credentials are supplied.
+
+
 SessionInitializationBehavior
 -----------------------------
 
@@ -55,17 +102,17 @@ GrpcSessionOptions
 
 
     :param grpc_channel:
-        
+
 
         Specifies the channel to the NI gRPC Device Server.
 
-        
+
 
     :type grpc_channel: grpc.Channel
 
 
     :param session_name:
-        
+
 
         User-specified name that identifies the driver session on the NI gRPC Device Server.
 
@@ -74,18 +121,18 @@ GrpcSessionOptions
         You can use an empty string if you want to always initialize a new session on the server.
         To attach to an existing session, you must specify the session name it was initialized with.
 
-        
+
 
     :type session_name: str
 
 
     :param initialization_behavior:
-        
+
 
         Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired.
 
         The driver session exists on the NI gRPC Device Server.
 
-        
+
 
     :type initialization_behavior: :py:data:`nirfsa.SessionInitializationBehavior`

--- a/docs/nirfsg/conf.py
+++ b/docs/nirfsg/conf.py
@@ -195,4 +195,6 @@ intersphinx_mapping = {
     'nise': ('https://nise.readthedocs.io/en/latest/', None),
     'niswitch': ('https://niswitch.readthedocs.io/en/latest/', None),
     'nitclk': ('https://nitclk.readthedocs.io/en/latest/', None),
+    # Read the Docs project slug differs from the module name.
+    'nitlsconfig': ('https://nitlsconfig-python.readthedocs.io/en/latest/', None),
 }

--- a/docs/nirfsg/grpc_session_options.rst
+++ b/docs/nirfsg/grpc_session_options.rst
@@ -19,9 +19,10 @@ Every NI-RFSG gRPC session is created from a ``grpc.Channel`` that you build and
 close it after the last session using it is closed.
 
 The recommended way to create a gRPC channel to a remote system running NI gRPC Device Server is
-``create_grpc_device_channel`` from the `nitlsconfig <https://pypi.org/project/nitlsconfig/>`_ package,
-which the ``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed
-with the NI-RFSG runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
+:py:func:`nitlsconfig.create_grpc_device_channel() <nitlsconfig.grpc_channel.create_grpc_device_channel>`
+from the `nitlsconfig <https://nitlsconfig-python.readthedocs.io/en/latest/>`_ package, which the
+``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed with the
+NI-RFSG runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
 
 Before ``create_grpc_device_channel`` can succeed, you must use NI Hardware Manager to perform a
 certificate exchange with the remote system.

--- a/docs/nirfsg/grpc_session_options.rst
+++ b/docs/nirfsg/grpc_session_options.rst
@@ -7,6 +7,53 @@ Support for using NI-RFSG over gRPC
 
 
 
+Creating a gRPC channel
+-----------------------
+
+Using NI-RFSG over gRPC requires the ``grpc`` extra::
+
+  $ python -m pip install nirfsg[grpc]
+
+Every NI-RFSG gRPC session is created from a ``grpc.Channel`` that you build and pass to
+:py:class:`nirfsg.GrpcSessionOptions`. You own the channel, not the session, so you must
+close it after the last session using it is closed.
+
+The recommended way to create a gRPC channel to a remote system running NI gRPC Device Server is
+``create_grpc_device_channel`` from the `nitlsconfig <https://pypi.org/project/nitlsconfig/>`_ package,
+which the ``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed
+with the NI-RFSG runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
+
+Before ``create_grpc_device_channel`` can succeed, you must use NI Hardware Manager to perform a
+certificate exchange with the remote system.
+See `Managing mTLS <https://www.ni.com/docs/en-US/bundle/hardwaremanager/page/mtls-manage.html>`_ for
+additional information.
+
+For example::
+
+  import nirfsg
+  import nitlsconfig
+
+  with nitlsconfig.create_grpc_device_channel('remote_grpc_device', 31763) as channel:
+      options = nirfsg.GrpcSessionOptions(channel, '')
+      with nirfsg.Session('dev1', grpc_options=options) as session:
+          # Calls to session over the encrypted channel
+
+.. note:: From NI Hardware Manager, you can disable TLS to make ``create_grpc_device_channel``
+    produce an insecure channel.
+
+.. note:: ``create_grpc_device_channel`` also accepts an ``options`` parameter for gRPC channel
+    arguments such as ``grpc.ssl_target_name_override``, and a ``retry_policy`` parameter. Channel
+    arguments cannot be changed after the channel is built, so they must be supplied here.
+
+.. note:: NI gRPC Device Server must be configured to accept remote connections and to take its
+    TLS settings from nitlsconfig. See
+    `Bind Address Support <https://github.com/ni/grpc-device#bind-address-support>`_ and
+    `NI TLS Config Integration <https://github.com/ni/grpc-device#ni-tls-config-integration>`_ for details.
+
+You can also build the gRPC channel yourself with ``grpc.insecure_channel`` or ``grpc.secure_channel``
+if you need full control over how credentials are supplied.
+
+
 SessionInitializationBehavior
 -----------------------------
 
@@ -55,17 +102,17 @@ GrpcSessionOptions
 
 
     :param grpc_channel:
-        
+
 
         Specifies the channel to the NI gRPC Device Server.
 
-        
+
 
     :type grpc_channel: grpc.Channel
 
 
     :param session_name:
-        
+
 
         User-specified name that identifies the driver session on the NI gRPC Device Server.
 
@@ -74,18 +121,18 @@ GrpcSessionOptions
         You can use an empty string if you want to always initialize a new session on the server.
         To attach to an existing session, you must specify the session name it was initialized with.
 
-        
+
 
     :type session_name: str
 
 
     :param initialization_behavior:
-        
+
 
         Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired.
 
         The driver session exists on the NI gRPC Device Server.
 
-        
+
 
     :type initialization_behavior: :py:data:`nirfsg.SessionInitializationBehavior`

--- a/docs/niscope/conf.py
+++ b/docs/niscope/conf.py
@@ -195,4 +195,6 @@ intersphinx_mapping = {
     'nise': ('https://nise.readthedocs.io/en/latest/', None),
     'niswitch': ('https://niswitch.readthedocs.io/en/latest/', None),
     'nitclk': ('https://nitclk.readthedocs.io/en/latest/', None),
+    # Read the Docs project slug differs from the module name.
+    'nitlsconfig': ('https://nitlsconfig-python.readthedocs.io/en/latest/', None),
 }

--- a/docs/niscope/grpc_session_options.rst
+++ b/docs/niscope/grpc_session_options.rst
@@ -7,6 +7,53 @@ Support for using NI-SCOPE over gRPC
 
 
 
+Creating a gRPC channel
+-----------------------
+
+Using NI-SCOPE over gRPC requires the ``grpc`` extra::
+
+  $ python -m pip install niscope[grpc]
+
+Every NI-SCOPE gRPC session is created from a ``grpc.Channel`` that you build and pass to
+:py:class:`niscope.GrpcSessionOptions`. You own the channel, not the session, so you must
+close it after the last session using it is closed.
+
+The recommended way to create a gRPC channel to a remote system running NI gRPC Device Server is
+``create_grpc_device_channel`` from the `nitlsconfig <https://pypi.org/project/nitlsconfig/>`_ package,
+which the ``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed
+with the NI-SCOPE runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
+
+Before ``create_grpc_device_channel`` can succeed, you must use NI Hardware Manager to perform a
+certificate exchange with the remote system.
+See `Managing mTLS <https://www.ni.com/docs/en-US/bundle/hardwaremanager/page/mtls-manage.html>`_ for
+additional information.
+
+For example::
+
+  import niscope
+  import nitlsconfig
+
+  with nitlsconfig.create_grpc_device_channel('remote_grpc_device', 31763) as channel:
+      options = niscope.GrpcSessionOptions(channel, '')
+      with niscope.Session('dev1', grpc_options=options) as session:
+          # Calls to session over the encrypted channel
+
+.. note:: From NI Hardware Manager, you can disable TLS to make ``create_grpc_device_channel``
+    produce an insecure channel.
+
+.. note:: ``create_grpc_device_channel`` also accepts an ``options`` parameter for gRPC channel
+    arguments such as ``grpc.ssl_target_name_override``, and a ``retry_policy`` parameter. Channel
+    arguments cannot be changed after the channel is built, so they must be supplied here.
+
+.. note:: NI gRPC Device Server must be configured to accept remote connections and to take its
+    TLS settings from nitlsconfig. See
+    `Bind Address Support <https://github.com/ni/grpc-device#bind-address-support>`_ and
+    `NI TLS Config Integration <https://github.com/ni/grpc-device#ni-tls-config-integration>`_ for details.
+
+You can also build the gRPC channel yourself with ``grpc.insecure_channel`` or ``grpc.secure_channel``
+if you need full control over how credentials are supplied.
+
+
 SessionInitializationBehavior
 -----------------------------
 
@@ -55,17 +102,17 @@ GrpcSessionOptions
 
 
     :param grpc_channel:
-        
+
 
         Specifies the channel to the NI gRPC Device Server.
 
-        
+
 
     :type grpc_channel: grpc.Channel
 
 
     :param session_name:
-        
+
 
         User-specified name that identifies the driver session on the NI gRPC Device Server.
 
@@ -74,18 +121,18 @@ GrpcSessionOptions
         You can use an empty string if you want to always initialize a new session on the server.
         To attach to an existing session, you must specify the session name it was initialized with.
 
-        
+
 
     :type session_name: str
 
 
     :param initialization_behavior:
-        
+
 
         Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired.
 
         The driver session exists on the NI gRPC Device Server.
 
-        
+
 
     :type initialization_behavior: :py:data:`niscope.SessionInitializationBehavior`

--- a/docs/niscope/grpc_session_options.rst
+++ b/docs/niscope/grpc_session_options.rst
@@ -19,9 +19,10 @@ Every NI-SCOPE gRPC session is created from a ``grpc.Channel`` that you build an
 close it after the last session using it is closed.
 
 The recommended way to create a gRPC channel to a remote system running NI gRPC Device Server is
-``create_grpc_device_channel`` from the `nitlsconfig <https://pypi.org/project/nitlsconfig/>`_ package,
-which the ``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed
-with the NI-SCOPE runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
+:py:func:`nitlsconfig.create_grpc_device_channel() <nitlsconfig.grpc_channel.create_grpc_device_channel>`
+from the `nitlsconfig <https://nitlsconfig-python.readthedocs.io/en/latest/>`_ package, which the
+``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed with the
+NI-SCOPE runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
 
 Before ``create_grpc_device_channel`` can succeed, you must use NI Hardware Manager to perform a
 certificate exchange with the remote system.

--- a/docs/nise/conf.py
+++ b/docs/nise/conf.py
@@ -195,4 +195,6 @@ intersphinx_mapping = {
     'niscope': ('https://niscope.readthedocs.io/en/latest/', None),
     'niswitch': ('https://niswitch.readthedocs.io/en/latest/', None),
     'nitclk': ('https://nitclk.readthedocs.io/en/latest/', None),
+    # Read the Docs project slug differs from the module name.
+    'nitlsconfig': ('https://nitlsconfig-python.readthedocs.io/en/latest/', None),
 }

--- a/docs/niswitch/conf.py
+++ b/docs/niswitch/conf.py
@@ -195,4 +195,6 @@ intersphinx_mapping = {
     'niscope': ('https://niscope.readthedocs.io/en/latest/', None),
     'nise': ('https://nise.readthedocs.io/en/latest/', None),
     'nitclk': ('https://nitclk.readthedocs.io/en/latest/', None),
+    # Read the Docs project slug differs from the module name.
+    'nitlsconfig': ('https://nitlsconfig-python.readthedocs.io/en/latest/', None),
 }

--- a/docs/niswitch/grpc_session_options.rst
+++ b/docs/niswitch/grpc_session_options.rst
@@ -19,9 +19,10 @@ Every NI-SWITCH gRPC session is created from a ``grpc.Channel`` that you build a
 close it after the last session using it is closed.
 
 The recommended way to create a gRPC channel to a remote system running NI gRPC Device Server is
-``create_grpc_device_channel`` from the `nitlsconfig <https://pypi.org/project/nitlsconfig/>`_ package,
-which the ``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed
-with the NI-SWITCH runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
+:py:func:`nitlsconfig.create_grpc_device_channel() <nitlsconfig.grpc_channel.create_grpc_device_channel>`
+from the `nitlsconfig <https://nitlsconfig-python.readthedocs.io/en/latest/>`_ package, which the
+``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed with the
+NI-SWITCH runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
 
 Before ``create_grpc_device_channel`` can succeed, you must use NI Hardware Manager to perform a
 certificate exchange with the remote system.

--- a/docs/niswitch/grpc_session_options.rst
+++ b/docs/niswitch/grpc_session_options.rst
@@ -7,6 +7,53 @@ Support for using NI-SWITCH over gRPC
 
 
 
+Creating a gRPC channel
+-----------------------
+
+Using NI-SWITCH over gRPC requires the ``grpc`` extra::
+
+  $ python -m pip install niswitch[grpc]
+
+Every NI-SWITCH gRPC session is created from a ``grpc.Channel`` that you build and pass to
+:py:class:`niswitch.GrpcSessionOptions`. You own the channel, not the session, so you must
+close it after the last session using it is closed.
+
+The recommended way to create a gRPC channel to a remote system running NI gRPC Device Server is
+``create_grpc_device_channel`` from the `nitlsconfig <https://pypi.org/project/nitlsconfig/>`_ package,
+which the ``grpc`` extra installs for you. It reads the nitlsconfig client configuration installed
+with the NI-SWITCH runtime and by default will attempt to build an encrypted gRPC channel using mTLS.
+
+Before ``create_grpc_device_channel`` can succeed, you must use NI Hardware Manager to perform a
+certificate exchange with the remote system.
+See `Managing mTLS <https://www.ni.com/docs/en-US/bundle/hardwaremanager/page/mtls-manage.html>`_ for
+additional information.
+
+For example::
+
+  import niswitch
+  import nitlsconfig
+
+  with nitlsconfig.create_grpc_device_channel('remote_grpc_device', 31763) as channel:
+      options = niswitch.GrpcSessionOptions(channel, '')
+      with niswitch.Session('dev1', grpc_options=options) as session:
+          # Calls to session over the encrypted channel
+
+.. note:: From NI Hardware Manager, you can disable TLS to make ``create_grpc_device_channel``
+    produce an insecure channel.
+
+.. note:: ``create_grpc_device_channel`` also accepts an ``options`` parameter for gRPC channel
+    arguments such as ``grpc.ssl_target_name_override``, and a ``retry_policy`` parameter. Channel
+    arguments cannot be changed after the channel is built, so they must be supplied here.
+
+.. note:: NI gRPC Device Server must be configured to accept remote connections and to take its
+    TLS settings from nitlsconfig. See
+    `Bind Address Support <https://github.com/ni/grpc-device#bind-address-support>`_ and
+    `NI TLS Config Integration <https://github.com/ni/grpc-device#ni-tls-config-integration>`_ for details.
+
+You can also build the gRPC channel yourself with ``grpc.insecure_channel`` or ``grpc.secure_channel``
+if you need full control over how credentials are supplied.
+
+
 SessionInitializationBehavior
 -----------------------------
 
@@ -55,17 +102,17 @@ GrpcSessionOptions
 
 
     :param grpc_channel:
-        
+
 
         Specifies the channel to the NI gRPC Device Server.
 
-        
+
 
     :type grpc_channel: grpc.Channel
 
 
     :param session_name:
-        
+
 
         User-specified name that identifies the driver session on the NI gRPC Device Server.
 
@@ -74,18 +121,18 @@ GrpcSessionOptions
         You can use an empty string if you want to always initialize a new session on the server.
         To attach to an existing session, you must specify the session name it was initialized with.
 
-        
+
 
     :type session_name: str
 
 
     :param initialization_behavior:
-        
+
 
         Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired.
 
         The driver session exists on the NI gRPC Device Server.
 
-        
+
 
     :type initialization_behavior: :py:data:`niswitch.SessionInitializationBehavior`

--- a/docs/nitclk/conf.py
+++ b/docs/nitclk/conf.py
@@ -195,4 +195,6 @@ intersphinx_mapping = {
     'niscope': ('https://niscope.readthedocs.io/en/latest/', None),
     'nise': ('https://nise.readthedocs.io/en/latest/', None),
     'niswitch': ('https://niswitch.readthedocs.io/en/latest/', None),
+    # Read the Docs project slug differs from the module name.
+    'nitlsconfig': ('https://nitlsconfig-python.readthedocs.io/en/latest/', None),
 }


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nimi-python/blob/master/CONTRIBUTING.md).

- ~[] I've updated [CHANGELOG.md](https://github.com/ni/nimi-python/blob/master/CHANGELOG.md) if applicable.~
This change is just documentation.

- ~[] I've added tests applicable for this pull request~

Purely documentation. No tests required.

### What does this Pull Request accomplish?

Add public-facing documentation for how to use our new Python nitlsconfig package to create mTLS encrypted gRPC channels.

Add initial documentation as well for creating gRPC channels as well, including how to even install gRPC. Ensure we link to and add tidbits for how to get this setup even working in the first place since it has a fair bit of nuance.

### List issues fixed by this Pull Request below, if any.

N/A

### What testing has been done?

Checked the produced documentation:

<img width="573" height="908" alt="image" src="https://github.com/user-attachments/assets/3d79d908-bd24-4d76-b5ca-42db51082135" />

